### PR TITLE
Run indent script on all c source files.

### DIFF
--- a/base/broker.c
+++ b/base/broker.c
@@ -39,7 +39,8 @@
 
 
 /* sends program data (starts, restarts, stops, etc.) to broker */
-void broker_program_state(int type, int flags, int attr, struct timeval *timestamp) {
+void broker_program_state(int type, int flags, int attr, struct timeval *timestamp)
+{
 	nebstruct_process_data ds;
 
 	if(!(event_broker_options & BROKER_PROGRAM_STATE))
@@ -55,11 +56,12 @@ void broker_program_state(int type, int flags, int attr, struct timeval *timesta
 	neb_make_callbacks(NEBCALLBACK_PROCESS_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* send timed event data to broker */
-void broker_timed_event(int type, int flags, int attr, timed_event *event, struct timeval *timestamp) {
+void broker_timed_event(int type, int flags, int attr, timed_event *event, struct timeval *timestamp)
+{
 	nebstruct_timed_event_data ds;
 
 	if(!(event_broker_options & BROKER_TIMED_EVENTS))
@@ -84,12 +86,13 @@ void broker_timed_event(int type, int flags, int attr, timed_event *event, struc
 	neb_make_callbacks(NEBCALLBACK_TIMED_EVENT_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* send log data to broker */
-void broker_log_data(int type, int flags, int attr, char *data, unsigned long data_type, time_t entry_time, struct timeval *timestamp) {
+void broker_log_data(int type, int flags, int attr, char *data, unsigned long data_type, time_t entry_time, struct timeval *timestamp)
+{
 	nebstruct_log_data ds;
 
 	if(!(event_broker_options & BROKER_LOGGED_DATA))
@@ -109,12 +112,13 @@ void broker_log_data(int type, int flags, int attr, char *data, unsigned long da
 	neb_make_callbacks(NEBCALLBACK_LOG_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* send system command data to broker */
-void broker_system_command(int type, int flags, int attr, struct timeval start_time, struct timeval end_time, double exectime, int timeout, int early_timeout, int retcode, char *cmd, char *output, struct timeval *timestamp) {
+void broker_system_command(int type, int flags, int attr, struct timeval start_time, struct timeval end_time, double exectime, int timeout, int early_timeout, int retcode, char *cmd, char *output, struct timeval *timestamp)
+{
 	nebstruct_system_command_data ds;
 
 	if(!(event_broker_options & BROKER_SYSTEM_COMMANDS))
@@ -142,12 +146,13 @@ void broker_system_command(int type, int flags, int attr, struct timeval start_t
 	neb_make_callbacks(NEBCALLBACK_SYSTEM_COMMAND_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* send event handler data to broker */
-int broker_event_handler(int type, int flags, int attr, int eventhandler_type, void *data, int state, int state_type, struct timeval start_time, struct timeval end_time, double exectime, int timeout, int early_timeout, int retcode, char *cmd, char *cmdline, char *output, struct timeval *timestamp) {
+int broker_event_handler(int type, int flags, int attr, int eventhandler_type, void *data, int state, int state_type, struct timeval start_time, struct timeval end_time, double exectime, int timeout, int early_timeout, int retcode, char *cmd, char *cmdline, char *output, struct timeval *timestamp)
+{
 	service *temp_service = NULL;
 	host *temp_host = NULL;
 	char *command_buf = NULL;
@@ -167,7 +172,7 @@ int broker_event_handler(int type, int flags, int attr, int eventhandler_type, v
 		command_buf = (char *)strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
-		}
+	}
 
 	/* fill struct with relevant data */
 	ds.type = type;
@@ -180,12 +185,11 @@ int broker_event_handler(int type, int flags, int attr, int eventhandler_type, v
 		temp_service = (service *)data;
 		ds.host_name = temp_service->host_name;
 		ds.service_description = temp_service->description;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
-		}
+	}
 	ds.object_ptr = data;
 	ds.state = state;
 	ds.state_type = state_type;
@@ -207,13 +211,14 @@ int broker_event_handler(int type, int flags, int attr, int eventhandler_type, v
 	my_free(command_buf);
 
 	return return_code;
-	}
+}
 
 
 
 
 /* send host check data to broker */
-int broker_host_check(int type, int flags, int attr, host *hst, int check_type, int state, int state_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, char *output, char *long_output, char *perfdata, struct timeval *timestamp, check_result *cr) {
+int broker_host_check(int type, int flags, int attr, host *hst, int check_type, int state, int state_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, char *output, char *long_output, char *perfdata, struct timeval *timestamp, check_result *cr)
+{
 	char *command_buf = NULL;
 	char *command_name = NULL;
 	char *command_args = NULL;
@@ -231,7 +236,7 @@ int broker_host_check(int type, int flags, int attr, host *hst, int check_type, 
 		command_buf = (char *)strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
-		}
+	}
 
 	/* fill struct with relevant data */
 	ds.type = type;
@@ -268,12 +273,13 @@ int broker_host_check(int type, int flags, int attr, host *hst, int check_type, 
 	my_free(command_buf);
 
 	return return_code;
-	}
+}
 
 
 
 /* send service check data to broker */
-int broker_service_check(int type, int flags, int attr, service *svc, int check_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, struct timeval *timestamp, check_result *cr) {
+int broker_service_check(int type, int flags, int attr, service *svc, int check_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, struct timeval *timestamp, check_result *cr)
+{
 	char *command_buf = NULL;
 	char *command_name = NULL;
 	char *command_args = NULL;
@@ -291,7 +297,7 @@ int broker_service_check(int type, int flags, int attr, service *svc, int check_
 		command_buf = (char *)strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
-		}
+	}
 
 	/* fill struct with relevant data */
 	ds.type = type;
@@ -329,12 +335,13 @@ int broker_service_check(int type, int flags, int attr, service *svc, int check_
 	my_free(command_buf);
 
 	return return_code;
-	}
+}
 
 
 
 /* send comment data to broker */
-void broker_comment_data(int type, int flags, int attr, int comment_type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long comment_id, struct timeval *timestamp) {
+void broker_comment_data(int type, int flags, int attr, int comment_type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long comment_id, struct timeval *timestamp)
+{
 	nebstruct_comment_data ds;
 
 	if(!(event_broker_options & BROKER_COMMENT_DATA))
@@ -364,12 +371,13 @@ void broker_comment_data(int type, int flags, int attr, int comment_type, int en
 	neb_make_callbacks(NEBCALLBACK_COMMENT_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* send downtime data to broker */
-void broker_downtime_data(int type, int flags, int attr, int downtime_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, struct timeval *timestamp) {
+void broker_downtime_data(int type, int flags, int attr, int downtime_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, struct timeval *timestamp)
+{
 	nebstruct_downtime_data ds;
 
 	if(!(event_broker_options & BROKER_DOWNTIME_DATA))
@@ -399,12 +407,13 @@ void broker_downtime_data(int type, int flags, int attr, int downtime_type, char
 	neb_make_callbacks(NEBCALLBACK_DOWNTIME_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* send flapping data to broker */
-void broker_flapping_data(int type, int flags, int attr, int flapping_type, void *data, double percent_change, double high_threshold, double low_threshold, struct timeval *timestamp) {
+void broker_flapping_data(int type, int flags, int attr, int flapping_type, void *data, double percent_change, double high_threshold, double low_threshold, struct timeval *timestamp)
+{
 	nebstruct_flapping_data ds;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -427,13 +436,12 @@ void broker_flapping_data(int type, int flags, int attr, int flapping_type, void
 		ds.host_name = temp_service->host_name;
 		ds.service_description = temp_service->description;
 		ds.comment_id = temp_service->flapping_comment_id;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
 		ds.comment_id = temp_host->flapping_comment_id;
-		}
+	}
 	ds.object_ptr = data;
 	ds.percent_change = percent_change;
 	ds.high_threshold = high_threshold;
@@ -443,11 +451,12 @@ void broker_flapping_data(int type, int flags, int attr, int flapping_type, void
 	neb_make_callbacks(NEBCALLBACK_FLAPPING_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* sends program status updates to broker */
-void broker_program_status(int type, int flags, int attr, struct timeval *timestamp) {
+void broker_program_status(int type, int flags, int attr, struct timeval *timestamp)
+{
 	nebstruct_program_status_data ds;
 
 	if(!(event_broker_options & BROKER_STATUS_DATA))
@@ -482,12 +491,13 @@ void broker_program_status(int type, int flags, int attr, struct timeval *timest
 	neb_make_callbacks(NEBCALLBACK_PROGRAM_STATUS_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* sends host status updates to broker */
-void broker_host_status(int type, int flags, int attr, host *hst, struct timeval *timestamp) {
+void broker_host_status(int type, int flags, int attr, host *hst, struct timeval *timestamp)
+{
 	nebstruct_host_status_data ds;
 
 	if(!(event_broker_options & BROKER_STATUS_DATA))
@@ -505,12 +515,13 @@ void broker_host_status(int type, int flags, int attr, host *hst, struct timeval
 	neb_make_callbacks(NEBCALLBACK_HOST_STATUS_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* sends service status updates to broker */
-void broker_service_status(int type, int flags, int attr, service *svc, struct timeval *timestamp) {
+void broker_service_status(int type, int flags, int attr, service *svc, struct timeval *timestamp)
+{
 	nebstruct_service_status_data ds;
 
 	if(!(event_broker_options & BROKER_STATUS_DATA))
@@ -528,12 +539,13 @@ void broker_service_status(int type, int flags, int attr, service *svc, struct t
 	neb_make_callbacks(NEBCALLBACK_SERVICE_STATUS_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* sends contact status updates to broker */
-void broker_contact_status(int type, int flags, int attr, contact *cntct, struct timeval *timestamp) {
+void broker_contact_status(int type, int flags, int attr, contact *cntct, struct timeval *timestamp)
+{
 	nebstruct_service_status_data ds;
 
 	if(!(event_broker_options & BROKER_STATUS_DATA))
@@ -551,12 +563,13 @@ void broker_contact_status(int type, int flags, int attr, contact *cntct, struct
 	neb_make_callbacks(NEBCALLBACK_CONTACT_STATUS_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
 /* send notification data to broker */
-int broker_notification_data(int type, int flags, int attr, int notification_type, int reason_type, struct timeval start_time, struct timeval end_time, void *data, char *ack_author, char *ack_data, int escalated, int contacts_notified, struct timeval *timestamp) {
+int broker_notification_data(int type, int flags, int attr, int notification_type, int reason_type, struct timeval start_time, struct timeval end_time, void *data, char *ack_author, char *ack_data, int escalated, int contacts_notified, struct timeval *timestamp)
+{
 	nebstruct_notification_data ds;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -581,14 +594,13 @@ int broker_notification_data(int type, int flags, int attr, int notification_typ
 		ds.service_description = temp_service->description;
 		ds.state = temp_service->current_state;
 		ds.output = temp_service->plugin_output;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
 		ds.state = temp_host->current_state;
 		ds.output = temp_host->plugin_output;
-		}
+	}
 	ds.object_ptr = data;
 	ds.ack_author = ack_author;
 	ds.ack_data = ack_data;
@@ -599,12 +611,13 @@ int broker_notification_data(int type, int flags, int attr, int notification_typ
 	return_code = neb_make_callbacks(NEBCALLBACK_NOTIFICATION_DATA, (void *)&ds);
 
 	return return_code;
-	}
+}
 
 
 
 /* send contact notification data to broker */
-int broker_contact_notification_data(int type, int flags, int attr, int notification_type, int reason_type, struct timeval start_time, struct timeval end_time, void *data, contact *cntct, char *ack_author, char *ack_data, int escalated, struct timeval *timestamp) {
+int broker_contact_notification_data(int type, int flags, int attr, int notification_type, int reason_type, struct timeval start_time, struct timeval end_time, void *data, contact *cntct, char *ack_author, char *ack_data, int escalated, struct timeval *timestamp)
+{
 	nebstruct_contact_notification_data ds;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -630,14 +643,13 @@ int broker_contact_notification_data(int type, int flags, int attr, int notifica
 		ds.service_description = temp_service->description;
 		ds.state = temp_service->current_state;
 		ds.output = temp_service->plugin_output;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
 		ds.state = temp_host->current_state;
 		ds.output = temp_host->plugin_output;
-		}
+	}
 	ds.object_ptr = data;
 	ds.contact_ptr = (void *)cntct;
 	ds.ack_author = ack_author;
@@ -648,11 +660,12 @@ int broker_contact_notification_data(int type, int flags, int attr, int notifica
 	return_code = neb_make_callbacks(NEBCALLBACK_CONTACT_NOTIFICATION_DATA, (void *)&ds);
 
 	return return_code;
-	}
+}
 
 
 /* send contact notification data to broker */
-int broker_contact_notification_method_data(int type, int flags, int attr, int notification_type, int reason_type, struct timeval start_time, struct timeval end_time, void *data, contact *cntct, char *cmd, char *ack_author, char *ack_data, int escalated, struct timeval *timestamp) {
+int broker_contact_notification_method_data(int type, int flags, int attr, int notification_type, int reason_type, struct timeval start_time, struct timeval end_time, void *data, contact *cntct, char *cmd, char *ack_author, char *ack_data, int escalated, struct timeval *timestamp)
+{
 	nebstruct_contact_notification_method_data ds;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -669,7 +682,7 @@ int broker_contact_notification_method_data(int type, int flags, int attr, int n
 		command_buf = (char *)strdup(cmd);
 		command_name = strtok(command_buf, "!");
 		command_args = strtok(NULL, "\x0");
-		}
+	}
 
 	/* fill struct with relevant data */
 	ds.type = type;
@@ -690,14 +703,13 @@ int broker_contact_notification_method_data(int type, int flags, int attr, int n
 		ds.service_description = temp_service->description;
 		ds.state = temp_service->current_state;
 		ds.output = temp_service->plugin_output;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
 		ds.state = temp_host->current_state;
 		ds.output = temp_host->plugin_output;
-		}
+	}
 	ds.object_ptr = data;
 	ds.contact_ptr = (void *)cntct;
 	ds.ack_author = ack_author;
@@ -711,11 +723,12 @@ int broker_contact_notification_method_data(int type, int flags, int attr, int n
 	my_free(command_buf);
 
 	return return_code;
-	}
+}
 
 
 /* sends adaptive programs updates to broker */
-void broker_adaptive_program_data(int type, int flags, int attr, int command_type, unsigned long modhattr, unsigned long modhattrs, unsigned long modsattr, unsigned long modsattrs, struct timeval *timestamp) {
+void broker_adaptive_program_data(int type, int flags, int attr, int command_type, unsigned long modhattr, unsigned long modhattrs, unsigned long modsattr, unsigned long modsattrs, struct timeval *timestamp)
+{
 	nebstruct_adaptive_program_data ds;
 
 	if(!(event_broker_options & BROKER_ADAPTIVE_DATA))
@@ -737,11 +750,12 @@ void broker_adaptive_program_data(int type, int flags, int attr, int command_typ
 	neb_make_callbacks(NEBCALLBACK_ADAPTIVE_PROGRAM_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* sends adaptive host updates to broker */
-void broker_adaptive_host_data(int type, int flags, int attr, host *hst, int command_type, unsigned long modattr, unsigned long modattrs, struct timeval *timestamp) {
+void broker_adaptive_host_data(int type, int flags, int attr, host *hst, int command_type, unsigned long modattr, unsigned long modattrs, struct timeval *timestamp)
+{
 	nebstruct_adaptive_host_data ds;
 
 	if(!(event_broker_options & BROKER_ADAPTIVE_DATA))
@@ -762,11 +776,12 @@ void broker_adaptive_host_data(int type, int flags, int attr, host *hst, int com
 	neb_make_callbacks(NEBCALLBACK_ADAPTIVE_HOST_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* sends adaptive service updates to broker */
-void broker_adaptive_service_data(int type, int flags, int attr, service *svc, int command_type, unsigned long modattr, unsigned long modattrs, struct timeval *timestamp) {
+void broker_adaptive_service_data(int type, int flags, int attr, service *svc, int command_type, unsigned long modattr, unsigned long modattrs, struct timeval *timestamp)
+{
 	nebstruct_adaptive_service_data ds;
 
 	if(!(event_broker_options & BROKER_ADAPTIVE_DATA))
@@ -787,11 +802,12 @@ void broker_adaptive_service_data(int type, int flags, int attr, service *svc, i
 	neb_make_callbacks(NEBCALLBACK_ADAPTIVE_SERVICE_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* sends adaptive contact updates to broker */
-void broker_adaptive_contact_data(int type, int flags, int attr, contact *cntct, int command_type, unsigned long modattr, unsigned long modattrs, unsigned long modhattr, unsigned long modhattrs, unsigned long modsattr, unsigned long modsattrs, struct timeval *timestamp) {
+void broker_adaptive_contact_data(int type, int flags, int attr, contact *cntct, int command_type, unsigned long modattr, unsigned long modattrs, unsigned long modhattr, unsigned long modhattrs, unsigned long modsattr, unsigned long modsattrs, struct timeval *timestamp)
+{
 	nebstruct_adaptive_contact_data ds;
 
 	if(!(event_broker_options & BROKER_ADAPTIVE_DATA))
@@ -816,11 +832,12 @@ void broker_adaptive_contact_data(int type, int flags, int attr, contact *cntct,
 	neb_make_callbacks(NEBCALLBACK_ADAPTIVE_CONTACT_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* sends external commands to broker */
-void broker_external_command(int type, int flags, int attr, int command_type, time_t entry_time, char *command_string, char *command_args, struct timeval *timestamp) {
+void broker_external_command(int type, int flags, int attr, int command_type, time_t entry_time, char *command_string, char *command_args, struct timeval *timestamp)
+{
 	nebstruct_external_command_data ds;
 
 	if(!(event_broker_options & BROKER_EXTERNALCOMMAND_DATA))
@@ -841,11 +858,12 @@ void broker_external_command(int type, int flags, int attr, int command_type, ti
 	neb_make_callbacks(NEBCALLBACK_EXTERNAL_COMMAND_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* brokers aggregated status dumps */
-void broker_aggregated_status_data(int type, int flags, int attr, struct timeval *timestamp) {
+void broker_aggregated_status_data(int type, int flags, int attr, struct timeval *timestamp)
+{
 	nebstruct_aggregated_status_data ds;
 
 	if(!(event_broker_options & BROKER_STATUS_DATA))
@@ -861,11 +879,12 @@ void broker_aggregated_status_data(int type, int flags, int attr, struct timeval
 	neb_make_callbacks(NEBCALLBACK_AGGREGATED_STATUS_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* brokers retention data */
-void broker_retention_data(int type, int flags, int attr, struct timeval *timestamp) {
+void broker_retention_data(int type, int flags, int attr, struct timeval *timestamp)
+{
 	nebstruct_retention_data ds;
 
 	if(!(event_broker_options & BROKER_RETENTION_DATA))
@@ -881,11 +900,12 @@ void broker_retention_data(int type, int flags, int attr, struct timeval *timest
 	neb_make_callbacks(NEBCALLBACK_RETENTION_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* send acknowledgement data to broker */
-void broker_acknowledgement_data(int type, int flags, int attr, int acknowledgement_type, void *data, char *ack_author, char *ack_data, int subtype, int notify_contacts, int persistent_comment, struct timeval *timestamp) {
+void broker_acknowledgement_data(int type, int flags, int attr, int acknowledgement_type, void *data, char *ack_author, char *ack_data, int subtype, int notify_contacts, int persistent_comment, struct timeval *timestamp)
+{
 	nebstruct_acknowledgement_data ds;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -905,13 +925,12 @@ void broker_acknowledgement_data(int type, int flags, int attr, int acknowledgem
 		ds.host_name = temp_service->host_name;
 		ds.service_description = temp_service->description;
 		ds.state = temp_service->current_state;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
 		ds.state = temp_host->current_state;
-		}
+	}
 	ds.object_ptr = data;
 	ds.author_name = ack_author;
 	ds.comment_data = ack_data;
@@ -923,11 +942,12 @@ void broker_acknowledgement_data(int type, int flags, int attr, int acknowledgem
 	neb_make_callbacks(NEBCALLBACK_ACKNOWLEDGEMENT_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 /* send state change data to broker */
-void broker_statechange_data(int type, int flags, int attr, int statechange_type, void *data, int state, int state_type, int current_attempt, int max_attempts, struct timeval *timestamp) {
+void broker_statechange_data(int type, int flags, int attr, int statechange_type, void *data, int state, int state_type, int current_attempt, int max_attempts, struct timeval *timestamp)
+{
 	nebstruct_statechange_data ds;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -947,13 +967,12 @@ void broker_statechange_data(int type, int flags, int attr, int statechange_type
 		ds.host_name = temp_service->host_name;
 		ds.service_description = temp_service->description;
 		ds.output = temp_service->plugin_output;
-		}
-	else {
+	} else {
 		temp_host = (host *)data;
 		ds.host_name = temp_host->name;
 		ds.service_description = NULL;
 		ds.output = temp_host->plugin_output;
-		}
+	}
 	ds.object_ptr = data;
 	ds.state = state;
 	ds.state_type = state_type;
@@ -964,7 +983,7 @@ void broker_statechange_data(int type, int flags, int attr, int statechange_type
 	neb_make_callbacks(NEBCALLBACK_STATE_CHANGE_DATA, (void *)&ds);
 
 	return;
-	}
+}
 
 
 
@@ -973,7 +992,8 @@ void broker_statechange_data(int type, int flags, int attr, int statechange_type
 /******************************************************************/
 
 /* gets timestamp for use by broker */
-struct timeval get_broker_timestamp(struct timeval *timestamp) {
+struct timeval get_broker_timestamp(struct timeval *timestamp)
+{
 	struct timeval tv;
 
 	if(timestamp == NULL)
@@ -982,6 +1002,6 @@ struct timeval get_broker_timestamp(struct timeval *timestamp) {
 		tv = *timestamp;
 
 	return tv;
-	}
+}
 
 #endif

--- a/base/checks.c
+++ b/base/checks.c
@@ -44,7 +44,8 @@
 /******************************************************************/
 
 /* reaps host and service check results */
-int reap_check_results(void) {
+int reap_check_results(void)
+{
 	int reaped_checks = 0;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "reap_check_results() start\n");
@@ -57,7 +58,7 @@ int reap_check_results(void) {
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "reap_check_results() end\n");
 
 	return OK;
-	}
+}
 
 
 
@@ -67,7 +68,8 @@ int reap_check_results(void) {
 /******************************************************************/
 
 /* executes a scheduled service check */
-int run_scheduled_service_check(service *svc, int check_options, double latency) {
+int run_scheduled_service_check(service *svc, int check_options, double latency)
+{
 	int result = OK;
 	time_t current_time = 0L;
 	time_t preferred_time = 0L;
@@ -119,7 +121,7 @@ int run_scheduled_service_check(service *svc, int check_options, double latency)
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Check of service '%s' on host '%s' could not be rescheduled properly.  Scheduling check for %s...\n", svc->description, svc->host_name, ctime(&preferred_time));
 
 				log_debug_info(DEBUGL_CHECKS, 1, "Unable to find any valid times to reschedule the next service check!\n");
-				}
+			}
 
 			/* this service could be rescheduled... */
 			else {
@@ -127,8 +129,8 @@ int run_scheduled_service_check(service *svc, int check_options, double latency)
 				svc->should_be_scheduled = TRUE;
 
 				log_debug_info(DEBUGL_CHECKS, 1, "Rescheduled next service check for %s", ctime(&next_valid_time));
-				}
 			}
+		}
 
 		/*
 		 * reschedule the next service check - unless we couldn't
@@ -141,14 +143,15 @@ int run_scheduled_service_check(service *svc, int check_options, double latency)
 		update_service_status(svc, FALSE);
 
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* forks a child process to run a service check, but does not wait for the service check result */
-int run_async_service_check(service *svc, int check_options, double latency, int scheduled_check, int reschedule_check, int *time_is_valid, time_t *preferred_time) {
+int run_async_service_check(service *svc, int check_options, double latency, int scheduled_check, int reschedule_check, int *time_is_valid, time_t *preferred_time)
+{
 	nagios_macros mac;
 	char *raw_command = NULL;
 	char *processed_command = NULL;
@@ -198,7 +201,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 		if(preferred_time)
 			*preferred_time += (svc->check_interval * interval_length);
 		return ERROR;
-		}
+	}
 
 	/* neb module wants to override (or cancel) the service check - perhaps it will check the service itself */
 	/* NOTE: if a module does this, it has to do a lot of the stuff found below to make sure things don't get whacked out of shape! */
@@ -233,7 +236,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 			*preferred_time += (svc->check_interval * interval_length);
 		svc->latency = old_latency;
 		return ERROR;
-		}
+	}
 
 	/* process any macros contained in the argument */
 	process_macros_r(&mac, raw_command, &processed_command, macro_options);
@@ -245,7 +248,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 			*preferred_time += (svc->check_interval * interval_length);
 		svc->latency = old_latency;
 		return ERROR;
-		}
+	}
 
 	/* get the command start time */
 	gettimeofday(&start_time, NULL);
@@ -286,7 +289,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 		free_check_result(cr);
 		my_free(processed_command);
 		return OK;
-		}
+	}
 #endif
 
 	/* reset latency (permanent value will be set later) */
@@ -296,8 +299,7 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 	runchk_result = wproc_run_check(cr, processed_command, &mac);
 	if (runchk_result == ERROR) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Unable to run check for service '%s' on host '%s'\n", svc->description, svc->host_name);
-	}
-	else {
+	} else {
 		/* do the book-keeping */
 		currently_running_service_checks++;
 		svc->is_executing = TRUE;
@@ -309,11 +311,12 @@ int run_async_service_check(service *svc, int check_options, double latency, int
 	clear_volatile_macros_r(&mac);
 
 	return runchk_result;
-	}
+}
 
 
 static int get_service_check_return_code(service *temp_service,
-		check_result *queued_check_result) {
+        check_result *queued_check_result)
+{
 
 	int rc;
 	char *temp_plugin_output = NULL;
@@ -322,7 +325,7 @@ static int get_service_check_return_code(service *temp_service,
 
 	if(NULL == temp_service || NULL == queued_check_result) {
 		return STATE_UNKNOWN;
-		}
+	}
 
 	/* grab the return code */
 	rc = queued_check_result->return_code;
@@ -336,12 +339,12 @@ static int get_service_check_return_code(service *temp_service,
 			my_free(temp_service->perf_data);
 			asprintf(&temp_service->plugin_output, "(Service check timed out after %.2lf seconds)\n", temp_service->execution_time);
 			rc = service_check_timeout_state;
-			}
+		}
 		/* if there was some error running the command, just skip it (this shouldn't be happening) */
 		else if(queued_check_result->exited_ok == FALSE) {
 
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning:  Check of service '%s' on host '%s' did not exit properly!\n", temp_service->description, temp_service->host_name);
-			
+
 			my_free(temp_service->plugin_output);
 			my_free(temp_service->long_plugin_output);
 			my_free(temp_service->perf_data);
@@ -349,7 +352,7 @@ static int get_service_check_return_code(service *temp_service,
 			temp_service->plugin_output = (char *)strdup("(Service check did not exit properly)");
 
 			rc = STATE_CRITICAL;
-			}
+		}
 
 		/* make sure the return code is within bounds */
 		else if(queued_check_result->return_code < 0 || queued_check_result->return_code > 3) {
@@ -359,21 +362,22 @@ static int get_service_check_return_code(service *temp_service,
 			my_free(temp_service->plugin_output);
 			my_free(temp_service->long_plugin_output);
 			my_free(temp_service->perf_data);
-			
+
 			asprintf(&temp_plugin_output, "\x73\x6f\x69\x67\x61\x6e\x20\x74\x68\x67\x69\x72\x79\x70\x6f\x63\x20\x6e\x61\x68\x74\x65\x20\x64\x61\x74\x73\x6c\x61\x67");
 			my_free(temp_plugin_output);
 			asprintf(&temp_service->plugin_output, "(Return code of %d is out of bounds%s)", queued_check_result->return_code, (queued_check_result->return_code == 126 ? " - plugin may not be executable" : (queued_check_result->return_code == 127 ? " - plugin may be missing" : "")));
 
 			rc = STATE_CRITICAL;
-			}
 		}
+	}
 
 	return rc;
-	}
+}
 
 
 /* handles asynchronous service check results */
-int handle_async_service_check_result(service *temp_service, check_result *queued_check_result) {
+int handle_async_service_check_result(service *temp_service, check_result *queued_check_result)
+{
 	host *temp_host = NULL;
 	time_t next_service_check = 0L;
 	time_t preferred_time = 0L;
@@ -417,12 +421,12 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 		if(accept_passive_service_checks == FALSE) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Discarding passive service check result because passive service checks are disabled globally.\n");
 			return ERROR;
-			}
+		}
 		if(temp_service->accept_passive_checks == FALSE) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Discarding passive service check result because passive checks are disabled for this service.\n");
 			return ERROR;
-			}
 		}
+	}
 
 	/* clear the freshening flag (it would have been set if this service was determined to be stale) */
 	if(queued_check_result->check_options & CHECK_OPTION_FRESHNESS_CHECK)
@@ -439,7 +443,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	if((queued_check_result->check_options & CHECK_OPTION_FRESHNESS_CHECK) && is_service_result_fresh(temp_service, current_time, FALSE) == TRUE) {
 		log_debug_info(DEBUGL_CHECKS, 0, "Discarding service freshness check result because the service is currently fresh (race condition avoided).\n");
 		return OK;
-		}
+	}
 
 	/* check latency is passed to us */
 	temp_service->latency = queued_check_result->latency;
@@ -485,11 +489,11 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	else if((temp_ptr = temp_service->plugin_output)) {
 		while((temp_ptr = strchr(temp_ptr, ';')))
 			* temp_ptr = ':';
-		}
+	}
 
 	/* grab the return code */
 	temp_service->current_state = get_service_check_return_code(temp_service,
-			queued_check_result);
+	                              queued_check_result);
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Parsing check output...\n");
 	log_debug_info(DEBUGL_CHECKS, 2, "Short Output: %s\n", (temp_service->plugin_output == NULL) ? "NULL" : temp_service->plugin_output);
@@ -498,27 +502,27 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 	/* record the time the last state ended */
 	switch(temp_service->last_state) {
-		case STATE_OK:
-			temp_service->last_time_ok = temp_service->last_check;
-			break;
-		case STATE_WARNING:
-			temp_service->last_time_warning = temp_service->last_check;
-			break;
-		case STATE_UNKNOWN:
-			temp_service->last_time_unknown = temp_service->last_check;
-			break;
-		case STATE_CRITICAL:
-			temp_service->last_time_critical = temp_service->last_check;
-			break;
-		default:
-			break;
-		}
+	case STATE_OK:
+		temp_service->last_time_ok = temp_service->last_check;
+		break;
+	case STATE_WARNING:
+		temp_service->last_time_warning = temp_service->last_check;
+		break;
+	case STATE_UNKNOWN:
+		temp_service->last_time_unknown = temp_service->last_check;
+		break;
+	case STATE_CRITICAL:
+		temp_service->last_time_critical = temp_service->last_check;
+		break;
+	default:
+		break;
+	}
 
 	/* log passive checks - we need to do this here, as some my bypass external commands by getting dropped in checkresults dir */
 	if(temp_service->check_type == CHECK_TYPE_PASSIVE) {
 		if(log_passive_checks == TRUE)
 			logit(NSLOG_PASSIVE_CHECK, FALSE, "PASSIVE SERVICE CHECK: %s;%s;%d;%s\n", temp_service->host_name, temp_service->description, temp_service->current_state, temp_service->plugin_output);
-		}
+	}
 
 	/* get the host that this service runs on */
 	temp_host = (host *)temp_service->host_ptr;
@@ -533,8 +537,8 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 			/* set a flag to remember that we launched a check */
 			first_host_check_initiated = TRUE;
 			schedule_host_check(temp_host, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-			}
 		}
+	}
 
 
 	/* increment the current attempt number if this is a soft state (service was rechecked) */
@@ -548,7 +552,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	if(temp_service->current_state != temp_service->last_state) {
 		log_debug_info(DEBUGL_CHECKS, 2, "Service has changed state since last check!\n");
 		state_change = TRUE;
-		}
+	}
 
 	/* checks for a hard state change where host was down at last service check */
 	/* this occurs in the case where host goes down and service current attempt gets reset to 1 */
@@ -556,13 +560,13 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	if(temp_service->host_problem_at_last_check == TRUE && temp_service->current_state == STATE_OK) {
 		log_debug_info(DEBUGL_CHECKS, 2, "Service had a HARD STATE CHANGE!!\n");
 		hard_state_change = TRUE;
-		}
+	}
 
 	/* check for a "normal" hard state change where max check attempts is reached */
 	if(temp_service->current_attempt >= temp_service->max_attempts && temp_service->current_state != temp_service->last_hard_state) {
 		log_debug_info(DEBUGL_CHECKS, 2, "Service had a HARD STATE CHANGE!!\n");
 		hard_state_change = TRUE;
-		}
+	}
 
 	/* a state change occurred... */
 	/* reset last and next notification times and acknowledgement flag if necessary, misc other stuff */
@@ -585,21 +589,20 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 			/* remove any non-persistant comments associated with the ack */
 			delete_service_acknowledgement_comments(temp_service);
-			}
-		else if(temp_service->acknowledgement_type == ACKNOWLEDGEMENT_STICKY && temp_service->current_state == STATE_OK) {
+		} else if(temp_service->acknowledgement_type == ACKNOWLEDGEMENT_STICKY && temp_service->current_state == STATE_OK) {
 
 			temp_service->problem_has_been_acknowledged = FALSE;
 			temp_service->acknowledgement_type = ACKNOWLEDGEMENT_NONE;
 
 			/* remove any non-persistant comments associated with the ack */
 			delete_service_acknowledgement_comments(temp_service);
-			}
+		}
 
 		/*
 		 * hard changes between non-OK states should continue
 		 * to be escalated, so don't reset current notification number
 		 */
-		}
+	}
 
 	/* initialize the last host and service state change times if necessary */
 	if(temp_service->last_state_change == (time_t)0)
@@ -630,14 +633,14 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 			/* don't reset last problem id, or it will be zero the next time a problem is encountered */
 			temp_service->current_problem_id = next_problem_id;
 			next_problem_id++;
-			}
+		}
 
 		/* clear the problem id when transitioning from a problem state to an OK state */
 		if(temp_service->current_state == STATE_OK) {
 			temp_service->last_problem_id = temp_service->current_problem_id;
 			temp_service->current_problem_id = 0L;
-			}
 		}
+	}
 
 
 	/**************************************/
@@ -667,13 +670,13 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 					log_debug_info(DEBUGL_CHECKS, 1, "* Using cached host state: %d\n", temp_host->current_state);
 					update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
 					update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
-					}
+				}
 
 				/* else launch an async (parallel) check of the host */
 				else
 					schedule_host_check(temp_host, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-				}
 			}
+		}
 
 		/* if a hard service recovery has occurred... */
 		if(hard_state_change == TRUE) {
@@ -698,7 +701,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 			/* run the service event handler to handle the hard state change */
 			handle_service_event(temp_service);
-			}
+		}
 
 		/* else if a soft service recovery has occurred... */
 		else if(state_change == TRUE) {
@@ -714,12 +717,12 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 			/* run the service event handler to handle the soft state change */
 			handle_service_event(temp_service);
-			}
+		}
 
 		/* else no service state change has occurred... */
 		else {
 			log_debug_info(DEBUGL_CHECKS, 1, "Service did not change state.\n");
-			}
+		}
 
 		/* should we obsessive over service checks? */
 		if(obsess_over_services == TRUE)
@@ -739,7 +742,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 		if(reschedule_check == TRUE)
 			next_service_check = (time_t)(temp_service->last_check + (temp_service->check_interval * interval_length));
-		}
+	}
 
 
 	/*******************************************/
@@ -759,14 +762,13 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 			/* only run a new check if we can and have to */
 			if(execute_host_checks && temp_host->last_check + cached_host_check_horizon < current_time) {
 				schedule_host_check(temp_host, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-				}
-			else {
+			} else {
 				log_debug_info(DEBUGL_CHECKS, 1, "* Using cached host state: %d\n", temp_host->current_state);
 				route_result = temp_host->current_state;
 				update_check_stats(ACTIVE_ONDEMAND_HOST_CHECK_STATS, current_time);
 				update_check_stats(ACTIVE_CACHED_HOST_CHECK_STATS, current_time);
-				}
 			}
+		}
 
 		/* else the host is either down or unreachable, so recheck it if necessary */
 		else {
@@ -775,7 +777,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 			if(execute_host_checks) {
 				schedule_host_check(temp_host, current_time, CHECK_OPTION_NONE);
-				}
+			}
 			/* else fake the host check, but (possibly) resend host notifications to contacts... */
 			else {
 
@@ -786,15 +788,15 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 				if(temp_host->has_been_checked == FALSE) {
 					temp_host->has_been_checked = TRUE;
 					temp_host->last_check = temp_service->last_check;
-					}
+				}
 
 				/* fake the route check result */
 				route_result = temp_host->current_state;
 
 				/* possibly re-send host notifications... */
 				host_notification(temp_host, NOTIFICATION_NORMAL, NULL, NULL, NOTIFICATION_OPTION_NONE);
-				}
 			}
+		}
 
 		/* if the host is down or unreachable ... */
 		/* The host might be in a SOFT problem state due to host check retries/caching.  Not sure if we should take that into account and do something different or not... */
@@ -813,11 +815,11 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 				temp_service->last_hard_state_change = temp_service->last_check;
 				temp_service->state_type = HARD_STATE;
 				temp_service->last_hard_state = temp_service->current_state;
-				}
+			}
 
 			/* put service into a hard state without attempting check retries and don't send out notifications about it */
 			temp_service->host_problem_at_last_check = TRUE;
-			}
+		}
 
 		/* the host is up - it recovered since the last time the service was checked... */
 		else if(temp_service->host_problem_at_last_check == TRUE) {
@@ -833,7 +835,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 			/* the hosts recovered.  This caused problems, so hopefully this will fix it */
 			if(temp_service->state_type == SOFT_STATE)
 				temp_service->current_attempt = 1;
-			}
+		}
 
 		log_debug_info(DEBUGL_CHECKS, 1, "Current/Max Attempt(s): %d/%d\n", temp_service->current_attempt, temp_service->max_attempts);
 
@@ -856,8 +858,8 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 					/* run the service event handler to handle the hard state */
 					handle_service_event(temp_service);
-					}
 				}
+			}
 
 			/* the host is up, so continue to retry the service check */
 			else {
@@ -876,7 +878,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 
 				if(reschedule_check == TRUE)
 					next_service_check = (time_t)(temp_service->last_check + (temp_service->retry_interval * interval_length));
-				}
+			}
 
 			/* perform dependency checks on the second to last check of the service */
 			if(execute_service_checks && enable_predictive_service_dependency_checks == TRUE && temp_service->current_attempt == (temp_service->max_attempts - 1)) {
@@ -892,18 +894,18 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 						master_service = (service *)temp_dependency->master_service_ptr;
 						log_debug_info(DEBUGL_CHECKS, 2, "Predictive check of service '%s' on host '%s' queued.\n", master_service->description, master_service->host_name);
 						schedule_service_check(master_service, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-						}
 					}
+				}
 				for(list = temp_service->notify_deps; list; list = list->next) {
 					temp_dependency = (servicedependency *)list->object_ptr;
 					if(temp_dependency->dependent_service_ptr == temp_service && temp_dependency->master_service_ptr != NULL) {
 						master_service = (service *)temp_dependency->master_service_ptr;
 						log_debug_info(DEBUGL_CHECKS, 2, "Predictive check of service '%s' on host '%s' queued.\n", master_service->description, master_service->host_name);
 						schedule_service_check(master_service, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-						}
 					}
 				}
 			}
+		}
 
 
 		/* we've reached the maximum number of service rechecks, so handle the error */
@@ -920,13 +922,13 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 				/* log the service problem (even if host is not up, which is new in 0.0.5) */
 				log_service_event(temp_service);
 				state_was_logged = TRUE;
-				}
+			}
 
 			/* else log the problem (again) if this service is flagged as being volatile */
 			else if(temp_service->is_volatile == TRUE) {
 				log_service_event(temp_service);
 				state_was_logged = TRUE;
-				}
+			}
 
 			/* check for start of flexible (non-fixed) scheduled downtime if we just had a hard error */
 			/* we need to check for both, state_change (SOFT) and hard_state_change (HARD) values */
@@ -952,13 +954,13 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 			/* reschedule the next check at the regular interval */
 			if(reschedule_check == TRUE)
 				next_service_check = (time_t)(temp_service->last_check + (temp_service->check_interval * interval_length));
-			}
+		}
 
 
 		/* should we obsessive over service checks? */
 		if(obsess_over_services == TRUE)
 			obsessive_compulsive_service_check_processor(temp_service);
-		}
+	}
 
 	/* reschedule the next service check ONLY for active, scheduled checks */
 	if(reschedule_check == TRUE) {
@@ -991,7 +993,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 		/* schedule a non-forced check if we can */
 		if(temp_service->should_be_scheduled == TRUE)
 			schedule_service_check(temp_service, temp_service->next_check, CHECK_OPTION_NONE);
-		}
+	}
 
 	/* if we're stalking this state type and state was not already logged AND the plugin output changed since last check, log it now.. */
 	if(temp_service->state_type == HARD_STATE && state_change == FALSE && state_was_logged == FALSE && compare_strings(old_plugin_output, temp_service->plugin_output)) {
@@ -999,7 +1001,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 		if(should_stalk(temp_service))
 			log_service_event(temp_service);
 
-		}
+	}
 
 #ifdef USE_EVENT_BROKER
 	/* send data to event broker */
@@ -1016,7 +1018,7 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	if(flapping_check_done == FALSE) {
 		check_for_service_flapping(temp_service, TRUE, TRUE);
 		check_for_host_flapping(temp_host, TRUE, FALSE, TRUE);
-		}
+	}
 
 	/* update service performance info */
 	update_service_performance_data(temp_service);
@@ -1026,12 +1028,13 @@ int handle_async_service_check_result(service *temp_service, check_result *queue
 	my_free(old_plugin_output);
 
 	return OK;
-	}
+}
 
 
 
 /* schedules an immediate or delayed service check */
-void schedule_service_check(service *svc, time_t check_time, int options) {
+void schedule_service_check(service *svc, time_t check_time, int options)
+{
 	timed_event *temp_event = NULL;
 	int use_original_event = TRUE;
 
@@ -1046,15 +1049,15 @@ void schedule_service_check(service *svc, time_t check_time, int options) {
 	if(svc->checks_enabled == FALSE && !(options & CHECK_OPTION_FORCE_EXECUTION)) {
 		log_debug_info(DEBUGL_CHECKS, 0, "Active checks of this service are disabled.\n");
 		return;
-		}
+	}
 
 	/* we may have to nudge this check a bit */
 	if (options == CHECK_OPTION_DEPENDENCY_CHECK) {
 		if (svc->last_check + cached_service_check_horizon > check_time) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Last check result is recent enough (%s)", ctime(&svc->last_check));
 			return;
-			}
 		}
+	}
 
 	/* default is to use the new event */
 	use_original_event = FALSE;
@@ -1079,8 +1082,8 @@ void schedule_service_check(service *svc, time_t check_time, int options) {
 			if((options & CHECK_OPTION_FORCE_EXECUTION) && (check_time < temp_event->run_time)) {
 				use_original_event = FALSE;
 				log_debug_info(DEBUGL_CHECKS, 2, "New service check event is forced and occurs before the existing event, so the new event will be used instead.\n");
-				}
 			}
+		}
 
 		/* the original event is not a forced check... */
 		else {
@@ -1089,35 +1092,34 @@ void schedule_service_check(service *svc, time_t check_time, int options) {
 			if((options & CHECK_OPTION_FORCE_EXECUTION)) {
 				use_original_event = FALSE;
 				log_debug_info(DEBUGL_CHECKS, 2, "New service check event is forced, so it will be used instead of the existing event.\n");
-				}
+			}
 
 			/* the new event is not forced either and its execution time is earlier than the original, so use it instead */
 			else if(check_time < temp_event->run_time) {
 				use_original_event = FALSE;
 				log_debug_info(DEBUGL_CHECKS, 2, "New service check event occurs before the existing (older) event, so it will be used instead.\n");
-				}
+			}
 
 			/* the new event is older, so override the existing one */
 			else {
 				log_debug_info(DEBUGL_CHECKS, 2, "New service check event occurs after the existing event, so we'll ignore it.\n");
-				}
 			}
 		}
+	}
 
 	/* schedule a new event */
 	if(use_original_event == FALSE) {
 		/* make sure we remove the old event from the queue */
 		if(temp_event) {
 			remove_event(nagios_squeue, temp_event);
-			}
-		else {
+		} else {
 			/* allocate memory for a new event item */
 			temp_event = (timed_event *)calloc(1, sizeof(timed_event));
 			if(temp_event == NULL) {
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not reschedule check of service '%s' on host '%s'!\n", svc->description, svc->host_name);
 				return;
-				}
 			}
+		}
 
 		log_debug_info(DEBUGL_CHECKS, 2, "Scheduling new service check event.\n");
 
@@ -1139,7 +1141,7 @@ void schedule_service_check(service *svc, time_t check_time, int options) {
 		temp_event->timing_func = NULL;
 		temp_event->compensate_for_time_change = TRUE;
 		add_event(nagios_squeue, temp_event);
-		}
+	}
 
 	else {
 		/* reset the next check time (it may be out of sync) */
@@ -1147,19 +1149,20 @@ void schedule_service_check(service *svc, time_t check_time, int options) {
 			svc->next_check = temp_event->run_time;
 
 		log_debug_info(DEBUGL_CHECKS, 2, "Keeping original service check event (ignoring the new one).\n");
-		}
+	}
 
 
 	/* update the status log */
 	update_service_status(svc, FALSE);
 
 	return;
-	}
+}
 
 
 
 /* checks viability of performing a service check */
-int check_service_check_viability(service *svc, int check_options, int *time_is_valid, time_t *new_time) {
+int check_service_check_viability(service *svc, int check_options, int *time_is_valid, time_t *new_time)
+{
 	int result = OK;
 	int perform_check = TRUE;
 	time_t current_time = 0L;
@@ -1193,7 +1196,7 @@ int check_service_check_viability(service *svc, int check_options, int *time_is_
 			perform_check = FALSE;
 
 			log_debug_info(DEBUGL_CHECKS, 2, "Active checks of the service are currently disabled.\n");
-			}
+		}
 
 		/* make sure this is a valid time to check the service */
 		if(check_time_against_period((unsigned long)current_time, svc->check_period_ptr) == ERROR) {
@@ -1203,7 +1206,7 @@ int check_service_check_viability(service *svc, int check_options, int *time_is_
 			perform_check = FALSE;
 
 			log_debug_info(DEBUGL_CHECKS, 2, "This is not a valid time for this service to be actively checked.\n");
-			}
+		}
 
 		/* check service dependencies for execution */
 		if(check_service_dependencies(svc, EXECUTION_DEPENDENCY) == DEPENDENCIES_FAILED) {
@@ -1211,8 +1214,8 @@ int check_service_check_viability(service *svc, int check_options, int *time_is_
 			perform_check = FALSE;
 
 			log_debug_info(DEBUGL_CHECKS, 2, "Execution dependencies for this service failed, so it will not be actively checked.\n");
-			}
 		}
+	}
 
 	/* pass back the next viable check time */
 	if(new_time)
@@ -1221,12 +1224,13 @@ int check_service_check_viability(service *svc, int check_options, int *time_is_
 	result = (perform_check == TRUE) ? OK : ERROR;
 
 	return result;
-	}
+}
 
 
 
 /* checks service dependencies */
-int check_service_dependencies(service *svc, int dependency_type) {
+int check_service_dependencies(service *svc, int dependency_type)
+{
 	objectlist *list;
 	int state = STATE_OK;
 	time_t current_time = 0L;
@@ -1268,16 +1272,17 @@ int check_service_dependencies(service *svc, int dependency_type) {
 		if(temp_dependency->inherits_parent == TRUE) {
 			if(check_service_dependencies(temp_service, dependency_type) != DEPENDENCIES_OK)
 				return DEPENDENCIES_FAILED;
-			}
 		}
+	}
 
 	return DEPENDENCIES_OK;
-	}
+}
 
 
 
 /* check for services that never returned from a check... */
-void check_for_orphaned_services(void) {
+void check_for_orphaned_services(void)
+{
 	service *temp_service = NULL;
 	time_t current_time = 0L;
 	time_t expected_time = 0L;
@@ -1306,8 +1311,8 @@ void check_for_orphaned_services(void) {
 
 			log_debug_info(DEBUGL_CHECKS, 1, "Service '%s' on host '%s' was orphaned, so we're scheduling an immediate check...\n", temp_service->description, temp_service->host_name);
 			log_debug_info(DEBUGL_CHECKS, 1, "  next_check=%lu (%s); last_check=%lu (%s);\n",
-						   temp_service->next_check, ctime(&temp_service->next_check),
-						   temp_service->last_check, ctime(&temp_service->last_check));
+			               temp_service->next_check, ctime(&temp_service->next_check),
+			               temp_service->last_check, ctime(&temp_service->last_check));
 
 			/* decrement the number of running service checks */
 			if(currently_running_service_checks > 0)
@@ -1318,17 +1323,18 @@ void check_for_orphaned_services(void) {
 
 			/* schedule an immediate check of the service */
 			schedule_service_check(temp_service, current_time, CHECK_OPTION_ORPHAN_CHECK);
-			}
-
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 
 /* check freshness of service results */
-void check_service_result_freshness(void) {
+void check_service_result_freshness(void)
+{
 	service *temp_service = NULL;
 	time_t current_time = 0L;
 
@@ -1340,7 +1346,7 @@ void check_service_result_freshness(void) {
 	if(check_service_freshness == FALSE) {
 		log_debug_info(DEBUGL_CHECKS, 1, "Service freshness checking is disabled.\n");
 		return;
-		}
+	}
 
 	/* get the current time */
 	time(&current_time);
@@ -1381,17 +1387,18 @@ void check_service_result_freshness(void) {
 
 			/* schedule an immediate forced check of the service */
 			schedule_service_check(temp_service, current_time, CHECK_OPTION_FORCE_EXECUTION | CHECK_OPTION_FRESHNESS_CHECK);
-			}
-
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 
 /* tests whether or not a service's check results are fresh */
-int is_service_result_fresh(service *temp_service, time_t current_time, int log_this) {
+int is_service_result_fresh(service *temp_service, time_t current_time, int log_this)
+{
 	int freshness_threshold = 0;
 	time_t expiration_time = 0L;
 	int days = 0;
@@ -1411,8 +1418,7 @@ int is_service_result_fresh(service *temp_service, time_t current_time, int log_
 			freshness_threshold = (temp_service->check_interval * interval_length) + temp_service->latency + additional_freshness_latency;
 		else
 			freshness_threshold = (temp_service->retry_interval * interval_length) + temp_service->latency + additional_freshness_latency;
-		}
-	else
+	} else
 		freshness_threshold = temp_service->freshness_threshold;
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Freshness thresholds: service=%d, use=%d\n", temp_service->freshness_threshold, freshness_threshold);
@@ -1465,8 +1471,7 @@ int is_service_result_fresh(service *temp_service, time_t current_time, int log_
 	 */
 	if (temp_service->check_type == CHECK_TYPE_PASSIVE) {
 		if (temp_service->last_check < event_start &&
-			event_start - last_program_stop > freshness_threshold * 0.618)
-		{
+		    event_start - last_program_stop > freshness_threshold * 0.618) {
 			expiration_time = event_start + freshness_threshold;
 		}
 	}
@@ -1485,12 +1490,12 @@ int is_service_result_fresh(service *temp_service, time_t current_time, int log_
 		log_debug_info(DEBUGL_CHECKS, 1, "Check results for service '%s' on host '%s' are stale by %dd %dh %dm %ds (threshold=%dd %dh %dm %ds).  Forcing an immediate check of the service...\n", temp_service->description, temp_service->host_name, days, hours, minutes, seconds, tdays, thours, tminutes, tseconds);
 
 		return FALSE;
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 1, "Check results for service '%s' on host '%s' are fresh.\n", temp_service->description, temp_service->host_name);
 
 	return TRUE;
-	}
+}
 
 
 
@@ -1500,7 +1505,8 @@ int is_service_result_fresh(service *temp_service, time_t current_time, int log_
 /******************************************************************/
 
 /* schedules an immediate or delayed host check */
-void schedule_host_check(host *hst, time_t check_time, int options) {
+void schedule_host_check(host *hst, time_t check_time, int options)
+{
 	timed_event *temp_event = NULL;
 	int use_original_event = TRUE;
 
@@ -1516,7 +1522,7 @@ void schedule_host_check(host *hst, time_t check_time, int options) {
 	if(hst->checks_enabled == FALSE && !(options & CHECK_OPTION_FORCE_EXECUTION)) {
 		log_debug_info(DEBUGL_CHECKS, 0, "Active checks are disabled for this host.\n");
 		return;
-		}
+	}
 
 	if (options == CHECK_OPTION_DEPENDENCY_CHECK) {
 		if (hst->last_check + cached_host_check_horizon > check_time) {
@@ -1548,8 +1554,8 @@ void schedule_host_check(host *hst, time_t check_time, int options) {
 			if((options & CHECK_OPTION_FORCE_EXECUTION) && (check_time < temp_event->run_time)) {
 				log_debug_info(DEBUGL_CHECKS, 2, "New host check event is forced and occurs before the existing event, so the new event be used instead.\n");
 				use_original_event = FALSE;
-				}
 			}
+		}
 
 		/* the original event is not a forced check... */
 		else {
@@ -1558,20 +1564,20 @@ void schedule_host_check(host *hst, time_t check_time, int options) {
 			if((options & CHECK_OPTION_FORCE_EXECUTION)) {
 				use_original_event = FALSE;
 				log_debug_info(DEBUGL_CHECKS, 2, "New host check event is forced, so it will be used instead of the existing event.\n");
-				}
+			}
 
 			/* the new event is not forced either and its execution time is earlier than the original, so use it instead */
 			else if(check_time < temp_event->run_time) {
 				use_original_event = FALSE;
 				log_debug_info(DEBUGL_CHECKS, 2, "New host check event occurs before the existing (older) event, so it will be used instead.\n");
-				}
+			}
 
 			/* the new event is older, so override the existing one */
 			else {
 				log_debug_info(DEBUGL_CHECKS, 2, "New host check event occurs after the existing event, so we'll ignore it.\n");
-				}
 			}
 		}
+	}
 
 	/* use the new event */
 	if(use_original_event == FALSE) {
@@ -1581,11 +1587,10 @@ void schedule_host_check(host *hst, time_t check_time, int options) {
 		/* possibly allocate memory for a new event item */
 		if (temp_event) {
 			remove_event(nagios_squeue, temp_event);
-			}
-		else if((temp_event = (timed_event *)calloc(1, sizeof(timed_event))) == NULL) {
+		} else if((temp_event = (timed_event *)calloc(1, sizeof(timed_event))) == NULL) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not reschedule check of host '%s'!\n", hst->name);
 			return;
-			}
+		}
 
 
 		/* set the next host check event and time */
@@ -1606,7 +1611,7 @@ void schedule_host_check(host *hst, time_t check_time, int options) {
 		temp_event->timing_func = NULL;
 		temp_event->compensate_for_time_change = TRUE;
 		add_event(nagios_squeue, temp_event);
-		}
+	}
 
 	else {
 		/* reset the next check time (it may be out of sync) */
@@ -1614,18 +1619,19 @@ void schedule_host_check(host *hst, time_t check_time, int options) {
 			hst->next_check = temp_event->run_time;
 
 		log_debug_info(DEBUGL_CHECKS, 2, "Keeping original host check event (ignoring the new one).\n");
-		}
+	}
 
 	/* update the status log */
 	update_host_status(hst, FALSE);
 
 	return;
-	}
+}
 
 
 
 /* checks host dependencies */
-int check_host_dependencies(host *hst, int dependency_type) {
+int check_host_dependencies(host *hst, int dependency_type)
+{
 	hostdependency *temp_dependency = NULL;
 	objectlist *list;
 	host *temp_host = NULL;
@@ -1668,16 +1674,17 @@ int check_host_dependencies(host *hst, int dependency_type) {
 		if(temp_dependency->inherits_parent == TRUE) {
 			if(check_host_dependencies(temp_host, dependency_type) != DEPENDENCIES_OK)
 				return DEPENDENCIES_FAILED;
-			}
 		}
+	}
 
 	return DEPENDENCIES_OK;
-	}
+}
 
 
 
 /* check for hosts that never returned from a check... */
-void check_for_orphaned_hosts(void) {
+void check_for_orphaned_hosts(void)
+{
 	host *temp_host = NULL;
 	time_t current_time = 0L;
 	time_t expected_time = 0L;
@@ -1719,17 +1726,18 @@ void check_for_orphaned_hosts(void) {
 
 			/* schedule an immediate check of the host */
 			schedule_host_check(temp_host, current_time, CHECK_OPTION_ORPHAN_CHECK);
-			}
-
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 
 /* check freshness of host results */
-void check_host_result_freshness(void) {
+void check_host_result_freshness(void)
+{
 	host *temp_host = NULL;
 	time_t current_time = 0L;
 
@@ -1741,7 +1749,7 @@ void check_host_result_freshness(void) {
 	if(check_host_freshness == FALSE) {
 		log_debug_info(DEBUGL_CHECKS, 2, "Host freshness checking is disabled.\n");
 		return;
-		}
+	}
 
 	/* get the current time */
 	time(&current_time);
@@ -1777,16 +1785,17 @@ void check_host_result_freshness(void) {
 
 			/* schedule an immediate forced check of the host */
 			schedule_host_check(temp_host, current_time, CHECK_OPTION_FORCE_EXECUTION | CHECK_OPTION_FRESHNESS_CHECK);
-			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* checks to see if a hosts's check results are fresh */
-int is_host_result_fresh(host *temp_host, time_t current_time, int log_this) {
+int is_host_result_fresh(host *temp_host, time_t current_time, int log_this)
+{
 	time_t expiration_time = 0L;
 	int freshness_threshold = 0;
 	int days = 0;
@@ -1805,13 +1814,11 @@ int is_host_result_fresh(host *temp_host, time_t current_time, int log_this) {
 	if(temp_host->freshness_threshold == 0) {
 		if(temp_host->state_type == HARD_STATE || temp_host->current_state == STATE_OK) {
 			interval = temp_host->check_interval;
-			}
-		else {
+		} else {
 			interval = temp_host->retry_interval;
-			}
-		freshness_threshold = (interval * interval_length) + temp_host->latency + additional_freshness_latency;
 		}
-	else
+		freshness_threshold = (interval * interval_length) + temp_host->latency + additional_freshness_latency;
+	} else
 		freshness_threshold = temp_host->freshness_threshold;
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Freshness thresholds: host=%d, use=%d\n", temp_host->freshness_threshold, freshness_threshold);
@@ -1854,8 +1861,7 @@ int is_host_result_fresh(host *temp_host, time_t current_time, int log_this) {
 	 */
 	if (temp_host->check_type == CHECK_TYPE_PASSIVE) {
 		if (temp_host->last_check < event_start &&
-			event_start - last_program_stop > freshness_threshold * 0.618)
-		{
+		    event_start - last_program_stop > freshness_threshold * 0.618) {
 			expiration_time = event_start + freshness_threshold;
 		}
 	}
@@ -1875,16 +1881,16 @@ int is_host_result_fresh(host *temp_host, time_t current_time, int log_this) {
 		log_debug_info(DEBUGL_CHECKS, 1, "Check results for host '%s' are stale by %dd %dh %dm %ds (threshold=%dd %dh %dm %ds).  Forcing an immediate check of the host...\n", temp_host->name, days, hours, minutes, seconds, tdays, thours, tminutes, tseconds);
 
 		return FALSE;
-		}
-	else
+	} else
 		log_debug_info(DEBUGL_CHECKS, 1, "Check results for host '%s' are fresh.\n", temp_host->name);
 
 	return TRUE;
-	}
+}
 
 
 /* run a scheduled host check asynchronously */
-int run_scheduled_host_check(host *hst, int check_options, double latency) {
+int run_scheduled_host_check(host *hst, int check_options, double latency)
+{
 	int result = OK;
 	time_t current_time = 0L;
 	time_t preferred_time = 0L;
@@ -1938,7 +1944,7 @@ int run_scheduled_host_check(host *hst, int check_options, double latency) {
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Check of host '%s' could not be rescheduled properly.  Scheduling check for %s...\n", hst->name, ctime(&preferred_time));
 
 				log_debug_info(DEBUGL_CHECKS, 1, "Unable to find any valid times to reschedule the next host check!\n");
-				}
+			}
 
 			/* this service could be rescheduled... */
 			else {
@@ -1946,8 +1952,8 @@ int run_scheduled_host_check(host *hst, int check_options, double latency) {
 				hst->should_be_scheduled = TRUE;
 
 				log_debug_info(DEBUGL_CHECKS, 1, "Rescheduled next host check for %s", ctime(&next_valid_time));
-				}
 			}
+		}
 
 		/* update the status log */
 		update_host_status(hst, FALSE);
@@ -1958,16 +1964,17 @@ int run_scheduled_host_check(host *hst, int check_options, double latency) {
 			schedule_host_check(hst, hst->next_check, check_options);
 
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* perform an asynchronous check of a host */
 /* scheduled host checks will use this, as will some checks that result from on-demand checks... */
-int run_async_host_check(host *hst, int check_options, double latency, int scheduled_check, int reschedule_check, int *time_is_valid, time_t *preferred_time) {
+int run_async_host_check(host *hst, int check_options, double latency, int scheduled_check, int reschedule_check, int *time_is_valid, time_t *preferred_time)
+{
 	nagios_macros mac;
 	char *raw_command = NULL;
 	char *processed_command = NULL;
@@ -1993,20 +2000,20 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 		if(hst->is_executing == TRUE) {
 			log_debug_info(DEBUGL_CHECKS, 1, "A check of this host is already being executed, so we'll pass for the moment...\n");
 			return ERROR;
-			}
+		}
 
 		if (hst->last_check + cached_host_check_horizon > time(NULL)) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Host '%s' was last checked within its cache horizon. Aborting check\n", hst->name);
 			return ERROR;
-			}
 		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 0, "Host '%s' passed first hurdle (caching/execution)\n", hst->name);
 	/* is the host check viable at this time? */
 	if(check_host_check_viability(hst, check_options, time_is_valid, preferred_time) == ERROR) {
 		log_debug_info(DEBUGL_CHECKS, 0, "Host check isn't viable at this point.\n");
 		return ERROR;
-		}
+	}
 
 	/******** GOOD TO GO FOR A REAL HOST CHECK AT THIS POINT ********/
 
@@ -2024,13 +2031,13 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 		log_debug_info(DEBUGL_CHECKS, 0, "Check of host '%s' (id=%u) was %s by a module\n",
 		               hst->name, hst->id,
 		               neb_result == NEBERROR_CALLBACKCANCEL ? "cancelled" : "overridden");
-		}
+	}
 	/* neb module wants to cancel the host check - the check will be rescheduled for a later time by the scheduling logic */
 	if(neb_result == NEBERROR_CALLBACKCANCEL) {
 		if(preferred_time)
 			*preferred_time += check_window(hst);
 		return ERROR;
-		}
+	}
 
 	/* neb module wants to override the host check - perhaps it will check the host itself */
 	/* NOTE: if a module does this, it has to do a lot of the stuff found below to make sure things don't get whacked out of shape! */
@@ -2062,7 +2069,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 		clear_volatile_macros_r(&mac);
 		log_debug_info(DEBUGL_CHECKS, 0, "Raw check command for host '%s' was NULL - aborting.\n", hst->name);
 		return ERROR;
-		}
+	}
 
 	/* process any macros contained in the argument */
 	process_macros_r(&mac, raw_command, &processed_command, macro_options);
@@ -2071,7 +2078,7 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 		clear_volatile_macros_r(&mac);
 		log_debug_info(DEBUGL_CHECKS, 0, "Processed check command for host '%s' was NULL - aborting.\n", hst->name);
 		return ERROR;
-		}
+	}
 
 	/* get the command start time */
 	gettimeofday(&start_time, NULL);
@@ -2126,12 +2133,13 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 	my_free(processed_command);
 
 	return runchk_result;
-	}
+}
 
 
 
 static int get_host_check_return_code(host *temp_host,
-		check_result *queued_check_result) {
+                                      check_result *queued_check_result)
+{
 
 	int rc;
 
@@ -2150,7 +2158,7 @@ static int get_host_check_return_code(host *temp_host,
 			my_free(temp_host->perf_data);
 			asprintf(&temp_host->plugin_output, "(Host check timed out after %.2lf seconds)", temp_host->execution_time);
 			rc = STATE_UNKNOWN;
-			}
+		}
 
 		/* if there was some error running the command, just skip it (this shouldn't be happening) */
 		else if(queued_check_result->exited_ok == FALSE) {
@@ -2164,7 +2172,7 @@ static int get_host_check_return_code(host *temp_host,
 			temp_host->plugin_output = (char *)strdup("(Host check did not exit properly)");
 
 			rc = STATE_CRITICAL;
-			}
+		}
 
 		/* make sure the return code is within bounds */
 		else if(queued_check_result->return_code < 0 || queued_check_result->return_code > 3) {
@@ -2178,20 +2186,21 @@ static int get_host_check_return_code(host *temp_host,
 			asprintf(&temp_host->plugin_output, "(Return code of %d is out of bounds%s)", queued_check_result->return_code, (queued_check_result->return_code == 126 || queued_check_result->return_code == 127) ? " - plugin may be missing" : "");
 
 			rc = STATE_CRITICAL;
-			}
+		}
 
 		/* a NULL host check command means we should assume the host is UP */
 		if(temp_host->check_command == NULL) {
 			my_free(temp_host->plugin_output);
 			temp_host->plugin_output = (char *)strdup("(Host assumed to be UP)");
 			rc = STATE_OK;
-			}
 		}
-	return rc;
 	}
+	return rc;
+}
 
 /* process results of an asynchronous host check */
-int handle_async_host_check_result(host *temp_host, check_result *queued_check_result) {
+int handle_async_host_check_result(host *temp_host, check_result *queued_check_result)
+{
 	time_t current_time;
 	int result = STATE_OK;
 	int reschedule_check = FALSE;
@@ -2229,12 +2238,12 @@ int handle_async_host_check_result(host *temp_host, check_result *queued_check_r
 		if(accept_passive_host_checks == FALSE) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Discarding passive host check result because passive host checks are disabled globally.\n");
 			return ERROR;
-			}
+		}
 		if(temp_host->accept_passive_checks == FALSE) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Discarding passive host check result because passive checks are disabled for this host.\n");
 			return ERROR;
-			}
 		}
+	}
 
 	/* clear the freshening flag (it would have been set if this host was determined to be stale) */
 	if(queued_check_result->check_options & CHECK_OPTION_FRESHNESS_CHECK)
@@ -2247,7 +2256,7 @@ int handle_async_host_check_result(host *temp_host, check_result *queued_check_r
 	if((queued_check_result->check_options & CHECK_OPTION_FRESHNESS_CHECK) && is_host_result_fresh(temp_host, current_time, FALSE) == TRUE) {
 		log_debug_info(DEBUGL_CHECKS, 0, "Discarding host freshness check result because the host is currently fresh (race condition avoided).\n");
 		return OK;
-		}
+	}
 
 	/* was this check passive or active? */
 	temp_host->check_type = (queued_check_result->check_type == CHECK_TYPE_ACTIVE) ? CHECK_TYPE_ACTIVE : CHECK_TYPE_PASSIVE;
@@ -2301,13 +2310,13 @@ int handle_async_host_check_result(host *temp_host, check_result *queued_check_r
 	if(temp_host->plugin_output == NULL || !strcmp(temp_host->plugin_output, "")) {
 		my_free(temp_host->plugin_output);
 		temp_host->plugin_output = (char *)strdup("(No output returned from host check)");
-		}
+	}
 
 	/* replace semicolons in plugin output (but not performance data) with colons */
 	if((temp_ptr = temp_host->plugin_output)) {
 		while((temp_ptr = strchr(temp_ptr, ';')))
 			* temp_ptr = ':';
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Parsing check output...\n");
 	log_debug_info(DEBUGL_CHECKS, 2, "Short Output: %s\n", (temp_host->plugin_output == NULL) ? "NULL" : temp_host->plugin_output);
@@ -2332,7 +2341,7 @@ int handle_async_host_check_result(host *temp_host, check_result *queued_check_r
 		/* any problem state indicates the host is not UP */
 		else
 			result = HOST_DOWN;
-		}
+	}
 
 
 	/******************* PROCESS THE CHECK RESULTS ******************/
@@ -2357,12 +2366,13 @@ int handle_async_host_check_result(host *temp_host, check_result *queued_check_r
 #endif
 
 	return OK;
-	}
+}
 
 
 
 /* processes the result of a synchronous or asynchronous host check */
-int process_host_check_result(host *hst, int new_state, char *old_plugin_output, int check_options, int reschedule_check, int use_cached_result, unsigned long check_timestamp_horizon) {
+int process_host_check_result(host *hst, int new_state, char *old_plugin_output, int check_options, int reschedule_check, int use_cached_result, unsigned long check_timestamp_horizon)
+{
 	hostsmember *temp_hostsmember = NULL;
 	host *child_host = NULL;
 	host *parent_host = NULL;
@@ -2391,7 +2401,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 	if(hst->check_type == CHECK_TYPE_PASSIVE) {
 		if(log_passive_checks == TRUE)
 			logit(NSLOG_PASSIVE_CHECK, FALSE, "PASSIVE HOST CHECK: %s;%d;%s\n", hst->name, new_state, hst->plugin_output);
-		}
+	}
 
 
 	/******* HOST WAS DOWN/UNREACHABLE INITIALLY *******/
@@ -2427,8 +2437,8 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 				if(parent_host->current_state != HOST_UP) {
 					log_debug_info(DEBUGL_CHECKS, 1, "Check of parent host '%s' queued.\n", parent_host->name);
 					schedule_host_check(parent_host, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-					}
 				}
+			}
 
 			/* propagate checks to immediate children if they are not already UP */
 			/* we do this because children may currently be UNREACHABLE, but may (as a result of this recovery) switch to UP or DOWN states */
@@ -2438,10 +2448,10 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 				if(child_host->current_state != HOST_UP) {
 					log_debug_info(DEBUGL_CHECKS, 1, "Check of child host '%s' queued.\n", child_host->name);
 					schedule_host_check(child_host, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-					}
 				}
-
 			}
+
+		}
 
 		/***** HOST IS STILL DOWN/UNREACHABLE *****/
 		/* we're still in a problem state... */
@@ -2457,7 +2467,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 
 				/* reset the current attempt */
 				hst->current_attempt = 1;
-				}
+			}
 
 			/* active checks and passive checks (treated as SOFT states) */
 			else {
@@ -2472,7 +2482,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 				/* the host is in a soft state and the check will be retried */
 				else
 					hst->state_type = SOFT_STATE;
-				}
+			}
 
 			/* make a determination of the host's state */
 			/* translate host state between DOWN/UNREACHABLE (only for passive checks if enabled) */
@@ -2492,11 +2502,11 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 				/* host has maxed out on retries (or was previously in a hard problem state), so reschedule the next check at the normal interval */
 				else
 					next_check = (unsigned long)(current_time + (hst->check_interval * interval_length));
-				}
-
 			}
 
 		}
+
+	}
 
 	/******* HOST WAS UP INITIALLY *******/
 	else {
@@ -2518,7 +2528,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 			/* reschedule the next check at the normal interval */
 			if(reschedule_check == TRUE)
 				next_check = (unsigned long)(current_time + (hst->check_interval * interval_length));
-			}
+		}
 
 		/***** HOST IS NOW DOWN/UNREACHABLE *****/
 		else {
@@ -2530,7 +2540,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 
 				/* set the state type */
 				hst->state_type = SOFT_STATE;
-				}
+			}
 
 			/* by default, passive check results are treated as HARD states */
 			else {
@@ -2540,7 +2550,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 
 				/* reset the current attempt */
 				hst->current_attempt = 1;
-				}
+			}
 
 			/* make a (in some cases) preliminary determination of the host's state */
 			/* translate host state between DOWN/UNREACHABLE (for passive checks only if enabled) */
@@ -2569,8 +2579,8 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 				if(parent_host->current_state == HOST_UP) {
 					schedule_host_check(parent_host, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
 					log_debug_info(DEBUGL_CHECKS, 1, "Check of host '%s' queued.\n", parent_host->name);
-					}
 				}
+			}
 
 			/* propagate checks to immediate children if they are not UNREACHABLE */
 			/* we do this because we may now be blocking the route to child hosts */
@@ -2580,8 +2590,8 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 				if(child_host->current_state != HOST_UNREACHABLE) {
 					log_debug_info(DEBUGL_CHECKS, 1, "Check of child host '%s' queued.\n", child_host->name);
 					schedule_host_check(child_host, current_time, CHECK_OPTION_NONE);
-					}
 				}
+			}
 
 			/* check dependencies on second to last host check */
 			if(enable_predictive_host_dependency_checks == TRUE && hst->current_attempt == (hst->max_attempts - 1)) {
@@ -2597,19 +2607,19 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 						master_host = (host *)dep->master_host_ptr;
 						log_debug_info(DEBUGL_CHECKS, 1, "Check of host '%s' queued.\n", master_host->name);
 						schedule_host_check(master_host, current_time, CHECK_OPTION_NONE);
-						}
 					}
+				}
 				for(list = hst->exec_deps; list; list = list->next) {
 					hostdependency *dep = (hostdependency *)list->object_ptr;
 					if(dep->dependent_host_ptr == hst && dep->master_host_ptr != NULL) {
 						master_host = (host *)dep->master_host_ptr;
 						log_debug_info(DEBUGL_CHECKS, 1, "Check of host '%s' queued.\n", master_host->name);
 						schedule_host_check(master_host, current_time, CHECK_OPTION_NONE);
-						}
 					}
 				}
 			}
 		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 1, "Pre-handle_host_state() Host: %s, Attempt=%d/%d, Type=%s, Final State=%d (%s)\n", hst->name, hst->current_attempt, hst->max_attempts, (hst->state_type == HARD_STATE) ? "HARD" : "SOFT", hst->current_state, host_state_name(hst->current_state));
 
@@ -2624,7 +2634,7 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 	/* if the plugin output differs from previous check and no state change, log the current state/output if state stalking is enabled */
 	if(hst->last_state == hst->current_state && should_stalk(hst) && compare_strings(old_plugin_output, hst->plugin_output)) {
 		log_host_event(hst);
-		}
+	}
 
 	/* check to see if the associated host is flapping */
 	check_for_host_flapping(hst, TRUE, TRUE, TRUE);
@@ -2662,19 +2672,20 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 		/* schedule a non-forced check if we can */
 		if(hst->should_be_scheduled == TRUE) {
 			schedule_host_check(hst, hst->next_check, CHECK_OPTION_NONE);
-			}
 		}
+	}
 
 	/* update host status - for both active (scheduled) and passive (non-scheduled) hosts */
 	update_host_status(hst, FALSE);
 
 	return OK;
-	}
+}
 
 
 
 /* checks viability of performing a host check */
-int check_host_check_viability(host *hst, int check_options, int *time_is_valid, time_t *new_time) {
+int check_host_check_viability(host *hst, int check_options, int *time_is_valid, time_t *new_time)
+{
 	int result = OK;
 	int perform_check = TRUE;
 	time_t current_time = 0L;
@@ -2710,7 +2721,7 @@ int check_host_check_viability(host *hst, int check_options, int *time_is_valid,
 		if(hst->checks_enabled == FALSE) {
 			preferred_time = current_time + check_interval;
 			perform_check = FALSE;
-			}
+		}
 
 		/* make sure this is a valid time to check the host */
 		if(check_time_against_period((unsigned long)current_time, hst->check_period_ptr) == ERROR) {
@@ -2719,15 +2730,15 @@ int check_host_check_viability(host *hst, int check_options, int *time_is_valid,
 			if(time_is_valid)
 				*time_is_valid = FALSE;
 			perform_check = FALSE;
-			}
+		}
 
 		/* check host dependencies for execution */
 		if(check_host_dependencies(hst, EXECUTION_DEPENDENCY) == DEPENDENCIES_FAILED) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Host check dependencies failed\n");
 			preferred_time = current_time + check_interval;
 			perform_check = FALSE;
-			}
 		}
+	}
 
 	/* pass back the next viable check time */
 	if(new_time)
@@ -2736,12 +2747,13 @@ int check_host_check_viability(host *hst, int check_options, int *time_is_valid,
 	result = (perform_check == TRUE) ? OK : ERROR;
 
 	return result;
-	}
+}
 
 
 
 /* adjusts current host check attempt before a new check is performed */
-int adjust_host_check_attempt(host *hst, int is_active) {
+int adjust_host_check_attempt(host *hst, int is_active)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "adjust_host_check_attempt()\n");
 
@@ -2765,13 +2777,14 @@ int adjust_host_check_attempt(host *hst, int is_active) {
 	log_debug_info(DEBUGL_CHECKS, 2, "New check attempt number = %d\n", hst->current_attempt);
 
 	return OK;
-	}
+}
 
 
 
 /* determination of the host's state based on route availability*/
 /* used only to determine difference between DOWN and UNREACHABLE states */
-int determine_host_reachability(host *hst) {
+int determine_host_reachability(host *hst)
+{
 	host *parent_host = NULL;
 	hostsmember *temp_hostsmember = NULL;
 
@@ -2786,13 +2799,13 @@ int determine_host_reachability(host *hst) {
 	if(hst->current_state == HOST_UP) {
 		log_debug_info(DEBUGL_CHECKS, 2, "Host is UP, no state translation needed.\n");
 		return HOST_UP;
-		}
+	}
 
 	/* host has no parents, so it is DOWN */
 	if(hst->parent_hosts == NULL) {
 		log_debug_info(DEBUGL_CHECKS, 2, "Host has no parents, so it is DOWN.\n");
 		return HOST_DOWN;
-		}
+	}
 
 	/* check all parent hosts to see if we're DOWN or UNREACHABLE */
 	else {
@@ -2804,13 +2817,13 @@ int determine_host_reachability(host *hst) {
 				/* set the current state */
 				log_debug_info(DEBUGL_CHECKS, 2, "At least one parent (%s) is up, so host is DOWN.\n", parent_host->name);
 				return HOST_DOWN;
-				}
 			}
 		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 2, "No parents were up, so host is UNREACHABLE.\n");
 	return HOST_UNREACHABLE;
-	}
+}
 
 
 
@@ -2820,7 +2833,8 @@ int determine_host_reachability(host *hst) {
 
 
 /* top level host state handler - occurs after every host check (soft/hard and active/passive) */
-int handle_host_state(host *hst) {
+int handle_host_state(host *hst)
+{
 	int state_change = FALSE;
 	int hard_state_change = FALSE;
 	time_t current_time = 0L;
@@ -2839,18 +2853,18 @@ int handle_host_state(host *hst) {
 
 	/* record the time the last state ended */
 	switch(hst->last_state) {
-		case HOST_UP:
-			hst->last_time_up = current_time;
-			break;
-		case HOST_DOWN:
-			hst->last_time_down = current_time;
-			break;
-		case HOST_UNREACHABLE:
-			hst->last_time_unreachable = current_time;
-			break;
-		default:
-			break;
-		}
+	case HOST_UP:
+		hst->last_time_up = current_time;
+		break;
+	case HOST_DOWN:
+		hst->last_time_down = current_time;
+		break;
+	case HOST_UNREACHABLE:
+		hst->last_time_unreachable = current_time;
+		break;
+	default:
+		break;
+	}
 
 	/* has the host state changed? */
 	if(hst->last_state != hst->current_state || (hst->current_state == HOST_UP && hst->state_type == SOFT_STATE))
@@ -2877,17 +2891,16 @@ int handle_host_state(host *hst) {
 
 			/* remove any non-persistant comments associated with the ack */
 			delete_host_acknowledgement_comments(hst);
-			}
-		else if(hst->acknowledgement_type == ACKNOWLEDGEMENT_STICKY && hst->current_state == HOST_UP) {
+		} else if(hst->acknowledgement_type == ACKNOWLEDGEMENT_STICKY && hst->current_state == HOST_UP) {
 
 			hst->problem_has_been_acknowledged = FALSE;
 			hst->acknowledgement_type = ACKNOWLEDGEMENT_NONE;
 
 			/* remove any non-persistant comments associated with the ack */
 			delete_host_acknowledgement_comments(hst);
-			}
-
 		}
+
+	}
 
 	/* Not sure about this, but is old behaviour */
 	if(hst->last_hard_state != hst->current_state)
@@ -2910,13 +2923,13 @@ int handle_host_state(host *hst) {
 			/* don't reset last problem id, or it will be zero the next time a problem is encountered */
 			hst->current_problem_id = next_problem_id;
 			next_problem_id++;
-			}
+		}
 
 		/* clear the problem id when transitioning from a problem state to an UP state */
 		if(hst->current_state == HOST_UP) {
 			hst->last_problem_id = hst->current_problem_id;
 			hst->current_problem_id = 0L;
-			}
+		}
 
 		/* write the host state change to the main log file */
 		if(hst->state_type == HARD_STATE || (hst->state_type == SOFT_STATE && log_host_retries == TRUE))
@@ -2941,8 +2954,8 @@ int handle_host_state(host *hst) {
 		if(hst->current_state == HOST_UP) {
 			hst->current_notification_number = 0;
 			hst->notified_on = 0;
-			}
 		}
+	}
 
 	/* else the host state has not changed */
 	else {
@@ -2954,14 +2967,15 @@ int handle_host_state(host *hst) {
 		/* if we're in a soft state and we should log host retries, do so now... */
 		if(hst->state_type == SOFT_STATE && log_host_retries == TRUE)
 			log_host_event(hst);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* parse raw plugin output and return: short and long output, perf data */
-int parse_check_output(char *buf, char **short_output, char **long_output, char **perf_data, int escape_newlines_please, int newlines_are_escaped) {
+int parse_check_output(char *buf, char **short_output, char **long_output, char **perf_data, int escape_newlines_please, int newlines_are_escaped)
+{
 	int current_line = 0;
 	int found_newline = FALSE;
 	int eof = FALSE;
@@ -2999,16 +3013,14 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 			if(buf[x] == '\\' && buf[x + 1] == '\\') {
 				x++;
 				buf[y++] = buf[x];
-				}
-			else if(buf[x] == '\\' && buf[x + 1] == 'n') {
+			} else if(buf[x] == '\\' && buf[x + 1] == 'n') {
 				x++;
 				buf[y++] = '\n';
-				}
-			else
+			} else
 				buf[y++] = buf[x];
-			}
-		buf[y] = '\x0';
 		}
+		buf[y] = '\x0';
+	}
 
 	/* process each line of input */
 	for(x = 0; eof == FALSE; x++) {
@@ -3020,12 +3032,10 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 			found_newline = TRUE;
 			buf[x] = '\x0';
 			x++;
-			}
-		else if(buf[x] == '\x0') {
+		} else if(buf[x] == '\x0') {
 			found_newline = TRUE;
 			eof = TRUE;
-			}
-		else
+		} else
 			found_newline = FALSE;
 
 		if(found_newline == TRUE) {
@@ -3047,8 +3057,8 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 						/* get the optional perf data */
 						if((ptr = strtok(NULL, "\n")))
 							dbuf_strcat(&db2, ptr);
-						}
 					}
+				}
 
 				/* additional lines contain long plugin output and optional perf data */
 				else {
@@ -3057,7 +3067,7 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 					if(in_perf_data == TRUE) {
 						dbuf_strcat(&db2, tempbuf);
 						dbuf_strcat(&db2, " ");
-						}
+					}
 
 					/* we're still in long output */
 					else {
@@ -3077,25 +3087,25 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 								if((ptr = my_strtok(NULL, "\n"))) {
 									dbuf_strcat(&db2, ptr);
 									dbuf_strcat(&db2, " ");
-									}
 								}
+							}
 
 							/* set the perf data flag */
 							in_perf_data = TRUE;
-							}
+						}
 
 						/* just long output */
 						else {
 							if(current_line > 2)
 								dbuf_strcat(&db1, "\n");
 							dbuf_strcat(&db1, tempbuf);
-							}
 						}
 					}
+				}
 
 				my_free(tempbuf);
 				tempbuf = NULL;
-				}
+			}
 
 
 			/* shift data back to front of buffer and adjust counters */
@@ -3103,8 +3113,8 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 			used_buf -= (x + 1);
 			buf[used_buf] = '\x0';
 			x = -1;
-			}
 		}
+	}
 
 	/* save long output */
 	if(long_output && (db1.buf && strcmp(db1.buf, ""))) {
@@ -3122,21 +3132,19 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 					if(db1.buf[x] == '\n') {
 						tempbuf[y++] = '\\';
 						tempbuf[y++] = 'n';
-						}
-					else if(db1.buf[x] == '\\') {
+					} else if(db1.buf[x] == '\\') {
 						tempbuf[y++] = '\\';
 						tempbuf[y++] = '\\';
-						}
-					else
+					} else
 						tempbuf[y++] = db1.buf[x];
-					}
+				}
 
 				tempbuf[y] = '\x0';
 				*long_output = (char *)strdup(tempbuf);
 				my_free(tempbuf);
-				}
 			}
 		}
+	}
 
 	/* save perf data */
 	if(perf_data && (db2.buf && strcmp(db2.buf, "")))
@@ -3153,4 +3161,4 @@ int parse_check_output(char *buf, char **short_output, char **long_output, char 
 	dbuf_free(&db2);
 
 	return OK;
-	}
+}

--- a/base/config.c
+++ b/base/config.c
@@ -60,7 +60,8 @@ static command *find_bang_command(char *name)
 /******************************************************************/
 
 /* read all configuration data */
-int read_all_object_data(char *main_config_file) {
+int read_all_object_data(char *main_config_file)
+{
 	int result = OK;
 	int options = 0;
 
@@ -72,21 +73,22 @@ int read_all_object_data(char *main_config_file) {
 		return ERROR;
 
 	return OK;
-	}
+}
 
 static objectlist *deprecated = NULL;
 static void obsoleted_warning(const char *key, const char *msg)
 {
 	char *buf;
 	asprintf(&buf, "Warning: %s is deprecated and will be removed.%s%s\n",
-		     key, msg ? " " : "", msg ? msg : "");
+	         key, msg ? " " : "", msg ? msg : "");
 	if (!buf)
 		return;
 	prepend_object_to_objectlist(&deprecated, buf);
 }
 
 /* process the main configuration file */
-int read_main_config_file(char *main_config_file) {
+int read_main_config_file(char *main_config_file)
+{
 	char *input = NULL;
 	char *variable = NULL;
 	char *value = NULL;
@@ -108,7 +110,7 @@ int read_main_config_file(char *main_config_file) {
 	if((thefile = mmap_fopen(main_config_file)) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open main configuration file '%s' for reading!", main_config_file);
 		return ERROR;
-		}
+	}
 
 	/* save the main config file macro */
 	my_free(mac->x[MACRO_MAINCONFIGFILE]);
@@ -140,24 +142,24 @@ int read_main_config_file(char *main_config_file) {
 			asprintf(&error_message, "NULL variable");
 			error = TRUE;
 			break;
-			}
+		}
 		if((variable = (char *)strdup(temp_ptr)) == NULL) {
 			asprintf(&error_message, "malloc() error");
 			error = TRUE;
 			break;
-			}
+		}
 
 		/* get the value */
 		if((temp_ptr = my_strtok(NULL, "\n")) == NULL) {
 			asprintf(&error_message, "NULL value");
 			error = TRUE;
 			break;
-			}
+		}
 		if((value = (char *)strdup(temp_ptr)) == NULL) {
 			asprintf(&error_message, "malloc() error");
 			error = TRUE;
 			break;
-			}
+		}
 		strip(variable);
 		strip(value);
 
@@ -172,8 +174,8 @@ int read_main_config_file(char *main_config_file) {
 			/* process the resource file */
 			if(read_resource_file(mac->x[MACRO_RESOURCEFILE]) == ERROR) {
 				error = TRUE;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "loadctl_options"))
 			error = set_loadctl_options(value, strlen(value)) != OK;
@@ -182,21 +184,19 @@ int read_main_config_file(char *main_config_file) {
 		else if(!strcmp(variable, "query_socket")) {
 			my_free(qh_socket_path);
 			qh_socket_path = nspath_absolute(value, config_file_dir);
-		}
-		else if(!strcmp(variable, "log_file")) {
+		} else if(!strcmp(variable, "log_file")) {
 
 			if(strlen(value) > MAX_FILENAME_LENGTH - 1) {
 				asprintf(&error_message, "Log file is too long");
 				error = TRUE;
 				break;
-				}
+			}
 
 			my_free(log_file);
 			log_file = nspath_absolute(value, config_file_dir);
 			/* make sure the configured logfile takes effect */
 			close_log_file();
-			}
-		else if(!strcmp(variable, "debug_level"))
+		} else if(!strcmp(variable, "debug_level"))
 			debug_level = atoi(value);
 
 		else if(!strcmp(variable, "debug_verbosity"))
@@ -208,11 +208,11 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Debug log file is too long");
 				error = TRUE;
 				break;
-				}
+			}
 
 			my_free(debug_file);
 			debug_file = nspath_absolute(value, config_file_dir);
-			}
+		}
 
 		else if(!strcmp(variable, "max_debug_file_size"))
 			max_debug_file_size = strtoul(value, NULL, 0);
@@ -223,24 +223,24 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Command file is too long");
 				error = TRUE;
 				break;
-				}
+			}
 
 			my_free(command_file);
 			command_file = nspath_absolute(value, config_file_dir);
 
 			/* save the macro */
 			mac->x[MACRO_COMMANDFILE] = command_file;
-			}
+		}
 
 		else if(!strcmp(variable, "temp_file")) {
 			my_free(temp_file);
 			temp_file = strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "temp_path")) {
 			my_free(temp_path);
 			temp_path = nspath_absolute(value, config_file_dir);
-			}
+		}
 
 		else if(!strcmp(variable, "check_result_path")) {
 
@@ -248,7 +248,7 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Check result path is too long");
 				error = TRUE;
 				break;
-				}
+			}
 
 			my_free(check_result_path);
 			check_result_path = nspath_absolute(value, config_file_dir);
@@ -260,10 +260,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Check result path '%s' is not a valid directory", check_result_path);
 				error = TRUE;
 				break;
-				}
+			}
 			closedir(tmpdir);
 
-			}
+		}
 
 		else if(!strcmp(variable, "max_check_result_file_age"))
 			max_check_result_file_age = strtoul(value, NULL, 0);
@@ -274,55 +274,55 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Lock file is too long");
 				error = TRUE;
 				break;
-				}
+			}
 
 			my_free(lock_file);
 			lock_file = nspath_absolute(value, config_file_dir);
-			}
+		}
 
 		else if(!strcmp(variable, "global_host_event_handler")) {
 			my_free(global_host_event_handler);
 			global_host_event_handler = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "global_service_event_handler")) {
 			my_free(global_service_event_handler);
 			global_service_event_handler = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "ocsp_command")) {
 			my_free(ocsp_command);
 			ocsp_command = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "ochp_command")) {
 			my_free(ochp_command);
 			ochp_command = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "nagios_user")) {
 			my_free(nagios_user);
 			nagios_user = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "nagios_group")) {
 			my_free(nagios_group);
 			nagios_group = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "admin_email")) {
 
 			/* save the macro */
 			my_free(mac->x[MACRO_ADMINEMAIL]);
 			mac->x[MACRO_ADMINEMAIL] = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "admin_pager")) {
 
 			/* save the macro */
 			my_free(mac->x[MACRO_ADMINPAGER]);
 			mac->x[MACRO_ADMINPAGER] = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "use_syslog")) {
 
@@ -330,10 +330,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for use_syslog");
 				error = TRUE;
 				break;
-				}
+			}
 
 			use_syslog = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_notifications")) {
 
@@ -341,10 +341,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_notifications");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_notifications = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_service_retries")) {
 
@@ -352,10 +352,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_service_retries");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_service_retries = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_host_retries")) {
 
@@ -363,10 +363,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_host_retries");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_host_retries = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_event_handlers")) {
 
@@ -374,10 +374,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_event_handlers");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_event_handlers = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_external_commands")) {
 
@@ -385,10 +385,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_external_commands");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_external_commands = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_passive_checks")) {
 
@@ -396,10 +396,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_passive_checks");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_passive_checks = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_initial_states")) {
 
@@ -407,10 +407,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_initial_states");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_initial_states = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_current_states")) {
 
@@ -418,10 +418,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_current_states");
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_current_states = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "retain_state_information")) {
 
@@ -429,10 +429,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for retain_state_information");
 				error = TRUE;
 				break;
-				}
+			}
 
 			retain_state_information = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "retention_update_interval")) {
 
@@ -441,8 +441,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for retention_update_interval");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "use_retained_program_state")) {
 
@@ -450,10 +450,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for use_retained_program_state");
 				error = TRUE;
 				break;
-				}
+			}
 
 			use_retained_program_state = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "use_retained_scheduling_info")) {
 
@@ -461,10 +461,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for use_retained_scheduling_info");
 				error = TRUE;
 				break;
-				}
+			}
 
 			use_retained_scheduling_info = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "retention_scheduling_horizon")) {
 
@@ -474,8 +474,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for retention_scheduling_horizon");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "additional_freshness_latency"))
 			additional_freshness_latency = atoi(value);
@@ -504,10 +504,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for obsess_over_services");
 				error = TRUE;
 				break;
-				}
+			}
 
 			obsess_over_services = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "obsess_over_hosts")) {
 
@@ -515,10 +515,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for obsess_over_hosts");
 				error = TRUE;
 				break;
-				}
+			}
 
 			obsess_over_hosts = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "translate_passive_host_checks")) {
 
@@ -526,10 +526,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for translate_passive_host_checks");
 				error = TRUE;
 				break;
-				}
+			}
 
 			translate_passive_host_checks = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "passive_host_checks_are_soft"))
 			passive_host_checks_are_soft = (atoi(value) > 0) ? TRUE : FALSE;
@@ -542,11 +542,11 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for service_check_timeout");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 
-		else if(!strcmp(variable,"service_check_timeout_state")){
+		else if(!strcmp(variable,"service_check_timeout_state")) {
 
 			if(!strcmp(value,"o"))
 				service_check_timeout_state=STATE_OK;
@@ -556,12 +556,12 @@ int read_main_config_file(char *main_config_file) {
 				service_check_timeout_state=STATE_CRITICAL;
 			else if(!strcmp(value,"u"))
 				service_check_timeout_state=STATE_UNKNOWN;
-			else{
+			else {
 				asprintf(&error_message,"Illegal value for service_check_timeout_state");
 				error=TRUE;
 				break;
-					}
-				}
+			}
+		}
 
 		else if(!strcmp(variable, "host_check_timeout")) {
 
@@ -571,8 +571,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for host_check_timeout");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "event_handler_timeout")) {
 
@@ -582,8 +582,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for event_handler_timeout");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "notification_timeout")) {
 
@@ -593,8 +593,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for notification_timeout");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "ocsp_timeout")) {
 
@@ -604,8 +604,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for ocsp_timeout");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "ochp_timeout")) {
 
@@ -615,8 +615,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for ochp_timeout");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "use_agressive_host_checking") || !strcmp(variable, "use_aggressive_host_checking")) {
 
@@ -624,10 +624,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for use_aggressive_host_checking");
 				error = TRUE;
 				break;
-				}
+			}
 
 			use_aggressive_host_checking = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "cached_host_check_horizon"))
 			cached_host_check_horizon = strtoul(value, NULL, 0);
@@ -646,10 +646,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for soft_state_dependencies");
 				error = TRUE;
 				break;
-				}
+			}
 
 			soft_state_dependencies = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "log_rotation_method")) {
 			if(!strcmp(value, "n"))
@@ -666,8 +666,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for log_rotation_method");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "log_archive_path")) {
 
@@ -675,11 +675,11 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Log archive path too long");
 				error = TRUE;
 				break;
-				}
+			}
 
 			my_free(log_archive_path);
 			log_archive_path = nspath_absolute(value, config_file_dir);
-			}
+		}
 
 		else if(!strcmp(variable, "enable_event_handlers"))
 			enable_event_handlers = (atoi(value) > 0) ? TRUE : FALSE;
@@ -713,9 +713,9 @@ int read_main_config_file(char *main_config_file) {
 					asprintf(&error_message, "Illegal value for service_inter_check_delay_method");
 					error = TRUE;
 					break;
-					}
 				}
 			}
+		}
 
 		else if(!strcmp(variable, "max_service_check_spread")) {
 			strip(value);
@@ -724,8 +724,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for max_service_check_spread");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "host_inter_check_delay_method")) {
 
@@ -742,9 +742,9 @@ int read_main_config_file(char *main_config_file) {
 					asprintf(&error_message, "Illegal value for host_inter_check_delay_method");
 					error = TRUE;
 					break;
-					}
 				}
 			}
+		}
 
 		else if(!strcmp(variable, "max_host_check_spread")) {
 
@@ -753,8 +753,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for max_host_check_spread");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "service_interleave_factor")) {
 			if(!strcmp(value, "s"))
@@ -764,8 +764,8 @@ int read_main_config_file(char *main_config_file) {
 				scheduling_info.service_interleave_factor = atoi(value);
 				if(scheduling_info.service_interleave_factor < 1)
 					scheduling_info.service_interleave_factor = 1;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "max_concurrent_checks")) {
 
@@ -774,8 +774,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for max_concurrent_checks");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "check_result_reaper_frequency") || !strcmp(variable, "service_reaper_frequency")) {
 
@@ -784,8 +784,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for check_result_reaper_frequency");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "max_check_result_reaper_time")) {
 
@@ -794,12 +794,12 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for max_check_result_reaper_time");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "sleep_time")) {
 			obsoleted_warning(variable, NULL);
-			}
+		}
 
 		else if(!strcmp(variable, "interval_length")) {
 
@@ -808,8 +808,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for interval_length");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "check_external_commands")) {
 
@@ -817,15 +817,15 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for check_external_commands");
 				error = TRUE;
 				break;
-				}
+			}
 
 			check_external_commands = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		/* @todo Remove before Nagios 4.3 */
 		else if(!strcmp(variable, "command_check_interval")) {
 			obsoleted_warning(variable, "Commands are always handled on arrival");
-			}
+		}
 
 		else if(!strcmp(variable, "check_for_orphaned_services")) {
 
@@ -833,10 +833,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for check_for_orphaned_services");
 				error = TRUE;
 				break;
-				}
+			}
 
 			check_orphaned_services = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "check_for_orphaned_hosts")) {
 
@@ -844,10 +844,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for check_for_orphaned_hosts");
 				error = TRUE;
 				break;
-				}
+			}
 
 			check_orphaned_hosts = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "check_service_freshness")) {
 
@@ -855,10 +855,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for check_service_freshness");
 				error = TRUE;
 				break;
-				}
+			}
 
 			check_service_freshness = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "check_host_freshness")) {
 
@@ -866,10 +866,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for check_host_freshness");
 				error = TRUE;
 				break;
-				}
+			}
 
 			check_host_freshness = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "service_freshness_check_interval") || !strcmp(variable, "freshness_check_interval")) {
 
@@ -878,8 +878,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for service_freshness_check_interval");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "host_freshness_check_interval")) {
 
@@ -888,18 +888,17 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for host_freshness_check_interval");
 				error = TRUE;
 				break;
-				}
 			}
-		else if(!strcmp(variable, "auto_reschedule_checks")) {
+		} else if(!strcmp(variable, "auto_reschedule_checks")) {
 
 			if(strlen(value) != 1 || value[0] < '0' || value[0] > '1') {
 				asprintf(&error_message, "Illegal value for auto_reschedule_checks");
 				error = TRUE;
 				break;
-				}
+			}
 
 			auto_reschedule_checks = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "auto_rescheduling_interval")) {
 
@@ -908,8 +907,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for auto_rescheduling_interval");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "auto_rescheduling_window")) {
 
@@ -918,8 +917,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for auto_rescheduling_window");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "status_update_interval")) {
 
@@ -928,8 +927,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for status_update_interval");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "time_change_threshold")) {
 
@@ -939,8 +938,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for time_change_threshold");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "process_performance_data"))
 			process_performance_data = (atoi(value) > 0) ? TRUE : FALSE;
@@ -958,8 +957,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for low_service_flap_threshold");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "high_service_flap_threshold")) {
 
@@ -968,8 +967,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for high_service_flap_threshold");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "low_host_flap_threshold")) {
 
@@ -978,8 +977,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for low_host_flap_threshold");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "high_host_flap_threshold")) {
 
@@ -988,8 +987,8 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for high_host_flap_threshold");
 				error = TRUE;
 				break;
-				}
 			}
+		}
 
 		else if(!strcmp(variable, "date_format")) {
 
@@ -1001,12 +1000,12 @@ int read_main_config_file(char *main_config_file) {
 				date_format = DATE_FORMAT_STRICT_ISO8601;
 			else
 				date_format = DATE_FORMAT_US;
-			}
+		}
 
 		else if(!strcmp(variable, "use_timezone")) {
 			my_free(use_timezone);
 			use_timezone = (char *)strdup(value);
-			}
+		}
 
 		else if(!strcmp(variable, "event_broker_options")) {
 
@@ -1014,7 +1013,7 @@ int read_main_config_file(char *main_config_file) {
 				event_broker_options = BROKER_EVERYTHING;
 			else
 				event_broker_options = strtoul(value, NULL, 0);
-			}
+		}
 
 		else if(!strcmp(variable, "illegal_object_name_chars"))
 			illegal_object_chars = (char *)strdup(value);
@@ -1031,12 +1030,11 @@ int read_main_config_file(char *main_config_file) {
 			if (modptr) {
 				neb_add_module(modptr, argptr, TRUE);
 				free(modptr);
-				}
-			else {
+			} else {
 				logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to allocate module path memory for '%s'\n", value);
-				}
-#endif
 			}
+#endif
+		}
 
 		else if(!strcmp(variable, "use_regexp_matching"))
 			use_regexp_matches = (atoi(value) > 0) ? TRUE : FALSE;
@@ -1050,10 +1048,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for daemon_dumps_core");
 				error = TRUE;
 				break;
-				}
+			}
 
 			daemon_dumps_core = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "use_large_installation_tweaks")) {
 
@@ -1061,10 +1059,10 @@ int read_main_config_file(char *main_config_file) {
 				asprintf(&error_message, "Illegal value for use_large_installation_tweaks ");
 				error = TRUE;
 				break;
-				}
+			}
 
 			use_large_installation_tweaks = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		else if(!strcmp(variable, "enable_environment_macros"))
 			enable_environment_macros = (atoi(value) > 0) ? TRUE : FALSE;
@@ -1105,8 +1103,7 @@ int read_main_config_file(char *main_config_file) {
 		/*** BEGIN perfdata variables ***/
 		else if(!strcmp(variable, "perfdata_timeout")) {
 			perfdata_timeout = atoi(value);
-			}
-		else if(!strcmp(variable, "host_perfdata_command"))
+		} else if(!strcmp(variable, "host_perfdata_command"))
 			host_perfdata_command = (char *)strdup(value);
 		else if(!strcmp(variable, "service_perfdata_command"))
 			service_perfdata_command = (char *)strdup(value);
@@ -1126,8 +1123,7 @@ int read_main_config_file(char *main_config_file) {
 				host_perfdata_file_append = FALSE;
 			else
 				host_perfdata_file_append = TRUE;
-			}
-		else if(!strcmp(variable, "service_perfdata_file_mode")) {
+		} else if(!strcmp(variable, "service_perfdata_file_mode")) {
 			service_perfdata_file_pipe = FALSE;
 			if(strstr(value, "p") != NULL)
 				service_perfdata_file_pipe = TRUE;
@@ -1135,8 +1131,7 @@ int read_main_config_file(char *main_config_file) {
 				service_perfdata_file_append = FALSE;
 			else
 				service_perfdata_file_append = TRUE;
-			}
-		else if(!strcmp(variable, "host_perfdata_file_processing_interval"))
+		} else if(!strcmp(variable, "host_perfdata_file_processing_interval"))
 			host_perfdata_file_processing_interval = strtoul(value, NULL, 0);
 		else if(!strcmp(variable, "service_perfdata_file_processing_interval"))
 			service_perfdata_file_processing_interval = strtoul(value, NULL, 0);
@@ -1157,14 +1152,12 @@ int read_main_config_file(char *main_config_file) {
 			object_cache_file = nspath_absolute(value, config_file_dir);
 			my_free(mac->x[MACRO_OBJECTCACHEFILE]);
 			mac->x[MACRO_OBJECTCACHEFILE] = strdup(object_cache_file);
-		}
-		else if(strstr(input, "precached_object_file=") == input) {
+		} else if(strstr(input, "precached_object_file=") == input) {
 			my_free(object_precache_file);
 			object_precache_file = nspath_absolute(value, config_file_dir);
-		}
-		else if(!strcmp(variable, "allow_empty_hostgroup_assignment")) {
+		} else if(!strcmp(variable, "allow_empty_hostgroup_assignment")) {
 			allow_empty_hostgroup_assignment = (atoi(value) > 0) ? TRUE : FALSE;
-			}
+		}
 		/* skip external data directives */
 		else if(strstr(input, "x") == input)
 			continue;
@@ -1174,27 +1167,26 @@ int read_main_config_file(char *main_config_file) {
 			asprintf(&error_message, "UNKNOWN VARIABLE");
 			error = TRUE;
 			break;
-			}
-
 		}
+
+	}
 
 	if (deprecated) {
 		for (list = deprecated; list; list = list->next) {
 			logit(NSLOG_CONFIG_WARNING, TRUE, "%s", (char *)list->object_ptr);
 			free(list->object_ptr);
-			}
+		}
 		free_objectlist(&deprecated);
 		deprecated = NULL;
-		}
+	}
 
 	if (!temp_path && !(temp_path = getenv("TMPDIR")) && !(temp_path = getenv("TMP"))) {
 		temp_path = strdup("/tmp");
-		}
-	else {
+	} else {
 		/* make sure we don't have a trailing slash */
 		if(temp_path[strlen(temp_path) - 1] == '/')
 			temp_path[strlen(temp_path) - 1] = '\x0';
-		}
+	}
 
 	if((strlen(temp_path) > MAX_FILENAME_LENGTH - 1)) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: temp_path is too long\n");
@@ -1203,20 +1195,18 @@ int read_main_config_file(char *main_config_file) {
 	if((tmpdir = opendir(temp_path)) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: temp_path '%s' is not a valid directory\n", temp_path);
 		return ERROR;
-		}
+	}
 	closedir(tmpdir);
 
 	/* now that we know we have temp_path, we can set temp_file properly */
 	if (!temp_file) {
 		temp_file = nspath_absolute("nagios.tmp", temp_path);
-		}
-	else if (*temp_file == '.') {
+	} else if (*temp_file == '.') {
 		/* temp_file is relative. Make it nagios.cfg-relative */
 		char *foo = temp_file;
 		temp_file = nspath_absolute(temp_file, config_file_dir);
 		free(foo);
-		}
-	else if (*temp_file != '/') {
+	} else if (*temp_file != '/') {
 		/*
 		 * tempfile is not relative and not absolute, so
 		 * put it in temp_path
@@ -1224,12 +1214,12 @@ int read_main_config_file(char *main_config_file) {
 		char *foo = temp_file;
 		temp_file = nspath_absolute(temp_file, temp_path);
 		free(foo);
-		}
+	}
 
 	if(strlen(temp_file) > MAX_FILENAME_LENGTH - 1) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Temp file '%s' is too long\n", temp_file);
 		return ERROR;
-		}
+	}
 
 	/* save the macros */
 	mac->x[MACRO_TEMPPATH] = temp_path;
@@ -1251,7 +1241,7 @@ int read_main_config_file(char *main_config_file) {
 	if(error == TRUE) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error in configuration file '%s' - Line %d (%s)", main_config_file, current_line, (error_message == NULL) ? "NULL" : error_message);
 		return ERROR;
-		}
+	}
 
 	/* free leftover memory and close the file */
 	my_free(input);
@@ -1269,15 +1259,16 @@ int read_main_config_file(char *main_config_file) {
 		if(daemon_mode == FALSE)
 			printf("Error: Log file is not specified anywhere in main config file '%s'!\n", main_config_file);
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* processes macros in resource file */
-int read_resource_file(char *resource_file) {
+int read_resource_file(char *resource_file)
+{
 	char *input = NULL;
 	char *variable = NULL;
 	char *value = NULL;
@@ -1290,7 +1281,7 @@ int read_resource_file(char *resource_file) {
 	if((thefile = mmap_fopen(resource_file)) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open resource file '%s' for reading!", resource_file);
 		return ERROR;
-		}
+	}
 
 	/* process all lines in the resource file */
 	while(1) {
@@ -1317,22 +1308,22 @@ int read_resource_file(char *resource_file) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: NULL variable - Line %d of resource file '%s'", current_line, resource_file);
 			error = TRUE;
 			break;
-			}
+		}
 		if((variable = (char *)strdup(temp_ptr)) == NULL) {
 			error = TRUE;
 			break;
-			}
+		}
 
 		/* get the value */
 		if((temp_ptr = my_strtok(NULL, "\n")) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: NULL variable value - Line %d of resource file '%s'", current_line, resource_file);
 			error = TRUE;
 			break;
-			}
+		}
 		if((value = (char *)strdup(temp_ptr)) == NULL) {
 			error = TRUE;
 			break;
-			}
+		}
 
 		/* what should we do with the variable/value pair? */
 
@@ -1345,10 +1336,10 @@ int read_resource_file(char *resource_file) {
 				if(user_index >= 0 && user_index < MAX_USER_MACROS) {
 					my_free(macro_user[user_index]);
 					macro_user[user_index] = (char *)strdup(value);
-					}
 				}
 			}
 		}
+	}
 
 	/* free leftover memory and close the file */
 	my_free(input);
@@ -1362,7 +1353,7 @@ int read_resource_file(char *resource_file) {
 		return ERROR;
 
 	return OK;
-	}
+}
 
 
 
@@ -1374,7 +1365,8 @@ int read_resource_file(char *resource_file) {
 /****************************************************************/
 
 /* do a pre-flight check to make sure object relationships, etc. make sense */
-int pre_flight_check(void) {
+int pre_flight_check(void)
+{
 	char *buf = NULL;
 	int warnings = 0;
 	int errors = 0;
@@ -1412,15 +1404,15 @@ int pre_flight_check(void) {
 		if (global_host_event_handler_ptr == NULL) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Global host event handler command '%s' is not defined anywhere!", global_host_event_handler);
 			errors++;
-			}
 		}
+	}
 	if(global_service_event_handler != NULL) {
 		global_service_event_handler_ptr = find_bang_command(global_service_event_handler);
 		if (global_service_event_handler_ptr == NULL) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Global service event handler command '%s' is not defined anywhere!", global_service_event_handler);
 			errors++;
-			}
 		}
+	}
 
 
 	/**************************************************/
@@ -1433,15 +1425,15 @@ int pre_flight_check(void) {
 		if (!ocsp_command_ptr) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: OCSP command '%s' is not defined anywhere!\n", ocsp_command);
 			errors++;
-			}
 		}
+	}
 	if(ochp_command != NULL) {
 		ochp_command_ptr = find_bang_command(ochp_command);
 		if (!ochp_command_ptr) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: OCHP command '%s' is not defined anywhere!\n", ochp_command);
 			errors++;
-			}
 		}
+	}
 
 
 	/**************************************************/
@@ -1455,11 +1447,10 @@ int pre_flight_check(void) {
 	if((temp_path_fd = mkstemp(buf)) == -1) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "\tError: Unable to write to temp_path ('%s') - %s\n", temp_path, strerror(errno));
 		errors++;
-		}
-	else {
+	} else {
 		close(temp_path_fd);
 		remove(buf);
-		}
+	}
 	my_free(buf);
 
 	/* check if we can write to check_result_path */
@@ -1467,30 +1458,28 @@ int pre_flight_check(void) {
 	if((temp_path_fd = mkstemp(buf)) == -1) {
 		logit(NSLOG_VERIFICATION_WARNING, TRUE, "\tError: Unable to write to check_result_path ('%s') - %s\n", check_result_path, strerror(errno));
 		errors++;
-		}
-	else {
+	} else {
 		close(temp_path_fd);
 		remove(buf);
-		}
+	}
 	my_free(buf);
 
 	/* warn if user didn't specify any illegal macro output chars */
 	if(illegal_output_chars == NULL) {
 		logit(NSLOG_VERIFICATION_WARNING, TRUE, "%s", "Warning: Nothing specified for illegal_macro_output_chars variable!\n");
 		warnings++;
-		}
-	else {
+	} else {
 		char *p;
 		for(p = illegal_output_chars; *p; p++) {
 			illegal_output_char_map[(int)*p] = 1;
-			}
 		}
+	}
 
 	if(verify_config) {
 		printf("\n");
 		printf("Total Warnings: %d\n", warnings);
 		printf("Total Errors:   %d\n", errors);
-		}
+	}
 
 	if(test_scheduling == TRUE)
 		gettimeofday(&tv[3], NULL);
@@ -1512,15 +1501,16 @@ int pre_flight_check(void) {
 		printf("                      ============\n");
 		printf("TOTAL:                %.6lf sec\n", runtime[3]);
 		printf("\n\n");
-		}
+	}
 
 	return (errors > 0) ? ERROR : OK;
-	}
+}
 
 
 
 /* do a pre-flight check to make sure object relationships make sense */
-int pre_flight_object_check(int *w, int *e) {
+int pre_flight_object_check(int *w, int *e)
+{
 	contact *temp_contact = NULL;
 	commandsmember *temp_commandsmember = NULL;
 	contactgroup *temp_contactgroup = NULL;
@@ -1548,10 +1538,10 @@ int pre_flight_object_check(int *w, int *e) {
 	buf2 = "Probe 2";
 	for(temp_se = get_first_serviceescalation_by_service(buf1, buf2, &ptr); temp_se != NULL; temp_se = get_next_serviceescalation_by_service(buf1, buf2, &ptr)) {
 		printf("FOUND ESCALATION FOR SVC '%s'/'%s': %d-%d/%.3f, PTR=%p\n", buf1, buf2, temp_se->first_notification, temp_se->last_notification, temp_se->notification_interval, ptr);
-		}
+	}
 	for(temp_he = get_first_hostescalation_by_host(buf1, &ptr); temp_he != NULL; temp_he = get_next_hostescalation_by_host(buf1, &ptr)) {
 		printf("FOUND ESCALATION FOR HOST '%s': %d-%d/%d, PTR=%p\n", buf1, temp_he->first_notification, temp_he->last_notification, temp_he->notification_interval, ptr);
-		}
+	}
 #endif
 
 	if(verify_config)
@@ -1563,7 +1553,7 @@ int pre_flight_object_check(int *w, int *e) {
 	if(get_service_count() == 0) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: There are no services defined!");
 		errors++;
-		}
+	}
 	total_objects = 0;
 	for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 
@@ -1575,68 +1565,68 @@ int pre_flight_object_check(int *w, int *e) {
 			if(temp_service->event_handler_ptr == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Event handler command '%s' specified in service '%s' for host '%s' not defined anywhere", temp_service->event_handler, temp_service->description, temp_service->host_name);
 				errors++;
-				}
 			}
+		}
 
 		/* check the service check_command */
 		temp_service->check_command_ptr = find_bang_command(temp_service->check_command);
 		if(temp_service->check_command_ptr == NULL) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Service check command '%s' specified in service '%s' for host '%s' not defined anywhere!", temp_service->check_command, temp_service->description, temp_service->host_name);
 			errors++;
-			}
+		}
 
 		/* check for sane recovery options */
 		if(temp_service->notification_options == OPT_RECOVERY) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Recovery notification option in service '%s' for host '%s' doesn't make any sense - specify warning and/or critical options as well", temp_service->description, temp_service->host_name);
 			warnings++;
-			}
+		}
 
 		/* check to see if there is at least one contact/group */
 		if(temp_service->contacts == NULL && temp_service->contact_groups == NULL) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Service '%s' on host '%s' has no default contacts or contactgroups defined!", temp_service->description, temp_service->host_name);
 			warnings++;
-			}
+		}
 
 		/* verify service check timeperiod */
 		if(temp_service->check_period == NULL) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Service '%s' on host '%s' has no check time period defined!", temp_service->description, temp_service->host_name);
 			warnings++;
-			}
+		}
 
 		/* check service notification timeperiod */
 		if(temp_service->notification_period == NULL) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Service '%s' on host '%s' has no notification time period defined!", temp_service->description, temp_service->host_name);
 			warnings++;
-			}
+		}
 
 		/* check parent services */
 		for(sm = temp_service->parents; sm; sm = sm->next) {
 			sm->service_ptr = find_service(sm->host_name, sm->service_description);
 			if(sm->service_ptr == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Service '%s' on host '%s' is not a valid parent for service '%s' on host '%s'\n",
-					  sm->host_name, sm->service_description,
-					  temp_service->host_name, temp_service->description);
+				      sm->host_name, sm->service_description,
+				      temp_service->host_name, temp_service->description);
 				errors++;
-				}
+			}
 
 			/* add a reverse (child) link to make searches faster later on */
 			add_child_link_to_service(sm->service_ptr, temp_service);
-			}
+		}
 
 		/* see if the notification interval is less than the check interval */
 		if(temp_service->notification_interval < temp_service->check_interval && temp_service->notification_interval != 0) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Service '%s' on host '%s'  has a notification interval less than its check interval!  Notifications are only re-sent after checks are made, so the effective notification interval will be that of the check interval.", temp_service->description, temp_service->host_name);
 			warnings++;
-			}
+		}
 
 		/* check for illegal characters in service description */
 		if(use_precached_objects == FALSE) {
 			if(contains_illegal_object_chars(temp_service->description) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The description string for service '%s' on host '%s' contains one or more illegal characters.", temp_service->description, temp_service->host_name);
 				errors++;
-				}
 			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d services.\n", total_objects);
@@ -1649,7 +1639,7 @@ int pre_flight_object_check(int *w, int *e) {
 	if(get_host_count() == 0) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: There are no hosts defined!");
 		errors++;
-		}
+	}
 
 	total_objects = 0;
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -1660,7 +1650,7 @@ int pre_flight_object_check(int *w, int *e) {
 		if(temp_host->total_services == 0 && verify_config >= 2) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Host '%s' has no services associated with it!", temp_host->name);
 			warnings++;
-			}
+		}
 
 		/* check the event handler command */
 		if(temp_host->event_handler != NULL) {
@@ -1668,8 +1658,8 @@ int pre_flight_object_check(int *w, int *e) {
 			if(temp_host->event_handler_ptr == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Event handler command '%s' specified for host '%s' not defined anywhere", temp_host->event_handler, temp_host->name);
 				errors++;
-				}
 			}
+		}
 
 		/* hosts that don't have check commands defined shouldn't ever be checked... */
 		if(temp_host->check_command != NULL) {
@@ -1677,8 +1667,8 @@ int pre_flight_object_check(int *w, int *e) {
 			if(temp_host->check_command_ptr == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Host check command '%s' specified for host '%s' is not defined anywhere!", temp_host->check_command, temp_host->name);
 				errors++;
-				}
 			}
+		}
 
 		/* check host check timeperiod */
 		if(temp_host->check_period != NULL) {
@@ -1686,17 +1676,17 @@ int pre_flight_object_check(int *w, int *e) {
 			if(temp_timeperiod == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Check period '%s' specified for host '%s' is not defined anywhere!", temp_host->check_period, temp_host->name);
 				errors++;
-				}
+			}
 
 			/* save the pointer to the check timeperiod for later */
 			temp_host->check_period_ptr = temp_timeperiod;
-			}
+		}
 
 		/* check to see if there is at least one contact/group */
 		if(temp_host->contacts == NULL && temp_host->contact_groups == NULL) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Host '%s' has no default contacts or contactgroups defined!", temp_host->name);
 			warnings++;
-			}
+		}
 
 		/* check notification timeperiod */
 		if(temp_host->notification_period != NULL) {
@@ -1704,11 +1694,11 @@ int pre_flight_object_check(int *w, int *e) {
 			if(temp_timeperiod == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Notification period '%s' specified for host '%s' is not defined anywhere!", temp_host->notification_period, temp_host->name);
 				errors++;
-				}
+			}
 
 			/* save the pointer to the notification timeperiod for later */
 			temp_host->notification_period_ptr = temp_timeperiod;
-			}
+		}
 
 		/* check all parent parent host */
 		for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
@@ -1716,29 +1706,29 @@ int pre_flight_object_check(int *w, int *e) {
 			if((temp_host2 = find_host(temp_hostsmember->host_name)) == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: '%s' is not a valid parent for host '%s'!", temp_hostsmember->host_name, temp_host->name);
 				errors++;
-				}
+			}
 
 			/* save the parent host pointer for later */
 			temp_hostsmember->host_ptr = temp_host2;
 
 			/* add a reverse (child) link to make searches faster later on */
 			add_child_link_to_host(temp_host2, temp_host);
-			}
+		}
 
 		/* check for sane recovery options */
 		if(temp_host->notification_options == OPT_RECOVERY) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Recovery notification option in host '%s' definition doesn't make any sense - specify down and/or unreachable options as well", temp_host->name);
 			warnings++;
-			}
+		}
 
 		/* check for illegal characters in host name */
 		if(use_precached_objects == FALSE) {
 			if(contains_illegal_object_chars(temp_host->name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of host '%s' contains one or more illegal characters.", temp_host->name);
 				errors++;
-				}
 			}
 		}
+	}
 
 
 	if(verify_config)
@@ -1754,9 +1744,9 @@ int pre_flight_object_check(int *w, int *e) {
 			if(contains_illegal_object_chars(temp_hostgroup->group_name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of hostgroup '%s' contains one or more illegal characters.", temp_hostgroup->group_name);
 				errors++;
-				}
 			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d host groups.\n", total_objects);
@@ -1771,9 +1761,9 @@ int pre_flight_object_check(int *w, int *e) {
 			if(contains_illegal_object_chars(temp_servicegroup->group_name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of servicegroup '%s' contains one or more illegal characters.", temp_servicegroup->group_name);
 				errors++;
-				}
 			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d service groups.\n", total_objects);
@@ -1786,19 +1776,18 @@ int pre_flight_object_check(int *w, int *e) {
 	if(contact_list == NULL) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: There are no contacts defined!");
 		errors++;
-		}
+	}
 	for(temp_contact = contact_list, total_objects = 0; temp_contact != NULL; temp_contact = temp_contact->next, total_objects++) {
 
 		/* check service notification commands */
 		if(temp_contact->service_notification_commands == NULL) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Contact '%s' has no service notification commands defined!", temp_contact->name);
 			errors++;
-			}
-		else for(temp_commandsmember = temp_contact->service_notification_commands; temp_commandsmember != NULL; temp_commandsmember = temp_commandsmember->next) {
-			temp_commandsmember->command_ptr = find_bang_command(temp_commandsmember->command);
-			if(temp_commandsmember->command_ptr == NULL) {
-				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Service notification command '%s' specified for contact '%s' is not defined anywhere!", temp_commandsmember->command, temp_contact->name);
-				errors++;
+		} else for(temp_commandsmember = temp_contact->service_notification_commands; temp_commandsmember != NULL; temp_commandsmember = temp_commandsmember->next) {
+				temp_commandsmember->command_ptr = find_bang_command(temp_commandsmember->command);
+				if(temp_commandsmember->command_ptr == NULL) {
+					logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Service notification command '%s' specified for contact '%s' is not defined anywhere!", temp_commandsmember->command, temp_contact->name);
+					errors++;
 				}
 			}
 
@@ -1806,12 +1795,11 @@ int pre_flight_object_check(int *w, int *e) {
 		if(temp_contact->host_notification_commands == NULL) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Contact '%s' has no host notification commands defined!", temp_contact->name);
 			errors++;
-			}
-		else for(temp_commandsmember = temp_contact->host_notification_commands; temp_commandsmember != NULL; temp_commandsmember = temp_commandsmember->next) {
-			temp_commandsmember->command_ptr = find_bang_command(temp_commandsmember->command);
-			if(temp_commandsmember->command_ptr == NULL) {
-				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Host notification command '%s' specified for contact '%s' is not defined anywhere!", temp_commandsmember->command, temp_contact->name);
-				errors++;
+		} else for(temp_commandsmember = temp_contact->host_notification_commands; temp_commandsmember != NULL; temp_commandsmember = temp_commandsmember->next) {
+				temp_commandsmember->command_ptr = find_bang_command(temp_commandsmember->command);
+				if(temp_commandsmember->command_ptr == NULL) {
+					logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Host notification command '%s' specified for contact '%s' is not defined anywhere!", temp_commandsmember->command, temp_contact->name);
+					errors++;
 				}
 			}
 
@@ -1819,56 +1807,56 @@ int pre_flight_object_check(int *w, int *e) {
 		if(temp_contact->service_notification_period == NULL) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Contact '%s' has no service notification time period defined!", temp_contact->name);
 			warnings++;
-			}
+		}
 
 		else {
 			temp_timeperiod = find_timeperiod(temp_contact->service_notification_period);
 			if(temp_timeperiod == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Service notification period '%s' specified for contact '%s' is not defined anywhere!", temp_contact->service_notification_period, temp_contact->name);
 				errors++;
-				}
+			}
 
 			/* save the pointer to the service notification timeperiod for later */
 			temp_contact->service_notification_period_ptr = temp_timeperiod;
-			}
+		}
 
 		/* check host notification timeperiod */
 		if(temp_contact->host_notification_period == NULL) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Contact '%s' has no host notification time period defined!", temp_contact->name);
 			warnings++;
-			}
+		}
 
 		else {
 			temp_timeperiod = find_timeperiod(temp_contact->host_notification_period);
 			if(temp_timeperiod == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Host notification period '%s' specified for contact '%s' is not defined anywhere!", temp_contact->host_notification_period, temp_contact->name);
 				errors++;
-				}
+			}
 
 			/* save the pointer to the host notification timeperiod for later */
 			temp_contact->host_notification_period_ptr = temp_timeperiod;
-			}
+		}
 
 		/* check for sane host recovery options */
 		if(temp_contact->host_notification_options == OPT_RECOVERY) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Host recovery notification option for contact '%s' doesn't make any sense - specify down and/or unreachable options as well", temp_contact->name);
 			warnings++;
-			}
+		}
 
 		/* check for sane service recovery options */
 		if(temp_contact->service_notification_options == OPT_RECOVERY) {
 			logit(NSLOG_VERIFICATION_WARNING, TRUE, "Warning: Service recovery notification option for contact '%s' doesn't make any sense - specify critical and/or warning options as well", temp_contact->name);
 			warnings++;
-			}
+		}
 
 		/* check for illegal characters in contact name */
 		if(use_precached_objects == FALSE) {
 			if(contains_illegal_object_chars(temp_contact->name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of contact '%s' contains one or more illegal characters.", temp_contact->name);
 				errors++;
-				}
 			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d contacts.\n", total_objects);
@@ -1884,9 +1872,9 @@ int pre_flight_object_check(int *w, int *e) {
 			if(contains_illegal_object_chars(temp_contactgroup->group_name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of contact group '%s' contains one or more illegal characters.", temp_contactgroup->group_name);
 				errors++;
-				}
 			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d contact groups.\n", total_objects);
@@ -1902,9 +1890,9 @@ int pre_flight_object_check(int *w, int *e) {
 			if(contains_illegal_object_chars(temp_command->name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of command '%s' contains one or more illegal characters.", temp_command->name);
 				errors++;
-				}
 			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d commands.\n", total_objects);
@@ -1921,8 +1909,8 @@ int pre_flight_object_check(int *w, int *e) {
 			if(contains_illegal_object_chars(temp_timeperiod->name) == TRUE) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The name of time period '%s' contains one or more illegal characters.", temp_timeperiod->name);
 				errors++;
-				}
 			}
+		}
 
 		/* check for valid timeperiod names in exclusion list */
 		for(temp_timeperiodexclusion = temp_timeperiod->exclusions; temp_timeperiodexclusion != NULL; temp_timeperiodexclusion = temp_timeperiodexclusion->next) {
@@ -1931,12 +1919,12 @@ int pre_flight_object_check(int *w, int *e) {
 			if(temp_timeperiod2 == NULL) {
 				logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Excluded time period '%s' specified in timeperiod '%s' is not defined anywhere!", temp_timeperiodexclusion->timeperiod_name, temp_timeperiod->name);
 				errors++;
-				}
+			}
 
 			/* save the timeperiod pointer for later */
 			temp_timeperiodexclusion->timeperiod_ptr = temp_timeperiod2;
-			}
 		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %d time periods.\n", total_objects);
@@ -1946,14 +1934,14 @@ int pre_flight_object_check(int *w, int *e) {
 	if(verify_config) {
 		printf("\tChecked %u host escalations.\n", num_objects.hostescalations);
 		printf("\tChecked %u service escalations.\n", num_objects.serviceescalations);
-		}
+	}
 
 	/* update warning and error count */
 	*w += warnings;
 	*e += errors;
 
 	return (errors > 0) ? ERROR : OK;
-	}
+}
 
 
 /* dfs status values */
@@ -2029,15 +2017,15 @@ static int dfs_servicedep_path(char *ary, service *root, int dep_type, int *erro
 
 		if(child_status == DFS_TEMP_CHECKED) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Circular %s dependency detected for services '%s;%s' and '%s;%s'\n",
-				  dep_type == NOTIFICATION_DEPENDENCY ? "notification" : "execution",
-				  root->host_name, root->description,
-				  child->host_name, child->description);
+			      dep_type == NOTIFICATION_DEPENDENCY ? "notification" : "execution",
+			      root->host_name, root->description,
+			      child->host_name, child->description);
 			(*errors)++;
 			dfs_set_status(child, DFS_LOOPY);
 			dfs_set_status(root, DFS_LOOPY);
 			continue;
-			}
 		}
+	}
 
 	/*
 	 * if we've hit ourself, we'll have marked us as loopy
@@ -2078,14 +2066,14 @@ static int dfs_hostdep_path(char *ary, host *root, int dep_type, int *errors)
 
 		if(child_status == DFS_TEMP_CHECKED) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Circular %s dependency detected for hosts '%s' and '%s'\n",
-				  dep_type == NOTIFICATION_DEPENDENCY ? "notification" : "execution",
-				  root->name, child->name);
+			      dep_type == NOTIFICATION_DEPENDENCY ? "notification" : "execution",
+			      root->name, child->name);
 			dfs_set_status(child, DFS_LOOPY);
 			dfs_set_status(root, DFS_LOOPY);
 			(*errors)++;
 			continue;
-			}
 		}
+	}
 
 	/*
 	 * if we've hit ourself, we'll have marked us as loopy
@@ -2097,7 +2085,8 @@ static int dfs_hostdep_path(char *ary, host *root, int dep_type, int *errors)
 }
 
 
-static int dfs_host_path(char *ary, host *root, int *errors) {
+static int dfs_host_path(char *ary, host *root, int *errors)
+{
 	hostsmember *child = NULL;
 
 	if(dfs_get_status(root) != DFS_UNCHECKED)
@@ -2122,8 +2111,8 @@ static int dfs_host_path(char *ary, host *root, int *errors) {
 			dfs_set_status(child->host_ptr, DFS_LOOPY);
 			dfs_set_status(root, DFS_LOOPY);
 			continue;
-			}
 		}
+	}
 
 	/*
 	 * If root have been modified, do not set it OK
@@ -2133,7 +2122,7 @@ static int dfs_host_path(char *ary, host *root, int *errors) {
 	if(dfs_get_status(root) == DFS_TEMP_CHECKED)
 		dfs_set_status(root, DFS_OK);
 	return dfs_get_status(root);
-	}
+}
 
 static int dfs_timeperiod_path(char *ary, timeperiod *root, int *errors)
 {
@@ -2150,13 +2139,13 @@ static int dfs_timeperiod_path(char *ary, timeperiod *root, int *errors)
 
 		if(child_status == DFS_TEMP_CHECKED) {
 			logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: The timeperiods '%s' and '%s' form or lead into a circular exclusion chain!",
-				  root->name, exc->timeperiod_ptr->name);
+			      root->name, exc->timeperiod_ptr->name);
 			(*errors)++;
 			dfs_set_status(exc->timeperiod_ptr, DFS_LOOPY);
 			dfs_set_status(root, DFS_LOOPY);
 			continue;
-			}
 		}
+	}
 
 	if(dfs_get_status(root) == DFS_TEMP_CHECKED)
 		dfs_set_status(root, DFS_OK);
@@ -2166,7 +2155,8 @@ static int dfs_timeperiod_path(char *ary, timeperiod *root, int *errors)
 
 
 /* check for circular paths and dependencies */
-int pre_flight_circular_check(int *w, int *e) {
+int pre_flight_circular_check(int *w, int *e)
+{
 	host *temp_host = NULL;
 	servicedependency *temp_sd = NULL;
 	hostdependency *temp_hd = NULL;
@@ -2187,12 +2177,12 @@ int pre_flight_circular_check(int *w, int *e) {
 		if (!(ary[i] = calloc(1, alloc))) {
 			while (i) {
 				my_free(ary[--i]);
-				}
+			}
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unable to allocate memory for circular path checks.\n");
 			errors++;
 			return ERROR;
-			}
 		}
+	}
 
 
 	/********************************************/
@@ -2203,7 +2193,7 @@ int pre_flight_circular_check(int *w, int *e) {
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 		dfs_host_path(ary[0], temp_host, &errors);
-		}
+	}
 	if (verify_config)
 		printf("\tChecked %u hosts\n", num_objects.hosts);
 
@@ -2224,7 +2214,7 @@ int pre_flight_circular_check(int *w, int *e) {
 		if(dep_type < 1 || dep_type > ARRAY_SIZE(ary))
 			continue;
 		dfs_servicedep_path(ary[dep_type - 1], temp_sd->dependent_service_ptr, dep_type, &errors);
-		}
+	}
 	if(verify_config)
 		printf("\tChecked %u service dependencies\n", num_objects.servicedependencies);
 
@@ -2238,7 +2228,7 @@ int pre_flight_circular_check(int *w, int *e) {
 		if(dep_type < 1 || dep_type > ARRAY_SIZE(ary))
 			continue;
 		dfs_hostdep_path(ary[dep_type - 1], temp_hd->dependent_host_ptr, dep_type, &errors);
-		}
+	}
 
 	if(verify_config)
 		printf("\tChecked %u host dependencies\n", num_objects.hostdependencies);
@@ -2248,7 +2238,7 @@ int pre_flight_circular_check(int *w, int *e) {
 		memset(ary[i], 0, alloc);
 	for (tp = timeperiod_list; tp; tp = tp->next) {
 		dfs_timeperiod_path(ary[0], tp, &errors);
-		}
+	}
 	if (verify_config)
 		printf("\tChecked %u timeperiods\n", num_objects.timeperiods);
 
@@ -2259,4 +2249,4 @@ int pre_flight_circular_check(int *w, int *e) {
 		free(ary[i]);
 
 	return (errors > 0) ? ERROR : OK;
-	}
+}

--- a/base/flapping.c
+++ b/base/flapping.c
@@ -37,7 +37,8 @@
 
 
 /* detects service flapping */
-void check_for_service_flapping(service *svc, int update, int allow_flapstart_notification) {
+void check_for_service_flapping(service *svc, int update, int allow_flapstart_notification)
+{
 	int update_history = TRUE;
 	int is_flapping = FALSE;
 	register int x = 0;
@@ -77,7 +78,7 @@ void check_for_service_flapping(service *svc, int update, int allow_flapstart_no
 		if(!should_flap_detect(svc))
 			update_history = FALSE;
 
-		}
+	}
 
 	/* record current service state */
 	if(update_history == TRUE) {
@@ -89,7 +90,7 @@ void check_for_service_flapping(service *svc, int update, int allow_flapstart_no
 		svc->state_history_index++;
 		if(svc->state_history_index >= MAX_STATE_HISTORY_ENTRIES)
 			svc->state_history_index = 0;
-		}
+	}
 
 	/* calculate overall and curved percent state changes */
 	for(x = 0, y = svc->state_history_index; x < MAX_STATE_HISTORY_ENTRIES; x++) {
@@ -100,7 +101,7 @@ void check_for_service_flapping(service *svc, int update, int allow_flapstart_no
 			if(y >= MAX_STATE_HISTORY_ENTRIES)
 				y = 0;
 			continue;
-			}
+		}
 
 		if(last_state_history_value != svc->state_history[y])
 			curved_changes += (((double)(x - 1) * (high_curve_value - low_curve_value)) / ((double)(MAX_STATE_HISTORY_ENTRIES - 2))) + low_curve_value;
@@ -110,7 +111,7 @@ void check_for_service_flapping(service *svc, int update, int allow_flapstart_no
 		y++;
 		if(y >= MAX_STATE_HISTORY_ENTRIES)
 			y = 0;
-		}
+	}
 
 	/* calculate overall percent change in state */
 	curved_percent_change = (double)(((double)curved_changes * 100.0) / (double)(MAX_STATE_HISTORY_ENTRIES - 1));
@@ -153,11 +154,12 @@ void check_for_service_flapping(service *svc, int update, int allow_flapstart_no
 		clear_service_flap(svc, curved_percent_change, high_threshold, low_threshold);
 
 	return;
-	}
+}
 
 
 /* detects host flapping */
-void check_for_host_flapping(host *hst, int update, int actual_check, int allow_flapstart_notification) {
+void check_for_host_flapping(host *hst, int update, int actual_check, int allow_flapstart_notification)
+{
 	int update_history = TRUE;
 	int is_flapping = FALSE;
 	register int x = 0;
@@ -196,14 +198,14 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 		if(!(hst->flap_detection_options & (1 << hst->current_state)))
 			update_history = FALSE;
 
-		}
+	}
 
 	/* if we didn't have an actual check, only update if we've waited long enough */
 	if(update_history == TRUE && actual_check == FALSE && (current_time - hst->last_state_history_update) < wait_threshold) {
 
 		update_history = FALSE;
 
-		}
+	}
 
 	/* what thresholds should we use (global or host-specific)? */
 	low_threshold = (hst->low_flap_threshold <= 0.0) ? low_host_flap_threshold : hst->low_flap_threshold;
@@ -222,7 +224,7 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 		hst->state_history_index++;
 		if(hst->state_history_index >= MAX_STATE_HISTORY_ENTRIES)
 			hst->state_history_index = 0;
-		}
+	}
 
 	/* calculate overall changes in state */
 	for(x = 0, y = hst->state_history_index; x < MAX_STATE_HISTORY_ENTRIES; x++) {
@@ -233,7 +235,7 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 			if(y >= MAX_STATE_HISTORY_ENTRIES)
 				y = 0;
 			continue;
-			}
+		}
 
 		if(last_state_history_value != hst->state_history[y])
 			curved_changes += (((double)(x - 1) * (high_curve_value - low_curve_value)) / ((double)(MAX_STATE_HISTORY_ENTRIES - 2))) + low_curve_value;
@@ -243,7 +245,7 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 		y++;
 		if(y >= MAX_STATE_HISTORY_ENTRIES)
 			y = 0;
-		}
+	}
 
 	/* calculate overall percent change in state */
 	curved_percent_change = (double)(((double)curved_changes * 100.0) / (double)(MAX_STATE_HISTORY_ENTRIES - 1));
@@ -286,7 +288,7 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 		clear_host_flap(hst, curved_percent_change, high_threshold, low_threshold);
 
 	return;
-	}
+}
 
 
 /******************************************************************/
@@ -295,7 +297,8 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 
 
 /* handles a service that is flapping */
-void set_service_flap(service *svc, double percent_change, double high_threshold, double low_threshold, int allow_flapstart_notification) {
+void set_service_flap(service *svc, double percent_change, double high_threshold, double low_threshold, int allow_flapstart_notification)
+{
 	char *temp_buffer = NULL;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "set_service_flap()\n");
@@ -332,11 +335,12 @@ void set_service_flap(service *svc, double percent_change, double high_threshold
 		service_notification(svc, NOTIFICATION_FLAPPINGSTART, NULL, NULL, NOTIFICATION_OPTION_NONE);
 
 	return;
-	}
+}
 
 
 /* handles a service that has stopped flapping */
-void clear_service_flap(service *svc, double percent_change, double high_threshold, double low_threshold) {
+void clear_service_flap(service *svc, double percent_change, double high_threshold, double low_threshold)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "clear_service_flap()\n");
 
@@ -372,11 +376,12 @@ void clear_service_flap(service *svc, double percent_change, double high_thresho
 	svc->check_flapping_recovery_notification = FALSE;
 
 	return;
-	}
+}
 
 
 /* handles a host that is flapping */
-void set_host_flap(host *hst, double percent_change, double high_threshold, double low_threshold, int allow_flapstart_notification) {
+void set_host_flap(host *hst, double percent_change, double high_threshold, double low_threshold, int allow_flapstart_notification)
+{
 	char *temp_buffer = NULL;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "set_host_flap()\n");
@@ -413,11 +418,12 @@ void set_host_flap(host *hst, double percent_change, double high_threshold, doub
 		host_notification(hst, NOTIFICATION_FLAPPINGSTART, NULL, NULL, NOTIFICATION_OPTION_NONE);
 
 	return;
-	}
+}
 
 
 /* handles a host that has stopped flapping */
-void clear_host_flap(host *hst, double percent_change, double high_threshold, double low_threshold) {
+void clear_host_flap(host *hst, double percent_change, double high_threshold, double low_threshold)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "clear_host_flap()\n");
 
@@ -453,7 +459,7 @@ void clear_host_flap(host *hst, double percent_change, double high_threshold, do
 	hst->check_flapping_recovery_notification = FALSE;
 
 	return;
-	}
+}
 
 
 
@@ -462,7 +468,8 @@ void clear_host_flap(host *hst, double percent_change, double high_threshold, do
 /******************************************************************/
 
 /* enables flap detection on a program wide basis */
-void enable_flap_detection_routines(void) {
+void enable_flap_detection_routines(void)
+{
 	unsigned int i;
 	unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
@@ -493,12 +500,13 @@ void enable_flap_detection_routines(void) {
 	for(i = 0; i < num_objects.services; i++)
 		check_for_service_flapping(service_ary[i], FALSE, TRUE);
 
-	}
+}
 
 
 
 /* disables flap detection on a program wide basis */
-void disable_flap_detection_routines(void) {
+void disable_flap_detection_routines(void)
+{
 	unsigned int i;
 	unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
@@ -530,12 +538,13 @@ void disable_flap_detection_routines(void) {
 		handle_service_flap_detection_disabled(service_ary[i]);
 
 	return;
-	}
+}
 
 
 
 /* enables flap detection for a specific host */
-void enable_host_flap_detection(host *hst) {
+void enable_host_flap_detection(host *hst)
+{
 	unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "enable_host_flap_detection()\n");
@@ -567,12 +576,13 @@ void enable_host_flap_detection(host *hst) {
 	update_host_status(hst, FALSE);
 
 	return;
-	}
+}
 
 
 
 /* disables flap detection for a specific host */
-void disable_host_flap_detection(host *hst) {
+void disable_host_flap_detection(host *hst)
+{
 	unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "disable_host_flap_detection()\n");
@@ -601,11 +611,12 @@ void disable_host_flap_detection(host *hst) {
 	handle_host_flap_detection_disabled(hst);
 
 	return;
-	}
+}
 
 
 /* handles the details for a host when flap detection is disabled (globally or per-host) */
-void handle_host_flap_detection_disabled(host *hst) {
+void handle_host_flap_detection_disabled(host *hst)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "handle_host_flap_detection_disabled()\n");
 
@@ -639,17 +650,18 @@ void handle_host_flap_detection_disabled(host *hst) {
 
 		/* clear the recovery notification flag */
 		hst->check_flapping_recovery_notification = FALSE;
-		}
+	}
 
 	/* update host status */
 	update_host_status(hst, FALSE);
 
 	return;
-	}
+}
 
 
 /* enables flap detection for a specific service */
-void enable_service_flap_detection(service *svc) {
+void enable_service_flap_detection(service *svc)
+{
 	unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "enable_service_flap_detection()\n");
@@ -681,12 +693,13 @@ void enable_service_flap_detection(service *svc) {
 	update_service_status(svc, FALSE);
 
 	return;
-	}
+}
 
 
 
 /* disables flap detection for a specific service */
-void disable_service_flap_detection(service *svc) {
+void disable_service_flap_detection(service *svc)
+{
 	unsigned long attr = MODATTR_FLAP_DETECTION_ENABLED;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "disable_service_flap_detection()\n");
@@ -715,11 +728,12 @@ void disable_service_flap_detection(service *svc) {
 	handle_service_flap_detection_disabled(svc);
 
 	return;
-	}
+}
 
 
 /* handles the details for a service when flap detection is disabled (globally or per-service) */
-void handle_service_flap_detection_disabled(service *svc) {
+void handle_service_flap_detection_disabled(service *svc)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "handle_service_flap_detection_disabled()\n");
 
@@ -753,10 +767,10 @@ void handle_service_flap_detection_disabled(service *svc) {
 
 		/* clear the recovery notification flag */
 		svc->check_flapping_recovery_notification = FALSE;
-		}
+	}
 
 	/* update service status */
 	update_service_status(svc, FALSE);
 
 	return;
-	}
+}

--- a/base/logging.c
+++ b/base/logging.c
@@ -37,15 +37,17 @@ static FILE *log_fp;
 /******************************************************************/
 
 /* write something to the console */
-static void write_to_console(char *buffer) {
+static void write_to_console(char *buffer)
+{
 	/* should we print to the console? */
 	if(daemon_mode == FALSE)
 		printf("%s\n", buffer);
-	}
+}
 
 
 /* write something to the log file, syslog, and possibly the console */
-static void write_to_logs_and_console(char *buffer, unsigned long data_type, int display) {
+static void write_to_logs_and_console(char *buffer, unsigned long data_type, int display)
+{
 	register int len = 0;
 	register int x = 0;
 
@@ -56,7 +58,7 @@ static void write_to_logs_and_console(char *buffer, unsigned long data_type, int
 			buffer[x] = '\x0';
 		else
 			break;
-		}
+	}
 
 	/* write messages to the logs */
 	write_to_all_logs(buffer, data_type);
@@ -69,12 +71,13 @@ static void write_to_logs_and_console(char *buffer, unsigned long data_type, int
 			return;
 
 		write_to_console(buffer);
-		}
 	}
+}
 
 
 /* The main logging function */
-void logit(int data_type, int display, const char *fmt, ...) {
+void logit(int data_type, int display, const char *fmt, ...)
+{
 	va_list ap;
 	char *buffer = NULL;
 
@@ -82,13 +85,14 @@ void logit(int data_type, int display, const char *fmt, ...) {
 	if(vasprintf(&buffer, fmt, ap) > 0) {
 		write_to_logs_and_console(buffer, data_type, display);
 		free(buffer);
-		}
-	va_end(ap);
 	}
+	va_end(ap);
+}
 
 
 /* write something to the log file and syslog facility */
-int write_to_all_logs(char *buffer, unsigned long data_type) {
+int write_to_all_logs(char *buffer, unsigned long data_type)
+{
 
 	/* write to syslog */
 	write_to_syslog(buffer, data_type);
@@ -97,17 +101,18 @@ int write_to_all_logs(char *buffer, unsigned long data_type) {
 	write_to_log(buffer, data_type, NULL);
 
 	return OK;
-	}
+}
 
 
 /* write something to the log file and syslog facility */
-static void write_to_all_logs_with_timestamp(char *buffer, unsigned long data_type, time_t *timestamp) {
+static void write_to_all_logs_with_timestamp(char *buffer, unsigned long data_type, time_t *timestamp)
+{
 	/* write to syslog */
 	write_to_syslog(buffer, data_type);
 
 	/* write to main log */
 	write_to_log(buffer, data_type, timestamp);
-	}
+}
 
 
 static FILE *open_log_file(void)
@@ -119,9 +124,9 @@ static FILE *open_log_file(void)
 	if(log_fp == NULL) {
 		if (daemon_mode == FALSE) {
 			printf("Warning: Cannot open log file '%s' for writing\n", log_file);
-			}
-		return NULL;
 		}
+		return NULL;
+	}
 
 	(void)fcntl(fileno(log_fp), F_SETFD, FD_CLOEXEC);
 	return log_fp;
@@ -156,7 +161,8 @@ int close_log_file(void)
 }
 
 /* write something to the nagios log file */
-int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp) {
+int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp)
+{
 	FILE *fp;
 	time_t log_time = 0L;
 
@@ -193,11 +199,12 @@ int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp) {
 #endif
 
 	return OK;
-	}
+}
 
 
 /* write something to the syslog facility */
-int write_to_syslog(char *buffer, unsigned long data_type) {
+int write_to_syslog(char *buffer, unsigned long data_type)
+{
 
 	if(buffer == NULL)
 		return ERROR;
@@ -218,11 +225,12 @@ int write_to_syslog(char *buffer, unsigned long data_type) {
 	syslog(LOG_USER | LOG_INFO, "%s", buffer);
 
 	return OK;
-	}
+}
 
 
 /* write a service problem/recovery to the nagios log file */
-int log_service_event(service *svc) {
+int log_service_event(service *svc)
+{
 	char *temp_buffer = NULL;
 	unsigned long log_options = 0L;
 	host *temp_host = NULL;
@@ -246,21 +254,22 @@ int log_service_event(service *svc) {
 		return ERROR;
 
 	asprintf(&temp_buffer, "SERVICE ALERT: %s;%s;%s;%s;%d;%s\n",
-			 svc->host_name, svc->description,
-			 service_state_name(svc->current_state),
-			 state_type_name(svc->state_type),
-			 svc->current_attempt,
-			 (svc->plugin_output == NULL) ? "" : svc->plugin_output);
+	         svc->host_name, svc->description,
+	         service_state_name(svc->current_state),
+	         state_type_name(svc->state_type),
+	         svc->current_attempt,
+	         (svc->plugin_output == NULL) ? "" : svc->plugin_output);
 
 	write_to_all_logs(temp_buffer, log_options);
 	free(temp_buffer);
 
 	return OK;
-	}
+}
 
 
 /* write a host problem/recovery to the log file */
-int log_host_event(host *hst) {
+int log_host_event(host *hst)
+{
 	char *temp_buffer = NULL;
 	unsigned long log_options = 0L;
 
@@ -273,22 +282,23 @@ int log_host_event(host *hst) {
 		log_options = NSLOG_HOST_UP;
 
 	asprintf(&temp_buffer, "HOST ALERT: %s;%s;%s;%d;%s\n",
-			 hst->name,
-			 host_state_name(hst->current_state),
-			 state_type_name(hst->state_type),
-			 hst->current_attempt,
-			 (hst->plugin_output == NULL) ? "" : hst->plugin_output);
+	         hst->name,
+	         host_state_name(hst->current_state),
+	         state_type_name(hst->state_type),
+	         hst->current_attempt,
+	         (hst->plugin_output == NULL) ? "" : hst->plugin_output);
 
 	write_to_all_logs(temp_buffer, log_options);
 
 	my_free(temp_buffer);
 
 	return OK;
-	}
+}
 
 
 /* logs host states */
-int log_host_states(int type, time_t *timestamp) {
+int log_host_states(int type, time_t *timestamp)
+{
 	char *temp_buffer = NULL;
 	host *temp_host = NULL;;
 
@@ -299,23 +309,24 @@ int log_host_states(int type, time_t *timestamp) {
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
 		asprintf(&temp_buffer, "%s HOST STATE: %s;%s;%s;%d;%s\n", (type == INITIAL_STATES) ? "INITIAL" : "CURRENT",
-				 temp_host->name,
-				 host_state_name(temp_host->current_state),
-				 state_type_name(temp_host->state_type),
-				 temp_host->current_attempt,
-				 (temp_host->plugin_output == NULL) ? "" : temp_host->plugin_output);
+		         temp_host->name,
+		         host_state_name(temp_host->current_state),
+		         state_type_name(temp_host->state_type),
+		         temp_host->current_attempt,
+		         (temp_host->plugin_output == NULL) ? "" : temp_host->plugin_output);
 
 		write_to_all_logs_with_timestamp(temp_buffer, NSLOG_INFO_MESSAGE, timestamp);
 
 		my_free(temp_buffer);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* logs service states */
-int log_service_states(int type, time_t *timestamp) {
+int log_service_states(int type, time_t *timestamp)
+{
 	char *temp_buffer = NULL;
 	service *temp_service = NULL;
 	host *temp_host = NULL;;
@@ -331,24 +342,25 @@ int log_service_states(int type, time_t *timestamp) {
 			continue;
 
 		asprintf(&temp_buffer, "%s SERVICE STATE: %s;%s;%s;%s;%d;%s\n",
-				 (type == INITIAL_STATES) ? "INITIAL" : "CURRENT",
-				 temp_service->host_name, temp_service->description,
-				 service_state_name(temp_service->current_state),
-				 state_type_name(temp_service->state_type),
-				 temp_service->current_attempt,
-				 temp_service->plugin_output);
+		         (type == INITIAL_STATES) ? "INITIAL" : "CURRENT",
+		         temp_service->host_name, temp_service->description,
+		         service_state_name(temp_service->current_state),
+		         state_type_name(temp_service->state_type),
+		         temp_service->current_attempt,
+		         temp_service->plugin_output);
 
 		write_to_all_logs_with_timestamp(temp_buffer, NSLOG_INFO_MESSAGE, timestamp);
 
 		my_free(temp_buffer);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* rotates the main log file */
-int rotate_log_file(time_t rotation_time) {
+int rotate_log_file(time_t rotation_time)
+{
 	char *temp_buffer = NULL;
 	char method_string[16] = "";
 	char *log_archive = NULL;
@@ -361,8 +373,7 @@ int rotate_log_file(time_t rotation_time) {
 
 	if(log_rotation_method == LOG_ROTATION_NONE) {
 		return OK;
-		}
-	else if(log_rotation_method == LOG_ROTATION_HOURLY)
+	} else if(log_rotation_method == LOG_ROTATION_HOURLY)
 		strcpy(method_string, "HOURLY");
 	else if(log_rotation_method == LOG_ROTATION_DAILY)
 		strcpy(method_string, "DAILY");
@@ -388,11 +399,11 @@ int rotate_log_file(time_t rotation_time) {
 
 	/* HACK: If the archive exists, don't overwrite it. This is a hack
 		because the real problem is that some log rotations are executed
-		early and as a result the next log rotatation is scheduled for 
+		early and as a result the next log rotatation is scheduled for
 		the same time as the one that ran early */
 	archive_stat_result = stat(log_archive, &archive_stat);
-	if((0 == archive_stat_result) || 
-			((-1 == archive_stat_result) && (ENOENT != errno))) {
+	if((0 == archive_stat_result) ||
+	   ((-1 == archive_stat_result) && (ENOENT != errno))) {
 		return OK;
 	}
 
@@ -405,7 +416,7 @@ int rotate_log_file(time_t rotation_time) {
 	if(rename_result) {
 		my_free(log_archive);
 		return ERROR;
-		}
+	}
 
 	/* record the log rotation after it has been done... */
 	asprintf(&temp_buffer, "LOG ROTATION: %s\n", method_string);
@@ -418,7 +429,7 @@ int rotate_log_file(time_t rotation_time) {
 	if(stat_result == 0) {
 		chmod(log_file, log_file_stat.st_mode);
 		chown(log_file, log_file_stat.st_uid, log_file_stat.st_gid);
-		}
+	}
 
 	/* log current host and service state if activated */
 	if(log_current_states==TRUE) {
@@ -430,11 +441,12 @@ int rotate_log_file(time_t rotation_time) {
 	my_free(log_archive);
 
 	return OK;
-	}
+}
 
 
 /* record log file version/info */
-int write_log_file_info(time_t *timestamp) {
+int write_log_file_info(time_t *timestamp)
+{
 	char *temp_buffer = NULL;
 
 	/* write log version */
@@ -443,11 +455,12 @@ int write_log_file_info(time_t *timestamp) {
 	my_free(temp_buffer);
 
 	return OK;
-	}
+}
 
 
 /* opens the debug log for writing */
-int open_debug_log(void) {
+int open_debug_log(void)
+{
 
 	/* don't do anything if we're not actually running... */
 	if(verify_config || test_scheduling == TRUE)
@@ -463,11 +476,12 @@ int open_debug_log(void) {
 	(void)fcntl(fileno(debug_file_fp), F_SETFD, FD_CLOEXEC);
 
 	return OK;
-	}
+}
 
 
 /* closes the debug log */
-int close_debug_log(void) {
+int close_debug_log(void)
+{
 
 	if(debug_file_fp != NULL)
 		fclose(debug_file_fp);
@@ -475,11 +489,12 @@ int close_debug_log(void) {
 	debug_file_fp = NULL;
 
 	return OK;
-	}
+}
 
 
 /* write to the debug log */
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	va_list ap;
 	char *tmppath = NULL;
 	struct timeval current_time;
@@ -523,11 +538,11 @@ int log_debug_info(int level, int verbosity, const char *fmt, ...) {
 
 			/* free memory */
 			my_free(tmppath);
-			}
+		}
 
 		/* open a new file */
 		open_debug_log();
-		}
+	}
 
 	return OK;
-	}
+}

--- a/base/nagios.c
+++ b/base/nagios.c
@@ -157,7 +157,7 @@ static int nagios_core_worker(const char *path)
 	sd = nsock_unix(path, NSOCK_TCP | NSOCK_CONNECT);
 	if (sd < 0) {
 		printf("Failed to connect to query socket '%s': %s: %s\n",
-			   path, nsock_strerror(sd), strerror(errno));
+		       path, nsock_strerror(sd), strerror(errno));
 		return 1;
 	}
 
@@ -206,7 +206,7 @@ static int test_configured_paths(void)
 		log_file = mac->x[MACRO_LOGFILE];
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to open logfile '%s' for writing: %s\n", value_absolute, strerror(errno));
 		return ERROR;
-		}
+	}
 
 	fclose(fp);
 
@@ -215,7 +215,8 @@ static int test_configured_paths(void)
 	return OK;
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 	int error = FALSE;
 	int display_license = FALSE;
@@ -231,18 +232,18 @@ int main(int argc, char **argv) {
 #ifdef HAVE_GETOPT_H
 	int option_index = 0;
 	static struct option long_options[] = {
-			{"help", no_argument, 0, 'h'},
-			{"version", no_argument, 0, 'V'},
-			{"license", no_argument, 0, 'V'},
-			{"verify-config", no_argument, 0, 'v'},
-			{"daemon", no_argument, 0, 'd'},
-			{"test-scheduling", no_argument, 0, 's'},
-			{"precache-objects", no_argument, 0, 'p'},
-			{"use-precached-objects", no_argument, 0, 'u'},
-			{"enable-timing-point", no_argument, 0, 'T'},
-			{"worker", required_argument, 0, 'W'},
-			{0, 0, 0, 0}
-		};
+		{"help", no_argument, 0, 'h'},
+		{"version", no_argument, 0, 'V'},
+		{"license", no_argument, 0, 'V'},
+		{"verify-config", no_argument, 0, 'v'},
+		{"daemon", no_argument, 0, 'd'},
+		{"test-scheduling", no_argument, 0, 's'},
+		{"precache-objects", no_argument, 0, 'p'},
+		{"use-precached-objects", no_argument, 0, 'u'},
+		{"enable-timing-point", no_argument, 0, 'T'},
+		{"worker", required_argument, 0, 'W'},
+		{0, 0, 0, 0}
+	};
 #define getopt(argc, argv, o) getopt_long(argc, argv, o, long_options, &option_index)
 #endif
 
@@ -262,50 +263,50 @@ int main(int argc, char **argv) {
 
 		switch(c) {
 
-			case '?': /* usage */
-			case 'h':
-				display_help = TRUE;
-				break;
+		case '?': /* usage */
+		case 'h':
+			display_help = TRUE;
+			break;
 
-			case 'V': /* version */
-				display_license = TRUE;
-				break;
+		case 'V': /* version */
+			display_license = TRUE;
+			break;
 
-			case 'v': /* verify */
-				verify_config++;
-				break;
+		case 'v': /* verify */
+			verify_config++;
+			break;
 
-			case 's': /* scheduling check */
-				test_scheduling = TRUE;
-				break;
+		case 's': /* scheduling check */
+			test_scheduling = TRUE;
+			break;
 
-			case 'd': /* daemon mode */
-				daemon_mode = TRUE;
-				break;
+		case 'd': /* daemon mode */
+			daemon_mode = TRUE;
+			break;
 
-			case 'p': /* precache object config */
-				precache_objects = TRUE;
-				break;
+		case 'p': /* precache object config */
+			precache_objects = TRUE;
+			break;
 
-			case 'u': /* use precached object config */
-				use_precached_objects = TRUE;
-				break;
-			case 'T':
-				enable_timing_point = TRUE;
-				break;
-			case 'W':
-				worker_socket = optarg;
-				break;
+		case 'u': /* use precached object config */
+			use_precached_objects = TRUE;
+			break;
+		case 'T':
+			enable_timing_point = TRUE;
+			break;
+		case 'W':
+			worker_socket = optarg;
+			break;
 
-			case 'x':
-				printf("Warning: -x is deprecated and will be removed\n");
-				break;
+		case 'x':
+			printf("Warning: -x is deprecated and will be removed\n");
+			break;
 
-			default:
-				break;
-			}
-
+		default:
+			break;
 		}
+
+	}
 
 #ifdef DEBUG_MEMORY
 	mtrace();
@@ -322,7 +323,7 @@ int main(int argc, char **argv) {
 		printf("Last Modified: %s\n", PROGRAM_MODIFICATION_DATE);
 		printf("License: GPL\n\n");
 		printf("Website: http://www.nagios.org\n");
-		}
+	}
 
 	/* just display the license */
 	if(display_license == TRUE) {
@@ -339,7 +340,7 @@ int main(int argc, char **argv) {
 		printf("Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.\n\n");
 
 		exit(OK);
-		}
+	}
 
 	/* make sure we got the main config file on the command line... */
 	if(optind >= argc)
@@ -368,7 +369,7 @@ int main(int argc, char **argv) {
 		printf("\n");
 
 		exit(ERROR);
-		}
+	}
 
 
 	/*
@@ -379,11 +380,11 @@ int main(int argc, char **argv) {
 	if(config_file == NULL) {
 		printf("Error allocating memory.\n");
 		exit(ERROR);
-		}
+	}
 
 	config_file_dir = nspath_absolute_dirname(config_file, NULL);
 
-	/* 
+	/*
 	 * Set the signal handler for the SIGXFSZ signal here because
 	 * we may encounter this signal before the other signal handlers
 	 * are set.
@@ -412,7 +413,7 @@ int main(int argc, char **argv) {
 		if(result != OK) {
 			printf("   Error processing main config file!\n\n");
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		if(verify_config)
 			printf("   Read main config file okay...\n");
@@ -421,7 +422,7 @@ int main(int argc, char **argv) {
 		if((result = drop_privileges(nagios_user, nagios_group)) == ERROR) {
 			printf("   Failed to drop privileges.  Aborting.");
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		/*
 		 * this must come after dropping privileges, so we make
@@ -430,7 +431,7 @@ int main(int argc, char **argv) {
 		if (!verify_config && test_configured_paths() == ERROR) {
 			printf("   One or more path problems detected. Aborting.\n");
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		/* read object config files */
 		result = read_all_object_data(config_file);
@@ -443,7 +444,7 @@ int main(int argc, char **argv) {
 				printf("     Make sure you are specifying the name of the MAIN configuration file on\n");
 				printf("     the command line and not the name of another configuration file.  The\n");
 				printf("     main configuration file is typically '%s'\n", DEFAULT_CONFIG_FILE);
-				}
+			}
 
 			printf("\n***> One or more problems was encountered while processing the config files...\n");
 			printf("\n");
@@ -454,12 +455,12 @@ int main(int argc, char **argv) {
 			printf("     the HTML documentation regarding the config files, as well as the\n");
 			printf("     'Whats New' section to find out what has changed.\n\n");
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		if(verify_config) {
 			printf("   Read object config files okay...\n\n");
 			printf("Running pre-flight check on configuration data...\n\n");
-			}
+		}
 
 		/* run the pre-flight check to make sure things look okay... */
 		result = pre_flight_check();
@@ -474,11 +475,11 @@ int main(int argc, char **argv) {
 			printf("     the HTML documentation regarding the config files, as well as the\n");
 			printf("     'Whats New' section to find out what has changed.\n\n");
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		if(verify_config) {
 			printf("\nThings look okay - No serious problems were detected during the pre-flight check\n");
-			}
+		}
 
 		/* scheduling tests need a bit more than config verifications */
 		if(test_scheduling == TRUE) {
@@ -498,18 +499,17 @@ int main(int argc, char **argv) {
 
 			/* display scheduling information */
 			display_scheduling_info();
-			}
+		}
 
 		if(precache_objects) {
 			result = fcache_objects(object_precache_file);
 			timing_point("Done precaching objects\n");
 			if(result == OK) {
 				printf("Object precache file created:\n%s\n", object_precache_file);
-				}
-			else {
+			} else {
 				printf("Failed to precache objects to '%s': %s\n", object_precache_file, strerror(errno));
-				}
 			}
+		}
 
 		/* clean up after ourselves */
 		cleanup();
@@ -523,7 +523,7 @@ int main(int argc, char **argv) {
 		free(config_file);
 
 		exit(result);
-		}
+	}
 
 
 	/* else start to monitor things... */
@@ -542,13 +542,13 @@ int main(int argc, char **argv) {
 		if (!nagios_binary_path) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to allocate memory for nagios_binary_path\n");
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		if (!(nagios_iobs = iobroker_create())) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to create IO broker set: %s\n",
-				  strerror(errno));
+			      strerror(errno));
 			exit(EXIT_FAILURE);
-			}
+		}
 
 		/* keep monitoring things until we get a shutdown command */
 		do {
@@ -569,7 +569,7 @@ int main(int argc, char **argv) {
 			if (result != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to process config file '%s'. Aborting\n", config_file);
 				exit(EXIT_FAILURE);
-				}
+			}
 			timing_point("Main config file read\n");
 
 			/* NOTE 11/06/07 EG moved to after we read config files, as user may have overridden timezone offset */
@@ -585,18 +585,18 @@ int main(int argc, char **argv) {
 
 				cleanup();
 				exit(ERROR);
-				}
+			}
 
 			if (test_path_access(nagios_binary_path, X_OK)) {
 				logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: failed to access() %s: %s\n", nagios_binary_path, strerror(errno));
 				logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Spawning workers will be impossible. Aborting.\n");
 				exit(EXIT_FAILURE);
-				}
+			}
 
 			if (test_configured_paths() == ERROR) {
 				/* error has already been logged */
 				exit(EXIT_FAILURE);
-				}
+			}
 			/* enter daemon mode (unless we're restarting...) */
 			if(daemon_mode == TRUE && sigrestart == FALSE) {
 
@@ -607,11 +607,11 @@ int main(int argc, char **argv) {
 					logit(NSLOG_PROCESS_INFO | NSLOG_RUNTIME_ERROR, TRUE, "Bailing out due to failure to daemonize. (PID=%d)", (int)getpid());
 					cleanup();
 					exit(EXIT_FAILURE);
-					}
+				}
 
 				/* get new PID */
 				nagios_pid = (int)getpid();
-				}
+			}
 
 			/* this must be logged after we read config data, as user may have changed location of main log file */
 			logit(NSLOG_PROCESS_INFO, TRUE, "Nagios %s starting... (PID=%d)\n", PROGRAM_VERSION, (int)getpid());
@@ -675,7 +675,7 @@ int main(int argc, char **argv) {
 				if (daemon_dumps_core)
 					neb_unload_all_modules(NEBMODULE_FORCE_UNLOAD, NEBMODULE_NEB_SHUTDOWN);
 				exit(EXIT_FAILURE);
-				}
+			}
 			timing_point("Modules loaded\n");
 
 			/* send program data to broker */
@@ -696,7 +696,7 @@ int main(int argc, char **argv) {
 				/* run the pre-flight check to make sure everything looks okay*/
 				if((result = pre_flight_check()) != OK)
 					logit(NSLOG_PROCESS_INFO | NSLOG_RUNTIME_ERROR | NSLOG_VERIFICATION_ERROR, TRUE, "Bailing out due to errors encountered while running the pre-flight check.  Run Nagios from the command line with the -v option to verify your config before restarting. (PID=%d)\n", (int)getpid());
-				}
+			}
 
 			/* an error occurred that prevented us from (re)starting */
 			if(result != OK) {
@@ -706,7 +706,7 @@ int main(int argc, char **argv) {
 
 					/* clean up the status data */
 					cleanup_status_data(TRUE);
-					}
+				}
 
 #ifdef USE_EVENT_BROKER
 				/* send program data to broker */
@@ -714,7 +714,7 @@ int main(int argc, char **argv) {
 #endif
 				cleanup();
 				exit(ERROR);
-				}
+			}
 
 			timing_point("Object configuration parsed and understood\n");
 
@@ -735,7 +735,7 @@ int main(int argc, char **argv) {
 			if(sigrestart == FALSE) {
 				initialize_status_data(config_file);
 				timing_point("Status data initialized\n");
-				}
+			}
 
 			/* initialize scheduled downtime data */
 			initialize_downtime_data();
@@ -812,7 +812,7 @@ int main(int argc, char **argv) {
 				if(sig_id == SIGHUP)
 					logit(NSLOG_PROCESS_INFO, TRUE, "Caught SIGHUP, restarting...\n");
 
-				}
+			}
 
 #ifdef USE_EVENT_BROKER
 			/* send program data to broker */
@@ -836,7 +836,7 @@ int main(int argc, char **argv) {
 			/* clean up the status data unless we're restarting */
 			if(sigrestart == FALSE) {
 				cleanup_status_data(TRUE);
-				}
+			}
 
 			free_worker_memory(WPROC_FORCE);
 			/* shutdown stuff... */
@@ -846,7 +846,7 @@ int main(int argc, char **argv) {
 
 				/* log a shutdown message */
 				logit(NSLOG_PROCESS_INFO, TRUE, "Successfully shutdown... (PID=%d)\n", (int)getpid());
-				}
+			}
 
 			/* clean up after ourselves */
 			cleanup();
@@ -854,8 +854,7 @@ int main(int argc, char **argv) {
 			/* close debug log */
 			close_debug_log();
 
-			}
-		while(sigrestart == TRUE && sigshutdown == FALSE);
+		} while(sigrestart == TRUE && sigshutdown == FALSE);
 
 		if(daemon_mode == TRUE)
 			unlink(lock_file);
@@ -865,7 +864,7 @@ int main(int argc, char **argv) {
 		my_free(config_file);
 		my_free(config_file_dir);
 		my_free(nagios_binary_path);
-		}
+	}
 
 	return OK;
-	}
+}

--- a/base/nagiostats.c
+++ b/base/nagiostats.c
@@ -196,7 +196,8 @@ static int read_config_file(void);
 static int read_status_file(void);
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 	int error = FALSE;
 	int display_license = FALSE;
@@ -206,16 +207,16 @@ int main(int argc, char **argv) {
 #ifdef HAVE_GETOPT_H
 	int option_index = 0;
 	static struct option long_options[] = {
-			{"help", no_argument, NULL, 'h'},
-			{"version", no_argument, NULL, 'V'},
-			{"license", no_argument, NULL, 'L'},
-			{"config", required_argument, NULL, 'c'},
-			{"statsfile", required_argument, NULL, 's'},
-			{"mrtg", no_argument, NULL, 'm'},
-			{"data", required_argument, NULL, 'd'},
-			{"delimiter", required_argument, NULL, 'D'},
-			{NULL, 0, NULL, 0}
-		};
+		{"help", no_argument, NULL, 'h'},
+		{"version", no_argument, NULL, 'V'},
+		{"license", no_argument, NULL, 'L'},
+		{"config", required_argument, NULL, 'c'},
+		{"statsfile", required_argument, NULL, 's'},
+		{"mrtg", no_argument, NULL, 'm'},
+		{"data", required_argument, NULL, 'd'},
+		{"delimiter", required_argument, NULL, 'D'},
+		{NULL, 0, NULL, 0}
+	};
 #define getopt(argc, argv, OPTSTR) getopt_long(argc, argv, OPTSTR, long_options, &option_index)
 #endif
 
@@ -232,45 +233,45 @@ int main(int argc, char **argv) {
 
 		switch(c) {
 
-			case '?':
-			case 'h':
-				display_help = TRUE;
-				break;
-			case 'V':
-				display_license = TRUE;
-				break;
-			case 'L':
-				display_license = TRUE;
-				break;
-			case 'c':
-				if(main_config_file)
-					free(main_config_file);
-				main_config_file = strdup(optarg);
-				break;
-			case 's':
-				status_file = strdup(optarg);
-				break;
-			case 'm':
-				mrtg_mode = TRUE;
-				break;
-			case 'd':
-				mrtg_variables = strdup(optarg);
-				break;
-			case 'D':
-				mrtg_delimiter = strdup(optarg);
-				break;
+		case '?':
+		case 'h':
+			display_help = TRUE;
+			break;
+		case 'V':
+			display_license = TRUE;
+			break;
+		case 'L':
+			display_license = TRUE;
+			break;
+		case 'c':
+			if(main_config_file)
+				free(main_config_file);
+			main_config_file = strdup(optarg);
+			break;
+		case 's':
+			status_file = strdup(optarg);
+			break;
+		case 'm':
+			mrtg_mode = TRUE;
+			break;
+		case 'd':
+			mrtg_variables = strdup(optarg);
+			break;
+		case 'D':
+			mrtg_delimiter = strdup(optarg);
+			break;
 
-			default:
-				break;
-			}
+		default:
+			break;
 		}
+	}
 
 	if(mrtg_mode == FALSE) {
 		printf("\nNagios Stats %s\n", PROGRAM_VERSION);
 		printf("Copyright (c) 2003-2008 Ethan Galstad (www.nagios.org)\n");
 		printf("Last Modified: %s\n", PROGRAM_MODIFICATION_DATE);
 		printf("License: GPL\n\n");
-		}
+	}
 
 	/* just display the license */
 	if(display_license == TRUE) {
@@ -287,7 +288,7 @@ int main(int argc, char **argv) {
 		printf("Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.\n\n");
 
 		exit(OK);
-		}
+	}
 
 	/* if there are no command line options (or if we encountered an error), print usage */
 	if(error == TRUE || display_help == TRUE) {
@@ -378,7 +379,7 @@ int main(int argc, char **argv) {
 		printf("\n");
 
 		exit(ERROR);
-		}
+	}
 
 	/* if we got no -s option, we must read the main config file */
 	if (status_file == NULL) {
@@ -387,15 +388,15 @@ int main(int argc, char **argv) {
 		if(result == ERROR && mrtg_mode == FALSE) {
 			printf("Error processing config file '%s'\n", main_config_file);
 			return ERROR;
-			}
 		}
+	}
 
 	/* read status file */
 	result = read_status_file();
 	if(result == ERROR && mrtg_mode == FALSE) {
 		printf("Error reading status file '%s': %s\n", status_file, strerror(errno));
 		return ERROR;
-		}
+	}
 
 	/* display stats */
 	if(mrtg_mode == FALSE)
@@ -408,11 +409,12 @@ int main(int argc, char **argv) {
 		return ERROR;
 	else
 		return OK;
-	}
+}
 
 
 
-static int display_mrtg_values(void) {
+static int display_mrtg_values(void)
+{
 	char *temp_ptr;
 	time_t current_time;
 	unsigned long time_difference;
@@ -433,21 +435,17 @@ static int display_mrtg_values(void) {
 			time_difference = (current_time - program_start);
 			get_time_breakdown(time_difference, &days, &hours, &minutes, &seconds);
 			printf("%dd %dh %dm %ds%s", days, hours, minutes, seconds, mrtg_delimiter);
-			}
-		else if(!strcmp(temp_ptr, "PROGRUNTIMETT")) {
+		} else if(!strcmp(temp_ptr, "PROGRUNTIMETT")) {
 			time_difference = (current_time - program_start);
 			printf("%lu%s", time_difference, mrtg_delimiter);
-			}
-		else if(!strcmp(temp_ptr, "STATUSFILEAGE")) {
+		} else if(!strcmp(temp_ptr, "STATUSFILEAGE")) {
 			time_difference = (current_time - status_creation_date);
 			get_time_breakdown(time_difference, &days, &hours, &minutes, &seconds);
 			printf("%dd %dh %dm %ds%s", days, hours, minutes, seconds, mrtg_delimiter);
-			}
-		else if(!strcmp(temp_ptr, "STATUSFILEAGETT")) {
+		} else if(!strcmp(temp_ptr, "STATUSFILEAGETT")) {
 			time_difference = (current_time - status_creation_date);
 			printf("%lu%s", time_difference, mrtg_delimiter);
-			}
-		else if(!strcmp(temp_ptr, "NAGIOSVERSION"))
+		} else if(!strcmp(temp_ptr, "NAGIOSVERSION"))
 			printf("%s%s", status_version, mrtg_delimiter);
 		else if(!strcmp(temp_ptr, "NAGIOSPID"))
 			printf("%d%s", nagios_pid, mrtg_delimiter);
@@ -724,17 +722,18 @@ static int display_mrtg_values(void) {
 
 		else
 			printf("%s%s", temp_ptr, mrtg_delimiter);
-		}
+	}
 
 	/* add a newline if necessary */
 	if(strcmp(mrtg_delimiter, "\n"))
 		printf("\n");
 
 	return OK;
-	}
+}
 
 
-static int display_stats(void) {
+static int display_stats(void)
+{
 	time_t current_time;
 	unsigned long time_difference;
 	int days;
@@ -822,10 +821,11 @@ static int display_stats(void) {
 	*/
 
 	return OK;
-	}
+}
 
 
-static int read_config_file(void) {
+static int read_config_file(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	FILE *fp;
 	char *var;
@@ -860,17 +860,18 @@ static int read_config_file(void) {
 			if(status_file)
 				free(status_file);
 			status_file = nspath_absolute(val, main_cfg_dir);
-			}
-
 		}
+
+	}
 
 	fclose(fp);
 
 	return OK;
-	}
+}
 
 
-static int read_status_file(void) {
+static int read_status_file(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	FILE *fp = NULL;
 	int data_type = STATUS_NO_DATA;
@@ -911,12 +912,10 @@ static int read_status_file(void) {
 		if(!strcmp(temp_buffer, "servicestatus {")) {
 			data_type = STATUS_SERVICE_DATA;
 			status_service_entries++;
-			}
-		else if(!strcmp(temp_buffer, "hoststatus {")) {
+		} else if(!strcmp(temp_buffer, "hoststatus {")) {
 			data_type = STATUS_HOST_DATA;
 			status_host_entries++;
-			}
-		else if(!strcmp(temp_buffer, "info {"))
+		} else if(!strcmp(temp_buffer, "info {"))
 			data_type = STATUS_INFO_DATA;
 		else if(!strcmp(temp_buffer, "programstatus {"))
 			data_type = STATUS_PROGRAM_DATA;
@@ -927,231 +926,229 @@ static int read_status_file(void) {
 
 			switch(data_type) {
 
-				case STATUS_INFO_DATA:
+			case STATUS_INFO_DATA:
+				break;
+
+			case STATUS_PROGRAM_DATA:
+				/* 02-15-2008 exclude cached host checks from total (they were ondemand checks that never actually executed) */
+				active_host_checks_last_1min = active_scheduled_host_checks_last_1min + active_ondemand_host_checks_last_1min;
+				active_host_checks_last_5min = active_scheduled_host_checks_last_5min + active_ondemand_host_checks_last_5min;
+				active_host_checks_last_15min = active_scheduled_host_checks_last_15min + active_ondemand_host_checks_last_15min;
+
+				/* 02-15-2008 exclude cached service checks from total (they were ondemand checks that never actually executed) */
+				active_service_checks_last_1min = active_scheduled_service_checks_last_1min + active_ondemand_service_checks_last_1min;
+				active_service_checks_last_5min = active_scheduled_service_checks_last_5min + active_ondemand_service_checks_last_5min;
+				active_service_checks_last_15min = active_scheduled_service_checks_last_15min + active_ondemand_service_checks_last_15min;
+				break;
+
+			case STATUS_HOST_DATA:
+				average_host_state_change = (((average_host_state_change * ((double)status_host_entries - 1.0)) + state_change) / (double)status_host_entries);
+				if(have_min_host_state_change == FALSE || min_host_state_change > state_change) {
+					have_min_host_state_change = TRUE;
+					min_host_state_change = state_change;
+				}
+				if(have_max_host_state_change == FALSE || max_host_state_change < state_change) {
+					have_max_host_state_change = TRUE;
+					max_host_state_change = state_change;
+				}
+				if(check_type == CHECK_TYPE_ACTIVE) {
+					active_host_checks++;
+					average_active_host_latency = (((average_active_host_latency * ((double)active_host_checks - 1.0)) + latency) / (double)active_host_checks);
+					if(have_min_active_host_latency == FALSE || min_active_host_latency > latency) {
+						have_min_active_host_latency = TRUE;
+						min_active_host_latency = latency;
+					}
+					if(have_max_active_host_latency == FALSE || max_active_host_latency < latency) {
+						have_max_active_host_latency = TRUE;
+						max_active_host_latency = latency;
+					}
+					average_active_host_execution_time = (((average_active_host_execution_time * ((double)active_host_checks - 1.0)) + execution_time) / (double)active_host_checks);
+					if(have_min_active_host_execution_time == FALSE || min_active_host_execution_time > execution_time) {
+						have_min_active_host_execution_time = TRUE;
+						min_active_host_execution_time = execution_time;
+					}
+					if(have_max_active_host_execution_time == FALSE || max_active_host_execution_time < execution_time) {
+						have_max_active_host_execution_time = TRUE;
+						max_active_host_execution_time = execution_time;
+					}
+					average_active_host_state_change = (((average_active_host_state_change * ((double)active_host_checks - 1.0)) + state_change) / (double)active_host_checks);
+					if(have_min_active_host_state_change == FALSE || min_active_host_state_change > state_change) {
+						have_min_active_host_state_change = TRUE;
+						min_active_host_state_change = state_change;
+					}
+					if(have_max_active_host_state_change == FALSE || max_active_host_state_change < state_change) {
+						have_max_active_host_state_change = TRUE;
+						max_active_host_state_change = state_change;
+					}
+					time_difference = current_time - last_check;
+					if(time_difference <= 3600)
+						active_hosts_checked_last_1hour++;
+					if(time_difference <= 900)
+						active_hosts_checked_last_15min++;
+					if(time_difference <= 300)
+						active_hosts_checked_last_5min++;
+					if(time_difference <= 60)
+						active_hosts_checked_last_1min++;
+				} else {
+					passive_host_checks++;
+					average_passive_host_latency = (((average_passive_host_latency * ((double)passive_host_checks - 1.0)) + latency) / (double)passive_host_checks);
+					if(have_min_passive_host_latency == FALSE || min_passive_host_latency > latency) {
+						have_min_passive_host_latency = TRUE;
+						min_passive_host_latency = latency;
+					}
+					if(have_max_passive_host_latency == FALSE || max_passive_host_latency < latency) {
+						have_max_passive_host_latency = TRUE;
+						max_passive_host_latency = latency;
+					}
+					average_passive_host_state_change = (((average_passive_host_state_change * ((double)passive_host_checks - 1.0)) + state_change) / (double)passive_host_checks);
+					if(have_min_passive_host_state_change == FALSE || min_passive_host_state_change > state_change) {
+						have_min_passive_host_state_change = TRUE;
+						min_passive_host_state_change = state_change;
+					}
+					if(have_max_passive_host_state_change == FALSE || max_passive_host_state_change < state_change) {
+						have_max_passive_host_state_change = TRUE;
+						max_passive_host_state_change = state_change;
+					}
+					time_difference = current_time - last_check;
+					if(time_difference <= 3600)
+						passive_hosts_checked_last_1hour++;
+					if(time_difference <= 900)
+						passive_hosts_checked_last_15min++;
+					if(time_difference <= 300)
+						passive_hosts_checked_last_5min++;
+					if(time_difference <= 60)
+						passive_hosts_checked_last_1min++;
+				}
+				switch(current_state) {
+				case HOST_UP:
+					hosts_up++;
 					break;
-
-				case STATUS_PROGRAM_DATA:
-					/* 02-15-2008 exclude cached host checks from total (they were ondemand checks that never actually executed) */
-					active_host_checks_last_1min = active_scheduled_host_checks_last_1min + active_ondemand_host_checks_last_1min;
-					active_host_checks_last_5min = active_scheduled_host_checks_last_5min + active_ondemand_host_checks_last_5min;
-					active_host_checks_last_15min = active_scheduled_host_checks_last_15min + active_ondemand_host_checks_last_15min;
-
-					/* 02-15-2008 exclude cached service checks from total (they were ondemand checks that never actually executed) */
-					active_service_checks_last_1min = active_scheduled_service_checks_last_1min + active_ondemand_service_checks_last_1min;
-					active_service_checks_last_5min = active_scheduled_service_checks_last_5min + active_ondemand_service_checks_last_5min;
-					active_service_checks_last_15min = active_scheduled_service_checks_last_15min + active_ondemand_service_checks_last_15min;
+				case HOST_DOWN:
+					hosts_down++;
 					break;
-
-				case STATUS_HOST_DATA:
-					average_host_state_change = (((average_host_state_change * ((double)status_host_entries - 1.0)) + state_change) / (double)status_host_entries);
-					if(have_min_host_state_change == FALSE || min_host_state_change > state_change) {
-						have_min_host_state_change = TRUE;
-						min_host_state_change = state_change;
-						}
-					if(have_max_host_state_change == FALSE || max_host_state_change < state_change) {
-						have_max_host_state_change = TRUE;
-						max_host_state_change = state_change;
-						}
-					if(check_type == CHECK_TYPE_ACTIVE) {
-						active_host_checks++;
-						average_active_host_latency = (((average_active_host_latency * ((double)active_host_checks - 1.0)) + latency) / (double)active_host_checks);
-						if(have_min_active_host_latency == FALSE || min_active_host_latency > latency) {
-							have_min_active_host_latency = TRUE;
-							min_active_host_latency = latency;
-							}
-						if(have_max_active_host_latency == FALSE || max_active_host_latency < latency) {
-							have_max_active_host_latency = TRUE;
-							max_active_host_latency = latency;
-							}
-						average_active_host_execution_time = (((average_active_host_execution_time * ((double)active_host_checks - 1.0)) + execution_time) / (double)active_host_checks);
-						if(have_min_active_host_execution_time == FALSE || min_active_host_execution_time > execution_time) {
-							have_min_active_host_execution_time = TRUE;
-							min_active_host_execution_time = execution_time;
-							}
-						if(have_max_active_host_execution_time == FALSE || max_active_host_execution_time < execution_time) {
-							have_max_active_host_execution_time = TRUE;
-							max_active_host_execution_time = execution_time;
-							}
-						average_active_host_state_change = (((average_active_host_state_change * ((double)active_host_checks - 1.0)) + state_change) / (double)active_host_checks);
-						if(have_min_active_host_state_change == FALSE || min_active_host_state_change > state_change) {
-							have_min_active_host_state_change = TRUE;
-							min_active_host_state_change = state_change;
-							}
-						if(have_max_active_host_state_change == FALSE || max_active_host_state_change < state_change) {
-							have_max_active_host_state_change = TRUE;
-							max_active_host_state_change = state_change;
-							}
-						time_difference = current_time - last_check;
-						if(time_difference <= 3600)
-							active_hosts_checked_last_1hour++;
-						if(time_difference <= 900)
-							active_hosts_checked_last_15min++;
-						if(time_difference <= 300)
-							active_hosts_checked_last_5min++;
-						if(time_difference <= 60)
-							active_hosts_checked_last_1min++;
-						}
-					else {
-						passive_host_checks++;
-						average_passive_host_latency = (((average_passive_host_latency * ((double)passive_host_checks - 1.0)) + latency) / (double)passive_host_checks);
-						if(have_min_passive_host_latency == FALSE || min_passive_host_latency > latency) {
-							have_min_passive_host_latency = TRUE;
-							min_passive_host_latency = latency;
-							}
-						if(have_max_passive_host_latency == FALSE || max_passive_host_latency < latency) {
-							have_max_passive_host_latency = TRUE;
-							max_passive_host_latency = latency;
-							}
-						average_passive_host_state_change = (((average_passive_host_state_change * ((double)passive_host_checks - 1.0)) + state_change) / (double)passive_host_checks);
-						if(have_min_passive_host_state_change == FALSE || min_passive_host_state_change > state_change) {
-							have_min_passive_host_state_change = TRUE;
-							min_passive_host_state_change = state_change;
-							}
-						if(have_max_passive_host_state_change == FALSE || max_passive_host_state_change < state_change) {
-							have_max_passive_host_state_change = TRUE;
-							max_passive_host_state_change = state_change;
-							}
-						time_difference = current_time - last_check;
-						if(time_difference <= 3600)
-							passive_hosts_checked_last_1hour++;
-						if(time_difference <= 900)
-							passive_hosts_checked_last_15min++;
-						if(time_difference <= 300)
-							passive_hosts_checked_last_5min++;
-						if(time_difference <= 60)
-							passive_hosts_checked_last_1min++;
-						}
-					switch(current_state) {
-						case HOST_UP:
-							hosts_up++;
-							break;
-						case HOST_DOWN:
-							hosts_down++;
-							break;
-						case HOST_UNREACHABLE:
-							hosts_unreachable++;
-							break;
-						default:
-							break;
-						}
-					if(is_flapping == TRUE)
-						hosts_flapping++;
-					if(downtime_depth > 0)
-						hosts_in_downtime++;
-					if(has_been_checked == TRUE)
-						hosts_checked++;
-					if(should_be_scheduled == TRUE)
-						hosts_scheduled++;
+				case HOST_UNREACHABLE:
+					hosts_unreachable++;
 					break;
-
-				case STATUS_SERVICE_DATA:
-					average_service_state_change = (((average_service_state_change * ((double)status_service_entries - 1.0)) + state_change) / (double)status_service_entries);
-					if(have_min_service_state_change == FALSE || min_service_state_change > state_change) {
-						have_min_service_state_change = TRUE;
-						min_service_state_change = state_change;
-						}
-					if(have_max_service_state_change == FALSE || max_service_state_change < state_change) {
-						have_max_service_state_change = TRUE;
-						max_service_state_change = state_change;
-						}
-					if(check_type == CHECK_TYPE_ACTIVE) {
-						active_service_checks++;
-						average_active_service_latency = (((average_active_service_latency * ((double)active_service_checks - 1.0)) + latency) / (double)active_service_checks);
-						if(have_min_active_service_latency == FALSE || min_active_service_latency > latency) {
-							have_min_active_service_latency = TRUE;
-							min_active_service_latency = latency;
-							}
-						if(have_max_active_service_latency == FALSE || max_active_service_latency < latency) {
-							have_max_active_service_latency = TRUE;
-							max_active_service_latency = latency;
-							}
-						average_active_service_execution_time = (((average_active_service_execution_time * ((double)active_service_checks - 1.0)) + execution_time) / (double)active_service_checks);
-						if(have_min_active_service_execution_time == FALSE || min_active_service_execution_time > execution_time) {
-							have_min_active_service_execution_time = TRUE;
-							min_active_service_execution_time = execution_time;
-							}
-						if(have_max_active_service_execution_time == FALSE || max_active_service_execution_time < execution_time) {
-							have_max_active_service_execution_time = TRUE;
-							max_active_service_execution_time = execution_time;
-							}
-						average_active_service_state_change = (((average_active_service_state_change * ((double)active_service_checks - 1.0)) + state_change) / (double)active_service_checks);
-						if(have_min_active_service_state_change == FALSE || min_active_service_state_change > state_change) {
-							have_min_active_service_state_change = TRUE;
-							min_active_service_state_change = state_change;
-							}
-						if(have_max_active_service_state_change == FALSE || max_active_service_state_change < state_change) {
-							have_max_active_service_state_change = TRUE;
-							max_active_service_state_change = state_change;
-							}
-						time_difference = current_time - last_check;
-						if(time_difference <= 3600)
-							active_services_checked_last_1hour++;
-						if(time_difference <= 900)
-							active_services_checked_last_15min++;
-						if(time_difference <= 300)
-							active_services_checked_last_5min++;
-						if(time_difference <= 60)
-							active_services_checked_last_1min++;
-						}
-					else {
-						passive_service_checks++;
-						average_passive_service_latency = (((average_passive_service_latency * ((double)passive_service_checks - 1.0)) + latency) / (double)passive_service_checks);
-						if(have_min_passive_service_latency == FALSE || min_passive_service_latency > latency) {
-							have_min_passive_service_latency = TRUE;
-							min_passive_service_latency = latency;
-							}
-						if(have_max_passive_service_latency == FALSE || max_passive_service_latency < latency) {
-							have_max_passive_service_latency = TRUE;
-							max_passive_service_latency = latency;
-							}
-						average_passive_service_state_change = (((average_passive_service_state_change * ((double)passive_service_checks - 1.0)) + state_change) / (double)passive_service_checks);
-						if(have_min_passive_service_state_change == FALSE || min_passive_service_state_change > state_change) {
-							have_min_passive_service_state_change = TRUE;
-							min_passive_service_state_change = state_change;
-							}
-						if(have_max_passive_service_state_change == FALSE || max_passive_service_state_change < state_change) {
-							have_max_passive_service_state_change = TRUE;
-							max_passive_service_state_change = state_change;
-							}
-						time_difference = current_time - last_check;
-						if(time_difference <= 3600)
-							passive_services_checked_last_1hour++;
-						if(time_difference <= 900)
-							passive_services_checked_last_15min++;
-						if(time_difference <= 300)
-							passive_services_checked_last_5min++;
-						if(time_difference <= 60)
-							passive_services_checked_last_1min++;
-						}
-					switch(current_state) {
-						case STATE_OK:
-							services_ok++;
-							break;
-						case STATE_WARNING:
-							services_warning++;
-							break;
-						case STATE_UNKNOWN:
-							services_unknown++;
-							break;
-						case STATE_CRITICAL:
-							services_critical++;
-							break;
-						default:
-							break;
-						}
-					if(is_flapping == TRUE)
-						services_flapping++;
-					if(downtime_depth > 0)
-						services_in_downtime++;
-					if(has_been_checked == TRUE)
-						services_checked++;
-					if(should_be_scheduled == TRUE)
-						services_scheduled++;
-					break;
-
 				default:
 					break;
 				}
+				if(is_flapping == TRUE)
+					hosts_flapping++;
+				if(downtime_depth > 0)
+					hosts_in_downtime++;
+				if(has_been_checked == TRUE)
+					hosts_checked++;
+				if(should_be_scheduled == TRUE)
+					hosts_scheduled++;
+				break;
+
+			case STATUS_SERVICE_DATA:
+				average_service_state_change = (((average_service_state_change * ((double)status_service_entries - 1.0)) + state_change) / (double)status_service_entries);
+				if(have_min_service_state_change == FALSE || min_service_state_change > state_change) {
+					have_min_service_state_change = TRUE;
+					min_service_state_change = state_change;
+				}
+				if(have_max_service_state_change == FALSE || max_service_state_change < state_change) {
+					have_max_service_state_change = TRUE;
+					max_service_state_change = state_change;
+				}
+				if(check_type == CHECK_TYPE_ACTIVE) {
+					active_service_checks++;
+					average_active_service_latency = (((average_active_service_latency * ((double)active_service_checks - 1.0)) + latency) / (double)active_service_checks);
+					if(have_min_active_service_latency == FALSE || min_active_service_latency > latency) {
+						have_min_active_service_latency = TRUE;
+						min_active_service_latency = latency;
+					}
+					if(have_max_active_service_latency == FALSE || max_active_service_latency < latency) {
+						have_max_active_service_latency = TRUE;
+						max_active_service_latency = latency;
+					}
+					average_active_service_execution_time = (((average_active_service_execution_time * ((double)active_service_checks - 1.0)) + execution_time) / (double)active_service_checks);
+					if(have_min_active_service_execution_time == FALSE || min_active_service_execution_time > execution_time) {
+						have_min_active_service_execution_time = TRUE;
+						min_active_service_execution_time = execution_time;
+					}
+					if(have_max_active_service_execution_time == FALSE || max_active_service_execution_time < execution_time) {
+						have_max_active_service_execution_time = TRUE;
+						max_active_service_execution_time = execution_time;
+					}
+					average_active_service_state_change = (((average_active_service_state_change * ((double)active_service_checks - 1.0)) + state_change) / (double)active_service_checks);
+					if(have_min_active_service_state_change == FALSE || min_active_service_state_change > state_change) {
+						have_min_active_service_state_change = TRUE;
+						min_active_service_state_change = state_change;
+					}
+					if(have_max_active_service_state_change == FALSE || max_active_service_state_change < state_change) {
+						have_max_active_service_state_change = TRUE;
+						max_active_service_state_change = state_change;
+					}
+					time_difference = current_time - last_check;
+					if(time_difference <= 3600)
+						active_services_checked_last_1hour++;
+					if(time_difference <= 900)
+						active_services_checked_last_15min++;
+					if(time_difference <= 300)
+						active_services_checked_last_5min++;
+					if(time_difference <= 60)
+						active_services_checked_last_1min++;
+				} else {
+					passive_service_checks++;
+					average_passive_service_latency = (((average_passive_service_latency * ((double)passive_service_checks - 1.0)) + latency) / (double)passive_service_checks);
+					if(have_min_passive_service_latency == FALSE || min_passive_service_latency > latency) {
+						have_min_passive_service_latency = TRUE;
+						min_passive_service_latency = latency;
+					}
+					if(have_max_passive_service_latency == FALSE || max_passive_service_latency < latency) {
+						have_max_passive_service_latency = TRUE;
+						max_passive_service_latency = latency;
+					}
+					average_passive_service_state_change = (((average_passive_service_state_change * ((double)passive_service_checks - 1.0)) + state_change) / (double)passive_service_checks);
+					if(have_min_passive_service_state_change == FALSE || min_passive_service_state_change > state_change) {
+						have_min_passive_service_state_change = TRUE;
+						min_passive_service_state_change = state_change;
+					}
+					if(have_max_passive_service_state_change == FALSE || max_passive_service_state_change < state_change) {
+						have_max_passive_service_state_change = TRUE;
+						max_passive_service_state_change = state_change;
+					}
+					time_difference = current_time - last_check;
+					if(time_difference <= 3600)
+						passive_services_checked_last_1hour++;
+					if(time_difference <= 900)
+						passive_services_checked_last_15min++;
+					if(time_difference <= 300)
+						passive_services_checked_last_5min++;
+					if(time_difference <= 60)
+						passive_services_checked_last_1min++;
+				}
+				switch(current_state) {
+				case STATE_OK:
+					services_ok++;
+					break;
+				case STATE_WARNING:
+					services_warning++;
+					break;
+				case STATE_UNKNOWN:
+					services_unknown++;
+					break;
+				case STATE_CRITICAL:
+					services_critical++;
+					break;
+				default:
+					break;
+				}
+				if(is_flapping == TRUE)
+					services_flapping++;
+				if(downtime_depth > 0)
+					services_in_downtime++;
+				if(has_been_checked == TRUE)
+					services_checked++;
+				if(should_be_scheduled == TRUE)
+					services_scheduled++;
+				break;
+
+			default:
+				break;
+			}
 
 			data_type = STATUS_NO_DATA;
 
@@ -1165,7 +1162,7 @@ static int read_status_file(void) {
 			last_check = (time_t)0;
 			has_been_checked = FALSE;
 			should_be_scheduled = FALSE;
-			}
+		}
 
 
 		/* inside definition */
@@ -1178,169 +1175,160 @@ static int read_status_file(void) {
 
 			switch(data_type) {
 
-				case STATUS_INFO_DATA:
-					if(!strcmp(var, "created"))
-						status_creation_date = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "version"))
-						status_version = strdup(val);
-					break;
+			case STATUS_INFO_DATA:
+				if(!strcmp(var, "created"))
+					status_creation_date = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "version"))
+					status_version = strdup(val);
+				break;
 
-				case STATUS_PROGRAM_DATA:
-					if(!strcmp(var, "program_start"))
-						program_start = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "nagios_pid"))
-						nagios_pid = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "active_scheduled_host_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							active_scheduled_host_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_scheduled_host_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_scheduled_host_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "active_ondemand_host_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							active_ondemand_host_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_ondemand_host_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_ondemand_host_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "cached_host_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							active_cached_host_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_cached_host_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_cached_host_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "passive_host_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							passive_host_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							passive_host_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							passive_host_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "active_scheduled_service_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							active_scheduled_service_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_scheduled_service_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_scheduled_service_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "active_ondemand_service_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							active_ondemand_service_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_ondemand_service_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_ondemand_service_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "cached_service_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							active_cached_service_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_cached_service_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							active_cached_service_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "passive_service_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							passive_service_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							passive_service_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							passive_service_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "external_command_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							external_commands_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							external_commands_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							external_commands_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "parallel_host_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							parallel_host_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							parallel_host_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							parallel_host_checks_last_15min = atoi(temp_ptr);
-						}
-					else if(!strcmp(var, "serial_host_check_stats")) {
-						if((temp_ptr = strtok(val, ",")))
-							serial_host_checks_last_1min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							serial_host_checks_last_5min = atoi(temp_ptr);
-						if((temp_ptr = strtok(NULL, ",")))
-							serial_host_checks_last_15min = atoi(temp_ptr);
-						}
-					break;
-
-				case STATUS_HOST_DATA:
-					if(!strcmp(var, "check_execution_time"))
-						execution_time = strtod(val, NULL);
-					else if(!strcmp(var, "check_latency"))
-						latency = strtod(val, NULL);
-					else if(!strcmp(var, "percent_state_change"))
-						state_change = strtod(val, NULL);
-					else if(!strcmp(var, "check_type"))
-						check_type = atoi(val);
-					else if(!strcmp(var, "current_state"))
-						current_state = atoi(val);
-					else if(!strcmp(var, "is_flapping"))
-						is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "scheduled_downtime_depth"))
-						downtime_depth = atoi(val);
-					else if(!strcmp(var, "last_check"))
-						last_check = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "has_been_checked"))
-						has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "should_be_scheduled"))
-						should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
-					break;
-
-				case STATUS_SERVICE_DATA:
-					if(!strcmp(var, "check_execution_time"))
-						execution_time = strtod(val, NULL);
-					else if(!strcmp(var, "check_latency"))
-						latency = strtod(val, NULL);
-					else if(!strcmp(var, "percent_state_change"))
-						state_change = strtod(val, NULL);
-					else if(!strcmp(var, "check_type"))
-						check_type = atoi(val);
-					else if(!strcmp(var, "current_state"))
-						current_state = atoi(val);
-					else if(!strcmp(var, "is_flapping"))
-						is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "scheduled_downtime_depth"))
-						downtime_depth = atoi(val);
-					else if(!strcmp(var, "last_check"))
-						last_check = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "has_been_checked"))
-						has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "should_be_scheduled"))
-						should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
-					break;
-
-				default:
-					break;
+			case STATUS_PROGRAM_DATA:
+				if(!strcmp(var, "program_start"))
+					program_start = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "nagios_pid"))
+					nagios_pid = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "active_scheduled_host_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						active_scheduled_host_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_scheduled_host_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_scheduled_host_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "active_ondemand_host_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						active_ondemand_host_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_ondemand_host_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_ondemand_host_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "cached_host_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						active_cached_host_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_cached_host_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_cached_host_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "passive_host_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						passive_host_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						passive_host_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						passive_host_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "active_scheduled_service_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						active_scheduled_service_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_scheduled_service_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_scheduled_service_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "active_ondemand_service_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						active_ondemand_service_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_ondemand_service_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_ondemand_service_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "cached_service_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						active_cached_service_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_cached_service_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						active_cached_service_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "passive_service_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						passive_service_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						passive_service_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						passive_service_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "external_command_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						external_commands_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						external_commands_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						external_commands_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "parallel_host_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						parallel_host_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						parallel_host_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						parallel_host_checks_last_15min = atoi(temp_ptr);
+				} else if(!strcmp(var, "serial_host_check_stats")) {
+					if((temp_ptr = strtok(val, ",")))
+						serial_host_checks_last_1min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						serial_host_checks_last_5min = atoi(temp_ptr);
+					if((temp_ptr = strtok(NULL, ",")))
+						serial_host_checks_last_15min = atoi(temp_ptr);
 				}
+				break;
 
+			case STATUS_HOST_DATA:
+				if(!strcmp(var, "check_execution_time"))
+					execution_time = strtod(val, NULL);
+				else if(!strcmp(var, "check_latency"))
+					latency = strtod(val, NULL);
+				else if(!strcmp(var, "percent_state_change"))
+					state_change = strtod(val, NULL);
+				else if(!strcmp(var, "check_type"))
+					check_type = atoi(val);
+				else if(!strcmp(var, "current_state"))
+					current_state = atoi(val);
+				else if(!strcmp(var, "is_flapping"))
+					is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "scheduled_downtime_depth"))
+					downtime_depth = atoi(val);
+				else if(!strcmp(var, "last_check"))
+					last_check = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "has_been_checked"))
+					has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "should_be_scheduled"))
+					should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
+				break;
+
+			case STATUS_SERVICE_DATA:
+				if(!strcmp(var, "check_execution_time"))
+					execution_time = strtod(val, NULL);
+				else if(!strcmp(var, "check_latency"))
+					latency = strtod(val, NULL);
+				else if(!strcmp(var, "percent_state_change"))
+					state_change = strtod(val, NULL);
+				else if(!strcmp(var, "check_type"))
+					check_type = atoi(val);
+				else if(!strcmp(var, "current_state"))
+					current_state = atoi(val);
+				else if(!strcmp(var, "is_flapping"))
+					is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "scheduled_downtime_depth"))
+					downtime_depth = atoi(val);
+				else if(!strcmp(var, "last_check"))
+					last_check = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "has_been_checked"))
+					has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "should_be_scheduled"))
+					should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
+				break;
+
+			default:
+				break;
 			}
+
 		}
+	}
 
 	fclose(fp);
 
 	return OK;
-	}
+}
 
 
 /* strip newline, carriage return, and tab characters from beginning and end of a string */
-void strip(char *buffer) {
+void strip(char *buffer)
+{
 	register int x;
 	register int y;
 	register int z;
@@ -1355,7 +1343,7 @@ void strip(char *buffer) {
 			buffer[x] = '\x0';
 		else
 			break;
-		}
+	}
 
 	/* strip beginning of string (by shifting) */
 	y = (int)strlen(buffer);
@@ -1364,20 +1352,21 @@ void strip(char *buffer) {
 			continue;
 		else
 			break;
-		}
+	}
 	if(x > 0) {
 		for(z = x; z < y; z++)
 			buffer[z - x] = buffer[z];
 		buffer[y - x] = '\x0';
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* get days, hours, minutes, and seconds from a raw time_t format or total seconds */
-void get_time_breakdown(unsigned long raw_time, int *days, int *hours, int *minutes, int *seconds) {
+void get_time_breakdown(unsigned long raw_time, int *days, int *hours, int *minutes, int *seconds)
+{
 	unsigned long temp_time;
 	int temp_days;
 	int temp_hours;
@@ -1400,4 +1389,4 @@ void get_time_breakdown(unsigned long raw_time, int *days, int *hours, int *minu
 	*seconds = temp_seconds;
 
 	return;
-	}
+}

--- a/base/nebmods.c
+++ b/base/nebmods.c
@@ -53,23 +53,26 @@ static nebcallback **neb_callback_list;
 /****************************************************************************/
 
 /* initialize module routines */
-int neb_init_modules(void) {
+int neb_init_modules(void)
+{
 	if(lt_dlinit())
 		return ERROR;
 	return OK;
-	}
+}
 
 
 /* deinitialize module routines */
-int neb_deinit_modules(void) {
+int neb_deinit_modules(void)
+{
 	if(lt_dlexit())
 		return ERROR;
 	return OK;
-	}
+}
 
 
 /* add a new module to module list */
-int neb_add_module(char *filename, char *args, int should_be_loaded) {
+int neb_add_module(char *filename, char *args, int should_be_loaded)
+{
 	nebmodule *new_module = NULL;
 	int x = OK;
 
@@ -99,10 +102,11 @@ int neb_add_module(char *filename, char *args, int should_be_loaded) {
 	log_debug_info(DEBUGL_EVENTBROKER, 0, "Added module: name='%s', args='%s', should_be_loaded='%d'\n", filename, args, should_be_loaded);
 
 	return OK;
-	}
+}
 
 
-int neb_add_core_module(nebmodule *mod) {
+int neb_add_core_module(nebmodule *mod)
+{
 	mod->should_be_loaded = FALSE;
 	mod->is_currently_loaded = TRUE;
 	mod->core_module = TRUE;
@@ -110,10 +114,11 @@ int neb_add_core_module(nebmodule *mod) {
 	mod->next = neb_module_list;
 	neb_module_list = mod;
 	return 0;
-	}
+}
 
 /* free memory allocated to module list */
-int neb_free_module_list(void) {
+int neb_free_module_list(void)
+{
 	nebmodule *temp_module = NULL;
 	nebmodule *next_module = NULL;
 	int x = OK;
@@ -130,12 +135,12 @@ int neb_free_module_list(void) {
 		my_free(temp_module->filename);
 		my_free(temp_module->args);
 		my_free(temp_module);
-		}
+	}
 
 	neb_module_list = NULL;
 
 	return OK;
-	}
+}
 
 
 
@@ -147,7 +152,8 @@ int neb_free_module_list(void) {
 
 
 /* load all modules */
-int neb_load_all_modules(void) {
+int neb_load_all_modules(void)
+{
 	nebmodule *temp_module = NULL;
 	int ret, errors = 0;
 
@@ -156,15 +162,16 @@ int neb_load_all_modules(void) {
 		if (ret != OK) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to load module '%s'.\n", temp_module->filename ? temp_module->filename : "(no file?)");
 			errors++;
-			}
 		}
+	}
 
 	return errors ? ERROR : OK;
-	}
+}
 
 
 /* load a particular module */
-int neb_load_module(nebmodule *mod) {
+int neb_load_module(nebmodule *mod)
+{
 	int (*initfunc)(int, char *, void *);
 	int *module_version_ptr = NULL;
 	int result = OK;
@@ -186,7 +193,7 @@ int neb_load_module(nebmodule *mod) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Could not load module '%s' -> %s\n", mod->filename, dlerror());
 
 		return ERROR;
-		}
+	}
 
 	/* mark the module as being loaded */
 	mod->is_currently_loaded = TRUE;
@@ -202,7 +209,7 @@ int neb_load_module(nebmodule *mod) {
 		neb_unload_module(mod, NEBMODULE_FORCE_UNLOAD, NEBMODULE_ERROR_API_VERSION);
 
 		return ERROR;
-		}
+	}
 
 	/* locate the initialization function */
 	mod->init_func = dlsym(mod->module_handle, "nebmodule_init");
@@ -215,7 +222,7 @@ int neb_load_module(nebmodule *mod) {
 		neb_unload_module(mod, NEBMODULE_FORCE_UNLOAD, NEBMODULE_ERROR_NO_INIT);
 
 		return ERROR;
-		}
+	}
 
 	/* run the module's init function */
 	initfunc = mod->init_func;
@@ -229,7 +236,7 @@ int neb_load_module(nebmodule *mod) {
 		neb_unload_module(mod, NEBMODULE_FORCE_UNLOAD, NEBMODULE_ERROR_BAD_INIT);
 
 		return ERROR;
-		}
+	}
 
 	logit(NSLOG_INFO_MESSAGE, TRUE, "Event broker module '%s' initialized successfully.\n", mod->filename);
 
@@ -241,11 +248,12 @@ int neb_load_module(nebmodule *mod) {
 		log_debug_info(DEBUGL_EVENTBROKER, 0, "nebmodule_deinit() found\n");
 
 	return OK;
-	}
+}
 
 
 /* close (unload) all modules that are currently loaded */
-int neb_unload_all_modules(int flags, int reason) {
+int neb_unload_all_modules(int flags, int reason)
+{
 	nebmodule *temp_module;
 
 	for(temp_module = neb_module_list; temp_module; temp_module = temp_module->next) {
@@ -260,15 +268,16 @@ int neb_unload_all_modules(int flags, int reason) {
 
 		/* close/unload the module */
 		neb_unload_module(temp_module, flags, reason);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* close (unload) a particular module */
-int neb_unload_module(nebmodule *mod, int flags, int reason) {
+int neb_unload_module(nebmodule *mod, int flags, int reason)
+{
 	int (*deinitfunc)(int, int);
 	int result = OK;
 
@@ -294,7 +303,7 @@ int neb_unload_module(nebmodule *mod, int flags, int reason) {
 		/* if module doesn't want to be unloaded, exit with error (unless its being forced) */
 		if(result != OK && !(flags & NEBMODULE_FORCE_UNLOAD))
 			return ERROR;
-		}
+	}
 
 	/* deregister all of the module's callbacks */
 	neb_deregister_module_callbacks(mod);
@@ -307,8 +316,8 @@ int neb_unload_module(nebmodule *mod, int flags, int reason) {
 		if (result != 0) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Could not unload module '%s' -> %s\n", mod->filename, dlerror());
 			return ERROR;
-			}
 		}
+	}
 
 	/* mark the module as being unloaded */
 	mod->is_currently_loaded = FALSE;
@@ -318,7 +327,7 @@ int neb_unload_module(nebmodule *mod, int flags, int reason) {
 	logit(NSLOG_INFO_MESSAGE, FALSE, "Event broker module '%s' deinitialized successfully.\n", mod->filename);
 
 	return OK;
-	}
+}
 
 
 
@@ -330,7 +339,8 @@ int neb_unload_module(nebmodule *mod, int flags, int reason) {
 /****************************************************************************/
 
 /* sets module information */
-int neb_set_module_info(void *handle, int type, char *data) {
+int neb_set_module_info(void *handle, int type, char *data)
+{
 	nebmodule *temp_module = NULL;
 
 	if(handle == NULL)
@@ -344,7 +354,7 @@ int neb_set_module_info(void *handle, int type, char *data) {
 	for(temp_module = neb_module_list; temp_module != NULL; temp_module = temp_module->next) {
 		if(temp_module->module_handle == handle)
 			break;
-		}
+	}
 	if(temp_module == NULL)
 		return NEBERROR_BADMODULEHANDLE;
 
@@ -356,7 +366,7 @@ int neb_set_module_info(void *handle, int type, char *data) {
 		return NEBERROR_NOMEM;
 
 	return OK;
-	}
+}
 
 
 
@@ -367,7 +377,8 @@ int neb_set_module_info(void *handle, int type, char *data) {
 /****************************************************************************/
 
 /* allows a module to register a callback function */
-int neb_register_callback(int callback_type, void *mod_handle, int priority, int (*callback_func)(int, void *)) {
+int neb_register_callback(int callback_type, void *mod_handle, int priority, int (*callback_func)(int, void *))
+{
 	nebmodule *temp_module = NULL;
 	nebcallback *new_callback = NULL;
 	nebcallback *temp_callback = NULL;
@@ -390,7 +401,7 @@ int neb_register_callback(int callback_type, void *mod_handle, int priority, int
 	for(temp_module = neb_module_list; temp_module; temp_module = temp_module->next) {
 		if(temp_module->module_handle == mod_handle)
 			break;
-		}
+	}
 	if(temp_module == NULL)
 		return NEBERROR_BADMODULEHANDLE;
 
@@ -413,7 +424,7 @@ int neb_register_callback(int callback_type, void *mod_handle, int priority, int
 			if(temp_callback->priority > new_callback->priority)
 				break;
 			last_callback = temp_callback;
-			}
+		}
 		if(last_callback == NULL)
 			neb_callback_list[callback_type] = new_callback;
 		else {
@@ -422,17 +433,18 @@ int neb_register_callback(int callback_type, void *mod_handle, int priority, int
 			else {
 				new_callback->next = temp_callback;
 				last_callback->next = new_callback;
-				}
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* dregisters all callback functions for a given module */
-int neb_deregister_module_callbacks(nebmodule *mod) {
+int neb_deregister_module_callbacks(nebmodule *mod)
+{
 	nebcallback *temp_callback = NULL;
 	nebcallback *next_callback = NULL;
 	int callback_type = 0;
@@ -448,16 +460,17 @@ int neb_deregister_module_callbacks(nebmodule *mod) {
 			next_callback = temp_callback->next;
 			if(temp_callback->module_handle == mod->module_handle)
 				neb_deregister_callback(callback_type, (int(*)(int, void*))temp_callback->callback_func);
-			}
-
 		}
 
-	return OK;
 	}
+
+	return OK;
+}
 
 
 /* allows a module to deregister a callback function */
-int neb_deregister_callback(int callback_type, int (*callback_func)(int, void *)) {
+int neb_deregister_callback(int callback_type, int (*callback_func)(int, void *))
+{
 	nebcallback *temp_callback = NULL;
 	nebcallback *last_callback = NULL;
 	nebcallback *next_callback = NULL;
@@ -481,7 +494,7 @@ int neb_deregister_callback(int callback_type, int (*callback_func)(int, void *)
 			break;
 
 		last_callback = temp_callback;
-		}
+	}
 
 	/* we couldn't find the callback */
 	if(temp_callback == NULL)
@@ -494,15 +507,16 @@ int neb_deregister_callback(int callback_type, int (*callback_func)(int, void *)
 		else
 			last_callback->next = next_callback;
 		my_free(temp_callback);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* make callbacks to modules */
-int neb_make_callbacks(int callback_type, void *data) {
+int neb_make_callbacks(int callback_type, void *data)
+{
 	nebcallback *temp_callback, *next_callback;
 	int (*callbackfunc)(int, void *);
 	register int cbresult = 0;
@@ -536,15 +550,16 @@ int neb_make_callbacks(int callback_type, void *data) {
 		/* not sure if we should bail out here just because one module wants to override things - what about other modules? EG 12/11/2006 */
 		else if(cbresult == NEBERROR_CALLBACKOVERRIDE)
 			break;
-		}
+	}
 
 	return cbresult;
-	}
+}
 
 
 
 /* initialize callback list */
-int neb_init_callback_list(void) {
+int neb_init_callback_list(void)
+{
 	register int x = 0;
 
 	/* allocate memory for the callback list */
@@ -557,11 +572,12 @@ int neb_init_callback_list(void) {
 		neb_callback_list[x] = NULL;
 
 	return OK;
-	}
+}
 
 
 /* free memory allocated to callback list */
-int neb_free_callback_list(void) {
+int neb_free_callback_list(void)
+{
 	nebcallback *temp_callback = NULL;
 	nebcallback *next_callback = NULL;
 	register int x = 0;
@@ -574,14 +590,14 @@ int neb_free_callback_list(void) {
 		for(temp_callback = neb_callback_list[x]; temp_callback != NULL; temp_callback = next_callback) {
 			next_callback = temp_callback->next;
 			my_free(temp_callback);
-			}
+		}
 
 		neb_callback_list[x] = NULL;
-		}
+	}
 
 	my_free(neb_callback_list);
 
 	return OK;
-	}
+}
 
 #endif

--- a/base/nerd.c
+++ b/base/nerd.c
@@ -84,7 +84,7 @@ static int nerd_register_channel_callbacks(struct nerd_channel *chan)
 		int result = neb_register_callback(chan->callbacks[i], &nerd_mod, 0, chan->handler);
 		if(result != 0) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "nerd: Failed to register callback %d for channel '%s': %d\n",
-				  chan->callbacks[i], chan->name, result);
+			      chan->callbacks[i], chan->name, result);
 			return -1;
 		}
 	}
@@ -148,7 +148,7 @@ static int cancel_channel_subscription(struct nerd_channel *chan, int sd)
 
 	if(cancelled) {
 		logit(NSLOG_INFO_MESSAGE, TRUE, "nerd: Cancelled %d subscription%s to channel '%s' for %d\n",
-			  cancelled, cancelled == 1 ? "" : "s", chan->name, sd);
+		      cancelled, cancelled == 1 ? "" : "s", chan->name, sd);
 	}
 
 	if(chan->subscriptions == NULL)
@@ -324,7 +324,7 @@ static int chan_opath_checks(int cb, void *data)
 		h = ds->object_ptr;
 		color = red | green;
 	} else if(cb == NEBCALLBACK_SERVICE_CHECK_DATA) {
-	   nebstruct_service_check_data *ds = (nebstruct_service_check_data *)data;
+		nebstruct_service_check_data *ds = (nebstruct_service_check_data *)data;
 		service *s;
 
 		if(ds->type != NEBTYPE_SERVICECHECK_PROCESSED)
@@ -338,7 +338,7 @@ static int chan_opath_checks(int cb, void *data)
 		return 0;
 
 	asprintf(&buf, "%lu|%s|M|%s/%s|%06X\n", cr->finish_time.tv_sec,
-			 check_result_source(cr), host_parent_path(h, '/'), name, color);
+	         check_result_source(cr), host_parent_path(h, '/'), name, color);
 	nerd_broadcast(chan_opath_checks_id, buf, strlen(buf));
 	free(buf);
 	return 0;
@@ -419,10 +419,10 @@ static int nerd_qh_handler(int sd, char *request, unsigned int len)
 
 	if (!*request || !strcmp(request, "help")) {
 		nsock_printf_nul(sd, "Manage subscriptions to NERD channels.\n"
-			"Valid commands:\n"
-			"  list                      list available channels\n"
-			"  subscribe <channel>       subscribe to a channel\n"
-			"  unsubscribe <channel>     unsubscribe to a channel\n");
+		                 "Valid commands:\n"
+		                 "  list                      list available channels\n"
+		                 "  subscribe <channel>       subscribe to a channel\n"
+		                 "  unsubscribe <channel>     unsubscribe to a channel\n");
 		return 0;
 	}
 
@@ -481,14 +481,14 @@ int nerd_init(void)
 	neb_add_core_module(&nerd_mod);
 
 	chan_host_checks_id = nerd_mkchan("hostchecks",
-			"Host check results",
-			chan_host_checks, nebcallback_flag(NEBCALLBACK_HOST_CHECK_DATA));
+	                                  "Host check results",
+	                                  chan_host_checks, nebcallback_flag(NEBCALLBACK_HOST_CHECK_DATA));
 	chan_service_checks_id = nerd_mkchan("servicechecks",
-			"Service check results",
-			chan_service_checks, nebcallback_flag(NEBCALLBACK_SERVICE_CHECK_DATA));
+	                                     "Service check results",
+	                                     chan_service_checks, nebcallback_flag(NEBCALLBACK_SERVICE_CHECK_DATA));
 	chan_opath_checks_id = nerd_mkchan("opathchecks",
-			"Host and service checks in gource's log format",
-			chan_opath_checks, nebcallback_flag(NEBCALLBACK_HOST_CHECK_DATA) | nebcallback_flag(NEBCALLBACK_SERVICE_CHECK_DATA));
+	                                   "Host and service checks in gource's log format",
+	                                   chan_opath_checks, nebcallback_flag(NEBCALLBACK_HOST_CHECK_DATA) | nebcallback_flag(NEBCALLBACK_SERVICE_CHECK_DATA));
 
 	logit(NSLOG_INFO_MESSAGE, TRUE, "nerd: Fully initialized and ready to rock!\n");
 	return 0;

--- a/base/netutils.c
+++ b/base/netutils.c
@@ -27,7 +27,8 @@
 
 
 /* connect to a TCP socket in nonblocking fashion */
-int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) {
+int my_tcp_connect(const char *host_name, int port, int *sd, int timeout)
+{
 	struct addrinfo hints;
 	struct addrinfo *res;
 	int result;
@@ -52,14 +53,14 @@ int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) {
 	if(result != 0) {
 		/*printf("GETADDRINFO: %s (%s) = %s\n",host_name,port_str,gai_strerror(result));*/
 		return ERROR;
-		}
+	}
 
 	/* create a socket */
 	*sd = socket(res->ai_family, SOCK_STREAM, res->ai_protocol);
 	if(*sd < 0) {
 		freeaddrinfo(res);
 		return ERROR;
-		}
+	}
 
 	/* make socket non-blocking */
 	flags = fcntl(*sd, F_GETFL, 0);
@@ -72,12 +73,12 @@ int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) {
 	if(result == 0) {
 		result = OK;
 		/*printf("IMMEDIATE SUCCESS\n");*/
-		}
+	}
 
 	/* connection error */
 	else if(result < 0 && errno != EINPROGRESS) {
 		result = ERROR;
-		}
+	}
 
 	/* connection in progress - wait for it... */
 	else {
@@ -101,13 +102,13 @@ int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) {
 				/*printf("TIMEOUT\n");*/
 				result = ERROR;
 				break;
-				}
+			}
 
 			/* an error occurred */
 			if(result < 0 && errno != EINTR) {
 				result = ERROR;
 				break;
-				}
+			}
 
 			/* got something - check it */
 			else if(result > 0) {
@@ -117,13 +118,13 @@ int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) {
 				if(getsockopt(*sd, SOL_SOCKET, SO_ERROR, (void *)(&optval), &optlen) < 0) {
 					result = ERROR;
 					break;
-					}
+				}
 
 				/* an error occurred in the connection */
 				if(optval != 0) {
 					result = ERROR;
 					break;
-					}
+				}
 
 				/* the connection was good! */
 				/*
@@ -132,27 +133,27 @@ int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) {
 				*/
 				result = OK;
 				break;
-				}
+			}
 
 			/* some other error occurred */
 			else {
 				result = ERROR;
 				break;
-				}
-
 			}
-		while(1);
-		}
+
+		} while(1);
+	}
 
 
 	freeaddrinfo(res);
 
 	return result;
-	}
+}
 
 
 /* based on Beej's sendall - thanks Beej! */
-int my_sendall(int s, const char *buf, int *len, int timeout) {
+int my_sendall(int s, const char *buf, int *len, int timeout)
+{
 	int total_sent = 0;
 	int bytes_left = 0;
 	int n;
@@ -182,13 +183,13 @@ int my_sendall(int s, const char *buf, int *len, int timeout) {
 			/*printf("RECV SELECT TIMEOUT\n");*/
 			result = ERROR;
 			break;
-			}
+		}
 		/* error */
 		else if(result < 0) {
 			/*printf("RECV SELECT ERROR: %s\n",strerror(errno));*/
 			result = ERROR;
 			break;
-			}
+		}
 
 		/* we're ready to write some data */
 		result = OK;
@@ -198,7 +199,7 @@ int my_sendall(int s, const char *buf, int *len, int timeout) {
 		if(n == -1) {
 			/*printf("SEND ERROR: (%d) %s\n",s,strerror(errno));*/
 			break;
-			}
+		}
 
 		total_sent += n;
 		bytes_left -= n;
@@ -208,17 +209,18 @@ int my_sendall(int s, const char *buf, int *len, int timeout) {
 		if(current_time - start_time > timeout) {
 			result = ERROR;
 			break;
-			}
 		}
+	}
 
 	*len = total_sent;
 
 	return result;
-	}
+}
 
 
 /* receives all data in non-blocking mode with a timeout  - modelled after sendall() */
-int my_recvall(int s, char *buf, int *len, int timeout) {
+int my_recvall(int s, char *buf, int *len, int timeout)
+{
 	int total_received = 0;
 	int bytes_left = *len;
 	int n = 0;
@@ -251,13 +253,13 @@ int my_recvall(int s, char *buf, int *len, int timeout) {
 			/*printf("RECV SELECT TIMEOUT\n");*/
 			result = ERROR;
 			break;
-			}
+		}
 		/* error */
 		else if(result < 0) {
 			/*printf("RECV SELECT ERROR: %s\n",strerror(errno));*/
 			result = ERROR;
 			break;
-			}
+		}
 
 		/* we're ready to read some data */
 		result = OK;
@@ -269,7 +271,7 @@ int my_recvall(int s, char *buf, int *len, int timeout) {
 		if(n == 0) {
 			/*printf("SERVER DISCONNECT\n");*/
 			break;
-			}
+		}
 
 		/* apply bytes we received */
 		total_received += n;
@@ -280,11 +282,11 @@ int my_recvall(int s, char *buf, int *len, int timeout) {
 		if(current_time - start_time > timeout) {
 			result = ERROR;
 			break;
-			}
 		}
+	}
 
 	/* return number of bytes actually received here */
 	*len = total_received;
 
 	return result;
-	}
+}

--- a/base/notifications.c
+++ b/base/notifications.c
@@ -66,7 +66,8 @@ const char *notification_reason_name(unsigned int reason_type)
 
 
 /* notify contacts about a service problem or recovery */
-int service_notification(service *svc, int type, char *not_author, char *not_data, int options) {
+int service_notification(service *svc, int type, char *not_author, char *not_data, int options)
+{
 	host *temp_host = NULL;
 	notification *temp_notification = NULL;
 	contact *temp_contact = NULL;
@@ -92,13 +93,13 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 	if((temp_host = svc->host_ptr) == NULL) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "Couldn't find the host associated with this service, so we won't send a notification!\n");
 		return ERROR;
-		}
+	}
 
 	/* check the viability of sending out a service notification */
 	if(check_service_notification_viability(svc, type, options) == ERROR) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "Notification viability test failed.  No notification will be sent out.\n");
 		return OK;
-		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 0, "Notification viability test passed.\n");
 
@@ -106,7 +107,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 	if(type == NOTIFICATION_NORMAL || (options & NOTIFICATION_OPTION_INCREMENT)) {
 		svc->current_notification_number++;
 		increment_notification_number = TRUE;
-		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Current notification number: %d (%s)\n", svc->current_notification_number, (increment_notification_number == TRUE) ? "incremented" : "unchanged");
 
@@ -126,7 +127,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 		               svc->host_name, svc->description, svc->id);
 		free_notification_list();
 		return neb_result == NEBERROR_CALLBACKOVERRIDE ? OK : ERROR;
-		}
+	}
 #endif
 
 	/* allocate memory for macros */
@@ -159,7 +160,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 		/* if this notification has an author, attempt to lookup the associated contact */
 		if(not_author != NULL) {
 			temp_contact = find_contact_by_name_or_alias(not_author);
-			}
+		}
 
 		/* get author and comment macros */
 		if(not_author)
@@ -167,7 +168,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 		if(temp_contact != NULL) {
 			mac.x[MACRO_NOTIFICATIONAUTHORNAME] = strdup(temp_contact->name);
 			mac.x[MACRO_NOTIFICATIONAUTHORALIAS] = strdup(temp_contact->alias);
-			}
+		}
 		if(not_data)
 			mac.x[MACRO_NOTIFICATIONCOMMENT] = strdup(not_data);
 
@@ -183,8 +184,8 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 			if(temp_contact != NULL) {
 				mac.x[MACRO_SERVICEACKAUTHORNAME] = strdup(temp_contact->name);
 				mac.x[MACRO_SERVICEACKAUTHORALIAS] = strdup(temp_contact->alias);
-				}
 			}
+		}
 
 		/* set the notification type macro */
 		if(type == NOTIFICATION_ACKNOWLEDGEMENT)
@@ -231,7 +232,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 			/* keep track of how many contacts were notified */
 			if(result == OK)
 				contacts_notified++;
-			}
+		}
 
 		/* free memory allocated to the notification list */
 		free_notification_list();
@@ -282,7 +283,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 
 				/* update notifications flags */
 				add_notified_on(svc, svc->current_state);
-				}
+			}
 
 			/* we didn't end up notifying anyone */
 			else if(increment_notification_number == TRUE) {
@@ -291,12 +292,12 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 				svc->current_notification_number--;
 
 				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were notified.  Next possible notification time: %s", ctime(&svc->next_notification));
-				}
-
 			}
 
-		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.\n", contacts_notified);
 		}
+
+		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.\n", contacts_notified);
+	}
 
 	/* there were no contacts, so no notification really occurred... */
 	else {
@@ -306,7 +307,7 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 			svc->current_notification_number--;
 
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were found for notification purposes.  No notification was sent out.\n");
-		}
+	}
 
 	/* this gets set in create_notification_list_from_service() */
 	my_free(mac.x[MACRO_NOTIFICATIONISESCALATED]);
@@ -323,12 +324,13 @@ int service_notification(service *svc, int type, char *not_author, char *not_dat
 	update_service_status(svc, FALSE);
 
 	return OK;
-	}
+}
 
 
 
 /* checks the viability of sending out a service alert (top level filters) */
-int check_service_notification_viability(service *svc, int type, int options) {
+int check_service_notification_viability(service *svc, int type, int options)
+{
 	host *temp_host;
 	timeperiod *temp_period;
 	time_t current_time;
@@ -341,7 +343,7 @@ int check_service_notification_viability(service *svc, int type, int options) {
 	if(options & NOTIFICATION_OPTION_FORCED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This is a forced service notification, so we'll send it out.\n");
 		return OK;
-		}
+	}
 
 	/* get current time */
 	time(&current_time);
@@ -350,7 +352,7 @@ int check_service_notification_viability(service *svc, int type, int options) {
 	if(enable_notifications == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Notifications are disabled, so service notifications will not be sent out.\n");
 		return ERROR;
-		}
+	}
 
 	/* find the host this service is associated with */
 	if((temp_host = (host *)svc->host_ptr) == NULL)
@@ -360,7 +362,7 @@ int check_service_notification_viability(service *svc, int type, int options) {
 	if(temp_host == NULL) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Couldn't find the host associated with this service, so we won't send a notification.\n");
 		return ERROR;
-		}
+	}
 
 	/* if all parents are bad (usually just one), we shouldn't notify */
 	if(svc->parents) {
@@ -371,18 +373,18 @@ int check_service_notification_viability(service *svc, int type, int options) {
 			if(sm->service_ptr->current_state == STATE_OK)
 				bad_parents += !!sm->service_ptr->current_state;
 			total_parents++;
-			}
+		}
 		if(bad_parents == total_parents) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service has no good parents, so notification will be blocked.\n");
 			return ERROR;
-			}
 		}
+	}
 
 	/* if the service has no notification period, inherit one from the host */
 	temp_period = svc->notification_period_ptr;
 	if(temp_period == NULL) {
 		temp_period = svc->host_ptr->notification_period_ptr;
-		}
+	}
 
 	/* see if the service can have notifications sent out at this time */
 	if(check_time_against_period(current_time, temp_period) == ERROR) {
@@ -403,16 +405,16 @@ int check_service_notification_viability(service *svc, int type, int options) {
 				svc->next_notification = timeperiod_start;
 
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next possible notification time: %s\n", ctime(&svc->next_notification));
-			}
+		}
 
 		return ERROR;
-		}
+	}
 
 	/* are notifications temporarily disabled for this service? */
 	if(svc->notifications_enabled == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Notifications are temporarily disabled for this service, so we won't send one out.\n");
 		return ERROR;
-		}
+	}
 
 
 	/*********************************************/
@@ -424,9 +426,9 @@ int check_service_notification_viability(service *svc, int type, int options) {
 		if(svc->scheduled_downtime_depth > 0 || temp_host->scheduled_downtime_depth > 0) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't send custom notification during scheduled downtime.\n");
 			return ERROR;
-			}
-		return OK;
 		}
+		return OK;
+	}
 
 
 
@@ -441,11 +443,11 @@ int check_service_notification_viability(service *svc, int type, int options) {
 		if(svc->current_state == STATE_OK) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "The service is currently OK, so we won't send an acknowledgement.\n");
 			return ERROR;
-			}
+		}
 
 		/* acknowledgement viability test passed, so the notification can be sent out */
 		return OK;
-		}
+	}
 
 
 	/****************************************/
@@ -459,17 +461,17 @@ int check_service_notification_viability(service *svc, int type, int options) {
 		if(flag_isset(svc->notification_options, OPT_FLAPPING) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about FLAPPING events for this service.\n");
 			return ERROR;
-			}
+		}
 
 		/* don't send notifications during scheduled downtime */
 		if(svc->scheduled_downtime_depth > 0 || temp_host->scheduled_downtime_depth > 0) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about FLAPPING events during scheduled downtime.\n");
 			return ERROR;
-			}
+		}
 
 		/* flapping viability test passed, so the notification can be sent out */
 		return OK;
-		}
+	}
 
 
 	/****************************************/
@@ -483,17 +485,17 @@ int check_service_notification_viability(service *svc, int type, int options) {
 		if(flag_isset(svc->notification_options, OPT_DOWNTIME) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about DOWNTIME events for this service.\n");
 			return ERROR;
-			}
+		}
 
 		/* don't send notifications during scheduled downtime (for service only, not host) */
 		if(svc->scheduled_downtime_depth > 0) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about DOWNTIME events during scheduled downtime.\n");
 			return ERROR;
-			}
+		}
 
 		/* downtime viability test passed, so the notification can be sent out */
 		return OK;
-		}
+	}
 
 
 	/****************************************/
@@ -504,35 +506,35 @@ int check_service_notification_viability(service *svc, int type, int options) {
 	if(svc->state_type == SOFT_STATE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service is in a soft state, so we won't send a notification out.\n");
 		return ERROR;
-		}
+	}
 
 	/* has this problem already been acknowledged? */
 	if(svc->problem_has_been_acknowledged == TRUE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service problem has already been acknowledged, so we won't send a notification out.\n");
 		return ERROR;
-		}
+	}
 
 	/* check service notification dependencies */
 	if(check_service_dependencies(svc, NOTIFICATION_DEPENDENCY) == DEPENDENCIES_FAILED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Service notification dependencies for this service have failed, so we won't sent a notification out.\n");
 		return ERROR;
-		}
+	}
 
 	/* check host notification dependencies */
 	if(check_host_dependencies(temp_host, NOTIFICATION_DEPENDENCY) == DEPENDENCIES_FAILED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Host notification dependencies for this service have failed, so we won't sent a notification out.\n");
 		return ERROR;
-		}
+	}
 
 	/* see if we should notify about problems with this service */
 	if(should_notify(svc) == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about %s states for this service.\n", service_state_name(svc->current_state));
 		return ERROR;
-		}
+	}
 	if(svc->current_state == STATE_OK && svc->notified_on == 0) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about this recovery.\n");
 		return ERROR;
-		}
+	}
 
 
 	/* see if enough time has elapsed for first notification (Mathias Sundman) */
@@ -545,14 +547,14 @@ int check_service_notification_viability(service *svc, int type, int options) {
 		if(current_time < first_problem_time + (time_t)(svc->first_notification_delay * interval_length)) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Not enough time has elapsed since the service changed to a non-OK state, so we should not notify about this problem yet\n");
 			return ERROR;
-			}
 		}
+	}
 
 	/* if this service is currently flapping, don't send the notification */
 	if(svc->is_flapping == TRUE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service is currently flapping, so we won't send notifications.\n");
 		return ERROR;
-		}
+	}
 
 	/***** RECOVERY NOTIFICATIONS ARE GOOD TO GO AT THIS POINT *****/
 	if(svc->current_state == STATE_OK)
@@ -562,40 +564,41 @@ int check_service_notification_viability(service *svc, int type, int options) {
 	if(svc->no_more_notifications == TRUE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't re-notify contacts about this service problem.\n");
 		return ERROR;
-		}
+	}
 
 	/* if the host is down or unreachable, don't notify contacts about service failures */
 	if(temp_host->current_state != HOST_UP) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "The host is either down or unreachable, so we won't notify contacts about this service.\n");
 		return ERROR;
-		}
+	}
 
 	/* don't notify if we haven't waited long enough since the last time (and the service is not marked as being volatile) */
 	if((current_time < svc->next_notification) && svc->is_volatile == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We haven't waited long enough to re-notify contacts about this service.\n");
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next valid notification time: %s", ctime(&svc->next_notification));
 		return ERROR;
-		}
+	}
 
 	/* if this service is currently in a scheduled downtime period, don't send the notification */
 	if(svc->scheduled_downtime_depth > 0) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service is currently in a scheduled downtime, so we won't send notifications.\n");
 		return ERROR;
-		}
+	}
 
 	/* if this host is currently in a scheduled downtime period, don't send the notification */
 	if(temp_host->scheduled_downtime_depth > 0) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "The host this service is associated with is currently in a scheduled downtime, so we won't send notifications.\n");
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* check viability of sending out a service notification to a specific contact (contact-specific filters) */
-int check_contact_service_notification_viability(contact *cntct, service *svc, int type, int options) {
+int check_contact_service_notification_viability(contact *cntct, service *svc, int type, int options)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "check_contact_service_notification_viability()\n");
 
@@ -605,25 +608,25 @@ int check_contact_service_notification_viability(contact *cntct, service *svc, i
 	if(options & NOTIFICATION_OPTION_FORCED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This is a forced service notification, so we'll send it out to this contact.\n");
 		return OK;
-		}
+	}
 
 	/* is this service not important enough? */
 	if(cntct->minimum_value > svc->hourly_value) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Contact's minimum_importance is higher than service's importance. Notification will be blocked\n");
 		return ERROR;
-		}
+	}
 
 	/* are notifications enabled? */
 	if(cntct->service_notifications_enabled == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Service notifications are disabled for this contact.\n");
 		return ERROR;
-		}
+	}
 
 	/* see if the contact can be notified at this time */
 	if(check_time_against_period(time(NULL), cntct->service_notification_period_ptr) == ERROR) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "This contact shouldn't be notified at this time.\n");
 		return ERROR;
-		}
+	}
 
 	/*********************************************/
 	/*** SPECIAL CASE FOR CUSTOM NOTIFICATIONS ***/
@@ -643,10 +646,10 @@ int check_contact_service_notification_viability(contact *cntct, service *svc, i
 		if((cntct->service_notification_options & OPT_FLAPPING) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about FLAPPING service events.\n");
 			return ERROR;
-			}
+		}
 
 		return OK;
-		}
+	}
 
 	/****************************************/
 	/*** SPECIAL CASE FOR DOWNTIME ALERTS ***/
@@ -657,10 +660,10 @@ int check_contact_service_notification_viability(contact *cntct, service *svc, i
 		if((cntct->service_notification_options & OPT_DOWNTIME) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about DOWNTIME service events.\n");
 			return ERROR;
-			}
+		}
 
 		return OK;
-		}
+	}
 
 	/*************************************/
 	/*** ACKS AND NORMAL NOTIFICATIONS ***/
@@ -670,30 +673,31 @@ int check_contact_service_notification_viability(contact *cntct, service *svc, i
 	if(!(cntct->service_notification_options & (1 << svc->current_state))) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about %s service states.\n", service_state_name(svc->current_state));
 		return ERROR;
-		}
+	}
 
 	if(svc->current_state == STATE_OK) {
 
 		if((cntct->service_notification_options & OPT_RECOVERY) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about RECOVERY service states.\n");
 			return ERROR;
-			}
+		}
 
 		if(!(svc->notified_on & cntct->service_notification_options)) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify about this recovery.\n");
 			return ERROR;
-			}
 		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 2, "** Service notification viability for contact '%s' PASSED.\n", cntct->name);
 
 	return OK;
-	}
+}
 
 
 
 /* notify a specific contact about a service problem or recovery */
-int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, int type, char *not_author, char *not_data, int options, int escalated) {
+int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, int type, char *not_author, char *not_data, int options, int escalated)
+{
 	commandsmember *temp_commandsmember = NULL;
 	char *command_name = NULL;
 	char *command_name_ptr = NULL;
@@ -765,41 +769,41 @@ int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, 
 		/* log the notification to program log file */
 		if(log_notifications == TRUE) {
 			switch(type) {
-				case NOTIFICATION_CUSTOM:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;CUSTOM ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_ACKNOWLEDGEMENT:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;ACKNOWLEDGEMENT ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_FLAPPINGSTART:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_FLAPPINGSTOP:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTOP ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_FLAPPINGDISABLED:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGDISABLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_DOWNTIMESTART:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMESTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_DOWNTIMEEND:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMEEND ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				case NOTIFICATION_DOWNTIMECANCELLED:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMECANCELLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				default:
-					asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;$SERVICESTATE$;%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
-					break;
-				}
+			case NOTIFICATION_CUSTOM:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;CUSTOM ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_ACKNOWLEDGEMENT:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;ACKNOWLEDGEMENT ($SERVICESTATE$);%s;$SERVICEOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_FLAPPINGSTART:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_FLAPPINGSTOP:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGSTOP ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_FLAPPINGDISABLED:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;FLAPPINGDISABLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_DOWNTIMESTART:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMESTART ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_DOWNTIMEEND:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMEEND ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			case NOTIFICATION_DOWNTIMECANCELLED:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;DOWNTIMECANCELLED ($SERVICESTATE$);%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			default:
+				asprintf(&temp_buffer, "SERVICE NOTIFICATION: %s;%s;%s;$SERVICESTATE$;%s;$SERVICEOUTPUT$\n", cntct->name, svc->host_name, svc->description, command_name_ptr);
+				break;
+			}
 
 			process_macros_r(mac, temp_buffer, &processed_buffer, 0);
 			write_to_all_logs(processed_buffer, NSLOG_SERVICE_NOTIFICATION);
 
 			my_free(temp_buffer);
 			my_free(processed_buffer);
-			}
+		}
 
 		/* run the notification command */
 		wproc_notify(cntct->name, svc->host_name, svc->description, processed_command, mac);
@@ -815,7 +819,7 @@ int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, 
 		/* send data to event broker */
 		broker_contact_notification_method_data(NEBTYPE_CONTACTNOTIFICATIONMETHOD_END, NEBFLAG_NONE, NEBATTR_NONE, SERVICE_NOTIFICATION, type, method_start_time, method_end_time, (void *)svc, cntct, temp_commandsmember->command, not_author, not_data, escalated, NULL);
 #endif
-		}
+	}
 
 	/* get end time */
 	gettimeofday(&end_time, NULL);
@@ -829,11 +833,12 @@ int notify_contact_of_service(nagios_macros *mac, contact *cntct, service *svc, 
 #endif
 
 	return OK;
-	}
+}
 
 
 /* checks to see if a service escalation entry is a match for the current service notification */
-int is_valid_escalation_for_service_notification(service *svc, serviceescalation *se, int options) {
+int is_valid_escalation_for_service_notification(service *svc, serviceescalation *se, int options)
+{
 	int notification_number = 0;
 	time_t current_time = 0L;
 	service *temp_service = NULL;
@@ -876,11 +881,12 @@ int is_valid_escalation_for_service_notification(service *svc, serviceescalation
 		return FALSE;
 
 	return TRUE;
-	}
+}
 
 
 /* checks to see whether a service notification should be escalation */
-int should_service_notification_be_escalated(service *svc) {
+int should_service_notification_be_escalated(service *svc)
+{
 	objectlist *list;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "should_service_notification_be_escalated()\n");
@@ -893,17 +899,18 @@ int should_service_notification_be_escalated(service *svc) {
 		if(is_valid_escalation_for_service_notification(svc, temp_se, NOTIFICATION_OPTION_NONE) == TRUE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Service notification WILL be escalated.\n");
 			return TRUE;
-			}
 		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Service notification will NOT be escalated.\n");
 
 	return FALSE;
-	}
+}
 
 
 /* given a service, create a list of contacts to be notified, removing duplicates, checking contact notification viability */
-int create_notification_list_from_service(nagios_macros *mac, service *svc, int options, int *escalated, int type) {
+int create_notification_list_from_service(nagios_macros *mac, service *svc, int options, int *escalated, int type)
+{
 	serviceescalation *temp_se = NULL;
 	contactsmember *temp_contactsmember = NULL;
 	contact *temp_contact = NULL;
@@ -954,7 +961,7 @@ int create_notification_list_from_service(nagios_macros *mac, service *svc, int 
 					add_notification(mac, temp_contact);
 				else
 					log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n",temp_contact->name);
-				}
+			}
 
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Adding members of contact groups from service escalation(s) to notification list.\n");
 
@@ -971,10 +978,10 @@ int create_notification_list_from_service(nagios_macros *mac, service *svc, int 
 						add_notification(mac, temp_contact);
 					else
 						log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n",temp_contact->name);
-					}
 				}
 			}
 		}
+	}
 
 	/* else use normal, non-escalated contacts */
 	if(escalate_notification == FALSE || (options & NOTIFICATION_OPTION_BROADCAST)) {
@@ -986,11 +993,11 @@ int create_notification_list_from_service(nagios_macros *mac, service *svc, int 
 			if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
 				continue;
 			/* check now if the contact can be notified */
-                        if (check_contact_service_notification_viability(temp_contact, svc, type, options) == OK)
-                                add_notification(mac, temp_contact);
-                        else
-                                log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n",temp_contact->name);
-			}
+			if (check_contact_service_notification_viability(temp_contact, svc, type, options) == OK)
+				add_notification(mac, temp_contact);
+			else
+				log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n",temp_contact->name);
+		}
 
 		/* add all contacts that belong to contactgroups for this service */
 		for(temp_contactgroupsmember = svc->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
@@ -1000,17 +1007,17 @@ int create_notification_list_from_service(nagios_macros *mac, service *svc, int 
 			for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
 				if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
 					continue;
-	                        /* check now if the contact can be notified */
-	                        if (check_contact_service_notification_viability(temp_contact, svc, type, options) == OK)
-                                	add_notification(mac, temp_contact);
-	                        else
-	                                log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n",temp_contact->name);
-				}
+				/* check now if the contact can be notified */
+				if (check_contact_service_notification_viability(temp_contact, svc, type, options) == OK)
+					add_notification(mac, temp_contact);
+				else
+					log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n",temp_contact->name);
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -1022,7 +1029,8 @@ int create_notification_list_from_service(nagios_macros *mac, service *svc, int 
 
 
 /* notify all contacts for a host that the entire host is down or up */
-int host_notification(host *hst, int type, char *not_author, char *not_data, int options) {
+int host_notification(host *hst, int type, char *not_author, char *not_data, int options)
+{
 	notification *temp_notification = NULL;
 	contact *temp_contact = NULL;
 	time_t current_time;
@@ -1046,7 +1054,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 	if(check_host_notification_viability(hst, type, options) == ERROR) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "Notification viability test failed.  No notification will be sent out.\n");
 		return OK;
-		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 0, "Notification viability test passed.\n");
 
@@ -1054,7 +1062,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 	if(type == NOTIFICATION_NORMAL || (options & NOTIFICATION_OPTION_INCREMENT)) {
 		hst->current_notification_number++;
 		increment_notification_number = TRUE;
-		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Current notification number: %d (%s)\n", hst->current_notification_number, (increment_notification_number == TRUE) ? "incremented" : "unchanged");
 
@@ -1073,7 +1081,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "Host notification to %s (id=%u) was blocked by a module.\n", hst->name, hst->id);
 		free_notification_list();
 		return neb_result == NEBERROR_CALLBACKOVERRIDE ? OK : ERROR;
-		}
+	}
 #endif
 
 	/* reset memory for local macro data */
@@ -1103,7 +1111,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 		/* if this notification has an author, attempt to lookup the associated contact */
 		if(not_author != NULL) {
 			temp_contact = find_contact_by_name_or_alias(not_author);
-			}
+		}
 
 		/* get author and comment macros */
 		if(not_author)
@@ -1111,7 +1119,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 		if(temp_contact != NULL) {
 			mac.x[MACRO_NOTIFICATIONAUTHORNAME] = strdup(temp_contact->name);
 			mac.x[MACRO_NOTIFICATIONAUTHORALIAS] = strdup(temp_contact->alias);
-			}
+		}
 		if(not_data)
 			mac.x[MACRO_NOTIFICATIONCOMMENT] = strdup(not_data);
 
@@ -1128,8 +1136,8 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 			if(temp_contact != NULL) {
 				mac.x[MACRO_HOSTACKAUTHORNAME] = strdup(temp_contact->name);
 				mac.x[MACRO_HOSTACKAUTHORALIAS] = strdup(temp_contact->alias);
-				}
 			}
+		}
 
 		/* set the notification type macro */
 		if(type == NOTIFICATION_ACKNOWLEDGEMENT)
@@ -1179,7 +1187,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 			/* keep track of how many contacts were notified */
 			if(result == OK)
 				contacts_notified++;
-			}
+		}
 
 		/* free memory allocated to the notification list */
 		free_notification_list();
@@ -1227,7 +1235,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 				add_notified_on(hst, hst->current_state);
 
 				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.  Next possible notification time: %s", contacts_notified, ctime(&hst->next_notification));
-				}
+			}
 
 			/* we didn't end up notifying anyone */
 			else if(increment_notification_number == TRUE) {
@@ -1236,11 +1244,11 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 				hst->current_notification_number--;
 
 				log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were notified.  Next possible notification time: %s", ctime(&hst->next_notification));
-				}
 			}
+		}
 
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "%d contacts were notified.\n", contacts_notified);
-		}
+	}
 
 	/* there were no contacts, so no notification really occurred... */
 	else {
@@ -1250,7 +1258,7 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 			hst->current_notification_number--;
 
 		log_debug_info(DEBUGL_NOTIFICATIONS, 0, "No contacts were found for notification purposes.  No notification was sent out.\n");
-		}
+	}
 
 	/* this gets set in create_notification_list_from_host() */
 	my_free(mac.x[MACRO_NOTIFICATIONISESCALATED]);
@@ -1267,12 +1275,13 @@ int host_notification(host *hst, int type, char *not_author, char *not_data, int
 	update_host_status(hst, FALSE);
 
 	return OK;
-	}
+}
 
 
 
 /* checks viability of sending a host notification */
-int check_host_notification_viability(host *hst, int type, int options) {
+int check_host_notification_viability(host *hst, int type, int options)
+{
 	time_t current_time;
 	time_t timeperiod_start;
 	time_t first_problem_time;
@@ -1283,7 +1292,7 @@ int check_host_notification_viability(host *hst, int type, int options) {
 	if(options & NOTIFICATION_OPTION_FORCED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This is a forced host notification, so we'll send it out.\n");
 		return OK;
-		}
+	}
 
 	/* get current time */
 	time(&current_time);
@@ -1292,7 +1301,7 @@ int check_host_notification_viability(host *hst, int type, int options) {
 	if(enable_notifications == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Notifications are disabled, so host notifications will not be sent out.\n");
 		return ERROR;
-		}
+	}
 
 	/* see if the host can have notifications sent out at this time */
 	if(check_time_against_period(current_time, hst->notification_period_ptr) == ERROR) {
@@ -1313,16 +1322,16 @@ int check_host_notification_viability(host *hst, int type, int options) {
 				hst->next_notification = timeperiod_start;
 
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next possible notification time: %s\n", ctime(&hst->next_notification));
-			}
+		}
 
 		return ERROR;
-		}
+	}
 
 	/* are notifications temporarily disabled for this host? */
 	if(hst->notifications_enabled == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Notifications are temporarily disabled for this host, so we won't send one out.\n");
 		return ERROR;
-		}
+	}
 
 
 	/*********************************************/
@@ -1334,9 +1343,9 @@ int check_host_notification_viability(host *hst, int type, int options) {
 		if(hst->scheduled_downtime_depth > 0) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't send custom notification during scheduled downtime.\n");
 			return ERROR;
-			}
-		return OK;
 		}
+		return OK;
+	}
 
 
 
@@ -1351,11 +1360,11 @@ int check_host_notification_viability(host *hst, int type, int options) {
 		if(hst->current_state == HOST_UP) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "The host is currently UP, so we won't send an acknowledgement.\n");
 			return ERROR;
-			}
+		}
 
 		/* acknowledgement viability test passed, so the notification can be sent out */
 		return OK;
-		}
+	}
 
 
 	/*****************************************/
@@ -1369,17 +1378,17 @@ int check_host_notification_viability(host *hst, int type, int options) {
 		if(!(hst->notification_options & OPT_FLAPPING)) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about FLAPPING events for this host.\n");
 			return ERROR;
-			}
+		}
 
 		/* don't send notifications during scheduled downtime */
 		if(hst->scheduled_downtime_depth > 0) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about FLAPPING events during scheduled downtime.\n");
 			return ERROR;
-			}
+		}
 
 		/* flapping viability test passed, so the notification can be sent out */
 		return OK;
-		}
+	}
 
 
 	/*****************************************/
@@ -1393,17 +1402,17 @@ int check_host_notification_viability(host *hst, int type, int options) {
 		if((hst->notification_options & OPT_DOWNTIME) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about DOWNTIME events for this host.\n");
 			return ERROR;
-			}
+		}
 
 		/* don't send notifications during scheduled downtime */
 		if(hst->scheduled_downtime_depth > 0) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about DOWNTIME events during scheduled downtime!\n");
 			return ERROR;
-			}
+		}
 
 		/* downtime viability test passed, so the notification can be sent out */
 		return OK;
-		}
+	}
 
 
 	/****************************************/
@@ -1414,37 +1423,37 @@ int check_host_notification_viability(host *hst, int type, int options) {
 	if(hst->state_type == SOFT_STATE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This host is in a soft state, so we won't send a notification out.\n");
 		return ERROR;
-		}
+	}
 
 	/* has this problem already been acknowledged? */
 	if(hst->problem_has_been_acknowledged == TRUE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This host problem has already been acknowledged, so we won't send a notification out!\n");
 		return ERROR;
-		}
+	}
 
 	/* check notification dependencies */
 	if(check_host_dependencies(hst, NOTIFICATION_DEPENDENCY) == DEPENDENCIES_FAILED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Notification dependencies for this host have failed, so we won't sent a notification out!\n");
 		return ERROR;
-		}
+	}
 
 	/* see if we should notify about problems with this host */
 	if((hst->notification_options & (1 << hst->current_state)) == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about %s status for this host.\n", host_state_name(hst->current_state));
 		return ERROR;
-		}
+	}
 	if(hst->current_state == HOST_UP) {
 
 		if((hst->notification_options & OPT_RECOVERY) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about RECOVERY states for this host.\n");
 			return ERROR;
-			}
+		}
 		if(!hst->notified_on) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't notify about this recovery.\n");
 			return ERROR;
-			}
-
 		}
+
+	}
 
 	/* see if enough time has elapsed for first notification (Mathias Sundman) */
 	/* 10/02/07 don't place restrictions on recoveries or non-normal notifications, must use last time up (or program start) in calculation */
@@ -1456,14 +1465,14 @@ int check_host_notification_viability(host *hst, int type, int options) {
 		if(current_time < first_problem_time + (time_t)(hst->first_notification_delay * interval_length)) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Not enough time has elapsed since the host changed to a non-UP state (or since program start), so we shouldn't notify about this problem yet.\n");
 			return ERROR;
-			}
 		}
+	}
 
 	/* if this host is currently flapping, don't send the notification */
 	if(hst->is_flapping == TRUE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This host is currently flapping, so we won't send notifications.\n");
 		return ERROR;
-		}
+	}
 
 	/***** RECOVERY NOTIFICATIONS ARE GOOD TO GO AT THIS POINT *****/
 	if(hst->current_state == HOST_UP)
@@ -1473,28 +1482,29 @@ int check_host_notification_viability(host *hst, int type, int options) {
 	if(hst->scheduled_downtime_depth > 0) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This host is currently in a scheduled downtime, so we won't send notifications.\n");
 		return ERROR;
-		}
+	}
 
 	/* check if we shouldn't renotify contacts about the host problem */
 	if(hst->no_more_notifications == TRUE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "We shouldn't re-notify contacts about this host problem.\n");
 		return ERROR;
-		}
+	}
 
 	/* check if its time to re-notify the contacts about the host... */
 	if(current_time < hst->next_notification) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Its not yet time to re-notify the contacts about this host problem...\n");
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next acceptable notification time: %s", ctime(&hst->next_notification));
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* checks the viability of notifying a specific contact about a host */
-int check_contact_host_notification_viability(contact *cntct, host *hst, int type, int options) {
+int check_contact_host_notification_viability(contact *cntct, host *hst, int type, int options)
+{
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "check_contact_host_notification_viability()\n");
 
@@ -1504,25 +1514,25 @@ int check_contact_host_notification_viability(contact *cntct, host *hst, int typ
 	if(options & NOTIFICATION_OPTION_FORCED) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "This is a forced host notification, so we'll send it out for this contact.\n");
 		return OK;
-		}
+	}
 
 	/* are notifications enabled? */
 	if(cntct->host_notifications_enabled == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Host notifications are disabled for this contact.\n");
 		return ERROR;
-		}
+	}
 
 	/* is this host important enough? */
 	if(cntct->minimum_value > hst->hourly_value + host_services_value(hst)) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Contact's minimum_importance is greater than the importance of the host and all its services. Notification will be blocked\n");
 		return ERROR;
-		}
+	}
 
 	/* see if the contact can be notified at this time */
 	if(check_time_against_period(time(NULL), cntct->host_notification_period_ptr) == ERROR) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "This contact shouldn't be notified at this time.\n");
 		return ERROR;
-		}
+	}
 
 
 	/*********************************************/
@@ -1543,10 +1553,10 @@ int check_contact_host_notification_viability(contact *cntct, host *hst, int typ
 		if((cntct->host_notification_options & OPT_FLAPPING) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about FLAPPING host events.\n");
 			return ERROR;
-			}
+		}
 
 		return OK;
-		}
+	}
 
 
 	/****************************************/
@@ -1558,10 +1568,10 @@ int check_contact_host_notification_viability(contact *cntct, host *hst, int typ
 		if(flag_isset(cntct->host_notification_options, OPT_DOWNTIME) == FALSE) {
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about DOWNTIME host events.\n");
 			return ERROR;
-			}
+		}
 
 		return OK;
-		}
+	}
 
 
 	/*************************************/
@@ -1572,22 +1582,23 @@ int check_contact_host_notification_viability(contact *cntct, host *hst, int typ
 	if(flag_isset(cntct->host_notification_options, 1 << hst->current_state) == FALSE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify this contact about %s states.\n", host_state_name(hst->current_state));
 		return ERROR;
-		}
+	}
 
 	if(hst->current_state == HOST_UP && hst->notified_on == 0) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "We shouldn't notify about this recovery.\n");
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 2, "** Host notification viability for contact '%s' PASSED.\n", cntct->name);
 
 	return OK;
-	}
+}
 
 
 
 /* notify a specific contact that an entire host is down or up */
-int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int type, char *not_author, char *not_data, int options, int escalated) {
+int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int type, char *not_author, char *not_data, int options, int escalated)
+{
 	commandsmember *temp_commandsmember = NULL;
 	char *command_name = NULL;
 	char *command_name_ptr = NULL;
@@ -1662,41 +1673,41 @@ int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int ty
 		/* log the notification to program log file */
 		if(log_notifications == TRUE) {
 			switch(type) {
-				case NOTIFICATION_CUSTOM:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;CUSTOM ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_ACKNOWLEDGEMENT:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;ACKNOWLEDGEMENT ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_FLAPPINGSTART:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_FLAPPINGSTOP:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTOP ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_FLAPPINGDISABLED:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGDISABLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_DOWNTIMESTART:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMESTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_DOWNTIMEEND:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMEEND ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				case NOTIFICATION_DOWNTIMECANCELLED:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMECANCELLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				default:
-					asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;$HOSTSTATE$;%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
-					break;
-				}
+			case NOTIFICATION_CUSTOM:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;CUSTOM ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_ACKNOWLEDGEMENT:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;ACKNOWLEDGEMENT ($HOSTSTATE$);%s;$HOSTOUTPUT$;$NOTIFICATIONAUTHOR$;$NOTIFICATIONCOMMENT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_FLAPPINGSTART:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_FLAPPINGSTOP:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGSTOP ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_FLAPPINGDISABLED:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;FLAPPINGDISABLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_DOWNTIMESTART:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMESTART ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_DOWNTIMEEND:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMEEND ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			case NOTIFICATION_DOWNTIMECANCELLED:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;DOWNTIMECANCELLED ($HOSTSTATE$);%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			default:
+				asprintf(&temp_buffer, "HOST NOTIFICATION: %s;%s;$HOSTSTATE$;%s;$HOSTOUTPUT$\n", cntct->name, hst->name, command_name_ptr);
+				break;
+			}
 
 			process_macros_r(mac, temp_buffer, &processed_buffer, 0);
 			write_to_all_logs(processed_buffer, NSLOG_HOST_NOTIFICATION);
 
 			my_free(temp_buffer);
 			my_free(processed_buffer);
-			}
+		}
 
 		/* run the notification command */
 		wproc_notify(cntct->name, hst->name, NULL, processed_command, mac);
@@ -1714,7 +1725,7 @@ int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int ty
 		/* send data to event broker */
 		broker_contact_notification_method_data(NEBTYPE_CONTACTNOTIFICATIONMETHOD_END, NEBFLAG_NONE, NEBATTR_NONE, HOST_NOTIFICATION, type, method_start_time, method_end_time, (void *)hst, cntct, temp_commandsmember->command, not_author, not_data, escalated, NULL);
 #endif
-		}
+	}
 
 	/* get end time */
 	gettimeofday(&end_time, NULL);
@@ -1728,11 +1739,12 @@ int notify_contact_of_host(nagios_macros *mac, contact *cntct, host *hst, int ty
 #endif
 
 	return OK;
-	}
+}
 
 
 /* checks to see if a host escalation entry is a match for the current host notification */
-int is_valid_escalation_for_host_notification(host *hst, hostescalation *he, int options) {
+int is_valid_escalation_for_host_notification(host *hst, hostescalation *he, int options)
+{
 	int notification_number = 0;
 	time_t current_time = 0L;
 	host *temp_host = NULL;
@@ -1775,12 +1787,13 @@ int is_valid_escalation_for_host_notification(host *hst, hostescalation *he, int
 		return FALSE;
 
 	return TRUE;
-	}
+}
 
 
 
 /* checks to see whether a host notification should be escalation */
-int should_host_notification_be_escalated(host *hst) {
+int should_host_notification_be_escalated(host *hst)
+{
 	objectlist *list;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "should_host_notification_be_escalated()\n");
@@ -1794,16 +1807,17 @@ int should_host_notification_be_escalated(host *hst) {
 		/* we found a matching entry, so escalate this notification! */
 		if(is_valid_escalation_for_host_notification(hst, temp_he, NOTIFICATION_OPTION_NONE) == TRUE)
 			return TRUE;
-		}
+	}
 
 	log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Host notification will NOT be escalated.\n");
 
 	return FALSE;
-	}
+}
 
 
 /* given a host, create a list of contacts to be notified, removing duplicates, checking contact notification viability */
-int create_notification_list_from_host(nagios_macros *mac, host *hst, int options, int *escalated, int type) {
+int create_notification_list_from_host(nagios_macros *mac, host *hst, int options, int *escalated, int type)
+{
 	hostescalation *temp_he = NULL;
 	contactsmember *temp_contactsmember = NULL;
 	contact *temp_contact = NULL;
@@ -1853,7 +1867,7 @@ int create_notification_list_from_host(nagios_macros *mac, host *hst, int option
 					add_notification(mac, temp_contact);
 				else
 					log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
-				}
+			}
 
 			log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Adding members of contact groups from host escalation(s) to notification list.\n");
 
@@ -1865,15 +1879,15 @@ int create_notification_list_from_host(nagios_macros *mac, host *hst, int option
 				for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
 					if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
 						continue;
-	                                /* check now if the contact can be notified */
-	                                if (check_contact_host_notification_viability(temp_contact, hst, type, options) == OK)
-	                                        add_notification(mac, temp_contact);
-	                                else
-	                                        log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
-					}
+					/* check now if the contact can be notified */
+					if (check_contact_host_notification_viability(temp_contact, hst, type, options) == OK)
+						add_notification(mac, temp_contact);
+					else
+						log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
 				}
 			}
 		}
+	}
 
 	/* use normal, non-escalated contacts for this notification */
 	if(escalate_notification == FALSE  || (options & NOTIFICATION_OPTION_BROADCAST)) {
@@ -1886,12 +1900,12 @@ int create_notification_list_from_host(nagios_macros *mac, host *hst, int option
 		for(temp_contactsmember = hst->contacts; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
 			if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
 				continue;
-                        /* check now if the contact can be notified */
-                        if (check_contact_host_notification_viability(temp_contact, hst, type, options) == OK)
-                                add_notification(mac, temp_contact);
-                        else
-                                log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
-			}
+			/* check now if the contact can be notified */
+			if (check_contact_host_notification_viability(temp_contact, hst, type, options) == OK)
+				add_notification(mac, temp_contact);
+			else
+				log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
+		}
 
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Adding members of contact groups for host to notification list.\n");
 
@@ -1904,17 +1918,17 @@ int create_notification_list_from_host(nagios_macros *mac, host *hst, int option
 			for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
 				if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
 					continue;
-	                        /* check now if the contact can be notified */
-	                        if (check_contact_host_notification_viability(temp_contact, hst, type, options) == OK)
-	                                add_notification(mac, temp_contact);
-	                        else
-	                                log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
-				}
+				/* check now if the contact can be notified */
+				if (check_contact_host_notification_viability(temp_contact, hst, type, options) == OK)
+					add_notification(mac, temp_contact);
+				else
+					log_debug_info(DEBUGL_NOTIFICATIONS, 2, "Not adding contact '%s'\n", temp_contact->name);
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -1925,7 +1939,8 @@ int create_notification_list_from_host(nagios_macros *mac, host *hst, int option
 
 
 /* calculates next acceptable re-notification time for a service */
-time_t get_next_service_notification_time(service *svc, time_t offset) {
+time_t get_next_service_notification_time(service *svc, time_t offset)
+{
 	time_t next_notification = 0L;
 	double interval_to_use = 0.0;
 	objectlist *list;
@@ -1958,14 +1973,14 @@ time_t get_next_service_notification_time(service *svc, time_t offset) {
 		if(have_escalated_interval == FALSE) {
 			have_escalated_interval = TRUE;
 			interval_to_use = temp_se->notification_interval;
-			}
+		}
 
 		/* else use the shortest of all valid escalation intervals */
 		else if(temp_se->notification_interval < interval_to_use)
 			interval_to_use = temp_se->notification_interval;
 
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "New interval: %f\n", interval_to_use);
-		}
+	}
 
 	/* if notification interval is 0, we shouldn't send any more problem notifications (unless service is volatile) */
 	if(interval_to_use == 0.0 && svc->is_volatile == FALSE)
@@ -1979,12 +1994,13 @@ time_t get_next_service_notification_time(service *svc, time_t offset) {
 	next_notification = offset + (interval_to_use * interval_length);
 
 	return next_notification;
-	}
+}
 
 
 
 /* calculates next acceptable re-notification time for a host */
-time_t get_next_host_notification_time(host *hst, time_t offset) {
+time_t get_next_host_notification_time(host *hst, time_t offset)
+{
 	time_t next_notification = 0L;
 	double interval_to_use = 0.0;
 	objectlist *list;
@@ -2018,14 +2034,14 @@ time_t get_next_host_notification_time(host *hst, time_t offset) {
 		if(have_escalated_interval == FALSE) {
 			have_escalated_interval = TRUE;
 			interval_to_use = temp_he->notification_interval;
-			}
+		}
 
 		/* else use the shortest of all valid escalation intervals  */
 		else if(temp_he->notification_interval < interval_to_use)
 			interval_to_use = temp_he->notification_interval;
 
 		log_debug_info(DEBUGL_NOTIFICATIONS, 2, "New interval: %f\n", interval_to_use);
-		}
+	}
 
 	/* if interval is 0, no more notifications should be sent */
 	if(interval_to_use == 0.0)
@@ -2039,7 +2055,7 @@ time_t get_next_host_notification_time(host *hst, time_t offset) {
 	next_notification = offset + (interval_to_use * interval_length);
 
 	return next_notification;
-	}
+}
 
 
 
@@ -2049,7 +2065,8 @@ time_t get_next_host_notification_time(host *hst, time_t offset) {
 
 
 /* given a contact name, find the notification entry for them for the list in memory */
-notification * find_notification(contact *cntct) {
+notification * find_notification(contact *cntct)
+{
 	notification *temp_notification = NULL;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "find_notification() start\n");
@@ -2060,16 +2077,17 @@ notification * find_notification(contact *cntct) {
 	for(temp_notification = notification_list; temp_notification != NULL; temp_notification = temp_notification->next) {
 		if(temp_notification->contact == cntct)
 			return temp_notification;
-		}
+	}
 
 	/* we couldn't find the contact in the notification list */
 	return NULL;
-	}
+}
 
 
 
 /* add a new notification to the list in memory */
-int add_notification(nagios_macros *mac, contact *cntct) {
+int add_notification(nagios_macros *mac, contact *cntct)
+{
 	notification *new_notification = NULL;
 	notification *temp_notification = NULL;
 
@@ -2102,8 +2120,8 @@ int add_notification(nagios_macros *mac, contact *cntct) {
 		if((mac->x[MACRO_NOTIFICATIONRECIPIENTS] = (char *)realloc(mac->x[MACRO_NOTIFICATIONRECIPIENTS], strlen(mac->x[MACRO_NOTIFICATIONRECIPIENTS]) + strlen(cntct->name) + 2))) {
 			strcat(mac->x[MACRO_NOTIFICATIONRECIPIENTS], ",");
 			strcat(mac->x[MACRO_NOTIFICATIONRECIPIENTS], cntct->name);
-			}
 		}
+	}
 
 	return OK;
-	}
+}

--- a/base/perfdata.c
+++ b/base/perfdata.c
@@ -36,16 +36,18 @@
 /******************************************************************/
 
 /* initializes performance data */
-int initialize_performance_data(const char *cfgfile) {
+int initialize_performance_data(const char *cfgfile)
+{
 	return xpddefault_initialize_performance_data(cfgfile);
-	}
+}
 
 
 
 /* cleans up performance data */
-int cleanup_performance_data(void) {
+int cleanup_performance_data(void)
+{
 	return xpddefault_cleanup_performance_data();
-	}
+}
 
 
 
@@ -55,7 +57,8 @@ int cleanup_performance_data(void) {
 
 
 /* updates service performance data */
-int update_service_performance_data(service *svc) {
+int update_service_performance_data(service *svc)
+{
 
 	/* should we be processing performance data for anything? */
 	if(process_performance_data == FALSE)
@@ -69,12 +72,13 @@ int update_service_performance_data(service *svc) {
 	xpddefault_update_service_performance_data(svc);
 
 	return OK;
-	}
+}
 
 
 
 /* updates host performance data */
-int update_host_performance_data(host *hst) {
+int update_host_performance_data(host *hst)
+{
 
 	/* should we be processing performance data for anything? */
 	if(process_performance_data == FALSE)
@@ -88,4 +92,4 @@ int update_host_performance_data(host *hst) {
 	xpddefault_update_host_performance_data(hst);
 
 	return OK;
-	}
+}

--- a/base/query-handler.c
+++ b/base/query-handler.c
@@ -26,7 +26,7 @@ static int qh_echo(int sd, char *buf, unsigned int len)
 {
 	if (!strcmp(buf, "help")) {
 		nsock_printf_nul(sd,
-			"Query handler that simply echoes back what you send it.");
+		                 "Query handler that simply echoes back what you send it.");
 		return 0;
 	}
 	(void)write(sd, buf, len);
@@ -56,29 +56,49 @@ const char *qh_strerror(int code)
 		return "Redirected (possibly deprecated address)";
 
 	switch (code) {
-		/* client errors */
-	case 400: return "Bad request";
-	case 401: return "Unathorized";
-	case 403: return "Forbidden (disabled by config)";
-	case 404: return "Not found";
-	case 405: return "Method not allowed";
-	case 406: return "Not acceptable";
-	case 407: return "Proxy authentication required";
-	case 408: return "Request timed out";
-	case 409: return "Conflict";
-	case 410: return "Gone";
-	case 411: return "Length required";
-	case 412: return "Precondition failed";
-	case 413: return "Request too large";
-	case 414: return "Request-URI too long";
+	/* client errors */
+	case 400:
+		return "Bad request";
+	case 401:
+		return "Unathorized";
+	case 403:
+		return "Forbidden (disabled by config)";
+	case 404:
+		return "Not found";
+	case 405:
+		return "Method not allowed";
+	case 406:
+		return "Not acceptable";
+	case 407:
+		return "Proxy authentication required";
+	case 408:
+		return "Request timed out";
+	case 409:
+		return "Conflict";
+	case 410:
+		return "Gone";
+	case 411:
+		return "Length required";
+	case 412:
+		return "Precondition failed";
+	case 413:
+		return "Request too large";
+	case 414:
+		return "Request-URI too long";
 
-		/* server errors */
-	case 500: return "Internal server error";
-	case 501: return "Not implemented";
-	case 502: return "Bad gateway";
-	case 503: return "Service unavailable";
-	case 504: return "Gateway timeout";
-	case 505: return "Version not supported";
+	/* server errors */
+	case 500:
+		return "Internal server error";
+	case 501:
+		return "Not implemented";
+	case 502:
+		return "Bad gateway";
+	case 503:
+		return "Service unavailable";
+	case 504:
+		return "Gateway timeout";
+	case 505:
+		return "Version not supported";
 	}
 	return "Unknown error";
 }
@@ -123,8 +143,7 @@ static int qh_input(int sd, int events, void *ioc_)
 		worker_set_sockopts(nsd, 0);
 		qh_running++;
 		return 0;
-	}
-	else {
+	} else {
 		int result;
 		unsigned long len;
 		unsigned int query_len = 0;
@@ -200,7 +219,7 @@ static int qh_input(int sd, int events, void *ioc_)
 		case QH_CLOSE: /* oneshot handler */
 		case -1:       /* general error */
 			iobroker_close(nagios_iobs, sd);
-			/* fallthrough */
+		/* fallthrough */
 		case QH_TAKEOVER: /* handler takes over */
 		case 101:         /* switch protocol (takeover + message) */
 			iocache_destroy(ioc);
@@ -272,8 +291,8 @@ int qh_register_handler(const char *name, const char *description, unsigned int 
 	result = dkhash_insert(qh_table, qh->name, NULL, qh);
 	if(result < 0) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE,
-			  "qh: Failed to insert query handler '%s' (%p) into hash table %p (%d): %s\n",
-			  name, qh, qh_table, result, strerror(errno));
+		      "qh: Failed to insert query handler '%s' (%p) into hash table %p (%d): %s\n",
+		      name, qh, qh_table, result, strerror(errno));
 		free(qh);
 		return result;
 	}
@@ -305,8 +324,8 @@ static int qh_help(int sd, char *buf, unsigned int len)
 
 	if (!*buf || !strcmp(buf, "help")) {
 		nsock_printf_nul(sd,
-			"  help <name>   show help for handler <name>\n"
-			"  help list     list registered handlers\n");
+		                 "  help <name>   show help for handler <name>\n"
+		                 "  help list     list registered handlers\n");
 		return 0;
 	}
 
@@ -333,33 +352,33 @@ static int qh_core(int sd, char *buf, unsigned int len)
 
 	if (!*buf || !strcmp(buf, "help")) {
 		nsock_printf_nul(sd, "Query handler for manipulating nagios core.\n"
-			"Available commands:\n"
-			"  loadctl           Print information about current load control settings\n"
-			"  loadctl <options> Configure nagios load control.\n"
-			"                    The options are the same parameters and format as\n"
-			"                    returned above.\n"
-			"  squeuestats       scheduling queue statistics\n"
-		);
+		                 "Available commands:\n"
+		                 "  loadctl           Print information about current load control settings\n"
+		                 "  loadctl <options> Configure nagios load control.\n"
+		                 "                    The options are the same parameters and format as\n"
+		                 "                    returned above.\n"
+		                 "  squeuestats       scheduling queue statistics\n"
+		                );
 		return 0;
 	}
 	if ((space = memchr(buf, ' ', len)))
 		*(space++) = 0;
 	if (!space && !strcmp(buf, "loadctl")) {
 		nsock_printf_nul
-			(sd, "jobs_max=%u;jobs_min=%u;"
-				"jobs_running=%u;jobs_limit=%u;"
-				"load=%.2f;"
-				"backoff_limit=%.2f;backoff_change=%u;"
-				"rampup_limit=%.2f;rampup_change=%u;"
-				"nproc_limit=%u;nofile_limit=%u;"
-				"options=%u;changes=%u;",
-				loadctl.jobs_max, loadctl.jobs_min,
-				loadctl.jobs_running, loadctl.jobs_limit,
-				loadctl.load[0],
-				loadctl.backoff_limit, loadctl.backoff_change,
-				loadctl.rampup_limit, loadctl.rampup_change,
-				loadctl.nproc_limit, loadctl.nofile_limit,
-				loadctl.options, loadctl.changes);
+		(sd, "jobs_max=%u;jobs_min=%u;"
+		 "jobs_running=%u;jobs_limit=%u;"
+		 "load=%.2f;"
+		 "backoff_limit=%.2f;backoff_change=%u;"
+		 "rampup_limit=%.2f;rampup_change=%u;"
+		 "nproc_limit=%u;nofile_limit=%u;"
+		 "options=%u;changes=%u;",
+		 loadctl.jobs_max, loadctl.jobs_min,
+		 loadctl.jobs_running, loadctl.jobs_limit,
+		 loadctl.load[0],
+		 loadctl.backoff_limit, loadctl.backoff_change,
+		 loadctl.rampup_limit, loadctl.rampup_change,
+		 loadctl.nproc_limit, loadctl.nofile_limit,
+		 loadctl.options, loadctl.changes);
 		return 0;
 	}
 
@@ -395,7 +414,7 @@ int qh_init(const char *path)
 	umask(old_umask);
 	if(qh_listen_sock < 0) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "qh: Failed to init socket '%s'. %s: %s\n",
-			  path, nsock_strerror(qh_listen_sock), strerror(errno));
+		      path, nsock_strerror(qh_listen_sock), strerror(errno));
 		return ERROR;
 	}
 

--- a/base/sehandlers.c
+++ b/base/sehandlers.c
@@ -41,7 +41,8 @@
 
 
 /* handles service check results in an obsessive compulsive manner... */
-int obsessive_compulsive_service_check_processor(service *svc) {
+int obsessive_compulsive_service_check_processor(service *svc)
+{
 	char *raw_command = NULL;
 	char *processed_command = NULL;
 	host *temp_host = NULL;
@@ -75,7 +76,7 @@ int obsessive_compulsive_service_check_processor(service *svc) {
 	if(raw_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Raw obsessive compulsive service processor command line: %s\n", raw_command);
 
@@ -85,7 +86,7 @@ int obsessive_compulsive_service_check_processor(service *svc) {
 	if(processed_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Processed obsessive compulsive service processor command line: %s\n", processed_command);
 
@@ -97,12 +98,13 @@ int obsessive_compulsive_service_check_processor(service *svc) {
 	my_free(processed_command);
 
 	return OK;
-	}
+}
 
 
 
 /* handles host check results in an obsessive compulsive manner... */
-int obsessive_compulsive_host_check_processor(host *hst) {
+int obsessive_compulsive_host_check_processor(host *hst)
+{
 	char *raw_command = NULL;
 	char *processed_command = NULL;
 	int macro_options = STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS;
@@ -130,7 +132,7 @@ int obsessive_compulsive_host_check_processor(host *hst) {
 	if(raw_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Raw obsessive compulsive host processor command line: %s\n", raw_command);
 
@@ -140,7 +142,7 @@ int obsessive_compulsive_host_check_processor(host *hst) {
 	if(processed_command == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 2, "Processed obsessive compulsive host processor command line: %s\n", processed_command);
 
@@ -152,7 +154,7 @@ int obsessive_compulsive_host_check_processor(host *hst) {
 	my_free(processed_command);
 
 	return OK;
-	}
+}
 
 
 
@@ -163,7 +165,8 @@ int obsessive_compulsive_host_check_processor(host *hst) {
 
 
 /* handles changes in the state of a service */
-int handle_service_event(service *svc) {
+int handle_service_event(service *svc)
+{
 	host *temp_host = NULL;
 	nagios_macros mac;
 
@@ -201,12 +204,13 @@ int handle_service_event(service *svc) {
 	clear_volatile_macros_r(&mac);
 
 	return OK;
-	}
+}
 
 
 
 /* runs the global service event handler */
-int run_global_service_event_handler(nagios_macros *mac, service *svc) {
+int run_global_service_event_handler(nagios_macros *mac, service *svc)
+{
 	char *raw_command = NULL;
 	char *processed_command = NULL;
 	char *raw_logentry = NULL;
@@ -247,7 +251,7 @@ int run_global_service_event_handler(nagios_macros *mac, service *svc) {
 	get_raw_command_line_r(mac, global_service_event_handler_ptr, global_service_event_handler, &raw_command, macro_options);
 	if(raw_command == NULL) {
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_EVENTHANDLERS, 2, "Raw global service event handler command line: %s\n", raw_command);
 
@@ -263,7 +267,7 @@ int run_global_service_event_handler(nagios_macros *mac, service *svc) {
 		asprintf(&raw_logentry, "GLOBAL SERVICE EVENT HANDLER: %s;%s;$SERVICESTATE$;$SERVICESTATETYPE$;$SERVICEATTEMPT$;%s\n", svc->host_name, svc->description, global_service_event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
-		}
+	}
 
 #ifdef USE_EVENT_BROKER
 	/* send event data to broker */
@@ -277,7 +281,7 @@ int run_global_service_event_handler(nagios_macros *mac, service *svc) {
 		my_free(raw_logentry);
 		my_free(processed_logentry);
 		return OK;
-		}
+	}
 #endif
 
 	/* run the command through a worker */
@@ -305,12 +309,13 @@ int run_global_service_event_handler(nagios_macros *mac, service *svc) {
 	my_free(processed_logentry);
 
 	return OK;
-	}
+}
 
 
 
 /* runs a service event handler command */
-int run_service_event_handler(nagios_macros *mac, service *svc) {
+int run_service_event_handler(nagios_macros *mac, service *svc)
+{
 	char *raw_command = NULL;
 	char *processed_command = NULL;
 	char *raw_logentry = NULL;
@@ -363,7 +368,7 @@ int run_service_event_handler(nagios_macros *mac, service *svc) {
 		asprintf(&raw_logentry, "SERVICE EVENT HANDLER: %s;%s;$SERVICESTATE$;$SERVICESTATETYPE$;$SERVICEATTEMPT$;%s\n", svc->host_name, svc->description, svc->event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
-		}
+	}
 
 #ifdef USE_EVENT_BROKER
 	/* send event data to broker */
@@ -377,7 +382,7 @@ int run_service_event_handler(nagios_macros *mac, service *svc) {
 		my_free(raw_logentry);
 		my_free(processed_logentry);
 		return OK;
-		}
+	}
 #endif
 
 	/* run the command through a worker */
@@ -405,7 +410,7 @@ int run_service_event_handler(nagios_macros *mac, service *svc) {
 	my_free(processed_logentry);
 
 	return OK;
-	}
+}
 
 
 
@@ -416,7 +421,8 @@ int run_service_event_handler(nagios_macros *mac, service *svc) {
 
 
 /* handles a change in the status of a host */
-int handle_host_event(host *hst) {
+int handle_host_event(host *hst)
+{
 	nagios_macros mac;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "handle_host_event()\n");
@@ -447,11 +453,12 @@ int handle_host_event(host *hst) {
 		run_host_event_handler(&mac, hst);
 
 	return OK;
-	}
+}
 
 
 /* runs the global host event handler */
-int run_global_host_event_handler(nagios_macros *mac, host *hst) {
+int run_global_host_event_handler(nagios_macros *mac, host *hst)
+{
 	char *raw_command = NULL;
 	char *processed_command = NULL;
 	char *raw_logentry = NULL;
@@ -507,7 +514,7 @@ int run_global_host_event_handler(nagios_macros *mac, host *hst) {
 		asprintf(&raw_logentry, "GLOBAL HOST EVENT HANDLER: %s;$HOSTSTATE$;$HOSTSTATETYPE$;$HOSTATTEMPT$;%s\n", hst->name, global_host_event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
-		}
+	}
 
 #ifdef USE_EVENT_BROKER
 	/* send event data to broker */
@@ -521,7 +528,7 @@ int run_global_host_event_handler(nagios_macros *mac, host *hst) {
 		my_free(raw_logentry);
 		my_free(processed_logentry);
 		return OK;
-		}
+	}
 #endif
 
 	/* run the command through a worker */
@@ -549,11 +556,12 @@ int run_global_host_event_handler(nagios_macros *mac, host *hst) {
 	my_free(processed_logentry);
 
 	return OK;
-	}
+}
 
 
 /* runs a host event handler command */
-int run_host_event_handler(nagios_macros *mac, host *hst) {
+int run_host_event_handler(nagios_macros *mac, host *hst)
+{
 	char *raw_command = NULL;
 	char *processed_command = NULL;
 	char *raw_logentry = NULL;
@@ -605,7 +613,7 @@ int run_host_event_handler(nagios_macros *mac, host *hst) {
 		asprintf(&raw_logentry, "HOST EVENT HANDLER: %s;$HOSTSTATE$;$HOSTSTATETYPE$;$HOSTATTEMPT$;%s\n", hst->name, hst->event_handler);
 		process_macros_r(mac, raw_logentry, &processed_logentry, macro_options);
 		logit(NSLOG_EVENT_HANDLER, FALSE, "%s", processed_logentry);
-		}
+	}
 
 #ifdef USE_EVENT_BROKER
 	/* send event data to broker */
@@ -619,7 +627,7 @@ int run_host_event_handler(nagios_macros *mac, host *hst) {
 		my_free(raw_logentry);
 		my_free(processed_logentry);
 		return OK;
-		}
+	}
 #endif
 
 	/* run the command through a worker */
@@ -646,4 +654,4 @@ int run_host_event_handler(nagios_macros *mac, host *hst) {
 	my_free(processed_logentry);
 
 	return OK;
-	}
+}

--- a/base/sretention.c
+++ b/base/sretention.c
@@ -38,21 +38,24 @@
 
 
 /* initializes retention data at program start */
-int initialize_retention_data(const char *cfgfile) {
+int initialize_retention_data(const char *cfgfile)
+{
 	return xrddefault_initialize_retention_data(cfgfile);
-	}
+}
 
 
 
 /* cleans up retention data before program termination */
-int cleanup_retention_data(void) {
+int cleanup_retention_data(void)
+{
 	return xrddefault_cleanup_retention_data();
-	}
+}
 
 
 
 /* save all host and service state information */
-int save_state_information(int autosave) {
+int save_state_information(int autosave)
+{
 	int result = OK;
 
 	if(retain_state_information == FALSE)
@@ -77,12 +80,13 @@ int save_state_information(int autosave) {
 		logit(NSLOG_PROCESS_INFO, FALSE, "Auto-save of retention data completed successfully.\n");
 
 	return OK;
-	}
+}
 
 
 
 /* reads in initial host and state information */
-int read_initial_state_information(void) {
+int read_initial_state_information(void)
+{
 	int result = OK;
 
 	if(retain_state_information == FALSE)
@@ -104,4 +108,4 @@ int read_initial_state_information(void) {
 		return ERROR;
 
 	return OK;
-	}
+}

--- a/base/utils.c
+++ b/base/utils.c
@@ -239,13 +239,15 @@ extern int errno;
 #endif
 
 
-static const char *worker_source_name(void *source) {
+static const char *worker_source_name(void *source)
+{
 	return source ? (const char *)source : "unknown internal source (voodoo, perhaps?)";
-	}
+}
 
-static const char *spool_file_source_name(void *source) {
+static const char *spool_file_source_name(void *source)
+{
 	return "check result spool dir";
-	}
+}
 
 struct check_engine nagios_check_engine = {
 	"Nagios Core",
@@ -259,11 +261,12 @@ static struct check_engine nagios_spool_check_engine = {
 	NULL,
 };
 
-const char *check_result_source(check_result *cr) {
+const char *check_result_source(check_result *cr)
+{
 	if(cr->engine)
 		return cr->engine->source_name(cr->source);
 	return cr->source ? (const char *)cr->source : "(unknown engine)";
-	}
+}
 
 
 int set_loadctl_options(char *opts, unsigned int len)
@@ -280,8 +283,7 @@ int set_loadctl_options(char *opts, unsigned int len)
 				if (!(loadctl.options & LOADCTL_ENABLED))
 					logit(0, 0, "Warning: Enabling experimental load control\n");
 				loadctl.options |= LOADCTL_ENABLED;
-			}
-			else {
+			} else {
 				if (loadctl.options & LOADCTL_ENABLED)
 					logit(0, 0, "Warning: Disabling experimental load control\n");
 				loadctl.options &= (~LOADCTL_ENABLED);
@@ -325,7 +327,8 @@ int set_loadctl_options(char *opts, unsigned int len)
 
 
 /* executes a system command - used for notifications, event handlers, etc. */
-int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, double *exectime, char **output, int max_output_length) {
+int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, double *exectime, char **output, int max_output_length)
+{
 	pid_t pid = 0;
 	int status = 0;
 	int result = 0;
@@ -382,7 +385,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 		close(fd[1]);
 
 		return STATE_UNKNOWN;
-		}
+	}
 
 	/* execute the command in the child process */
 	if(pid == 0) {
@@ -425,8 +428,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 			write(fd[1], buffer, strlen(buffer) + 1);
 
 			result = STATE_CRITICAL;
-			}
-		else {
+		} else {
 
 			/* write all the lines of output back to the parent process */
 			while(fgets(buffer, sizeof(buffer) - 1, fp))
@@ -442,8 +444,8 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 				if(WEXITSTATUS(status) == 0 && WIFSIGNALED(status))
 					result = 128 + WTERMSIG(status);
 				result = WEXITSTATUS(status);
-				}
 			}
+		}
 
 		/* close pipe for writing */
 		close(fd[1]);
@@ -462,7 +464,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 #endif
 
 		_exit(result);
-		}
+	}
 
 	/* parent waits for child to finish executing command */
 	else {
@@ -487,7 +489,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 		/* check for possibly missing scripts/binaries/etc */
 		if(result == 126 || result == 127) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Attempting to execute the command \"%s\" resulted in a return code of %d.  Make sure the script or binary you are trying to execute actually exists...\n", cmd, result);
-			}
+		}
 
 		/* check bounds on the return value */
 		if(result < -1 || result > 3)
@@ -507,7 +509,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 			kill((pid_t)(-pid), SIGTERM);
 			sleep(1);
 			kill((pid_t)(-pid), SIGKILL);
-			}
+		}
 
 		/* read output if timeout has not occurred */
 		else {
@@ -523,7 +525,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 				if(bytes_read > 0) {
 					buffer[bytes_read] = '\x0';
 					dbuf_strcat(&output_dbuf, buffer);
-					}
+				}
 
 				/* handle errors */
 				if(bytes_read == -1) {
@@ -538,17 +540,15 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 						pfd.events = POLLIN;
 						poll(&pfd, 1, -1);
 						continue;
-						}
-					else
+					} else
 						break;
-					}
+				}
 
 				/* we're done */
 				if(bytes_read == 0)
 					break;
 
-				}
-			while(1);
+			} while(1);
 
 			/* cap output length - this isn't necessary, but it keeps runaway plugin output from causing problems */
 			if(max_output_length > 0  && (int)output_dbuf.used_size > max_output_length)
@@ -557,7 +557,7 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 			if(output != NULL && output_dbuf.buf)
 				*output = (char *)strdup(output_dbuf.buf);
 
-			}
+		}
 
 		log_debug_info(DEBUGL_COMMANDS, 1, "Execution time=%.3f sec, early timeout=%d, result=%d, output=%s\n", *exectime, *early_timeout, result, (output_dbuf.buf == NULL) ? "(null)" : output_dbuf.buf);
 
@@ -571,23 +571,25 @@ int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, 
 
 		/* close the pipe for reading */
 		close(fd[0]);
-		}
+	}
 
 	return result;
-	}
+}
 
 /*
  * For API compatibility, we must include a my_system() whose
  * signature doesn't include the nagios_macros variable.
  * NDOUtils uses this. Possibly other modules as well.
  */
-int my_system(char *cmd, int timeout, int *early_timeout, double *exectime, char **output, int max_output_length) {
+int my_system(char *cmd, int timeout, int *early_timeout, double *exectime, char **output, int max_output_length)
+{
 	return my_system_r(get_global_macros(), cmd, timeout, early_timeout, exectime, output, max_output_length);
-	}
+}
 
 
 /* given a "raw" command, return the "expanded" or "whole" command line */
-int get_raw_command_line_r(nagios_macros *mac, command *cmd_ptr, char *cmd, char **full_command, int macro_options) {
+int get_raw_command_line_r(nagios_macros *mac, command *cmd_ptr, char *cmd, char **full_command, int macro_options)
+{
 	char temp_arg[MAX_COMMAND_BUFFER] = "";
 	char *arg_buffer = NULL;
 	register int x = 0;
@@ -616,7 +618,7 @@ int get_raw_command_line_r(nagios_macros *mac, command *cmd_ptr, char *cmd, char
 		for(arg_index = 0;; arg_index++) {
 			if(cmd[arg_index] == '!' || cmd[arg_index] == '\x0')
 				break;
-			}
+		}
 
 		/* get each command argument */
 		for(x = 0; x < MAX_COMMAND_ARGUMENTS; x++) {
@@ -640,7 +642,7 @@ int get_raw_command_line_r(nagios_macros *mac, command *cmd_ptr, char *cmd, char
 				/* copy the character */
 				temp_arg[y] = cmd[arg_index];
 				y++;
-				}
+			}
 			temp_arg[y] = '\x0';
 
 			/* ADDED 01/29/04 EG */
@@ -648,24 +650,25 @@ int get_raw_command_line_r(nagios_macros *mac, command *cmd_ptr, char *cmd, char
 			process_macros_r(mac, temp_arg, &arg_buffer, macro_options);
 
 			mac->argv[x] = arg_buffer;
-			}
 		}
+	}
 
 	log_debug_info(DEBUGL_COMMANDS | DEBUGL_CHECKS | DEBUGL_MACROS, 2, "Expanded Command Output: %s\n", *full_command);
 
 	return OK;
-	}
+}
 
 /*
  * This function modifies the global macro struct and is thus not
  * threadsafe
  */
-int get_raw_command_line(command *cmd_ptr, char *cmd, char **full_command, int macro_options) {
+int get_raw_command_line(command *cmd_ptr, char *cmd, char **full_command, int macro_options)
+{
 	nagios_macros *mac;
 
 	mac = get_global_macros();
 	return get_raw_command_line_r(mac, cmd_ptr, cmd, full_command, macro_options);
-	}
+}
 
 
 
@@ -674,7 +677,8 @@ int get_raw_command_line(command *cmd_ptr, char *cmd, char **full_command, int m
 /******************************************************************/
 
 /* sets or unsets an environment variable */
-int set_environment_var(char *name, char *value, int set) {
+int set_environment_var(char *name, char *value, int set)
+{
 #ifndef HAVE_SETENV
 	char *env_string = NULL;
 #endif
@@ -695,16 +699,16 @@ int set_environment_var(char *name, char *value, int set) {
 		if(env_string)
 			putenv(env_string);
 #endif
-		}
+	}
 	/* clear the variable */
 	else {
 #ifdef HAVE_UNSETENV
 		unsetenv(name);
 #endif
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -715,28 +719,30 @@ int set_environment_var(char *name, char *value, int set) {
 
 
 /* Checks if the given time is in daylight time saving period */
-static int is_dst_time(time_t *time) {
+static int is_dst_time(time_t *time)
+{
 	struct tm *bt = localtime(time);
 	return bt->tm_isdst;
-	}
+}
 
 /* Returns the shift in seconds if the given times are across the daylight time saving period change */
-static int get_dst_shift(time_t *start, time_t *end) {
+static int get_dst_shift(time_t *start, time_t *end)
+{
 	int shift = 0, dst_end, dst_start;
 	dst_start = is_dst_time(start);
 	dst_end = is_dst_time(end);
 	if(dst_start < dst_end) {
 		shift = 3600;
-		}
-	else if(dst_start > dst_end) {
+	} else if(dst_start > dst_end) {
 		shift = -3600;
-		}
-	return shift;
 	}
+	return shift;
+}
 
 /*#define TEST_TIMEPERIODS_A 1*/
 
-static timerange* _get_matching_timerange(time_t test_time, timeperiod *tperiod) {
+static timerange* _get_matching_timerange(time_t test_time, timeperiod *tperiod)
+{
 	daterange *temp_daterange = NULL;
 	time_t start_time = (time_t)0L;
 	time_t end_time = (time_t)0L;
@@ -779,75 +785,75 @@ static timerange* _get_matching_timerange(time_t test_time, timeperiod *tperiod)
 
 			/* get the start time */
 			switch(daterange_type) {
-				case DATERANGE_CALENDAR_DATE:
-					t->tm_sec = 0;
-					t->tm_min = 0;
-					t->tm_hour = 0;
-					t->tm_wday = 0;
-					t->tm_mday = temp_daterange->smday;
-					t->tm_mon = temp_daterange->smon;
-					t->tm_year = (temp_daterange->syear - 1900);
-					t->tm_isdst = -1;
-					start_time = mktime(t);
-					break;
-				case DATERANGE_MONTH_DATE:
-					start_time = calculate_time_from_day_of_month(test_time_year, temp_daterange->smon, temp_daterange->smday);
-					break;
-				case DATERANGE_MONTH_DAY:
-					start_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, temp_daterange->smday);
-					break;
-				case DATERANGE_MONTH_WEEK_DAY:
-					start_time = calculate_time_from_weekday_of_month(test_time_year, temp_daterange->smon, temp_daterange->swday, temp_daterange->swday_offset);
-					break;
-				case DATERANGE_WEEK_DAY:
-					start_time = calculate_time_from_weekday_of_month(test_time_year, test_time_mon, temp_daterange->swday, temp_daterange->swday_offset);
-					break;
-				default:
-					continue;
-					break;
-				}
+			case DATERANGE_CALENDAR_DATE:
+				t->tm_sec = 0;
+				t->tm_min = 0;
+				t->tm_hour = 0;
+				t->tm_wday = 0;
+				t->tm_mday = temp_daterange->smday;
+				t->tm_mon = temp_daterange->smon;
+				t->tm_year = (temp_daterange->syear - 1900);
+				t->tm_isdst = -1;
+				start_time = mktime(t);
+				break;
+			case DATERANGE_MONTH_DATE:
+				start_time = calculate_time_from_day_of_month(test_time_year, temp_daterange->smon, temp_daterange->smday);
+				break;
+			case DATERANGE_MONTH_DAY:
+				start_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, temp_daterange->smday);
+				break;
+			case DATERANGE_MONTH_WEEK_DAY:
+				start_time = calculate_time_from_weekday_of_month(test_time_year, temp_daterange->smon, temp_daterange->swday, temp_daterange->swday_offset);
+				break;
+			case DATERANGE_WEEK_DAY:
+				start_time = calculate_time_from_weekday_of_month(test_time_year, test_time_mon, temp_daterange->swday, temp_daterange->swday_offset);
+				break;
+			default:
+				continue;
+				break;
+			}
 
 			/* get the end time */
 			switch(daterange_type) {
-				case DATERANGE_CALENDAR_DATE:
-					t->tm_sec = 0;
-					t->tm_min = 0;
-					t->tm_hour = 0;
-					t->tm_wday = 0;
-					t->tm_mday = temp_daterange->emday;
-					t->tm_mon = temp_daterange->emon;
-					t->tm_year = (temp_daterange->eyear - 1900);
-					t->tm_isdst = -1;
-					end_time = mktime(t);
-					break;
-				case DATERANGE_MONTH_DATE:
-					year = test_time_year;
+			case DATERANGE_CALENDAR_DATE:
+				t->tm_sec = 0;
+				t->tm_min = 0;
+				t->tm_hour = 0;
+				t->tm_wday = 0;
+				t->tm_mday = temp_daterange->emday;
+				t->tm_mon = temp_daterange->emon;
+				t->tm_year = (temp_daterange->eyear - 1900);
+				t->tm_isdst = -1;
+				end_time = mktime(t);
+				break;
+			case DATERANGE_MONTH_DATE:
+				year = test_time_year;
+				end_time = calculate_time_from_day_of_month(year, temp_daterange->emon, temp_daterange->emday);
+				/* advance a year if necessary: august 2 - february 5 */
+				if(end_time < start_time) {
+					year++;
 					end_time = calculate_time_from_day_of_month(year, temp_daterange->emon, temp_daterange->emday);
-					/* advance a year if necessary: august 2 - february 5 */
-					if(end_time < start_time) {
-						year++;
-						end_time = calculate_time_from_day_of_month(year, temp_daterange->emon, temp_daterange->emday);
-						}
-					break;
-				case DATERANGE_MONTH_DAY:
-					end_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, temp_daterange->emday);
-					break;
-				case DATERANGE_MONTH_WEEK_DAY:
-					year = test_time_year;
-					end_time = calculate_time_from_weekday_of_month(year, temp_daterange->emon, temp_daterange->ewday, temp_daterange->ewday_offset);
-					/* advance a year if necessary: thursday 2 august - monday 3 february */
-					if(end_time < start_time) {
-						year++;
-						end_time = calculate_time_from_weekday_of_month(year, temp_daterange->emon, temp_daterange->ewday, temp_daterange->ewday_offset);
-						}
-					break;
-				case DATERANGE_WEEK_DAY:
-					end_time = calculate_time_from_weekday_of_month(test_time_year, test_time_mon, temp_daterange->ewday, temp_daterange->ewday_offset);
-					break;
-				default:
-					continue;
-					break;
 				}
+				break;
+			case DATERANGE_MONTH_DAY:
+				end_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, temp_daterange->emday);
+				break;
+			case DATERANGE_MONTH_WEEK_DAY:
+				year = test_time_year;
+				end_time = calculate_time_from_weekday_of_month(year, temp_daterange->emon, temp_daterange->ewday, temp_daterange->ewday_offset);
+				/* advance a year if necessary: thursday 2 august - monday 3 february */
+				if(end_time < start_time) {
+					year++;
+					end_time = calculate_time_from_weekday_of_month(year, temp_daterange->emon, temp_daterange->ewday, temp_daterange->ewday_offset);
+				}
+				break;
+			case DATERANGE_WEEK_DAY:
+				end_time = calculate_time_from_weekday_of_month(test_time_year, test_time_mon, temp_daterange->ewday, temp_daterange->ewday_offset);
+				break;
+			default:
+				continue;
+				break;
+			}
 
 #ifdef TEST_TIMEPERIODS_A
 			printf("START:    %lu = %s", (unsigned long)start_time, ctime(&start_time));
@@ -861,48 +867,48 @@ static timerange* _get_matching_timerange(time_t test_time, timeperiod *tperiod)
 			/* end date was bad - see if we can handle the error */
 			if((unsigned long)end_time == 0L) {
 				switch(daterange_type) {
-					case DATERANGE_CALENDAR_DATE:
+				case DATERANGE_CALENDAR_DATE:
+					continue;
+					break;
+				case DATERANGE_MONTH_DATE:
+					/* end date can't be helped, so skip it */
+					if(temp_daterange->emday < 0)
 						continue;
-						break;
-					case DATERANGE_MONTH_DATE:
-						/* end date can't be helped, so skip it */
-						if(temp_daterange->emday < 0)
-							continue;
 
-						/* else end date slipped past end of month, so use last day of month as end date */
-						/* use same year calculated above */
-						end_time = calculate_time_from_day_of_month(year, temp_daterange->emon, -1);
-						break;
-					case DATERANGE_MONTH_DAY:
-						/* end date can't be helped, so skip it */
-						if(temp_daterange->emday < 0)
-							continue;
-
-						/* else end date slipped past end of month, so use last day of month as end date */
-						end_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, -1);
-						break;
-					case DATERANGE_MONTH_WEEK_DAY:
-						/* end date can't be helped, so skip it */
-						if(temp_daterange->ewday_offset < 0)
-							continue;
-
-						/* else end date slipped past end of month, so use last day of month as end date */
-						/* use same year calculated above */
-						end_time = calculate_time_from_day_of_month(year, test_time_mon, -1);
-						break;
-					case DATERANGE_WEEK_DAY:
-						/* end date can't be helped, so skip it */
-						if(temp_daterange->ewday_offset < 0)
-							continue;
-
-						/* else end date slipped past end of month, so use last day of month as end date */
-						end_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, -1);
-						break;
-					default:
+					/* else end date slipped past end of month, so use last day of month as end date */
+					/* use same year calculated above */
+					end_time = calculate_time_from_day_of_month(year, temp_daterange->emon, -1);
+					break;
+				case DATERANGE_MONTH_DAY:
+					/* end date can't be helped, so skip it */
+					if(temp_daterange->emday < 0)
 						continue;
-						break;
-					}
+
+					/* else end date slipped past end of month, so use last day of month as end date */
+					end_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, -1);
+					break;
+				case DATERANGE_MONTH_WEEK_DAY:
+					/* end date can't be helped, so skip it */
+					if(temp_daterange->ewday_offset < 0)
+						continue;
+
+					/* else end date slipped past end of month, so use last day of month as end date */
+					/* use same year calculated above */
+					end_time = calculate_time_from_day_of_month(year, test_time_mon, -1);
+					break;
+				case DATERANGE_WEEK_DAY:
+					/* end date can't be helped, so skip it */
+					if(temp_daterange->ewday_offset < 0)
+						continue;
+
+					/* else end date slipped past end of month, so use last day of month as end date */
+					end_time = calculate_time_from_day_of_month(test_time_year, test_time_mon, -1);
+					break;
+				default:
+					continue;
+					break;
 				}
+			}
 
 			/* calculate skip date start (and end) */
 			if(temp_daterange->skip_interval > 1) {
@@ -928,7 +934,7 @@ static timerange* _get_matching_timerange(time_t test_time, timeperiod *tperiod)
 				/* if skipping range has no end, use test date as end */
 				if((daterange_type == DATERANGE_CALENDAR_DATE) && (is_daterange_single_day(temp_daterange) == TRUE))
 					end_time = midnight;
-				}
+			}
 
 #ifdef TEST_TIMEPERIODS_A
 			printf("NEW START:    %lu = %s", (unsigned long)start_time, ctime(&start_time));
@@ -945,15 +951,16 @@ static timerange* _get_matching_timerange(time_t test_time, timeperiod *tperiod)
 				printf("(MATCH)\n");
 #endif
 				return temp_daterange->times;
-				}
 			}
 		}
+	}
 
 	return tperiod->days[test_time_wday];
 }
 
 /* see if the specified time falls into a valid time range in the given time period */
-int check_time_against_period(time_t test_time, timeperiod *tperiod) {
+int check_time_against_period(time_t test_time, timeperiod *tperiod)
+{
 	timerange *temp_timerange = NULL;
 	timeperiodexclusion *temp_timeperiodexclusion = NULL;
 	struct tm *t, tm_s;
@@ -977,8 +984,8 @@ int check_time_against_period(time_t test_time, timeperiod *tperiod) {
 	for(temp_timeperiodexclusion = tperiod->exclusions; temp_timeperiodexclusion != NULL; temp_timeperiodexclusion = temp_timeperiodexclusion->next) {
 		if(check_time_against_period(test_time, temp_timeperiodexclusion->timeperiod_ptr) == OK) {
 			return ERROR;
-			}
 		}
+	}
 
 	for(temp_timerange = _get_matching_timerange(test_time, tperiod); temp_timerange != NULL; temp_timerange = temp_timerange->next) {
 
@@ -987,9 +994,9 @@ int check_time_against_period(time_t test_time, timeperiod *tperiod) {
 
 		if(test_time >= day_range_start && test_time <= day_range_end)
 			return OK;
-		}
-	return ERROR;
 	}
+	return ERROR;
+}
 
 
 
@@ -997,7 +1004,8 @@ int check_time_against_period(time_t test_time, timeperiod *tperiod) {
 
 void _get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperiod);
 
-static void _get_next_invalid_time(time_t pref_time, time_t *invalid_time, timeperiod *tperiod) {
+static void _get_next_invalid_time(time_t pref_time, time_t *invalid_time, timeperiod *tperiod)
+{
 	timeperiodexclusion *temp_timeperiodexclusion = NULL;
 	int depth = 0;
 	int max_depth = 300; // commonly roughly equal to "days in the future"
@@ -1050,27 +1058,28 @@ static void _get_next_invalid_time(time_t pref_time, time_t *invalid_time, timep
 #ifdef TEST_TIMEPERIODS_B
 				printf("    EARLIEST INVALID TIME: %lu = %s", (unsigned long)earliest_time, ctime(&earliest_time));
 #endif
-				}
 			}
+		}
 
 		for(temp_timeperiodexclusion = tperiod->exclusions; temp_timeperiodexclusion != NULL; temp_timeperiodexclusion = temp_timeperiodexclusion->next) {
 			_get_next_valid_time(last_earliest_time, &potential_time, temp_timeperiodexclusion->timeperiod_ptr);
 			if (potential_time + 60 < earliest_time)
 				earliest_time = potential_time + 60;
-			}
 		}
+	}
 #ifdef TEST_TIMEPERIODS_B
-		printf("    FINAL EARLIEST INVALID TIME: %lu = %s", (unsigned long)earliest_time, ctime(&earliest_time));
+	printf("    FINAL EARLIEST INVALID TIME: %lu = %s", (unsigned long)earliest_time, ctime(&earliest_time));
 #endif
 
 	if (depth == max_depth)
 		*invalid_time = pref_time;
 	else
 		*invalid_time = earliest_time;
-	}
+}
 
 /* Separate this out from public get_next_valid_time for testing */
-void _get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperiod) {
+void _get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperiod)
+{
 	timeperiodexclusion *temp_timeperiodexclusion = NULL;
 	int depth = 0;
 	int max_depth = 300; // commonly roughly equal to "days in the future"
@@ -1102,8 +1111,8 @@ void _get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tper
 
 		timerange *temp_timerange = _get_matching_timerange(earliest_time, tperiod);
 #ifdef TEST_TIMEPERIODS_B
-			printf("  RANGE START: %lu\n", temp_timerange ? temp_timerange->range_start : 0);
-			printf("  RANGE END:   %lu\n", temp_timerange ? temp_timerange->range_end : 0);
+		printf("  RANGE START: %lu\n", temp_timerange ? temp_timerange->range_start : 0);
+		printf("  RANGE END:   %lu\n", temp_timerange ? temp_timerange->range_end : 0);
 #endif
 
 		for(; temp_timerange != NULL; temp_timerange = temp_timerange->next) {
@@ -1136,9 +1145,9 @@ void _get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tper
 #ifdef TEST_TIMEPERIODS_B
 				printf("    EARLIEST TIME: %lu = %s", (unsigned long)earliest_time, ctime(&earliest_time));
 #endif
-				}
-			have_earliest_time = TRUE;
 			}
+			have_earliest_time = TRUE;
+		}
 
 		if (have_earliest_time == FALSE) {
 			earliest_time = midnight + 86400;
@@ -1148,19 +1157,20 @@ void _get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tper
 #ifdef TEST_TIMEPERIODS_B
 				printf("    FINAL EARLIEST TIME: %lu = %s", (unsigned long)earliest_time, ctime(&earliest_time));
 #endif
-				}
 			}
 		}
+	}
 
 	if (depth == max_depth)
 		*valid_time = pref_time;
 	else
 		*valid_time = earliest_time;
-	}
+}
 
 
 /* given a preferred time, get the next valid time within a time period */
-void get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperiod) {
+void get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperiod)
+{
 	time_t current_time = (time_t)0L;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "get_next_valid_time()\n");
@@ -1171,11 +1181,12 @@ void get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperi
 	pref_time = (pref_time < current_time) ? current_time : pref_time;
 
 	_get_next_valid_time(pref_time, valid_time, tperiod);
-	}
+}
 
 
 /* tests if a date range covers just a single day */
-int is_daterange_single_day(daterange *dr) {
+int is_daterange_single_day(daterange *dr)
+{
 
 	if(dr == NULL)
 		return FALSE;
@@ -1192,12 +1203,13 @@ int is_daterange_single_day(daterange *dr) {
 		return FALSE;
 
 	return TRUE;
-	}
+}
 
 
 
 /* returns a time (midnight) of particular (3rd, last) day in a given month */
-time_t calculate_time_from_day_of_month(int year, int month, int monthday) {
+time_t calculate_time_from_day_of_month(int year, int month, int monthday)
+{
 	time_t midnight;
 	int day = 0;
 	struct tm t;
@@ -1227,7 +1239,7 @@ time_t calculate_time_from_day_of_month(int year, int month, int monthday) {
 		/* assume the user's intention is to keep it in the current month */
 		if(t.tm_mon != month)
 			midnight = (time_t)0L;
-		}
+	}
 
 	/* negative offset (last day, 3rd to last day) */
 	else {
@@ -1244,8 +1256,7 @@ time_t calculate_time_from_day_of_month(int year, int month, int monthday) {
 			t.tm_isdst = -1;
 			midnight = mktime(&t);
 
-			}
-		while(t.tm_mon != month);
+		} while(t.tm_mon != month);
 
 		/* now that we know the last day, back up more */
 		/* make the new time */
@@ -1260,15 +1271,16 @@ time_t calculate_time_from_day_of_month(int year, int month, int monthday) {
 		/* assume the user's intention is to keep it in the current month */
 		if(t.tm_mon != month)
 			midnight = (time_t)0L;
-		}
+	}
 
 	return midnight;
-	}
+}
 
 
 
 /* returns a time (midnight) of particular (3rd, last) weekday in a given month */
-time_t calculate_time_from_weekday_of_month(int year, int month, int weekday, int weekday_offset) {
+time_t calculate_time_from_weekday_of_month(int year, int month, int weekday, int weekday_offset)
+{
 	time_t midnight;
 	int days = 0;
 	int weeks = 0;
@@ -1307,7 +1319,7 @@ time_t calculate_time_from_weekday_of_month(int year, int month, int weekday, in
 		/* assume the user's intention is to keep it in the current month */
 		if(t.tm_mon != month)
 			midnight = (time_t)0L;
-		}
+	}
 
 	/* negative offset (last thursday, 3rd to last tuesday) */
 	else {
@@ -1324,8 +1336,7 @@ time_t calculate_time_from_weekday_of_month(int year, int month, int weekday, in
 			t.tm_isdst = -1;
 			midnight = mktime(&t);
 
-			}
-		while(t.tm_mon != month);
+		} while(t.tm_mon != month);
 
 		/* now that we know the last instance of the weekday, back up more */
 		weeks = (weekday_offset < -5) ? -5 : weekday_offset;
@@ -1342,14 +1353,15 @@ time_t calculate_time_from_weekday_of_month(int year, int month, int weekday, in
 		/* assume the user's intention is to keep it in the current month */
 		if(t.tm_mon != month)
 			midnight = (time_t)0L;
-		}
+	}
 
 	return midnight;
-	}
+}
 
 
 /* get the next time to schedule a log rotation */
-time_t get_next_log_rotation_time(void) {
+time_t get_next_log_rotation_time(void)
+{
 	time_t current_time;
 	struct tm *t, tm_s;
 	int is_dst_now = FALSE;
@@ -1362,28 +1374,28 @@ time_t get_next_log_rotation_time(void) {
 	is_dst_now = (t->tm_isdst > 0) ? TRUE : FALSE;
 
 	switch(log_rotation_method) {
-		case LOG_ROTATION_HOURLY:
-			t->tm_hour++;
-			run_time = mktime(t);
-			break;
-		case LOG_ROTATION_DAILY:
-			t->tm_mday++;
-			t->tm_hour = 0;
-			run_time = mktime(t);
-			break;
-		case LOG_ROTATION_WEEKLY:
-			t->tm_mday += (7 - t->tm_wday);
-			t->tm_hour = 0;
-			run_time = mktime(t);
-			break;
-		case LOG_ROTATION_MONTHLY:
-		default:
-			t->tm_mon++;
-			t->tm_mday = 1;
-			t->tm_hour = 0;
-			run_time = mktime(t);
-			break;
-		}
+	case LOG_ROTATION_HOURLY:
+		t->tm_hour++;
+		run_time = mktime(t);
+		break;
+	case LOG_ROTATION_DAILY:
+		t->tm_mday++;
+		t->tm_hour = 0;
+		run_time = mktime(t);
+		break;
+	case LOG_ROTATION_WEEKLY:
+		t->tm_mday += (7 - t->tm_wday);
+		t->tm_hour = 0;
+		run_time = mktime(t);
+		break;
+	case LOG_ROTATION_MONTHLY:
+	default:
+		t->tm_mon++;
+		t->tm_mday = 1;
+		t->tm_hour = 0;
+		run_time = mktime(t);
+		break;
+	}
 
 	if(is_dst_now == TRUE && t->tm_isdst == 0)
 		run_time += 3600;
@@ -1391,7 +1403,7 @@ time_t get_next_log_rotation_time(void) {
 		run_time -= 3600;
 
 	return run_time;
-	}
+}
 
 
 
@@ -1401,7 +1413,8 @@ time_t get_next_log_rotation_time(void) {
 
 
 /* trap signals so we can exit gracefully */
-void setup_sighandler(void) {
+void setup_sighandler(void)
+{
 
 	/* reset the shutdown flag */
 	sigshutdown = FALSE;
@@ -1420,11 +1433,12 @@ void setup_sighandler(void) {
 		signal(SIGSEGV, sighandler);
 
 	return;
-	}
+}
 
 
 /* reset signal handling... */
-void reset_sighandler(void) {
+void reset_sighandler(void)
+{
 
 	/* set signal handling to default actions */
 	signal(SIGQUIT, SIG_DFL);
@@ -1435,11 +1449,12 @@ void reset_sighandler(void) {
 	signal(SIGXFSZ, SIG_DFL);
 
 	return;
-	}
+}
 
 
 /* handle signals */
-void sighandler(int sig) {
+void sighandler(int sig)
+{
 	const char *sigs[35] = {"EXIT", "HUP", "INT", "QUIT", "ILL", "TRAP", "ABRT", "BUS", "FPE", "KILL", "USR1", "SEGV", "USR2", "PIPE", "ALRM", "TERM", "STKFLT", "CHLD", "CONT", "STOP", "TSTP", "TTIN", "TTOU", "URG", "XCPU", "XFSZ", "VTALRM", "PROF", "WINCH", "IO", "PWR", "UNUSED", "ZERR", "DEBUG", (char *)NULL};
 	int x = 0;
 
@@ -1466,26 +1481,28 @@ void sighandler(int sig) {
 	else if(sig < 16) {
 		logit(NSLOG_PROCESS_INFO, TRUE, "Caught SIG%s, shutting down...\n", sigs[sig]);
 		sigshutdown = TRUE;
-		}
-
-	return;
 	}
 
+	return;
+}
+
 /* handle timeouts when executing commands via my_system_r() */
-void my_system_sighandler(int sig) {
+void my_system_sighandler(int sig)
+{
 
 	/* force the child process to exit... */
 	_exit(STATE_CRITICAL);
-	}
+}
 
 
 /* Handle the SIGXFSZ signal. A SIGXFSZ signal is received when a file exceeds
 	the maximum allowable size either as dictated by the fzise paramater in
 	/etc/security/limits.conf (ulimit -f) or by the maximum size allowed by
 	the filesystem */
-void handle_sigxfsz(int sig) {
+void handle_sigxfsz(int sig)
+{
 
-	static time_t lastlog_time = (time_t)0;	/* Save the last log time so we 
+	static time_t lastlog_time = (time_t)0;	/* Save the last log time so we
 											   don't log too often. */
 	unsigned long log_interval = 300;		/* How frequently to log messages
 											   about receiving the signal */
@@ -1500,7 +1517,7 @@ void handle_sigxfsz(int sig) {
 		object_precache_file,
 		status_file,
 		retention_file,
-		};
+	};
 	int x;
 	char **filep;
 	long long size;
@@ -1517,93 +1534,90 @@ void handle_sigxfsz(int sig) {
 		if(getrlimit(RLIMIT_FSIZE, &rlim) != 0) {
 			/* Attempt to log the error, realizing that the logging may fail
 				if it is the log file that is over the size limit. */
-			logit(NSLOG_RUNTIME_ERROR, TRUE, 
-					"Unable to determine current resoure limits: %s\n", 
-					strerror(errno));
-			}
+			logit(NSLOG_RUNTIME_ERROR, TRUE,
+			      "Unable to determine current resoure limits: %s\n",
+			      strerror(errno));
+		}
 
-		/* Try to figure out which file caused the signal and react 
+		/* Try to figure out which file caused the signal and react
 				appropriately */
-		for(x = 0, filep = files; x < (sizeof(files) / sizeof(files[0])); 
-				x++, filep++) {
+		for(x = 0, filep = files; x < (sizeof(files) / sizeof(files[0]));
+		    x++, filep++) {
 			if((*filep != NULL) && strcmp(*filep, "/dev/null")) {
 				if((size = check_file_size(*filep, 1024, rlim)) == -1) {
 					lastlog_time = now;
 					return;
-					}
-				else if(size > max_size) {
+				} else if(size > max_size) {
 					max_size = size;
 					max_name = log_file;
-					}
 				}
 			}
+		}
 		if((max_size > 0) && (max_name != NULL)) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "SIGXFSZ received because a "
-					"file's size may have exceeded the file size limits of "
-					"the filesystem. The largest file checked, '%s', has a "
-					"size of %lld bytes", max_name, max_size);
-			
-			}
-		else {
+			      "file's size may have exceeded the file size limits of "
+			      "the filesystem. The largest file checked, '%s', has a "
+			      "size of %lld bytes", max_name, max_size);
+
+		} else {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "SIGXFSZ received but unable to "
-					"determine which file may have caused it.");
-			}
+			      "determine which file may have caused it.");
 		}
-	return;
 	}
+	return;
+}
 
 /* Checks a file to determine whether it exceeds resource limit imposed
-	limits. Returns the file size if file is OK, 0 if it's status could not 
-	be determined, or -1 if not OK. fudge is the fudge factor (in bytes) for 
+	limits. Returns the file size if file is OK, 0 if it's status could not
+	be determined, or -1 if not OK. fudge is the fudge factor (in bytes) for
 	checking the file size */
-static long long check_file_size(char *path, unsigned long fudge, 
-		struct rlimit rlim) {
+static long long check_file_size(char *path, unsigned long fudge,
+                                 struct rlimit rlim)
+{
 
 	struct stat status;
 
 	/* Make sure we were passed a legitimate file path */
 	if(NULL == path) {
 		return 0;
-		}
+	}
 
 	/* Get the status of the file */
 	if(stat(path, &status) == 0) {
 		/* Make sure it is a file */
 		if(S_ISREG(status.st_mode)) {
-			/* If the file size plus the fudge factor exceeds the 
+			/* If the file size plus the fudge factor exceeds the
 				current resource limit imposed size limit, log an error */
 			if(status.st_size + fudge > rlim.rlim_cur) {
 				logit(NSLOG_RUNTIME_ERROR, TRUE, "Size of file '%s' (%llu) "
-						"exceeds (or nearly exceeds) size imposed by resource "
-						"limits (%llu). Consider increasing limits with "
-						"ulimit(1).\n", path, 
-						(unsigned long long)status.st_size, 
-						(unsigned long long)rlim.rlim_cur);
+				      "exceeds (or nearly exceeds) size imposed by resource "
+				      "limits (%llu). Consider increasing limits with "
+				      "ulimit(1).\n", path,
+				      (unsigned long long)status.st_size,
+				      (unsigned long long)rlim.rlim_cur);
 				return -1;
-				}
-			else {
+			} else {
 				return status.st_size;
-				}
 			}
-		else {
+		} else {
 			return 0;
-			}
 		}
-	else {
+	} else {
 		/* If we could not determine the file status, log an error message */
-		logit(NSLOG_RUNTIME_ERROR, TRUE, 
-				"Unable to determine status of file %s: %s\n", 
-				log_file, strerror(errno));
+		logit(NSLOG_RUNTIME_ERROR, TRUE,
+		      "Unable to determine status of file %s: %s\n",
+		      log_file, strerror(errno));
 		return 0;
-		}
 	}
+}
 
 
 /******************************************************************/
 /************************ DAEMON FUNCTIONS ************************/
 /******************************************************************/
 
-int daemon_init(void) {
+int daemon_init(void)
+{
 	pid_t pid = -1;
 	int pidno = 0;
 	int lockfile = 0;
@@ -1644,14 +1658,14 @@ int daemon_init(void) {
 
 		cleanup();
 		exit(ERROR);
-		}
+	}
 
 	/* see if we can read the contents of the lockfile */
 	if((val = read(lockfile, buf, (size_t)10)) < 0) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Lockfile exists but cannot be read");
 		cleanup();
 		exit(ERROR);
-		}
+	}
 
 	/* we read something - check the PID */
 	if(val > 0) {
@@ -1659,14 +1673,14 @@ int daemon_init(void) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Lockfile '%s' does not contain a valid PID (%s)", lock_file, buf);
 			cleanup();
 			exit(ERROR);
-			}
 		}
+	}
 
 	/* check for SIGHUP */
 	if(val == 1 && (pid = (pid_t)pidno) == getpid()) {
 		close(lockfile);
 		return OK;
-		}
+	}
 
 	/* exit on errors... */
 	if((pid = fork()) < 0)
@@ -1690,13 +1704,12 @@ int daemon_init(void) {
 		if(errno == EACCES || errno == EAGAIN) {
 			fcntl(lockfile, F_GETLK, &lock);
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Lockfile '%s' looks like its already held by another instance of Nagios (PID %d).  Bailing out...", lock_file, (int)lock.l_pid);
-			}
-		else
+		} else
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Cannot lock lockfile '%s': %s. Bailing out...", lock_file, strerror(errno));
 
 		cleanup();
 		exit(ERROR);
-		}
+	}
 
 	/* prevent daemon from dumping a core file... */
 #ifdef RLIMIT_CORE
@@ -1704,7 +1717,7 @@ int daemon_init(void) {
 		getrlimit(RLIMIT_CORE, &limit);
 		limit.rlim_cur = 0;
 		setrlimit(RLIMIT_CORE, &limit);
-		}
+	}
 #endif
 
 	/* write PID to lockfile... */
@@ -1724,7 +1737,7 @@ int daemon_init(void) {
 #endif
 
 	return OK;
-	}
+}
 
 
 
@@ -1733,7 +1746,8 @@ int daemon_init(void) {
 /******************************************************************/
 
 /* drops privileges */
-int drop_privileges(char *user, char *group) {
+int drop_privileges(char *user, char *group)
+{
 	uid_t uid = -1;
 	gid_t gid = -1;
 	struct group *grp = NULL;
@@ -1754,12 +1768,12 @@ int drop_privileges(char *user, char *group) {
 				gid = (gid_t)(grp->gr_gid);
 			else
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not get group entry for '%s'", group);
-			}
+		}
 
 		/* else we were passed the GID */
 		else
 			gid = (gid_t)atoi(group);
-		}
+	}
 
 	/* set effective user ID */
 	if(user != NULL) {
@@ -1771,12 +1785,12 @@ int drop_privileges(char *user, char *group) {
 				uid = (uid_t)(pw->pw_uid);
 			else
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not get passwd entry for '%s'", user);
-			}
+		}
 
 		/* else we were passed the UID */
 		else
 			uid = (uid_t)atoi(user);
-		}
+	}
 
 	/* now that we know what to change to, we fix log file permissions */
 	fix_log_file_owner(uid, gid);
@@ -1786,8 +1800,8 @@ int drop_privileges(char *user, char *group) {
 		if(setgid(gid) == -1) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not set effective GID=%d", (int)gid);
 			result = ERROR;
-			}
 		}
+	}
 #ifdef HAVE_INITGROUPS
 
 	if(uid != geteuid()) {
@@ -1799,9 +1813,9 @@ int drop_privileges(char *user, char *group) {
 			else {
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Possibly root user failed dropping privileges with initgroups()");
 				return ERROR;
-				}
 			}
 		}
+	}
 #endif
 	if(setuid(uid) == -1) {
 		logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not set effective UID=%d", (int)uid);
@@ -1809,7 +1823,7 @@ int drop_privileges(char *user, char *group) {
 	}
 
 	return result;
-	}
+}
 
 
 
@@ -1819,7 +1833,8 @@ int drop_privileges(char *user, char *group) {
 /******************************************************************/
 
 /* processes files in the check result queue directory */
-int process_check_result_queue(char *dirname) {
+int process_check_result_queue(char *dirname)
+{
 	char file[MAX_FILENAME_LENGTH];
 	DIR *dirp = NULL;
 	struct dirent *dirfile = NULL;
@@ -1834,13 +1849,13 @@ int process_check_result_queue(char *dirname) {
 	if(dirname == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: No check result queue directory specified.\n");
 		return ERROR;
-		}
+	}
 
 	/* open the directory for reading */
 	if((dirp = opendir(dirname)) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not open check result queue directory '%s' for reading.\n", dirname);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_CHECKS, 1, "Starting to read check result queue '%s'...\n", dirname);
 
@@ -1852,13 +1867,13 @@ int process_check_result_queue(char *dirname) {
 		if (sigshutdown == TRUE || sigrestart == TRUE) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Breaking out of check result reaper: signal encountered\n");
 			break;
-			}
+		}
 
 		/* break out if we've been here too long */
 		if (start + max_check_reaper_time < time(NULL)) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Breaking out of check result reaper: max time (%ds) exceeded\n", max_check_reaper_time);
 			break;
-			}
+		}
 
 		/* create /path/to/file */
 		snprintf(file, sizeof(file), "%s/%s", dirname, dirfile->d_name);
@@ -1871,7 +1886,7 @@ int process_check_result_queue(char *dirname) {
 			if(stat(file, &stat_buf) == -1) {
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Could not stat() check result file '%s'.\n", file);
 				continue;
-				}
+			}
 
 			/* we only care about real files */
 			if (!S_ISREG(stat_buf.st_mode))
@@ -1883,7 +1898,7 @@ int process_check_result_queue(char *dirname) {
 			if (stat_buf.st_mtime + max_check_result_file_age < time(NULL)) {
 				delete_check_result_file(dirfile->d_name);
 				continue;
-				}
+			}
 
 			/* can we find the associated ok-to-go file ? */
 			asprintf(&temp_buffer, "%s.ok", file);
@@ -1900,14 +1915,14 @@ int process_check_result_queue(char *dirname) {
 				break;
 
 			check_result_files++;
-			}
 		}
+	}
 
 	closedir(dirp);
 
 	return check_result_files;
 
-	}
+}
 
 
 int process_check_result(check_result *cr)
@@ -1925,23 +1940,23 @@ int process_check_result(check_result *cr)
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Got check result for service '%s' on host '%s'. Unable to find service\n",
 			      cr->service_description, cr->host_name);
 			return ERROR;
-			}
+		}
 		log_debug_info(DEBUGL_CHECKS, 2, "Processing check result for service '%s' on host '%s'\n",
 		               svc->description, svc->host_name);
 		svc->check_source = source_name;
 		return handle_async_service_check_result(svc, cr);
-		}
+	}
 	if (cr->object_check_type == HOST_CHECK) {
 		host *hst;
 		hst = find_host(cr->host_name);
 		if (!hst) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Got host checkresult for '%s', but no such host can be found\n", cr->host_name);
 			return ERROR;
-			}
+		}
 		log_debug_info(DEBUGL_CHECKS, 2, "Processing check result for host '%s'\n", hst->name);
 		hst->check_source = source_name;
 		return handle_async_host_check_result(hst, cr);
-		}
+	}
 
 	/* We should never end up here */
 	logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unknown object check type for checkresult: %d; (host_name: %s; service_description: %s)\n",
@@ -1950,10 +1965,11 @@ int process_check_result(check_result *cr)
 	      cr->service_description ? cr->service_description : "(null)");
 
 	return ERROR;
-	}
+}
 
 /* reads check result(s) from a file */
-int process_check_result_file(char *fname) {
+int process_check_result_file(char *fname)
+{
 	mmapfile *thefile = NULL;
 	char *input = NULL;
 	char *var = NULL;
@@ -1979,7 +1995,7 @@ int process_check_result_file(char *fname) {
 		unlink(fname);
 
 		return ERROR;
-		}
+	}
 
 	/* read in all lines from the file */
 	while(1) {
@@ -2004,13 +2020,13 @@ int process_check_result_file(char *fname) {
 				/* process the check result */
 				process_check_result(&cr);
 
-				}
+			}
 
 			/* cleanse for next check result */
 			free_check_result(&cr);
 			init_check_result(&cr);
 			cr.output_file = fname;
-			}
+		}
 
 		if((var = my_strtok(input, "=")) == NULL)
 			continue;
@@ -2024,8 +2040,8 @@ int process_check_result_file(char *fname) {
 			/* this will only work as intended if file_time comes before check results */
 			if(max_check_result_file_age > 0 && (current_time - (strtoul(val, NULL, 0)) > max_check_result_file_age)) {
 				break;
-				}
 			}
+		}
 
 		/* else we have check result data */
 		else {
@@ -2034,8 +2050,7 @@ int process_check_result_file(char *fname) {
 			else if(!strcmp(var, "service_description")) {
 				cr.service_description = (char *)strdup(val);
 				cr.object_check_type = SERVICE_CHECK;
-				}
-			else if(!strcmp(var, "check_type"))
+			} else if(!strcmp(var, "check_type"))
 				cr.check_type = atoi(val);
 			else if(!strcmp(var, "check_options"))
 				cr.check_options = atoi(val);
@@ -2052,16 +2067,14 @@ int process_check_result_file(char *fname) {
 					continue;
 				cr.start_time.tv_sec = strtoul(v1, NULL, 0);
 				cr.start_time.tv_usec = strtoul(v2, NULL, 0);
-				}
-			else if(!strcmp(var, "finish_time")) {
+			} else if(!strcmp(var, "finish_time")) {
 				if((v1 = strtok(val, ".")) == NULL)
 					continue;
 				if((v2 = strtok(NULL, "\n")) == NULL)
 					continue;
 				cr.finish_time.tv_sec = strtoul(v1, NULL, 0);
 				cr.finish_time.tv_usec = strtoul(v2, NULL, 0);
-				}
-			else if(!strcmp(var, "early_timeout"))
+			} else if(!strcmp(var, "early_timeout"))
 				cr.early_timeout = atoi(val);
 			else if(!strcmp(var, "exited_ok"))
 				cr.exited_ok = atoi(val);
@@ -2069,15 +2082,15 @@ int process_check_result_file(char *fname) {
 				cr.return_code = atoi(val);
 			else if(!strcmp(var, "output"))
 				cr.output = (char *)strdup(val);
-			}
 		}
+	}
 
 	/* do we have the minimum amount of data? */
 	if(cr.host_name != NULL && cr.output != NULL) {
 
 		/* process check result */
 		process_check_result(&cr);
-		}
+	}
 
 	free_check_result(&cr);
 
@@ -2089,13 +2102,14 @@ int process_check_result_file(char *fname) {
 	delete_check_result_file(fname);
 
 	return OK;
-	}
+}
 
 
 
 
 /* deletes as check result file, as well as its ok-to-go file */
-int delete_check_result_file(char *fname) {
+int delete_check_result_file(char *fname)
+{
 	char *temp_buffer = NULL;
 
 	/* delete the result file */
@@ -2107,13 +2121,14 @@ int delete_check_result_file(char *fname) {
 	my_free(temp_buffer);
 
 	return OK;
-	}
+}
 
 
 
 
 /* initializes a host/service check result */
-int init_check_result(check_result *info) {
+int init_check_result(check_result *info)
+{
 
 	if(info == NULL)
 		return ERROR;
@@ -2140,12 +2155,13 @@ int init_check_result(check_result *info) {
 	info->engine = NULL;
 
 	return OK;
-	}
+}
 
 
 
 /* frees memory associated with a host/service check result */
-int free_check_result(check_result *info) {
+int free_check_result(check_result *info)
+{
 
 	if(info == NULL)
 		return OK;
@@ -2155,7 +2171,7 @@ int free_check_result(check_result *info) {
 	my_free(info->output);
 
 	return OK;
-	}
+}
 
 
 /******************************************************************/
@@ -2163,7 +2179,8 @@ int free_check_result(check_result *info) {
 /******************************************************************/
 
 /* gets the next string from a buffer in memory - strings are terminated by newlines, which are removed */
-char *get_next_string_from_buf(char *buf, int *start_index, int bufsize) {
+char *get_next_string_from_buf(char *buf, int *start_index, int bufsize)
+{
 	char *sptr = NULL;
 	const char *nl = "\n";
 	int x;
@@ -2187,12 +2204,13 @@ char *get_next_string_from_buf(char *buf, int *start_index, int bufsize) {
 	*start_index += x + 1;
 
 	return sptr;
-	}
+}
 
 
 
 /* determines whether or not an object name (host, service, etc) contains illegal characters */
-int contains_illegal_object_chars(char *name) {
+int contains_illegal_object_chars(char *name)
+{
 	register int x = 0;
 	register int y = 0;
 
@@ -2207,14 +2225,15 @@ int contains_illegal_object_chars(char *name) {
 			for(y = 0; illegal_object_chars[y]; y++)
 				if(name[x] == illegal_object_chars[y])
 					return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /* escapes newlines in a string */
-char *escape_newlines(char *rawbuf) {
+char *escape_newlines(char *rawbuf)
+{
 	char *newbuf = NULL;
 	register int x, y;
 
@@ -2231,29 +2250,30 @@ char *escape_newlines(char *rawbuf) {
 		if(rawbuf[x] == '\\') {
 			newbuf[y++] = '\\';
 			newbuf[y++] = '\\';
-			}
+		}
 
 		/* escape newlines */
 		else if(rawbuf[x] == '\n') {
 			newbuf[y++] = '\\';
 			newbuf[y++] = 'n';
-			}
+		}
 
 		else
 			newbuf[y++] = rawbuf[x];
-		}
+	}
 	newbuf[y] = '\x0';
 
 	return newbuf;
-	}
+}
 
 
 /* compares strings */
-int compare_strings(char *val1a, char *val2a) {
+int compare_strings(char *val1a, char *val2a)
+{
 
 	/* use the compare_hashdata() function */
 	return compare_hashdata(val1a, NULL, val2a, NULL);
-	}
+}
 
 
 /******************************************************************/
@@ -2261,7 +2281,8 @@ int compare_strings(char *val1a, char *val2a) {
 /******************************************************************/
 
 /* renames a file - works across filesystems (Mike Wiacek) */
-int my_rename(char *source, char *dest) {
+int my_rename(char *source, char *dest)
+{
 	int rename_result = 0;
 
 
@@ -2282,31 +2303,32 @@ int my_rename(char *source, char *dest) {
 			if(my_fcopy(source, dest) == ERROR) {
 				logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to rename file '%s' to '%s': %s\n", source, dest, strerror(errno));
 				return -1;
-				}
+			}
 
 			/* delete the original file */
 			unlink(source);
 
 			/* reset result since we successfully copied file */
 			rename_result = 0;
-			}
+		}
 
 		/* some other error occurred */
 		else {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to rename file '%s' to '%s': %s\n", source, dest, strerror(errno));
 			return rename_result;
-			}
 		}
+	}
 
 	return rename_result;
-	}
+}
 
 /*
  * copy a file from the path at source to the already opened
  * destination file dest.
  * This is handy when creating tempfiles with mkstemp()
  */
-int my_fdcopy(char *source, char *dest, int dest_fd) {
+int my_fdcopy(char *source, char *dest, int dest_fd)
+{
 	int source_fd, rd_result = 0, wr_result = 0;
 	int tot_written = 0, tot_read = 0, buf_size = 0;
 	struct stat st;
@@ -2316,7 +2338,7 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 	if((source_fd = open(source, O_RDONLY, 0644)) < 0) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to open file '%s' for reading: %s\n", source, strerror(errno));
 		return ERROR;
-		}
+	}
 
 	/*
 	 * find out how large the source-file is so we can be sure
@@ -2326,7 +2348,7 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to stat source file '%s' for my_fcopy(): %s\n", source, strerror(errno));
 		close(source_fd);
 		return ERROR;
-		}
+	}
 
 	/*
 	 * If the file is huge, read it and write it in chunks.
@@ -2343,7 +2365,7 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to malloc(%d) bytes: %s\n", buf_size, strerror(errno));
 		close(source_fd);
 		return ERROR;
-		}
+	}
 	/* most of the times, this loop will be gone through once */
 	while(tot_written < st.st_size) {
 		int loop_wr = 0;
@@ -2354,7 +2376,7 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 				continue;
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: my_fcopy() failed to read from '%s': %s\n", source, strerror(errno));
 			break;
-			}
+		}
 		tot_read += rd_result;
 
 		while(loop_wr < rd_result) {
@@ -2365,13 +2387,13 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 					continue;
 				logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: my_fcopy() failed to write to '%s': %s\n", dest, strerror(errno));
 				break;
-				}
-			loop_wr += wr_result;
 			}
+			loop_wr += wr_result;
+		}
 		if(wr_result < 0)
 			break;
 		tot_written += loop_wr;
-		}
+	}
 
 	/*
 	 * clean up irregardless of how things went. dest_fd comes from
@@ -2384,13 +2406,14 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 		/* don't leave half-written files around */
 		unlink(dest);
 		return ERROR;
-		}
-
-	return OK;
 	}
 
+	return OK;
+}
+
 /* copies a file */
-int my_fcopy(char *source, char *dest) {
+int my_fcopy(char *source, char *dest)
+{
 	int dest_fd, result;
 
 	/* make sure we have something */
@@ -2404,19 +2427,20 @@ int my_fcopy(char *source, char *dest) {
 	if((dest_fd = open(dest, O_WRONLY | O_TRUNC | O_CREAT | O_APPEND, 0644)) < 0) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to open file '%s' for writing: %s\n", dest, strerror(errno));
 		return ERROR;
-		}
+	}
 
 	result = my_fdcopy(source, dest, dest_fd);
 	close(dest_fd);
 	return result;
-	}
+}
 
 /******************************************************************/
 /******************** DYNAMIC BUFFER FUNCTIONS ********************/
 /******************************************************************/
 
 /* initializes a dynamic buffer */
-int dbuf_init(dbuf *db, int chunk_size) {
+int dbuf_init(dbuf *db, int chunk_size)
+{
 
 	if(db == NULL)
 		return ERROR;
@@ -2427,11 +2451,12 @@ int dbuf_init(dbuf *db, int chunk_size) {
 	db->chunk_size = chunk_size;
 
 	return OK;
-	}
+}
 
 
 /* frees a dynamic buffer */
-int dbuf_free(dbuf *db) {
+int dbuf_free(dbuf *db)
+{
 
 	if(db == NULL)
 		return ERROR;
@@ -2443,11 +2468,12 @@ int dbuf_free(dbuf *db) {
 	db->allocated_size = 0L;
 
 	return OK;
-	}
+}
 
 
 /* dynamically expands a string */
-int dbuf_strcat(dbuf *db, const char *buf) {
+int dbuf_strcat(dbuf *db, const char *buf)
+{
 	char *newbuf = NULL;
 	unsigned long buflen = 0L;
 	unsigned long new_size = 0L;
@@ -2477,7 +2503,7 @@ int dbuf_strcat(dbuf *db, const char *buf) {
 
 		/* terminate buffer */
 		db->buf[db->used_size] = '\x0';
-		}
+	}
 
 	/* append the new string */
 	strcat(db->buf, buf);
@@ -2486,7 +2512,7 @@ int dbuf_strcat(dbuf *db, const char *buf) {
 	db->used_size += buflen;
 
 	return OK;
-	}
+}
 
 
 /******************************************************************/
@@ -2494,7 +2520,8 @@ int dbuf_strcat(dbuf *db, const char *buf) {
 /******************************************************************/
 
 /* initialize check statistics data structures */
-int init_check_stats(void) {
+int init_check_stats(void)
+{
 	int x = 0;
 	int y = 0;
 
@@ -2506,14 +2533,15 @@ int init_check_stats(void) {
 		for(y = 0; y < 3; y++)
 			check_statistics[x].minute_stats[y] = 0;
 		check_statistics[x].last_update = (time_t)0L;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* records stats for a given type of check */
-int update_check_stats(int check_type, time_t check_time) {
+int update_check_stats(int check_type, time_t check_time)
+{
 	time_t current_time;
 	unsigned long minutes = 0L;
 	int new_current_bucket = 0;
@@ -2530,7 +2558,7 @@ int update_check_stats(int check_type, time_t check_time) {
 		printf("TYPE[%d] CHECK TIME==0!\n", check_type);
 #endif
 		check_time = current_time;
-		}
+	}
 
 	/* do some sanity checks on the age of the stats data before we start... */
 	/* get the new current bucket number */
@@ -2545,7 +2573,7 @@ int update_check_stats(int check_type, time_t check_time) {
 #ifdef DEBUG_CHECK_STATS
 		printf("CLEARING ALL: TYPE[%d], CURRENT=%lu, LASTUPDATE=%lu\n", check_type, (unsigned long)current_time, (unsigned long)check_statistics[check_type].last_update);
 #endif
-		}
+	}
 
 	/* different current bucket number than last time */
 	else if(new_current_bucket != check_statistics[check_type].current_bucket) {
@@ -2564,13 +2592,13 @@ int update_check_stats(int check_type, time_t check_time) {
 
 			/* clear old bucket value */
 			check_statistics[check_type].bucket[this_bucket] = 0;
-			}
+		}
 
 		/* update the current bucket number, push old value to overflow bucket */
 		check_statistics[check_type].overflow_bucket = check_statistics[check_type].bucket[new_current_bucket];
 		check_statistics[check_type].current_bucket = new_current_bucket;
 		check_statistics[check_type].bucket[new_current_bucket] = 0;
-		}
+	}
 #ifdef DEBUG_CHECK_STATS
 	else
 		printf("NO CLEARING NEEDED\n");
@@ -2592,11 +2620,12 @@ int update_check_stats(int check_type, time_t check_time) {
 	check_statistics[check_type].last_update = current_time;
 
 	return OK;
-	}
+}
 
 
 /* generate 1/5/15 minute stats for a given type of check */
-int generate_check_stats(void) {
+int generate_check_stats(void)
+{
 	time_t current_time;
 	int x = 0;
 	int new_current_bucket = 0;
@@ -2627,7 +2656,7 @@ int generate_check_stats(void) {
 #ifdef DEBUG_CHECK_STATS
 			printf("GEN CLEARING ALL: TYPE[%d], CURRENT=%lu, LASTUPDATE=%lu\n", check_type, (unsigned long)current_time, (unsigned long)check_statistics[check_type].last_update);
 #endif
-			}
+		}
 
 		/* different current bucket number than last time */
 		else if(new_current_bucket != check_statistics[check_type].current_bucket) {
@@ -2646,13 +2675,13 @@ int generate_check_stats(void) {
 
 				/* clear old bucket value */
 				check_statistics[check_type].bucket[this_bucket] = 0;
-				}
+			}
 
 			/* update the current bucket number, push old value to overflow bucket */
 			check_statistics[check_type].overflow_bucket = check_statistics[check_type].bucket[new_current_bucket];
 			check_statistics[check_type].current_bucket = new_current_bucket;
 			check_statistics[check_type].bucket[new_current_bucket] = 0;
-			}
+		}
 #ifdef DEBUG_CHECK_STATS
 		else
 			printf("GEN NO CLEARING NEEDED: TYPE[%d], CURRENT=%lu, LASTUPDATE=%lu\n", check_type, (unsigned long)current_time, (unsigned long)check_statistics[check_type].last_update);
@@ -2660,7 +2689,7 @@ int generate_check_stats(void) {
 
 		/* update last check time */
 		check_statistics[check_type].last_update = current_time;
-		}
+	}
 
 	/* determine weights to use for this/last buckets */
 	seconds = ((unsigned long)current_time - (unsigned long)program_start) % 60;
@@ -2694,11 +2723,11 @@ int generate_check_stats(void) {
 			/* if this is the current bucket, use its full value + weighted % of last bucket */
 			if(x == 0) {
 				bucket_value = (int)(this_bucket_value + floor(last_bucket_value * last_bucket_weight));
-				}
+			}
 			/* otherwise use weighted % of this and last bucket */
 			else {
 				bucket_value = (int)(ceil(this_bucket_value * this_bucket_weight) + floor(last_bucket_value * last_bucket_weight));
-				}
+			}
 
 			/* 1 minute stats */
 			if(x == 0)
@@ -2717,15 +2746,15 @@ int generate_check_stats(void) {
 #endif
 			/* record last update time */
 			check_statistics[check_type].last_update = current_time;
-			}
+		}
 
 #ifdef DEBUG_CHECK_STATS
 		printf("TYPE[%d]   1/5/15 = %d, %d, %d (seconds=%d, this_weight=%f, last_weight=%f)\n", check_type, check_statistics[check_type].minute_stats[0], check_statistics[check_type].minute_stats[1], check_statistics[check_type].minute_stats[2], seconds, this_bucket_weight, last_bucket_weight);
 #endif
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -2735,7 +2764,8 @@ int generate_check_stats(void) {
 /******************************************************************/
 
 /* check for new releases of Nagios */
-int check_for_nagios_updates(int force, int reschedule) {
+int check_for_nagios_updates(int force, int reschedule)
+{
 	time_t current_time;
 	int result = OK;
 	int api_result = OK;
@@ -2777,7 +2807,7 @@ int check_for_nagios_updates(int force, int reschedule) {
 
 		/* query api */
 		api_result = query_update_api();
-		}
+	}
 
 	/* should we reschedule the update check? */
 	if(reschedule == TRUE) {
@@ -2798,7 +2828,7 @@ int check_for_nagios_updates(int force, int reschedule) {
 		if(do_check == FALSE) {
 			next_check = last_update_check + BASE_UPDATE_CHECK_INTERVAL;
 			next_check = next_check + (unsigned long)(((float)randnum / RAND_MAX) * UPDATE_CHECK_INTERVAL_WOBBLE);
-			}
+		}
 
 		/* we tried to check for an update */
 		else {
@@ -2807,14 +2837,14 @@ int check_for_nagios_updates(int force, int reschedule) {
 			if(api_result == OK) {
 				next_check = current_time + BASE_UPDATE_CHECK_INTERVAL;
 				next_check += (unsigned long)(((float)randnum / RAND_MAX) * UPDATE_CHECK_INTERVAL_WOBBLE);
-				}
+			}
 
 			/* query resulted in an error - retry at a shorter interval */
 			else {
 				next_check = current_time + BASE_UPDATE_CHECK_RETRY_INTERVAL;
 				next_check += (unsigned long)(((float)randnum / RAND_MAX) * UPDATE_CHECK_RETRY_INTERVAL_WOBBLE);
-				}
 			}
+		}
 
 		/* make sure next check isn't in the past - if it is, schedule a check in 1 minute */
 		if(next_check < current_time)
@@ -2824,15 +2854,16 @@ int check_for_nagios_updates(int force, int reschedule) {
 
 		/* schedule the next update event */
 		schedule_new_event(EVENT_CHECK_PROGRAM_UPDATE, TRUE, next_check, FALSE, BASE_UPDATE_CHECK_INTERVAL, NULL, TRUE, NULL, NULL, 0);
-		}
+	}
 
 	return result;
-	}
+}
 
 
 
 /* checks for updates at api.nagios.org */
-int query_update_api(void) {
+int query_update_api(void)
+{
 	const char *api_server = "api.nagios.org";
 	const char *api_path = "/versioncheck/";
 	char *api_query = NULL;
@@ -2864,8 +2895,8 @@ int query_update_api(void) {
 			asprintf(&qopts2, "%s&last_version=%s", api_query_opts, last_program_version);
 			my_free(api_query_opts);
 			api_query_opts = qopts2;
-			}
 		}
+	}
 
 	/* generate the query */
 	asprintf(&api_query, "v=1&product=nagios&tinycheck=1&stableonly=1&uid=%lu", update_uid);
@@ -2874,7 +2905,7 @@ int query_update_api(void) {
 		asprintf(&api_query2, "%s&version=%s%s", api_query, PROGRAM_VERSION, (api_query_opts == NULL) ? "" : api_query_opts);
 		my_free(api_query);
 		api_query = api_query2;
-		}
+	}
 
 	/* generate the HTTP request */
 	asprintf(&buf,
@@ -2909,7 +2940,7 @@ int query_update_api(void) {
 			if(!strcmp(ptr, "")) {
 				in_header = FALSE;
 				continue;
-				}
+			}
 			if(in_header == TRUE)
 				continue;
 
@@ -2920,16 +2951,14 @@ int query_update_api(void) {
 				update_available = atoi(val);
 				/* we were successful */
 				update_check_succeeded = TRUE;
-				}
-			else if(!strcmp(var, "UPDATE_VERSION")) {
+			} else if(!strcmp(var, "UPDATE_VERSION")) {
 				if(new_program_version)
 					my_free(new_program_version);
 				new_program_version = strdup(val);
-				}
-			else if(!strcmp(var, "UPDATE_RELEASEDATE")) {
-				}
+			} else if(!strcmp(var, "UPDATE_RELEASEDATE")) {
 			}
 		}
+	}
 
 	/* cleanup */
 	my_free(buf);
@@ -2943,10 +2972,10 @@ int query_update_api(void) {
 		if(last_program_version)
 			free(last_program_version);
 		last_program_version = (char *)strdup(PROGRAM_VERSION);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -2956,17 +2985,19 @@ int query_update_api(void) {
 /******************************************************************/
 
 /* returns Nagios version */
-char *get_program_version(void) {
+char *get_program_version(void)
+{
 
 	return (char *)PROGRAM_VERSION;
-	}
+}
 
 
 /* returns Nagios modification date */
-char *get_program_modification_date(void) {
+char *get_program_modification_date(void)
+{
 
 	return (char *)PROGRAM_MODIFICATION_DATE;
-	}
+}
 
 
 
@@ -2975,7 +3006,8 @@ char *get_program_modification_date(void) {
 /******************************************************************/
 
 /* do some cleanup before we exit */
-void cleanup(void) {
+void cleanup(void)
+{
 
 #ifdef USE_EVENT_BROKER
 	/* unload modules */
@@ -2984,7 +3016,7 @@ void cleanup(void) {
 		neb_unload_all_modules(NEBMODULE_FORCE_UNLOAD, (sigshutdown == TRUE) ? NEBMODULE_NEB_SHUTDOWN : NEBMODULE_NEB_RESTART);
 		neb_free_module_list();
 		neb_deinit_modules();
-		}
+	}
 #endif
 
 	/* free all allocated memory - including macros */
@@ -2992,11 +3024,12 @@ void cleanup(void) {
 	close_log_file();
 
 	return;
-	}
+}
 
 
 /* free the memory allocated to the linked lists */
-void free_memory(nagios_macros *mac) {
+void free_memory(nagios_macros *mac)
+{
 	int i;
 
 	/* free all allocated memory for the object definitions */
@@ -3072,11 +3105,12 @@ void free_memory(nagios_macros *mac) {
 	my_free(mac->x[MACRO_MAINCONFIGFILE]);
 
 	return;
-	}
+}
 
 
 /* free a notification list that was created */
-void free_notification_list(void) {
+void free_notification_list(void)
+{
 	notification *temp_notification = NULL;
 	notification *next_notification = NULL;
 
@@ -3085,17 +3119,18 @@ void free_notification_list(void) {
 		next_notification = temp_notification->next;
 		my_free(temp_notification);
 		temp_notification = next_notification;
-		}
+	}
 
 	/* reset notification list pointer */
 	notification_list = NULL;
 
 	return;
-	}
+}
 
 
 /* reset all system-wide variables, so when we've receive a SIGHUP we can restart cleanly */
-int reset_variables(void) {
+int reset_variables(void)
+{
 
 	log_file = (char *)strdup(DEFAULT_LOG_FILE);
 	temp_file = (char *)strdup(DEFAULT_TEMP_FILE);
@@ -3250,4 +3285,4 @@ int reset_variables(void) {
 	umask(S_IWGRP | S_IWOTH);
 
 	return OK;
-	}
+}

--- a/base/wp-phash.c
+++ b/base/wp-phash.c
@@ -55,8 +55,7 @@ static inline unsigned int
 wp_phash(register const char *str, register unsigned int len)
 {
 	/* the last 136 entries have been cut, as we don't need them */
-	static unsigned char asso_values[256] =
-    {
+	static unsigned char asso_values[256] = {
 		34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
 		34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
 		34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
@@ -83,13 +82,13 @@ wp_phash(register const char *str, register unsigned int len)
 		34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
 		34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
 		34, 34, 34, 34, 34, 34,
-    };
+	};
 	register int hval = len;
 
 	switch (hval) {
 	default:
-        hval += asso_values[(unsigned char)str[4]];
-		/*FALLTHROUGH*/
+		hval += asso_values[(unsigned char)str[4]];
+	/*FALLTHROUGH*/
 	case 4:
 		hval += asso_values[(unsigned char)str[3]];
 		break;

--- a/cgi/archivejson.c
+++ b/cgi/archivejson.c
@@ -66,22 +66,36 @@ int validate_arguments(json_object *, archive_json_cgi_data *, time_t);
 authdata current_authdata;
 
 const string_value_mapping valid_queries[] = {
-	{ "help", ARCHIVE_QUERY_HELP, 
-		"Display help for this CGI" },
-	{ "alertcount", ARCHIVE_QUERY_ALERTCOUNT, 
-		"Return the number of alerts" },
-	{ "alertlist", ARCHIVE_QUERY_ALERTLIST, 
-		"Return a list of alerts" },
-	{ "notificationcount", ARCHIVE_QUERY_NOTIFICATIONCOUNT, 
-		"Return the number of notifications" },
-	{ "notificationlist", ARCHIVE_QUERY_NOTIFICATIONLIST, 
-		"Return a list of notifications" },
-	{ "statechangelist", ARCHIVE_QUERY_STATECHANGELIST, 
-		"Return a list of state changes" },
-	{ "availability", ARCHIVE_QUERY_AVAILABILITY, 
-		"Return an availability report" },
+	{
+		"help", ARCHIVE_QUERY_HELP,
+		"Display help for this CGI"
+	},
+	{
+		"alertcount", ARCHIVE_QUERY_ALERTCOUNT,
+		"Return the number of alerts"
+	},
+	{
+		"alertlist", ARCHIVE_QUERY_ALERTLIST,
+		"Return a list of alerts"
+	},
+	{
+		"notificationcount", ARCHIVE_QUERY_NOTIFICATIONCOUNT,
+		"Return the number of notifications"
+	},
+	{
+		"notificationlist", ARCHIVE_QUERY_NOTIFICATIONLIST,
+		"Return a list of notifications"
+	},
+	{
+		"statechangelist", ARCHIVE_QUERY_STATECHANGELIST,
+		"Return a list of state changes"
+	},
+	{
+		"availability", ARCHIVE_QUERY_AVAILABILITY,
+		"Return an availability report"
+	},
 	{ NULL, -1, NULL },
-	};
+};
 
 static const int query_status[][2] = {
 	{ ARCHIVE_QUERY_HELP, QUERY_STATUS_BETA },
@@ -92,13 +106,13 @@ static const int query_status[][2] = {
 	{ ARCHIVE_QUERY_STATECHANGELIST, QUERY_STATUS_BETA },
 	{ ARCHIVE_QUERY_AVAILABILITY, QUERY_STATUS_BETA },
 	{ -1, -1 },
-	};
+};
 
 const string_value_mapping valid_object_types[] = {
 	{ "host", AU_OBJTYPE_HOST, "Host" },
 	{ "service", AU_OBJTYPE_SERVICE, "Service" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_availability_object_types[] = {
 	{ "hosts", AU_OBJTYPE_HOST, "Hosts" },
@@ -106,13 +120,13 @@ const string_value_mapping valid_availability_object_types[] = {
 	{ "services", AU_OBJTYPE_SERVICE, "Services" },
 	{ "servicegroups", AU_OBJTYPE_SERVICEGROUP, "Servicegroups" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_state_types[] = {
 	{ "hard", AU_STATETYPE_HARD, "Hard" },
 	{ "soft", AU_STATETYPE_SOFT, "Soft" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_states[] = {
 	{ "no_data", AU_STATE_NO_DATA, "No Data" },
@@ -134,7 +148,7 @@ const string_value_mapping valid_host_states[] = {
 	{ "down", AU_STATE_HOST_DOWN, "Down" },
 	{ "unreachable", AU_STATE_HOST_UNREACHABLE, "Unreachable" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_initial_host_states[] = {
 	{ "up", AU_STATE_HOST_UP, "Up" },
@@ -142,7 +156,7 @@ const string_value_mapping valid_initial_host_states[] = {
 	{ "unreachable", AU_STATE_HOST_UNREACHABLE, "Unreachable" },
 	{ "current", AU_STATE_CURRENT_STATE, "Current State" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_service_states[] = {
 	{ "ok", AU_STATE_SERVICE_OK, "Ok" },
@@ -150,7 +164,7 @@ const string_value_mapping valid_service_states[] = {
 	{ "critical", AU_STATE_SERVICE_CRITICAL, "Critical" },
 	{ "unknown", AU_STATE_SERVICE_UNKNOWN, "Unknown" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_initial_service_states[] = {
 	{ "ok", AU_STATE_SERVICE_OK, "Ok" },
@@ -159,52 +173,86 @@ const string_value_mapping valid_initial_service_states[] = {
 	{ "unknown", AU_STATE_SERVICE_UNKNOWN, "Unknown" },
 	{ "current", AU_STATE_CURRENT_STATE, "Current State" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_host_notification_types[] = {
-	{ "nodata", AU_NOTIFICATION_NO_DATA, 
-			"No Data" },
-	{ "down", AU_NOTIFICATION_HOST_DOWN, 
-			"Host Down" },
-	{ "unreachable", AU_NOTIFICATION_HOST_UNREACHABLE, 
-			"Host Unreachable" },
-	{ "recovery", AU_NOTIFICATION_HOST_RECOVERY, 
-			"Host Recovery" },
-	{ "hostcustom", AU_NOTIFICATION_HOST_CUSTOM, 
-			"Host Custom" },
-	{ "hostack", AU_NOTIFICATION_HOST_ACK, 
-			"Host Acknowlegement" },
-	{ "hostflapstart", AU_NOTIFICATION_HOST_FLAPPING_START, 
-			"Host Flapping Start" },
-	{ "hostflapstop", AU_NOTIFICATION_HOST_FLAPPING_STOP, 
-			"Host Flapping Stop" },
+	{
+		"nodata", AU_NOTIFICATION_NO_DATA,
+		"No Data"
+	},
+	{
+		"down", AU_NOTIFICATION_HOST_DOWN,
+		"Host Down"
+	},
+	{
+		"unreachable", AU_NOTIFICATION_HOST_UNREACHABLE,
+		"Host Unreachable"
+	},
+	{
+		"recovery", AU_NOTIFICATION_HOST_RECOVERY,
+		"Host Recovery"
+	},
+	{
+		"hostcustom", AU_NOTIFICATION_HOST_CUSTOM,
+		"Host Custom"
+	},
+	{
+		"hostack", AU_NOTIFICATION_HOST_ACK,
+		"Host Acknowlegement"
+	},
+	{
+		"hostflapstart", AU_NOTIFICATION_HOST_FLAPPING_START,
+		"Host Flapping Start"
+	},
+	{
+		"hostflapstop", AU_NOTIFICATION_HOST_FLAPPING_STOP,
+		"Host Flapping Stop"
+	},
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping valid_service_notification_types[] = {
-	{ "nodata", AU_NOTIFICATION_NO_DATA, 
-			"No Data" },
-	{ "critical", AU_NOTIFICATION_SERVICE_CRITICAL, 
-			"Service Critical" },
-	{ "warning", AU_NOTIFICATION_SERVICE_WARNING, 
-			"Service Warning" },
-	{ "recovery", AU_NOTIFICATION_SERVICE_RECOVERY, 
-			"Service Recovery" },
-	{ "custom", AU_NOTIFICATION_SERVICE_CUSTOM, 
-			"Service Custom" },
-	{ "serviceack", AU_NOTIFICATION_SERVICE_ACK, 
-			"Service Acknowlegement" },
-	{ "serviceflapstart", AU_NOTIFICATION_SERVICE_FLAPPING_START, 
-			"Service Flapping Start" },
-	{ "serviceflapstop", AU_NOTIFICATION_SERVICE_FLAPPING_STOP, 
-			"Service Flapping Stop" },
-	{ "unknown", AU_NOTIFICATION_SERVICE_UNKNOWN, 
-			"Service Unknown" },
+	{
+		"nodata", AU_NOTIFICATION_NO_DATA,
+		"No Data"
+	},
+	{
+		"critical", AU_NOTIFICATION_SERVICE_CRITICAL,
+		"Service Critical"
+	},
+	{
+		"warning", AU_NOTIFICATION_SERVICE_WARNING,
+		"Service Warning"
+	},
+	{
+		"recovery", AU_NOTIFICATION_SERVICE_RECOVERY,
+		"Service Recovery"
+	},
+	{
+		"custom", AU_NOTIFICATION_SERVICE_CUSTOM,
+		"Service Custom"
+	},
+	{
+		"serviceack", AU_NOTIFICATION_SERVICE_ACK,
+		"Service Acknowlegement"
+	},
+	{
+		"serviceflapstart", AU_NOTIFICATION_SERVICE_FLAPPING_START,
+		"Service Flapping Start"
+	},
+	{
+		"serviceflapstop", AU_NOTIFICATION_SERVICE_FLAPPING_STOP,
+		"Service Flapping Stop"
+	},
+	{
+		"unknown", AU_NOTIFICATION_SERVICE_UNKNOWN,
+		"Service Unknown"
+	},
 	{ NULL, -1, NULL },
-	};
+};
 
 option_help archive_json_help[] = {
-	{ 
+	{
 		"query",
 		"Query",
 		"enumeration",
@@ -213,8 +261,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Specifies the type of query to be executed.",
 		valid_queries
-		},
-	{ 
+	},
+	{
 		"formatoptions",
 		"Format Options",
 		"list",
@@ -223,8 +271,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Specifies the formatting options to be used when displaying the results. Multiple options are allowed and are separated by a plus (+) sign..",
 		svm_format_options
-		},
-	{ 
+	},
+	{
 		"start",
 		"Start",
 		"integer",
@@ -233,8 +281,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Specifies the index (zero-based) of the first object in the list to be returned.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"count",
 		"Count",
 		"integer",
@@ -243,8 +291,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Specifies the number of objects in the list to be returned.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"dateformat",
 		"Date Format",
 		"string",
@@ -253,19 +301,21 @@ option_help archive_json_help[] = {
 		NULL,
 		"strftime format string for values of type time_t. In the absence of a format, the Javascript default format of the number of milliseconds since the beginning of the Unix epoch is used. Because of URL encoding, percent signs must be encoded as %25 and a space must be encoded as a plus (+) sign.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"objecttypes",
 		"Object Types",
 		"list",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			NULL
+		},
 		NULL,
 		"Type(s) of object to be included in query results.",
 		valid_object_types
-		},
-	{ 
+	},
+	{
 		"objecttype",
 		"Object Type",
 		"enumeration",
@@ -274,8 +324,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Type of object to be included in query results.",
 		valid_object_types
-		},
-	{ 
+	},
+	{
 		"availabilityobjecttype",
 		"Availability Object Type",
 		"enumeration",
@@ -284,8 +334,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Type of object to be included in query results.",
 		valid_availability_object_types
-		},
-	{ 
+	},
+	{
 		"statetypes",
 		"State Types",
 		"list",
@@ -294,8 +344,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Type(s) of states to be included in query results.",
 		valid_state_types
-		},
-	{ 
+	},
+	{
 		"hoststates",
 		"Host States",
 		"list",
@@ -304,8 +354,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Host states to be included in query results.",
 		valid_host_states
-		},
-	{ 
+	},
+	{
 		"servicestates",
 		"Service States",
 		"list",
@@ -314,8 +364,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Service states to be included in query results.",
 		valid_service_states
-		},
-	{ 
+	},
+	{
 		"hostnotificationtypes",
 		"Host Notification Types",
 		"list",
@@ -324,8 +374,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Host notification types to be included in query results.",
 		valid_host_notification_types
-		},
-	{ 
+	},
+	{
 		"servicenotificationtypes",
 		"Service Notification Types",
 		"list",
@@ -334,36 +384,42 @@ option_help archive_json_help[] = {
 		NULL,
 		"Service notification types to be included in query results.",
 		valid_service_notification_types
-		},
-	{ 
+	},
+	{
 		"parenthost",
 		"Parent Host",
 		"nagios:objectjson/hostlist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			NULL
+		},
 		NULL,
 		"Limits the hosts or serivces returned to those whose host parent is specified. A value of 'none' returns all hosts or services reachable directly by the Nagios core host.",
 		parent_host_extras
-		},
-	{ 
+	},
+	{
 		"childhost",
 		"Child Host",
 		"nagios:objectjson/hostlist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			NULL
+		},
 		NULL,
 		"Limits the hosts or serivces returned to those whose having the host specified as a child host. A value of 'none' returns all hosts or services with no child hosts.",
 		child_host_extras
-		},
-	{ 
+	},
+	{
 		"hostname",
 		"Host Name",
 		"nagios:objectjson/hostlist",
 		{ "statechangelist", NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"availability", NULL
+		},
 		NULL,
 		"Name for the host requested. For availability reports if the "
 		"availability object type is hosts and the hostname is not "
@@ -373,36 +429,42 @@ option_help archive_json_help[] = {
 		"services with the same description, depending on the value for "
 		"service description.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hostgroup",
 		"Host Group",
 		"nagios:objectjson/hostgrouplist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"availability", NULL
+		},
 		NULL,
 		"Returns information applicable to the hosts in the hostgroup.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicegroup",
 		"Service Group",
 		"nagios:objectjson/servicegrouplist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"availability", NULL
+		},
 		NULL,
 		"Returns information applicable to the services in the servicegroup.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicedescription",
 		"Service Description",
 		"nagios:objectjson/servicelist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"statechangelist", "availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"statechangelist", "availability", NULL
+		},
 		"hostname",
 		"Description for the service requested. For availibility reports, "
 		"if the availability object type is services and the "
@@ -410,30 +472,34 @@ option_help archive_json_help[] = {
 		"either for all services or for all services on the specified host, "
 		"depending on the value specified for hostname",
 		NULL
-		},
-	{ 
+	},
+	{
 		"contactname",
 		"Contact Name",
 		"nagios:objectjson/contactlist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			NULL
+		},
 		NULL,
 		"Name for the contact requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"contactgroup",
 		"Contact Group",
 		"nagios:objectjson/contactgrouplist",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist",
-				NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			NULL
+		},
 		NULL,
 		"Returns information applicable to the contacts in the contactgroup.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"notificationmethod",
 		"Notification Method",
 		"nagios:objectjson/commandlist",
@@ -442,8 +508,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Returns objects that match the notification method.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"timeperiod",
 		"Report Time Period",
 		"nagios:objectjson/timeperiodlist",
@@ -452,8 +518,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Timeperiod to use for the report.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"assumeinitialstate",
 		"Assume Initial State",
 		"boolean",
@@ -462,8 +528,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Assume the initial state for the host(s) or service(s). Note that if true, assuming the initial state will be done only if the initial state could not be discovered by looking through the backtracked logs.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"assumestateretention",
 		"Assume State Retention",
 		"boolean",
@@ -472,8 +538,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Assume states are retained.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"assumestatesduringnagiosdowntime",
 		"Assume States During Nagios Downtime",
 		"boolean",
@@ -482,8 +548,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Assume states are retained during Nagios downtime.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"assumedinitialhoststate",
 		"Assumed Initial Host State",
 		"enumeration",
@@ -492,8 +558,8 @@ option_help archive_json_help[] = {
 		NULL,
 		"Host state assumed when it is not possible to determine the initial host state.",
 		valid_initial_host_states
-		},
-	{ 
+	},
+	{
 		"assumedinitialservicestate",
 		"Assumed Initial Service State",
 		"enumeration",
@@ -502,40 +568,46 @@ option_help archive_json_help[] = {
 		NULL,
 		"Service state assumed when it is not possible to determine the initial service state.",
 		valid_initial_service_states
-		},
-	{ 
+	},
+	{
 		"backtrackedarchives",
 		"Backtracked Archives",
 		"integer",
 		{ NULL },
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"statechangelist", "availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"statechangelist", "availability", NULL
+		},
 		NULL,
 		"Number of backtracked archives to read in an attempt to find initial states.",
 		NULL,
-		},
-	{ 
+	},
+	{
 		"starttime",
 		"Start Time",
 		"integer",
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"statechangelist", "availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"statechangelist", "availability", NULL
+		},
 		{ NULL },
 		NULL,
 		"Starting time to use. Supplying a plus or minus sign means times relative to the query time.",
 		NULL,
-		},
-	{ 
+	},
+	{
 		"endtime",
 		"End Time",
 		"integer",
-		{ "alertcount", "alertlist", "notificationcount", "notificationlist", 
-				"statechangelist", "availability", NULL },
+		{
+			"alertcount", "alertlist", "notificationcount", "notificationlist",
+			"statechangelist", "availability", NULL
+		},
 		{ NULL },
 		NULL,
 		"Ending time to use. Specifying plus or minus sign means times relative to the query time.",
 		NULL,
-		},
+	},
 	{ /* The last entry must contain all NULL entries */
 		NULL,
 		NULL,
@@ -545,55 +617,56 @@ option_help archive_json_help[] = {
 		NULL,
 		NULL,
 		NULL
-		},
-	};
+	},
+};
 
-int json_archive_alert_passes_selection(time_t, time_t, time_t, int, int, 
-		au_host *, char *, au_service *, char *, int, host *, int, host *,
-		hostgroup *, servicegroup *, contact *, contactgroup *, unsigned, 
-		unsigned, unsigned, unsigned, unsigned);
-json_object *json_archive_alert_selectors(unsigned, int, int, time_t, time_t, 
-		int, char *, char *, int, host *, int, host *, hostgroup *, 
-		servicegroup *, contact *, contactgroup *, unsigned, unsigned, 
-		unsigned);
+int json_archive_alert_passes_selection(time_t, time_t, time_t, int, int,
+                                        au_host *, char *, au_service *, char *, int, host *, int, host *,
+                                        hostgroup *, servicegroup *, contact *, contactgroup *, unsigned,
+                                        unsigned, unsigned, unsigned, unsigned);
+json_object *json_archive_alert_selectors(unsigned, int, int, time_t, time_t,
+        int, char *, char *, int, host *, int, host *, hostgroup *,
+        servicegroup *, contact *, contactgroup *, unsigned, unsigned,
+        unsigned);
 
-int json_archive_notification_passes_selection(time_t, time_t, time_t, int, 
-		int, au_host *, char *, au_service *, char *, int, host *, int, host *, 
-		hostgroup *, servicegroup *, au_contact *, char *, contactgroup *, 
-		unsigned, unsigned, unsigned, char *, char *);
-json_object *json_archive_notification_selectors(unsigned, int, int, time_t, 
-		time_t, int, char *, char *, int, host *, int, host *, hostgroup *, 
-		servicegroup *, char *, contactgroup *, unsigned, unsigned, char *);
+int json_archive_notification_passes_selection(time_t, time_t, time_t, int,
+        int, au_host *, char *, au_service *, char *, int, host *, int, host *,
+        hostgroup *, servicegroup *, au_contact *, char *, contactgroup *,
+        unsigned, unsigned, unsigned, char *, char *);
+json_object *json_archive_notification_selectors(unsigned, int, int, time_t,
+        time_t, int, char *, char *, int, host *, int, host *, hostgroup *,
+        servicegroup *, char *, contactgroup *, unsigned, unsigned, char *);
 
-int json_archive_statechange_passes_selection(time_t, time_t, int, int, 
-		au_host *, char *, au_service *, char *, unsigned, unsigned);
-json_object *json_archive_statechange_selectors(unsigned, int, int, time_t, 
-		time_t, int, char *, char *, unsigned);
+int json_archive_statechange_passes_selection(time_t, time_t, int, int,
+        au_host *, char *, au_service *, char *, unsigned, unsigned);
+json_object *json_archive_statechange_selectors(unsigned, int, int, time_t,
+        time_t, int, char *, char *, unsigned);
 
 int get_initial_nagios_state(au_linked_list *, time_t, time_t);
 int get_initial_downtime_state(au_linked_list *, time_t, time_t);
 int get_initial_subject_state(au_linked_list *, time_t, time_t);
 int get_log_entry_state(au_log_entry *);
 int have_data(au_linked_list *, int);
-void compute_window_availability(time_t, time_t, int, int, int, timeperiod *, 
-		au_availability *, int, int, int);
-static void compute_availability(au_linked_list *, time_t, time_t, time_t, 
-		timeperiod *, au_availability *, int, int, int, int);
-void compute_host_availability(time_t, time_t, time_t, au_log *, au_host *, 
-		timeperiod *, int, int, int, int);
-void compute_service_availability(time_t, time_t, time_t, au_log *, 
-		au_service *, timeperiod *, int, int, int, int);
-json_object *json_archive_single_host_availability(unsigned, time_t, time_t, 
-		time_t, char *, timeperiod *, int, int, int, int, unsigned, au_log *);
-json_object *json_archive_single_service_availability(unsigned, time_t, time_t, 
-		time_t, char *, char *, timeperiod *, int, int, int, int, unsigned, 
-		au_log *);
-json_object *json_archive_host_availability(unsigned, char *, 
-		au_availability *);
+void compute_window_availability(time_t, time_t, int, int, int, timeperiod *,
+                                 au_availability *, int, int, int);
+static void compute_availability(au_linked_list *, time_t, time_t, time_t,
+                                 timeperiod *, au_availability *, int, int, int, int);
+void compute_host_availability(time_t, time_t, time_t, au_log *, au_host *,
+                               timeperiod *, int, int, int, int);
+void compute_service_availability(time_t, time_t, time_t, au_log *,
+                                  au_service *, timeperiod *, int, int, int, int);
+json_object *json_archive_single_host_availability(unsigned, time_t, time_t,
+        time_t, char *, timeperiod *, int, int, int, int, unsigned, au_log *);
+json_object *json_archive_single_service_availability(unsigned, time_t, time_t,
+        time_t, char *, char *, timeperiod *, int, int, int, int, unsigned,
+        au_log *);
+json_object *json_archive_host_availability(unsigned, char *,
+        au_availability *);
 json_object *json_archive_service_availability(unsigned, char *, char *,
-		au_availability *);
+        au_availability *);
 
-int main(void) {
+int main(void)
+{
 	int result = OK;
 	time_t query_time;
 	archive_json_cgi_data	cgi_data;
@@ -610,9 +683,9 @@ int main(void) {
 	if(NULL == json_root) {
 		printf( "Failed to create new json object\n");
 		exit( 1);
-		}
-	json_object_append_integer(json_root, "format_version", 
-			OUTPUT_FORMAT_VERSION);
+	}
+	json_object_append_integer(json_root, "format_version",
+	                           OUTPUT_FORMAT_VERSION);
 
 	init_cgi_data(&cgi_data);
 
@@ -621,13 +694,13 @@ int main(void) {
 	/* get the arguments passed in the URL */
 	result = process_cgivars(json_root, &cgi_data, query_time);
 	if(result != RESULT_SUCCESS) {
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return result;
-		}
+	}
 	whitespace = cgi_data.format_options & JSON_FORMAT_WHITESPACE;
 
 	/* reset internal variables */
@@ -636,38 +709,38 @@ int main(void) {
 	/* read the CGI configuration file */
 	result = read_cgi_config_file(get_cgi_config_location());
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not open CGI configuration file '%s' for reading!", 
-				get_cgi_config_location()));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not open CGI configuration file '%s' for reading!",
+		                                      get_cgi_config_location()));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not open main configuration file '%s' for reading!",
-				main_config_file));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not open main configuration file '%s' for reading!",
+		                                      main_config_file));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
 		document_footer();
 		return ERROR;
-		}
+	}
 
-	/* Set the number of backtracked archives if it wasn't specified by the 
+	/* Set the number of backtracked archives if it wasn't specified by the
 		user */
 	if(0 == cgi_data.backtracked_archives) {
 		switch(log_rotation_method) {
@@ -686,283 +759,277 @@ int main(void) {
 		default:
 			cgi_data.backtracked_archives = 2;
 			break;
-			}
 		}
+	}
 
 	/* read all object configuration data */
-	result = read_all_object_configuration_data(main_config_file, 
-			READ_ALL_OBJECT_DATA);
+	result = read_all_object_configuration_data(main_config_file,
+	         READ_ALL_OBJECT_DATA);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not read some or all object configuration data!"));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not read some or all object configuration data!"));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all status data */
 	result = read_all_status_data(get_cgi_config_location(), READ_ALL_STATUS_DATA);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not read host and service status information!"));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not read host and service status information!"));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
 
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* validate arguments in URL */
 	result = validate_arguments(json_root, &cgi_data, query_time);
 	if((result != RESULT_SUCCESS) && (result != RESULT_OPTION_IGNORED)) {
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* get authentication information */
 	get_authentication_information(&current_authdata);
 
 	/* Allocate the structure for the logs */
 	if((log = au_init_log()) == NULL) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, &current_authdata, RESULT_MEMORY_ALLOCATION_ERROR,
-				"Unable to allocate memory for log data."));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, &current_authdata, RESULT_MEMORY_ALLOCATION_ERROR,
+		                                      "Unable to allocate memory for log data."));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
 
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* Return something to the user */
 	switch( cgi_data.query) {
 	case ARCHIVE_QUERY_HELP:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				compile_time(__DATE__, __TIME__), &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      compile_time(__DATE__, __TIME__), &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
 		break;
 	case ARCHIVE_QUERY_ALERTCOUNT:
-		read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.backtracked_archives, AU_OBJTYPE_ALL, 
-				AU_STATETYPE_ALL, AU_LOGTYPE_ALERT | AU_LOGTYPE_STATE, log,
-				&last_archive_data_update);
+		read_archived_data(cgi_data.start_time, cgi_data.end_time,
+		                   cgi_data.backtracked_archives, AU_OBJTYPE_ALL,
+		                   AU_STATETYPE_ALL, AU_LOGTYPE_ALERT | AU_LOGTYPE_STATE, log,
+		                   &last_archive_data_update);
 		if(result != RESULT_OPTION_IGNORED) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_archive_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_archive_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+		} else {
 			romp = json_get_object_member(json_root, "result");
 			json_object_append_time_t(romp->value.object, "last_data_update",
-					last_archive_data_update);
-			}
-		json_object_append_object(json_root, "data", 
-				json_archive_alertcount(cgi_data.format_options, 
-				cgi_data.start_time, cgi_data.end_time, cgi_data.object_types, 
-				cgi_data.host_name, cgi_data.service_description, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.servicegroup, cgi_data.contact, 
-				cgi_data.contactgroup, cgi_data.state_types, 
-				cgi_data.host_states, cgi_data.service_states, log));
+			                          last_archive_data_update);
+		}
+		json_object_append_object(json_root, "data",
+		                          json_archive_alertcount(cgi_data.format_options,
+		                                  cgi_data.start_time, cgi_data.end_time, cgi_data.object_types,
+		                                  cgi_data.host_name, cgi_data.service_description,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.servicegroup, cgi_data.contact,
+		                                  cgi_data.contactgroup, cgi_data.state_types,
+		                                  cgi_data.host_states, cgi_data.service_states, log));
 		break;
 	case ARCHIVE_QUERY_ALERTLIST:
-		read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.backtracked_archives, AU_OBJTYPE_ALL, 
-				AU_STATETYPE_ALL, AU_LOGTYPE_ALERT | AU_LOGTYPE_STATE, log,
-				&last_archive_data_update);
+		read_archived_data(cgi_data.start_time, cgi_data.end_time,
+		                   cgi_data.backtracked_archives, AU_OBJTYPE_ALL,
+		                   AU_STATETYPE_ALL, AU_LOGTYPE_ALERT | AU_LOGTYPE_STATE, log,
+		                   &last_archive_data_update);
 		if(result != RESULT_OPTION_IGNORED) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_archive_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_archive_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+		} else {
 			romp = json_get_object_member(json_root, "result");
 			json_object_append_time_t(romp->value.object, "last_data_update",
-					last_archive_data_update);
-			}
-		json_object_append_object(json_root, "data", 
-				json_archive_alertlist(cgi_data.format_options, cgi_data.start,
-				cgi_data.count, cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.object_types, cgi_data.host_name, 
-				cgi_data.service_description, cgi_data.use_parent_host, 
-				cgi_data.parent_host, cgi_data.use_child_host, 
-				cgi_data.child_host, cgi_data.hostgroup, cgi_data.servicegroup, 
-				cgi_data.contact, cgi_data.contactgroup, cgi_data.state_types, 
-				cgi_data.host_states, cgi_data.service_states, log));
+			                          last_archive_data_update);
+		}
+		json_object_append_object(json_root, "data",
+		                          json_archive_alertlist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.start_time, cgi_data.end_time,
+		                                  cgi_data.object_types, cgi_data.host_name,
+		                                  cgi_data.service_description, cgi_data.use_parent_host,
+		                                  cgi_data.parent_host, cgi_data.use_child_host,
+		                                  cgi_data.child_host, cgi_data.hostgroup, cgi_data.servicegroup,
+		                                  cgi_data.contact, cgi_data.contactgroup, cgi_data.state_types,
+		                                  cgi_data.host_states, cgi_data.service_states, log));
 		break;
 	case ARCHIVE_QUERY_NOTIFICATIONCOUNT:
-		read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.backtracked_archives, AU_OBJTYPE_ALL, 
-				AU_STATETYPE_ALL, AU_LOGTYPE_NOTIFICATION, log,
-				&last_archive_data_update);
+		read_archived_data(cgi_data.start_time, cgi_data.end_time,
+		                   cgi_data.backtracked_archives, AU_OBJTYPE_ALL,
+		                   AU_STATETYPE_ALL, AU_LOGTYPE_NOTIFICATION, log,
+		                   &last_archive_data_update);
 		if(result != RESULT_OPTION_IGNORED) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_archive_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_archive_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+		} else {
 			romp = json_get_object_member(json_root, "result");
 			json_object_append_time_t(romp->value.object, "last_data_update",
-					last_archive_data_update);
-			}
-		json_object_append_object(json_root, "data", 
-				json_archive_notificationcount(cgi_data.format_options, 
-				cgi_data.start_time, cgi_data.end_time, cgi_data.object_types, 
-				cgi_data.host_name, cgi_data.service_description, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.servicegroup, 
-				cgi_data.contact_name, cgi_data.contactgroup, 
-				cgi_data.host_notification_types, 
-				cgi_data.service_notification_types, 
-				cgi_data.notification_method, log));
+			                          last_archive_data_update);
+		}
+		json_object_append_object(json_root, "data",
+		                          json_archive_notificationcount(cgi_data.format_options,
+		                                  cgi_data.start_time, cgi_data.end_time, cgi_data.object_types,
+		                                  cgi_data.host_name, cgi_data.service_description,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.servicegroup,
+		                                  cgi_data.contact_name, cgi_data.contactgroup,
+		                                  cgi_data.host_notification_types,
+		                                  cgi_data.service_notification_types,
+		                                  cgi_data.notification_method, log));
 		break;
 	case ARCHIVE_QUERY_NOTIFICATIONLIST:
-		read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.backtracked_archives, AU_OBJTYPE_ALL, 
-				AU_STATETYPE_ALL, AU_LOGTYPE_NOTIFICATION, log,
-				&last_archive_data_update);
+		read_archived_data(cgi_data.start_time, cgi_data.end_time,
+		                   cgi_data.backtracked_archives, AU_OBJTYPE_ALL,
+		                   AU_STATETYPE_ALL, AU_LOGTYPE_NOTIFICATION, log,
+		                   &last_archive_data_update);
 		if(result != RESULT_OPTION_IGNORED) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_archive_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_archive_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+		} else {
 			romp = json_get_object_member(json_root, "result");
 			json_object_append_time_t(romp->value.object, "last_data_update",
-					last_archive_data_update);
-			}
-		json_object_append_object(json_root, "data", 
-				json_archive_notificationlist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.start_time, 
-				cgi_data.end_time, cgi_data.object_types, cgi_data.host_name, 
-				cgi_data.service_description, cgi_data.use_parent_host, 
-				cgi_data.parent_host, cgi_data.use_child_host, 
-				cgi_data.child_host, cgi_data.hostgroup, cgi_data.servicegroup, 
-				cgi_data.contact_name, cgi_data.contactgroup, 
-				cgi_data.host_notification_types, 
-				cgi_data.service_notification_types, 
-				cgi_data.notification_method, log));
+			                          last_archive_data_update);
+		}
+		json_object_append_object(json_root, "data",
+		                          json_archive_notificationlist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.object_types, cgi_data.host_name,
+		                                  cgi_data.service_description, cgi_data.use_parent_host,
+		                                  cgi_data.parent_host, cgi_data.use_child_host,
+		                                  cgi_data.child_host, cgi_data.hostgroup, cgi_data.servicegroup,
+		                                  cgi_data.contact_name, cgi_data.contactgroup,
+		                                  cgi_data.host_notification_types,
+		                                  cgi_data.service_notification_types,
+		                                  cgi_data.notification_method, log));
 		break;
 	case ARCHIVE_QUERY_STATECHANGELIST:
-		read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.backtracked_archives, cgi_data.object_type, 
-				AU_STATETYPE_ALL, (AU_LOGTYPE_ALERT | AU_LOGTYPE_STATE), log,
-				&last_archive_data_update);
+		read_archived_data(cgi_data.start_time, cgi_data.end_time,
+		                   cgi_data.backtracked_archives, cgi_data.object_type,
+		                   AU_STATETYPE_ALL, (AU_LOGTYPE_ALERT | AU_LOGTYPE_STATE), log,
+		                   &last_archive_data_update);
 		if(result != RESULT_OPTION_IGNORED) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_archive_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_archive_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+		} else {
 			romp = json_get_object_member(json_root, "result");
 			json_object_append_time_t(romp->value.object, "last_data_update",
-					last_archive_data_update);
-			}
-		json_object_append_object(json_root, "data", 
-				json_archive_statechangelist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.start_time, 
-				cgi_data.end_time, cgi_data.object_type, cgi_data.host_name, 
-				cgi_data.service_description, 
-				cgi_data.assumed_initial_host_state, 
-				cgi_data.assumed_initial_service_state, cgi_data.state_types, 
-				log));
+			                          last_archive_data_update);
+		}
+		json_object_append_object(json_root, "data",
+		                          json_archive_statechangelist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.object_type, cgi_data.host_name,
+		                                  cgi_data.service_description,
+		                                  cgi_data.assumed_initial_host_state,
+		                                  cgi_data.assumed_initial_service_state, cgi_data.state_types,
+		                                  log));
 		break;
 	case ARCHIVE_QUERY_AVAILABILITY:
 		switch(cgi_data.object_type) {
 		case AU_OBJTYPE_HOST:
 		case AU_OBJTYPE_HOSTGROUP:
-			read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-					cgi_data.backtracked_archives, AU_OBJTYPE_HOST, 
-					cgi_data.state_types, (AU_LOGTYPE_NAGIOS | AU_LOGTYPE_ALERT 
-					| AU_LOGTYPE_STATE | AU_LOGTYPE_DOWNTIME), log,
-					&last_archive_data_update);
+			read_archived_data(cgi_data.start_time, cgi_data.end_time,
+			                   cgi_data.backtracked_archives, AU_OBJTYPE_HOST,
+			                   cgi_data.state_types, (AU_LOGTYPE_NAGIOS | AU_LOGTYPE_ALERT
+			                           | AU_LOGTYPE_STATE | AU_LOGTYPE_DOWNTIME), log,
+			                   &last_archive_data_update);
 			break;
 		case AU_OBJTYPE_SERVICE:
 		case AU_OBJTYPE_SERVICEGROUP:
-			read_archived_data(cgi_data.start_time, cgi_data.end_time, 
-					cgi_data.backtracked_archives, AU_OBJTYPE_SERVICE, 
-					cgi_data.state_types, (AU_LOGTYPE_NAGIOS | AU_LOGTYPE_ALERT 
-					| AU_LOGTYPE_STATE | AU_LOGTYPE_DOWNTIME), log,
-					&last_archive_data_update);
+			read_archived_data(cgi_data.start_time, cgi_data.end_time,
+			                   cgi_data.backtracked_archives, AU_OBJTYPE_SERVICE,
+			                   cgi_data.state_types, (AU_LOGTYPE_NAGIOS | AU_LOGTYPE_ALERT
+			                           | AU_LOGTYPE_STATE | AU_LOGTYPE_DOWNTIME), log,
+			                   &last_archive_data_update);
 			break;
 		}
 		if(result != RESULT_OPTION_IGNORED) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_archive_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_archive_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+		} else {
 			romp = json_get_object_member(json_root, "result");
 			json_object_append_time_t(romp->value.object, "last_data_update",
-					last_archive_data_update);
-			}
-		json_object_append_object(json_root, "data", 
-				json_archive_availability(cgi_data.format_options, query_time,
-				cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.object_type, cgi_data.host_name, 
-				cgi_data.service_description, cgi_data.hostgroup, 
-				cgi_data.servicegroup, cgi_data.timeperiod, 
-				cgi_data.assume_initial_state, cgi_data.assume_state_retention, 
-				cgi_data.assume_states_during_nagios_downtime,
-				cgi_data.assumed_initial_host_state, 
-				cgi_data.assumed_initial_service_state, cgi_data.state_types, 
-				log));
+			                          last_archive_data_update);
+		}
+		json_object_append_object(json_root, "data",
+		                          json_archive_availability(cgi_data.format_options, query_time,
+		                                  cgi_data.start_time, cgi_data.end_time,
+		                                  cgi_data.object_type, cgi_data.host_name,
+		                                  cgi_data.service_description, cgi_data.hostgroup,
+		                                  cgi_data.servicegroup, cgi_data.timeperiod,
+		                                  cgi_data.assume_initial_state, cgi_data.assume_state_retention,
+		                                  cgi_data.assume_states_during_nagios_downtime,
+		                                  cgi_data.assumed_initial_host_state,
+		                                  cgi_data.assumed_initial_service_state, cgi_data.state_types,
+		                                  log));
 		break;
 	default:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, &current_authdata, RESULT_OPTION_MISSING,
-				"Error: Object Type not specified. See data for help."));
-		json_object_append_object(json_root, "data", 
-				json_help(archive_json_help));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, &current_authdata, RESULT_OPTION_MISSING,
+		                                      "Error: Object Type not specified. See data for help."));
+		json_object_append_object(json_root, "data",
+		                          json_help(archive_json_help));
 		break;
-		}
+	}
 
-	json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-			cgi_data.format_options);
+	json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+	                  cgi_data.format_options);
 	document_footer();
 
 	/* free all allocated memory */
@@ -972,9 +1039,10 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
-void document_header() {
+void document_header()
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t expire_time;
 	time_t current_time;
@@ -994,18 +1062,20 @@ void document_header() {
 	printf("Content-type: application/json; charset=utf-8\r\n\r\n");
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	printf( "\n");
 
 	return;
-	}
+}
 
 
-void init_cgi_data(archive_json_cgi_data *cgi_data) {
+void init_cgi_data(archive_json_cgi_data *cgi_data)
+{
 	cgi_data->format_options = 0;
 	cgi_data->query = ARCHIVE_QUERY_INVALID;
 	cgi_data->start = 0;
@@ -1052,7 +1122,8 @@ void init_cgi_data(archive_json_cgi_data *cgi_data) {
 	cgi_data->backtracked_archives = 0;
 }
 
-void free_cgi_data(archive_json_cgi_data *cgi_data) {
+void free_cgi_data(archive_json_cgi_data *cgi_data)
+{
 	if(NULL != cgi_data->strftime_format) free( cgi_data->strftime_format);
 	if(NULL != cgi_data->parent_host_name) free( cgi_data->parent_host_name);
 	if(NULL != cgi_data->child_host_name) free( cgi_data->child_host_name);
@@ -1064,11 +1135,12 @@ void free_cgi_data(archive_json_cgi_data *cgi_data) {
 	if(NULL != cgi_data->contactgroup_name) free(cgi_data->contactgroup_name);
 	if(NULL != cgi_data->notification_method) free(cgi_data->notification_method);
 	if(NULL != cgi_data->timeperiod_name) free(cgi_data->timeperiod_name);
-	}
+}
 
 
 int process_cgivars(json_object *json_root, archive_json_cgi_data *cgi_data,
-		time_t query_time) {
+                    time_t query_time)
+{
 	char **variables;
 	int result = RESULT_SUCCESS;
 	int x;
@@ -1086,419 +1158,420 @@ int process_cgivars(json_object *json_root, archive_json_cgi_data *cgi_data,
 		whitespace = cgi_data->format_options & JSON_FORMAT_WHITESPACE;
 
 		if(!strcmp(variables[x], "query")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_queries, &(cgi_data->query)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_queries, &(cgi_data->query)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "formatoptions")) {
 			cgi_data->format_options = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_format_options,
-					&(cgi_data->format_options))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_format_options,
+			                                  &(cgi_data->format_options))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "backtrackedarchives")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->backtracked_archives)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->backtracked_archives)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "start")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->start))) != RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->start))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "count")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->count))) != RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->count))) != RESULT_SUCCESS) {
 				break;
-				}
+			}
 
 			if(cgi_data->count == 0) {
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries),
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
-						"The count option value is invalid. "
-						"It must be an integer greater than zero"));
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
+				                                      "The count option value is invalid. "
+				                                      "It must be an integer greater than zero"));
 				result = RESULT_OPTION_VALUE_INVALID;
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "objecttype")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_object_types,
-					&(cgi_data->object_type))) != RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_object_types,
+			                                      &(cgi_data->object_type))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "objecttypes")) {
 			cgi_data->object_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_object_types,
-					&(cgi_data->object_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], valid_object_types,
+			                                  &(cgi_data->object_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "availabilityobjecttype")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_availability_object_types,
-					&(cgi_data->object_type))) != RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_availability_object_types,
+			                                      &(cgi_data->object_type))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "statetypes")) {
 			cgi_data->state_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_state_types,
-					&(cgi_data->state_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], valid_state_types,
+			                                  &(cgi_data->state_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hoststates")) {
 			cgi_data->host_states = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_host_states,
-					&(cgi_data->host_states))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], valid_host_states,
+			                                  &(cgi_data->host_states))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicestates")) {
 			cgi_data->service_states = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_service_states,
-					&(cgi_data->service_states))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], valid_service_states,
+			                                  &(cgi_data->service_states))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostnotificationtypes")) {
 			cgi_data->host_notification_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_host_notification_types,
-					&(cgi_data->host_notification_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], valid_host_notification_types,
+			                                  &(cgi_data->host_notification_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicenotificationtypes")) {
 			cgi_data->service_notification_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_service_notification_types,
-					&(cgi_data->service_notification_types))) 
-					!= RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], valid_service_notification_types,
+			                                  &(cgi_data->service_notification_types)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "parenthost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->parent_host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->parent_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "childhost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->child_host_name)))
-					!= RESULT_SUCCESS) {
-				}
-			x++;
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->child_host_name)))
+			   != RESULT_SUCCESS) {
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostname")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostgroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->hostgroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->hostgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicegroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->servicegroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->servicegroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicedescription")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->service_description)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->service_description)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactname")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contact_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contact_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactgroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contactgroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contactgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "notificationmethod")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->notification_method)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->notification_method)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "timeperiod")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "assumeinitialstate")) {
-			if((result = parse_boolean_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->assume_initial_state)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_boolean_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], &(cgi_data->assume_initial_state)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "assumestateretention")) {
-			if((result = parse_boolean_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->assume_state_retention)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_boolean_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], &(cgi_data->assume_state_retention)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "assumestatesduringnagiosdowntime")) {
-			if((result = parse_boolean_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1],
-					&(cgi_data->assume_states_during_nagios_downtime)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_boolean_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1],
+			                                  &(cgi_data->assume_states_during_nagios_downtime)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "assumedinitialhoststate")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_initial_host_states,
-					&(cgi_data->assumed_initial_host_state)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_initial_host_states,
+			                                      &(cgi_data->assumed_initial_host_state)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "assumedinitialservicestate")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_initial_service_states,
-					&(cgi_data->assumed_initial_service_state)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_initial_service_states,
+			                                      &(cgi_data->assumed_initial_service_state)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dateformat")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->strftime_format)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->strftime_format)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "starttime")) {
-			if((result = parse_time_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->start_time)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_time_cgivar(THISCGI,
+			                               svm_get_string_from_value(cgi_data->query, valid_queries),
+			                               get_query_status(query_status, cgi_data->query),
+			                               json_root, query_time, authinfo, variables[x],
+			                               variables[x+1], &(cgi_data->start_time)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "endtime")) {
-			if((result = parse_time_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->end_time))) != RESULT_SUCCESS) {
+			if((result = parse_time_cgivar(THISCGI,
+			                               svm_get_string_from_value(cgi_data->query, valid_queries),
+			                               get_query_status(query_status, cgi_data->query),
+			                               json_root, query_time, authinfo, variables[x],
+			                               variables[x+1], &(cgi_data->end_time))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], ""));
 
 		else {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, RESULT_OPTION_INVALID,
-					"Invalid option: '%s'.", variables[x]));
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, RESULT_OPTION_INVALID,
+			                                      "Invalid option: '%s'.", variables[x]));
 			result = RESULT_OPTION_INVALID;
 			break;
-			}
 		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return result;
-	}
+}
 
 int validate_arguments(json_object *json_root, archive_json_cgi_data *cgi_data,
-		time_t query_time) {
+                       time_t query_time)
+{
 
 	int result = RESULT_SUCCESS;
 	host *temp_host = NULL;
@@ -1524,137 +1597,137 @@ int validate_arguments(json_object *json_root, archive_json_cgi_data *cgi_data,
 	case ARCHIVE_QUERY_ALERTLIST:
 		if((0 == cgi_data->start_time) && (0 == cgi_data->end_time)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time must be supplied."));
+		}
 
 		if(!(cgi_data->object_types & (AU_OBJTYPE_HOST | AU_OBJTYPE_SERVICE))) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"At least one object type must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "At least one object type must be supplied."));
+		}
 		break;
 	case ARCHIVE_QUERY_NOTIFICATIONCOUNT:
 	case ARCHIVE_QUERY_NOTIFICATIONLIST:
 		if((0 == cgi_data->start_time) && (0 == cgi_data->end_time)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time must be supplied."));
+		}
 
 		if(!(cgi_data->object_types & (AU_OBJTYPE_HOST | AU_OBJTYPE_SERVICE))) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"At least one object type must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "At least one object type must be supplied."));
+		}
 		break;
 	case ARCHIVE_QUERY_STATECHANGELIST:
 		if((0 == cgi_data->start_time) && (0 == cgi_data->end_time)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time must be supplied."));
+		}
 
 		if(0 == cgi_data->object_type) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Object type must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Object type must be supplied."));
+		}
 
 		if(NULL == cgi_data->host_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Host name must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Host name must be supplied."));
+		}
 
-		if((AU_OBJTYPE_SERVICE == cgi_data->object_type) && 
-				(NULL == cgi_data->service_description)) {
+		if((AU_OBJTYPE_SERVICE == cgi_data->object_type) &&
+		   (NULL == cgi_data->service_description)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Service description must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Service description must be supplied."));
+		}
 
 		break;
 	case ARCHIVE_QUERY_AVAILABILITY:
 		if((0 == cgi_data->start_time) && (0 == cgi_data->end_time)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time must be supplied."));
+		}
 
 		if(0 == cgi_data->object_type) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Availability object type must be supplied."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Availability object type must be supplied."));
+		}
 
 		break;
 	default:
 		result = RESULT_OPTION_MISSING;
 		json_object_append_object(json_root, "result", json_result(query_time,
-				THISCGI,
-				svm_get_string_from_value(cgi_data->query, valid_queries),
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result,
-				"Missing validation for object type %u.", cgi_data->query));
+		                          THISCGI,
+		                          svm_get_string_from_value(cgi_data->query, valid_queries),
+		                          get_query_status(query_status, cgi_data->query),
+		                          (time_t)-1, authinfo, result,
+		                          "Missing validation for object type %u.", cgi_data->query));
 		break;
-		}
+	}
 
 	/* Attempt to find the host object associated with host_name. Because
-		we're looking at historical data, the host may no longer 
+		we're looking at historical data, the host may no longer
 		exist. */
 	if(NULL != cgi_data->host_name) {
 		cgi_data->host = find_host(cgi_data->host_name);
-		}
+	}
 
 	/* Attempt to find the service object associated with host_name and
 		service_description. Because we're looking at historical data,
 		the service may no longer exist. */
-	if((NULL != cgi_data->host_name) && 
-			(NULL != cgi_data->service_description)) {
-		cgi_data->service = find_service(cgi_data->host_name, 
-				cgi_data->service_description);
-		}
+	if((NULL != cgi_data->host_name) &&
+	   (NULL != cgi_data->service_description)) {
+		cgi_data->service = find_service(cgi_data->host_name,
+		                                 cgi_data->service_description);
+	}
 
 	/* Validate the requested parent host */
 	if( NULL != cgi_data->parent_host_name) {
@@ -1662,25 +1735,23 @@ int validate_arguments(json_object *json_root, archive_json_cgi_data *cgi_data,
 			temp_host = find_host(cgi_data->parent_host_name);
 			if( NULL == temp_host) {
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries), 
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The parenthost '%s' could not be found.", 
-						cgi_data->parent_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The parenthost '%s' could not be found.",
+				                                      cgi_data->parent_host_name));
+			} else {
 				cgi_data->use_parent_host = 1;
 				cgi_data->parent_host = temp_host;
-				}
 			}
-		else {
+		} else {
 			cgi_data->use_parent_host = 1;
 			cgi_data->parent_host = NULL;
-			}
 		}
+	}
 
 	/* Validate the requested child host */
 	if( NULL != cgi_data->child_host_name) {
@@ -1688,180 +1759,175 @@ int validate_arguments(json_object *json_root, archive_json_cgi_data *cgi_data,
 			temp_host = find_host(cgi_data->child_host_name);
 			if( NULL == temp_host) {
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries), 
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The childhost '%s' could not be found.", 
-						cgi_data->child_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The childhost '%s' could not be found.",
+				                                      cgi_data->child_host_name));
+			} else {
 				cgi_data->use_child_host = 1;
 				cgi_data->child_host = temp_host;
-				}
 			}
-		else {
+		} else {
 			cgi_data->use_child_host = 1;
 			cgi_data->child_host = NULL;
-			}
 		}
+	}
 
 	/* Validate the requested hostgroup */
 	if( NULL != cgi_data->hostgroup_name) {
 		temp_hostgroup = find_hostgroup(cgi_data->hostgroup_name);
 		if( NULL == temp_hostgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The hostgroup '%s' could not be found.", 
-					cgi_data->hostgroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The hostgroup '%s' could not be found.",
+			                                      cgi_data->hostgroup_name));
+		} else {
 			cgi_data->hostgroup = temp_hostgroup;
-			}
 		}
+	}
 
 	/* Validate the requested servicegroup */
 	if( NULL != cgi_data->servicegroup_name) {
 		temp_servicegroup = find_servicegroup(cgi_data->servicegroup_name);
 		if( NULL == temp_servicegroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The servicegroup '%s' could not be found.", 
-					cgi_data->servicegroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The servicegroup '%s' could not be found.",
+			                                      cgi_data->servicegroup_name));
+		} else {
 			cgi_data->servicegroup = temp_servicegroup;
-			}
 		}
+	}
 
-	/* Attempt to find the contact object associated with contact_name. 
-		Because we're looking at historical data, the contact may 
+	/* Attempt to find the contact object associated with contact_name.
+		Because we're looking at historical data, the contact may
 		no longer exist. */
 	if(NULL != cgi_data->contact_name) {
 		cgi_data->contact = find_contact(cgi_data->contact_name);
-		}
+	}
 
 	/* Validate the requested contactgroup */
 	if( NULL != cgi_data->contactgroup_name) {
 		temp_contactgroup = find_contactgroup(cgi_data->contactgroup_name);
 		if( NULL == temp_contactgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The contactgroup '%s' could not be found.", 
-					cgi_data->contactgroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The contactgroup '%s' could not be found.",
+			                                      cgi_data->contactgroup_name));
+		} else {
 			cgi_data->contactgroup = temp_contactgroup;
-			}
 		}
+	}
 
 	/* Validate the requested timeperiod */
 	if( NULL != cgi_data->timeperiod_name) {
 		temp_timeperiod = find_timeperiod(cgi_data->timeperiod_name);
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The timeperiod '%s' could not be found.", 
-					cgi_data->timeperiod_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The timeperiod '%s' could not be found.",
+			                                      cgi_data->timeperiod_name));
+		} else {
 			cgi_data->timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested start time is before the requested end time */
 	if((cgi_data->start_time > 0) && (cgi_data->end_time > 0) && (
-			cgi_data->start_time >= cgi_data->end_time)) {
+	       cgi_data->start_time >= cgi_data->end_time)) {
 		result = RESULT_OPTION_VALUE_INVALID;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result,
-				"The requested start time must be before the end time."));
-		}
-
-	/* If one or more host states were selected, but host objects were not, 
-			notify the user, but continue */
-	if((cgi_data->host_states != AU_STATE_HOST_ALL) && 
-			(!(cgi_data->object_types & AU_OBJTYPE_HOST))) {
-		result = RESULT_OPTION_IGNORED;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result, "The requested host states "
-				"were ignored because host objects were not selected."));
-		}
-	/* If one or more service states were selected, but service objects 
-			were not, notify the user but continue */
-	else if((cgi_data->service_states != AU_STATE_SERVICE_ALL) && 
-			(!(cgi_data->object_types & AU_OBJTYPE_SERVICE))) {
-		result = RESULT_OPTION_IGNORED;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result, "The requested service states "
-				"were ignored because service objects were not selected."));
-		}
-
-	/* If one or more host notification types were selected, but host 
-			objects were not, notify the user, but continue */
-	if((cgi_data->host_notification_types != AU_NOTIFICATION_HOST_ALL) && 
-			(!(cgi_data->object_types & AU_OBJTYPE_HOST))) {
-		result = RESULT_OPTION_IGNORED;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result,
-				"The requested host notification types were ignored because host objects were not selected."));
-		}
-	/* If one or more service notification types were selected, but 
-			service objects were not, notify the user but continue */
-	else if((cgi_data->service_notification_types != 
-			AU_NOTIFICATION_SERVICE_ALL) && 
-			(!(cgi_data->object_types & AU_OBJTYPE_SERVICE))) {
-		result = RESULT_OPTION_IGNORED;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result,
-				"The requested service notification types were ignored because service objects were not selected."));
-		}
-
-	return result;
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result,
+		                                      "The requested start time must be before the end time."));
 	}
 
-int json_archive_alert_passes_selection(time_t timestamp, time_t start_time, 
-		time_t end_time, int current_object_type, int match_object_types,
-		au_host *current_host, char *match_host, au_service *current_service, 
-		char *match_service, int use_parent_host, host *parent_host, 
-		int use_child_host, host *child_host, hostgroup *match_hostgroup, 
-		servicegroup *match_servicegroup, contact *match_contact, 
-		contactgroup *match_contactgroup, unsigned current_state_type, 
-		unsigned match_state_types, unsigned current_state, 
-		unsigned match_host_states, unsigned match_service_states) {
+	/* If one or more host states were selected, but host objects were not,
+			notify the user, but continue */
+	if((cgi_data->host_states != AU_STATE_HOST_ALL) &&
+	   (!(cgi_data->object_types & AU_OBJTYPE_HOST))) {
+		result = RESULT_OPTION_IGNORED;
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result, "The requested host states "
+		                                      "were ignored because host objects were not selected."));
+	}
+	/* If one or more service states were selected, but service objects
+			were not, notify the user but continue */
+	else if((cgi_data->service_states != AU_STATE_SERVICE_ALL) &&
+	        (!(cgi_data->object_types & AU_OBJTYPE_SERVICE))) {
+		result = RESULT_OPTION_IGNORED;
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result, "The requested service states "
+		                                      "were ignored because service objects were not selected."));
+	}
+
+	/* If one or more host notification types were selected, but host
+			objects were not, notify the user, but continue */
+	if((cgi_data->host_notification_types != AU_NOTIFICATION_HOST_ALL) &&
+	   (!(cgi_data->object_types & AU_OBJTYPE_HOST))) {
+		result = RESULT_OPTION_IGNORED;
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result,
+		                                      "The requested host notification types were ignored because host objects were not selected."));
+	}
+	/* If one or more service notification types were selected, but
+			service objects were not, notify the user but continue */
+	else if((cgi_data->service_notification_types !=
+	         AU_NOTIFICATION_SERVICE_ALL) &&
+	        (!(cgi_data->object_types & AU_OBJTYPE_SERVICE))) {
+		result = RESULT_OPTION_IGNORED;
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result,
+		                                      "The requested service notification types were ignored because service objects were not selected."));
+	}
+
+	return result;
+}
+
+int json_archive_alert_passes_selection(time_t timestamp, time_t start_time,
+                                        time_t end_time, int current_object_type, int match_object_types,
+                                        au_host *current_host, char *match_host, au_service *current_service,
+                                        char *match_service, int use_parent_host, host *parent_host,
+                                        int use_child_host, host *child_host, hostgroup *match_hostgroup,
+                                        servicegroup *match_servicegroup, contact *match_contact,
+                                        contactgroup *match_contactgroup, unsigned current_state_type,
+                                        unsigned match_state_types, unsigned current_state,
+                                        unsigned match_host_states, unsigned match_service_states)
+{
 
 	host *temp_host;
 	host *temp_host2;
@@ -1871,236 +1937,237 @@ int json_archive_alert_passes_selection(time_t timestamp, time_t start_time,
 
 	if((start_time > 0) && (timestamp < start_time)) {
 		return 0;
-		}
+	}
 
 	if((end_time > 0) && (timestamp > end_time)) {
 		return 0;
-		}
+	}
 
 	/* Skip if we're not interested in the current state type */
 	if(!(current_state_type & match_state_types)) {
 		return 0;
-		}
+	}
 
 	switch(current_object_type) {
 	case AU_OBJTYPE_HOST:
 		/* Skip if we're not interested in hosts */
 		if(!(match_object_types & AU_OBJTYPE_HOST)) {
 			return 0;
-			}
+		}
 
 		/* Skip if user is not authorized for this host */
-		if((NULL != current_host->hostp) && (FALSE == 
-				is_authorized_for_host(current_host->hostp, 
-				&current_authdata))) {
+		if((NULL != current_host->hostp) && (FALSE ==
+		                                     is_authorized_for_host(current_host->hostp,
+		                                             &current_authdata))) {
 			return 0;
-			}
+		}
 
 		/* Skip if we're not interested in the current host state */
 		if(!(current_state & match_host_states)) {
 			return 0;
-			}
+		}
 
-		/* If a specific host name was specified, skip this host if it's 
+		/* If a specific host name was specified, skip this host if it's
 			name does not match the one specified */
 		if((NULL != match_host) && strcmp(current_host->name, match_host)) {
 			return 0;
-			}
+		}
 
-		/* If a host parent was specified, skip this host if it's parent is 
+		/* If a host parent was specified, skip this host if it's parent is
 			not the parent host specified */
-		if((1 == use_parent_host) && (NULL != current_host->hostp) && 
-				FALSE == is_host_immediate_child_of_host(parent_host, 
-				current_host->hostp)) {
+		if((1 == use_parent_host) && (NULL != current_host->hostp) &&
+		   FALSE == is_host_immediate_child_of_host(parent_host,
+		           current_host->hostp)) {
 			return 0;
-			}
+		}
 
 		/* If a hostgroup was specified, skip this host if it is not a member
 			of the hostgroup specified */
 		if((NULL != match_hostgroup) && (NULL != current_host->hostp) &&
-				( FALSE == is_host_member_of_hostgroup(match_hostgroup, 
-						current_host->hostp))) {
+		   ( FALSE == is_host_member_of_hostgroup(match_hostgroup,
+		           current_host->hostp))) {
 			return 0;
-			}
+		}
 
 		/* If the contact was specified, skip this host if it does not have
 			the contact specified */
-		if((NULL != match_contact) && (NULL != current_host->hostp) && 
-				(FALSE == is_contact_for_host(current_host->hostp, 
-				match_contact))) {
+		if((NULL != match_contact) && (NULL != current_host->hostp) &&
+		   (FALSE == is_contact_for_host(current_host->hostp,
+		                                 match_contact))) {
 			return 0;
-			}
+		}
 
-		/* If the contact group was specified, skip this host if it does not 
+		/* If the contact group was specified, skip this host if it does not
 			have the contact group specified */
 		if((NULL != match_contactgroup) && (NULL != current_host->hostp)) {
 			found = 0;
-			for(temp_contact_groupsmember = 
-					current_host->hostp->contact_groups; 
-					temp_contact_groupsmember != NULL; 
-					temp_contact_groupsmember = 
-					temp_contact_groupsmember->next) {
-				if(!strcmp(temp_contact_groupsmember->group_name, 
-						match_contactgroup->group_name)) {
+			for(temp_contact_groupsmember =
+			        current_host->hostp->contact_groups;
+			    temp_contact_groupsmember != NULL;
+			    temp_contact_groupsmember =
+			        temp_contact_groupsmember->next) {
+				if(!strcmp(temp_contact_groupsmember->group_name,
+				           match_contactgroup->group_name)) {
 					found = 1;
 					break;
-					}
 				}
-			if(0 == found) return 0;
 			}
+			if(0 == found) return 0;
+		}
 
 		/* If a child host was specified... */
-		if((1 == use_child_host) && (NULL != current_host->hostp)) { 
+		if((1 == use_child_host) && (NULL != current_host->hostp)) {
 			/* If the child host is "none", skip this host if it has children */
 			if(NULL == child_host) {
-				for(temp_host2 = host_list; temp_host2 != NULL; 
-						temp_host2 = temp_host2->next) {
-					if(TRUE == 
-							is_host_immediate_child_of_host(current_host->hostp,
-							temp_host2)) {
+				for(temp_host2 = host_list; temp_host2 != NULL;
+				    temp_host2 = temp_host2->next) {
+					if(TRUE ==
+					   is_host_immediate_child_of_host(current_host->hostp,
+					                                   temp_host2)) {
 						return 0;
-						}
 					}
 				}
+			}
 			/* Otherwise, skip this host if it does not have the specified host
 				as a child */
-			else if(FALSE == 
-					is_host_immediate_child_of_host(current_host->hostp, 
-					child_host)) {
+			else if(FALSE ==
+			        is_host_immediate_child_of_host(current_host->hostp,
+			                                        child_host)) {
 				return 0;
-				}
 			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
 		/* Skip if we're not interested in services */
 		if(!(match_object_types & AU_OBJTYPE_SERVICE)) {
 			return 0;
-			}
+		}
 
 		/* Skip if user is not authorized for this service */
-		if((NULL != current_service->servicep) && (FALSE == 
-				is_authorized_for_service(current_service->servicep, 
-				&current_authdata))) {
+		if((NULL != current_service->servicep) && (FALSE ==
+		        is_authorized_for_service(current_service->servicep,
+		                                  &current_authdata))) {
 			return 0;
-			}
+		}
 
 		/* Skip if we're not interested in the current service state */
 		if(!(current_state & match_service_states)) {
 			return 0;
-			}
+		}
 
-		/* If a specific host name was specified, skip this service if it's 
+		/* If a specific host name was specified, skip this service if it's
 			host name does not match the one specified */
-		if((NULL != match_host) && strcmp(current_service->host_name, 
-				match_host)) {
+		if((NULL != match_host) && strcmp(current_service->host_name,
+		                                  match_host)) {
 			return 0;
-			}
+		}
 
-		/* If a specific service description was specified, skip this service 
+		/* If a specific service description was specified, skip this service
 			if it's description does not match the one specified */
-		if((NULL != match_service) && strcmp(current_service->description, 
-				match_service)) {
+		if((NULL != match_service) && strcmp(current_service->description,
+		                                     match_service)) {
 			return 0;
-			}
+		}
 
-		/* If a host parent was specified, skip this service if the parent 
+		/* If a host parent was specified, skip this service if the parent
 			of the host associated with it is not the parent host specified */
 		if((1 == use_parent_host) && (NULL != current_service->servicep)) {
 			temp_host = find_host(current_service->servicep->host_name);
-			if((NULL != temp_host) && (FALSE == 
-					is_host_immediate_child_of_host(parent_host, temp_host))) {
+			if((NULL != temp_host) && (FALSE ==
+			                           is_host_immediate_child_of_host(parent_host, temp_host))) {
 				return 0;
-				}
 			}
+		}
 
-		/* If a hostgroup was specified, skip this service if it's host is not 
+		/* If a hostgroup was specified, skip this service if it's host is not
 			a member of the hostgroup specified */
 		if((NULL != match_hostgroup) && (NULL != current_service->servicep)) {
 			temp_host = find_host(current_service->servicep->host_name);
-			if((NULL != temp_host) && (FALSE == 
-					is_host_member_of_hostgroup(match_hostgroup, temp_host))) {
+			if((NULL != temp_host) && (FALSE ==
+			                           is_host_member_of_hostgroup(match_hostgroup, temp_host))) {
 				return 0;
-				}
 			}
+		}
 
-		/* If a servicegroup was specified, skip this service if it is not 
+		/* If a servicegroup was specified, skip this service if it is not
 			a member of the servicegroup specified */
-		if((NULL != match_servicegroup) && 
-			(NULL != current_service->servicep)) {
-			temp_service = find_service(current_service->servicep->host_name, 
-					current_service->description);
-			if((NULL != temp_service) && (FALSE == 
-					is_service_member_of_servicegroup(match_servicegroup, 
-					temp_service))) {
+		if((NULL != match_servicegroup) &&
+		   (NULL != current_service->servicep)) {
+			temp_service = find_service(current_service->servicep->host_name,
+			                            current_service->description);
+			if((NULL != temp_service) && (FALSE ==
+			                              is_service_member_of_servicegroup(match_servicegroup,
+			                                      temp_service))) {
 				return 0;
-				}
 			}
+		}
 
 		/* If the contact was specified, skip this service if it does not have
 			the contact specified */
-		if((NULL != match_contact) && (NULL != current_service->servicep) && 
-				(FALSE == is_contact_for_service(current_service->servicep, 
-				match_contact))) {
+		if((NULL != match_contact) && (NULL != current_service->servicep) &&
+		   (FALSE == is_contact_for_service(current_service->servicep,
+		                                    match_contact))) {
 			return 0;
-			}
+		}
 
-		/* If the contact group was specified, skip this service if it does not 
+		/* If the contact group was specified, skip this service if it does not
 			have the contact group specified */
-		if((NULL != match_contactgroup) && 
-				(NULL != current_service->servicep)) {
+		if((NULL != match_contactgroup) &&
+		   (NULL != current_service->servicep)) {
 			found = 0;
-			for(temp_contact_groupsmember = 
-					current_service->servicep->contact_groups; 
-					temp_contact_groupsmember != NULL; 
-					temp_contact_groupsmember = 
-					temp_contact_groupsmember->next) {
-				if(!strcmp(temp_contact_groupsmember->group_name, 
-						match_contactgroup->group_name)) {
+			for(temp_contact_groupsmember =
+			        current_service->servicep->contact_groups;
+			    temp_contact_groupsmember != NULL;
+			    temp_contact_groupsmember =
+			        temp_contact_groupsmember->next) {
+				if(!strcmp(temp_contact_groupsmember->group_name,
+				           match_contactgroup->group_name)) {
 					found = 1;
 					break;
-					}
 				}
-			if(0 == found) return 0;
 			}
+			if(0 == found) return 0;
+		}
 
 		/* If a child host was specified... */
-		if((1 == use_child_host) && (NULL != current_service->servicep)) { 
+		if((1 == use_child_host) && (NULL != current_service->servicep)) {
 			temp_host = find_host(current_service->servicep->host_name);
 			if(NULL != temp_host) {
-				/* If the child host is "none", skip this service if it's 
+				/* If the child host is "none", skip this service if it's
 					host has children */
 				if(NULL == child_host) {
-					for(temp_host2 = host_list; temp_host2 != NULL; 
-							temp_host2 = temp_host2->next) {
+					for(temp_host2 = host_list; temp_host2 != NULL;
+					    temp_host2 = temp_host2->next) {
 						if(TRUE == is_host_immediate_child_of_host(temp_host,
-								temp_host2)) {
+						        temp_host2)) {
 							return 0;
-							}
 						}
 					}
-				/* Otherwise, skip this service if it's host does not have the 
+				}
+				/* Otherwise, skip this service if it's host does not have the
 					specified host as a child */
 				else if(FALSE == is_host_immediate_child_of_host(temp_host,
-						child_host)) {
+				        child_host)) {
 					return 0;
-					}
 				}
 			}
-		break;
 		}
+		break;
+	}
 
 
 	return 1;
-	}
+}
 
-json_object * json_archive_alert_selectors(unsigned format_options, int start, 
-		int count, time_t start_time, time_t end_time, int object_types, 
-		char *match_host, char *match_service, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup, 
-		contact *match_contact, contactgroup *match_contactgroup, 
-		unsigned match_state_types, unsigned match_host_states, 
-		unsigned match_service_states) {
+json_object * json_archive_alert_selectors(unsigned format_options, int start,
+        int count, time_t start_time, time_t end_time, int object_types,
+        char *match_host, char *match_service, int use_parent_host,
+        host *parent_host, int use_child_host, host *child_host,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        contact *match_contact, contactgroup *match_contactgroup,
+        unsigned match_state_types, unsigned match_host_states,
+        unsigned match_service_states)
+{
 
 	json_object *json_selectors;
 
@@ -2108,92 +2175,93 @@ json_object * json_archive_alert_selectors(unsigned format_options, int start,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 
 	if(object_types != AU_OBJTYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "objecttypes", 
-				object_types, valid_object_types);
-		}
+		json_bitmask(json_selectors, format_options, "objecttypes",
+		             object_types, valid_object_types);
+	}
 
 	if(match_state_types != AU_STATETYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "statetypes", 
-				match_state_types, valid_state_types);
-		}
+		json_bitmask(json_selectors, format_options, "statetypes",
+		             match_state_types, valid_state_types);
+	}
 
-	if((object_types & AU_OBJTYPE_HOST) && 
-			(match_host_states != AU_STATE_HOST_ALL)) {
-		json_bitmask(json_selectors, format_options, "hoststates", 
-				match_host_states, valid_host_states);
-		}
+	if((object_types & AU_OBJTYPE_HOST) &&
+	   (match_host_states != AU_STATE_HOST_ALL)) {
+		json_bitmask(json_selectors, format_options, "hoststates",
+		             match_host_states, valid_host_states);
+	}
 
-	if((object_types & AU_OBJTYPE_SERVICE) && 
-			(match_service_states != AU_STATE_SERVICE_ALL)) {
-		json_bitmask(json_selectors, format_options, "servicestates", 
-				match_service_states, valid_service_states);
-		}
+	if((object_types & AU_OBJTYPE_SERVICE) &&
+	   (match_service_states != AU_STATE_SERVICE_ALL)) {
+		json_bitmask(json_selectors, format_options, "servicestates",
+		             match_service_states, valid_service_states);
+	}
 
 	if(NULL != match_host) {
 		json_object_append_string(json_selectors, "hostname", match_host);
-		}
-
-	if(NULL != match_service) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				match_service);
-		}
-
-	if(1 == use_parent_host) {
-		json_object_append_string(json_selectors, "parenthost", 
-				( NULL == parent_host ? "none" : parent_host->name));
-		}
-
-	if( 1 == use_child_host) {
-		json_object_append_string(json_selectors, "childhost", 
-				( NULL == child_host ? "none" : child_host->name));
-		}
-
-	if(NULL != match_hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				match_hostgroup->group_name);
-		}
-
-	if((object_types & AU_OBJTYPE_SERVICE) && (NULL != match_servicegroup)) {
-		json_object_append_string(json_selectors, "servicegroup", 
-				match_servicegroup->group_name);
-		}
-
-	if(NULL != match_contact) {
-		json_object_append_string(json_selectors, "contact", 
-				match_contact->name);
-		}
-
-	if(NULL != match_contactgroup) {
-		json_object_append_string(json_selectors, "contactgroup", 
-				match_contactgroup->group_name);
-		}
-
-	return json_selectors;
 	}
 
-json_object * json_archive_alertcount(unsigned format_options, 
-		time_t start_time, time_t end_time, int object_types, 
-		char *match_host, char *match_service, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup, 
-		contact *match_contact, contactgroup *match_contactgroup, 
-		unsigned match_state_types, unsigned match_host_states, 
-		unsigned match_service_states, au_log *log) {
+	if(NULL != match_service) {
+		json_object_append_string(json_selectors, "servicedescription",
+		                          match_service);
+	}
+
+	if(1 == use_parent_host) {
+		json_object_append_string(json_selectors, "parenthost",
+		                          ( NULL == parent_host ? "none" : parent_host->name));
+	}
+
+	if( 1 == use_child_host) {
+		json_object_append_string(json_selectors, "childhost",
+		                          ( NULL == child_host ? "none" : child_host->name));
+	}
+
+	if(NULL != match_hostgroup) {
+		json_object_append_string(json_selectors, "hostgroup",
+		                          match_hostgroup->group_name);
+	}
+
+	if((object_types & AU_OBJTYPE_SERVICE) && (NULL != match_servicegroup)) {
+		json_object_append_string(json_selectors, "servicegroup",
+		                          match_servicegroup->group_name);
+	}
+
+	if(NULL != match_contact) {
+		json_object_append_string(json_selectors, "contact",
+		                          match_contact->name);
+	}
+
+	if(NULL != match_contactgroup) {
+		json_object_append_string(json_selectors, "contactgroup",
+		                          match_contactgroup->group_name);
+	}
+
+	return json_selectors;
+}
+
+json_object * json_archive_alertcount(unsigned format_options,
+                                      time_t start_time, time_t end_time, int object_types,
+                                      char *match_host, char *match_service, int use_parent_host,
+                                      host *parent_host, int use_child_host, host *child_host,
+                                      hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+                                      contact *match_contact, contactgroup *match_contactgroup,
+                                      unsigned match_state_types, unsigned match_host_states,
+                                      unsigned match_service_states, au_log *log)
+{
 
 	json_object *json_data;
 	au_node *temp_node;
@@ -2204,15 +2272,15 @@ json_object * json_archive_alertcount(unsigned format_options,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_archive_alert_selectors(format_options, 0, 0, start_time, 
-			end_time, object_types, match_host, match_service, use_parent_host, 
-			parent_host, use_child_host, child_host, match_hostgroup, 
-			match_servicegroup, match_contact, match_contactgroup, 
-			match_state_types, match_host_states, match_service_states));
+	json_object_append_object(json_data, "selectors",
+	                          json_archive_alert_selectors(format_options, 0, 0, start_time,
+	                                  end_time, object_types, match_host, match_service, use_parent_host,
+	                                  parent_host, use_child_host, child_host, match_hostgroup,
+	                                  match_servicegroup, match_contact, match_contactgroup,
+	                                  match_state_types, match_host_states, match_service_states));
 
-	for(temp_node = log->entry_list->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log->entry_list->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 
 		temp_entry = (au_log_entry *)temp_node->data;
 
@@ -2230,35 +2298,36 @@ json_object * json_archive_alertcount(unsigned format_options,
 			temp_host = NULL;
 			temp_service = (au_service *)temp_alert_log->object;
 			break;
-			}
+		}
 
 		/* Skip anything that does not pass the alert selection criteria */
-		if(json_archive_alert_passes_selection(temp_entry->timestamp, 
-				start_time, end_time, temp_alert_log->obj_type, 
-				object_types, temp_host, match_host, temp_service, 
-				match_service, use_parent_host, parent_host, use_child_host, 
-				child_host, match_hostgroup, match_servicegroup, 
-				match_contact, match_contactgroup, temp_alert_log->state_type, 
-				match_state_types, temp_alert_log->state, match_host_states, 
-				match_service_states) == 0) {
+		if(json_archive_alert_passes_selection(temp_entry->timestamp,
+		                                       start_time, end_time, temp_alert_log->obj_type,
+		                                       object_types, temp_host, match_host, temp_service,
+		                                       match_service, use_parent_host, parent_host, use_child_host,
+		                                       child_host, match_hostgroup, match_servicegroup,
+		                                       match_contact, match_contactgroup, temp_alert_log->state_type,
+		                                       match_state_types, temp_alert_log->state, match_host_states,
+		                                       match_service_states) == 0) {
 			continue;
-			}
+		}
 
 		count++;
-		}
+	}
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object * json_archive_alertlist(unsigned format_options, int start, 
-		int count, time_t start_time, time_t end_time, int object_types, 
-		char *match_host, char *match_service, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup, 
-		contact *match_contact, contactgroup *match_contactgroup, 
-		unsigned match_state_types, unsigned match_host_states, 
-		unsigned match_service_states, au_log *log) {
+json_object * json_archive_alertlist(unsigned format_options, int start,
+                                     int count, time_t start_time, time_t end_time, int object_types,
+                                     char *match_host, char *match_service, int use_parent_host,
+                                     host *parent_host, int use_child_host, host *child_host,
+                                     hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+                                     contact *match_contact, contactgroup *match_contactgroup,
+                                     unsigned match_state_types, unsigned match_host_states,
+                                     unsigned match_service_states, au_log *log)
+{
 
 	json_object *json_data;
 	json_array *json_alertlist;
@@ -2272,18 +2341,18 @@ json_object * json_archive_alertlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_archive_alert_selectors(format_options, start, count, 
-			start_time, end_time, object_types, match_host, match_service, 
-			use_parent_host, parent_host, use_child_host, child_host, 
-			match_hostgroup, match_servicegroup, match_contact, 
-			match_contactgroup, match_state_types, match_host_states, 
-			match_service_states));
+	json_object_append_object(json_data, "selectors",
+	                          json_archive_alert_selectors(format_options, start, count,
+	                                  start_time, end_time, object_types, match_host, match_service,
+	                                  use_parent_host, parent_host, use_child_host, child_host,
+	                                  match_hostgroup, match_servicegroup, match_contact,
+	                                  match_contactgroup, match_state_types, match_host_states,
+	                                  match_service_states));
 
 	json_alertlist = json_new_array();
 
-	for(temp_node = log->entry_list->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log->entry_list->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 
 		temp_entry = (au_log_entry *)temp_node->data;
 
@@ -2301,46 +2370,47 @@ json_object * json_archive_alertlist(unsigned format_options, int start,
 			temp_host = NULL;
 			temp_service = (au_service *)temp_alert_log->object;
 			break;
-			}
+		}
 
 		/* Skip anything that does not pass the alert selection criteria */
-		if(json_archive_alert_passes_selection(temp_entry->timestamp, 
-				start_time, end_time, temp_alert_log->obj_type, 
-				object_types, temp_host, match_host, temp_service, 
-				match_service, use_parent_host, parent_host, use_child_host, 
-				child_host, match_hostgroup, match_servicegroup, 
-				match_contact, match_contactgroup, temp_alert_log->state_type, 
-				match_state_types, temp_alert_log->state, match_host_states, 
-				match_service_states) == 0) {
+		if(json_archive_alert_passes_selection(temp_entry->timestamp,
+		                                       start_time, end_time, temp_alert_log->obj_type,
+		                                       object_types, temp_host, match_host, temp_service,
+		                                       match_service, use_parent_host, parent_host, use_child_host,
+		                                       child_host, match_hostgroup, match_servicegroup,
+		                                       match_contact, match_contactgroup, temp_alert_log->state_type,
+		                                       match_state_types, temp_alert_log->state, match_host_states,
+		                                       match_service_states) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			json_alert_details = json_new_object();
-			json_archive_alert_details(json_alert_details, format_options, 
-					temp_entry->timestamp, (au_log_alert *)temp_entry->entry);
+			json_archive_alert_details(json_alert_details, format_options,
+			                           temp_entry->timestamp, (au_log_alert *)temp_entry->entry);
 			json_array_append_object(json_alertlist, json_alert_details);
 			counted++;
-			}
-		current++; 
 		}
+		current++;
+	}
 
 	json_object_append_array(json_data, "alertlist", json_alertlist);
 
 	return json_data;
-	}
+}
 
-void json_archive_alert_details(json_object *json_details, 
-		unsigned format_options, time_t timestamp, au_log_alert *temp_alert) {
+void json_archive_alert_details(json_object *json_details,
+                                unsigned format_options, time_t timestamp, au_log_alert *temp_alert)
+{
 
 	au_host *temp_host;
 	au_service *temp_service;
 
 	json_object_append_time_t(json_details, "timestamp", timestamp);
 
-	json_enumeration(json_details, format_options, "object_type", 
-			temp_alert->obj_type, svm_au_object_types);
+	json_enumeration(json_details, format_options, "object_type",
+	                 temp_alert->obj_type, svm_au_object_types);
 
 	switch(temp_alert->obj_type) {
 	case AU_OBJTYPE_HOST:
@@ -2349,33 +2419,34 @@ void json_archive_alert_details(json_object *json_details,
 		break;
 	case AU_OBJTYPE_SERVICE:
 		temp_service = (au_service *)temp_alert->object;
-		json_object_append_string(json_details, "host_name", 
-				temp_service->host_name);
-		json_object_append_string(json_details, "description", 
-				temp_service->description);
+		json_object_append_string(json_details, "host_name",
+		                          temp_service->host_name);
+		json_object_append_string(json_details, "description",
+		                          temp_service->description);
 		break;
-		}
-
-	json_enumeration(json_details, format_options, "state_type", 
-			temp_alert->state_type, svm_au_state_types);
-	json_enumeration(json_details, format_options, "state", temp_alert->state, 
-			svm_au_states);
-	json_object_append_string(json_details, "plugin_output", 
-			temp_alert->plugin_output);
 	}
 
-int json_archive_notification_passes_selection(time_t timestamp, 
-		time_t start_time, time_t end_time, int current_object_type, 
-		int match_object_types, au_host *current_host, char *match_host,
-		au_service *current_service, char *match_service, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup, 
-		au_contact *current_contact, char *match_contact, 
-		contactgroup *match_contactgroup, 
-		unsigned current_notification_type, 
-		unsigned match_host_notification_types, 
-		unsigned match_service_notification_types, 
-		char *current_notification_method, char *match_notification_method) {
+	json_enumeration(json_details, format_options, "state_type",
+	                 temp_alert->state_type, svm_au_state_types);
+	json_enumeration(json_details, format_options, "state", temp_alert->state,
+	                 svm_au_states);
+	json_object_append_string(json_details, "plugin_output",
+	                          temp_alert->plugin_output);
+}
+
+int json_archive_notification_passes_selection(time_t timestamp,
+        time_t start_time, time_t end_time, int current_object_type,
+        int match_object_types, au_host *current_host, char *match_host,
+        au_service *current_service, char *match_service, int use_parent_host,
+        host *parent_host, int use_child_host, host *child_host,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        au_contact *current_contact, char *match_contact,
+        contactgroup *match_contactgroup,
+        unsigned current_notification_type,
+        unsigned match_host_notification_types,
+        unsigned match_service_notification_types,
+        char *current_notification_method, char *match_notification_method)
+{
 
 	host *temp_host;
 	host *temp_host2;
@@ -2385,232 +2456,233 @@ int json_archive_notification_passes_selection(time_t timestamp,
 
 	if((start_time > 0) && (timestamp < start_time)) {
 		return 0;
-		}
+	}
 
 	if((end_time > 0) && (timestamp > end_time)) {
 		return 0;
-		}
+	}
 
 	/* If the contact was specified, skip this notification if it does not have
 		the contact specified */
-	if((NULL != match_contact) && (NULL != current_contact) && 
-			strcmp(current_contact->name, match_contact)) {
+	if((NULL != match_contact) && (NULL != current_contact) &&
+	   strcmp(current_contact->name, match_contact)) {
 		return 0;
-		}
+	}
 
-	/* If the notification method was specified, skip this notification if 
+	/* If the notification method was specified, skip this notification if
 		it does not have the method specified */
-	if((NULL != match_notification_method) && 
-			(NULL != current_notification_method) && 
-			strcmp(current_notification_method, match_notification_method)) {
+	if((NULL != match_notification_method) &&
+	   (NULL != current_notification_method) &&
+	   strcmp(current_notification_method, match_notification_method)) {
 		return 0;
-		}
+	}
 
 	switch(current_object_type) {
 	case AU_OBJTYPE_HOST:
 		/* Skip if we're not interested in hosts */
 		if(!(match_object_types & AU_OBJTYPE_HOST)) {
 			return 0;
-			}
+		}
 
 		/* Skip if user is not authorized for this host */
-		if((NULL != current_host->hostp) && (FALSE == 
-				is_authorized_for_host(current_host->hostp, 
-				&current_authdata))) {
+		if((NULL != current_host->hostp) && (FALSE ==
+		                                     is_authorized_for_host(current_host->hostp,
+		                                             &current_authdata))) {
 			return 0;
-			}
+		}
 
 		/* Skip if we're not interested in the current host notification type */
 		if(!(current_notification_type & match_host_notification_types)) {
 			return 0;
-			}
+		}
 
-		/* If a specific host name was specified, skip this host if it's 
+		/* If a specific host name was specified, skip this host if it's
 			name does not match the one specified */
 		if((NULL != match_host) && strcmp(current_host->name, match_host)) {
 			return 0;
-			}
+		}
 
-		/* If a host parent was specified, skip this host if it's parent is 
+		/* If a host parent was specified, skip this host if it's parent is
 			not the parent host specified */
-		if((1 == use_parent_host) && (NULL != current_host->hostp) && 
-				FALSE == is_host_immediate_child_of_host(parent_host, 
-				current_host->hostp)) {
+		if((1 == use_parent_host) && (NULL != current_host->hostp) &&
+		   FALSE == is_host_immediate_child_of_host(parent_host,
+		           current_host->hostp)) {
 			return 0;
-			}
+		}
 
 		/* If a hostgroup was specified, skip this host if it is not a member
 			of the hostgroup specified */
 		if((NULL != match_hostgroup) && (NULL != current_host->hostp) &&
-				( FALSE == is_host_member_of_hostgroup(match_hostgroup, 
-						current_host->hostp))) {
+		   ( FALSE == is_host_member_of_hostgroup(match_hostgroup,
+		           current_host->hostp))) {
 			return 0;
-			}
+		}
 
-		/* If the contact group was specified, skip this host if it does not 
+		/* If the contact group was specified, skip this host if it does not
 			have the contact group specified */
 		if((NULL != match_contactgroup) && (NULL != current_host->hostp)) {
 			found = 0;
-			for(temp_contact_groupsmember = 
-					current_host->hostp->contact_groups; 
-					temp_contact_groupsmember != NULL; 
-					temp_contact_groupsmember = 
-					temp_contact_groupsmember->next) {
-				if(!strcmp(temp_contact_groupsmember->group_name, 
-						match_contactgroup->group_name)) {
+			for(temp_contact_groupsmember =
+			        current_host->hostp->contact_groups;
+			    temp_contact_groupsmember != NULL;
+			    temp_contact_groupsmember =
+			        temp_contact_groupsmember->next) {
+				if(!strcmp(temp_contact_groupsmember->group_name,
+				           match_contactgroup->group_name)) {
 					found = 1;
 					break;
-					}
 				}
-			if(0 == found) return 0;
 			}
+			if(0 == found) return 0;
+		}
 
 		/* If a child host was specified... */
-		if((1 == use_child_host) && (NULL != current_host->hostp)) { 
+		if((1 == use_child_host) && (NULL != current_host->hostp)) {
 			/* If the child host is "none", skip this host if it has children */
 			if(NULL == child_host) {
-				for(temp_host2 = host_list; temp_host2 != NULL; 
-						temp_host2 = temp_host2->next) {
-					if(TRUE == 
-							is_host_immediate_child_of_host(current_host->hostp,
-							temp_host2)) {
+				for(temp_host2 = host_list; temp_host2 != NULL;
+				    temp_host2 = temp_host2->next) {
+					if(TRUE ==
+					   is_host_immediate_child_of_host(current_host->hostp,
+					                                   temp_host2)) {
 						return 0;
-						}
 					}
 				}
+			}
 			/* Otherwise, skip this host if it does not have the specified host
 				as a child */
-			else if(FALSE == 
-					is_host_immediate_child_of_host(current_host->hostp, 
-					child_host)) {
+			else if(FALSE ==
+			        is_host_immediate_child_of_host(current_host->hostp,
+			                                        child_host)) {
 				return 0;
-				}
 			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
 		/* Skip if we're not interested in services */
 		if(!(match_object_types & AU_OBJTYPE_SERVICE)) {
 			return 0;
-			}
+		}
 
 		/* Skip if user is not authorized for this service */
-		if((NULL != current_service->servicep) && (FALSE == 
-				is_authorized_for_service(current_service->servicep, 
-				&current_authdata))) {
+		if((NULL != current_service->servicep) && (FALSE ==
+		        is_authorized_for_service(current_service->servicep,
+		                                  &current_authdata))) {
 			return 0;
-			}
+		}
 
-		/* Skip if we're not interested in the current service notification 
+		/* Skip if we're not interested in the current service notification
 			type */
 		if(!(current_notification_type & match_service_notification_types)) {
 			return 0;
-			}
+		}
 
-		/* If a specific host name was specified, skip this service if it's 
+		/* If a specific host name was specified, skip this service if it's
 			host name does not match the one specified */
-		if((NULL != match_host) && strcmp(current_service->host_name, 
-				match_host)) {
+		if((NULL != match_host) && strcmp(current_service->host_name,
+		                                  match_host)) {
 			return 0;
-			}
+		}
 
-		/* If a specific service description was specified, skip this service 
+		/* If a specific service description was specified, skip this service
 			if it's description does not match the one specified */
-		if((NULL != match_service) && strcmp(current_service->description, 
-				match_service)) {
+		if((NULL != match_service) && strcmp(current_service->description,
+		                                     match_service)) {
 			return 0;
-			}
+		}
 
-		/* If a host parent was specified, skip this service if the parent 
+		/* If a host parent was specified, skip this service if the parent
 			of the host associated with it is not the parent host specified */
 		if((1 == use_parent_host) && (NULL != current_service->servicep)) {
 			temp_host = find_host(current_service->servicep->host_name);
-			if((NULL != temp_host) && (FALSE == 
-					is_host_immediate_child_of_host(parent_host, temp_host))) {
+			if((NULL != temp_host) && (FALSE ==
+			                           is_host_immediate_child_of_host(parent_host, temp_host))) {
 				return 0;
-				}
 			}
+		}
 
-		/* If a hostgroup was specified, skip this service if it's host is not 
+		/* If a hostgroup was specified, skip this service if it's host is not
 			a member of the hostgroup specified */
 		if((NULL != match_hostgroup) && (NULL != current_service->servicep)) {
 			temp_host = find_host(current_service->servicep->host_name);
-			if((NULL != temp_host) && (FALSE == 
-					is_host_member_of_hostgroup(match_hostgroup, temp_host))) {
+			if((NULL != temp_host) && (FALSE ==
+			                           is_host_member_of_hostgroup(match_hostgroup, temp_host))) {
 				return 0;
-				}
 			}
-
-		/* If a servicegroup was specified, skip this service if it is not 
-			a member of the servicegroup specified */
-		if((NULL != match_servicegroup) && 
-			(NULL != current_service->servicep)) {
-			temp_service = find_service(current_service->servicep->host_name, 
-					current_service->description);
-			if((NULL != temp_service) && (FALSE == 
-					is_service_member_of_servicegroup(match_servicegroup, 
-					temp_service))) {
-				return 0;
-				}
-			}
-
-		/* If the contact group was specified, skip this service if it does not 
-			have the contact group specified */
-		if((NULL != match_contactgroup) && 
-				(NULL != current_service->servicep)) {
-			found = 0;
-			for(temp_contact_groupsmember = 
-					current_service->servicep->contact_groups; 
-					temp_contact_groupsmember != NULL; 
-					temp_contact_groupsmember = 
-					temp_contact_groupsmember->next) {
-				if(!strcmp(temp_contact_groupsmember->group_name, 
-						match_contactgroup->group_name)) {
-					found = 1;
-					break;
-					}
-				}
-			if(0 == found) return 0;
-			}
-
-		/* If a child host was specified... */
-		if((1 == use_child_host) && (NULL != current_service->servicep)) { 
-			temp_host = find_host(current_service->servicep->host_name);
-			if(NULL != temp_host) {
-				/* If the child host is "none", skip this service if it's 
-					host has children */
-				if(NULL == child_host) {
-					for(temp_host2 = host_list; temp_host2 != NULL; 
-							temp_host2 = temp_host2->next) {
-						if(TRUE == is_host_immediate_child_of_host(temp_host,
-								temp_host2)) {
-							return 0;
-							}
-						}
-					}
-				/* Otherwise, skip this service if it's host does not have the 
-					specified host as a child */
-				else if(FALSE == is_host_immediate_child_of_host(temp_host,
-						child_host)) {
-					return 0;
-					}
-				}
-			}
-		break;
 		}
 
-	return 1;
+		/* If a servicegroup was specified, skip this service if it is not
+			a member of the servicegroup specified */
+		if((NULL != match_servicegroup) &&
+		   (NULL != current_service->servicep)) {
+			temp_service = find_service(current_service->servicep->host_name,
+			                            current_service->description);
+			if((NULL != temp_service) && (FALSE ==
+			                              is_service_member_of_servicegroup(match_servicegroup,
+			                                      temp_service))) {
+				return 0;
+			}
+		}
+
+		/* If the contact group was specified, skip this service if it does not
+			have the contact group specified */
+		if((NULL != match_contactgroup) &&
+		   (NULL != current_service->servicep)) {
+			found = 0;
+			for(temp_contact_groupsmember =
+			        current_service->servicep->contact_groups;
+			    temp_contact_groupsmember != NULL;
+			    temp_contact_groupsmember =
+			        temp_contact_groupsmember->next) {
+				if(!strcmp(temp_contact_groupsmember->group_name,
+				           match_contactgroup->group_name)) {
+					found = 1;
+					break;
+				}
+			}
+			if(0 == found) return 0;
+		}
+
+		/* If a child host was specified... */
+		if((1 == use_child_host) && (NULL != current_service->servicep)) {
+			temp_host = find_host(current_service->servicep->host_name);
+			if(NULL != temp_host) {
+				/* If the child host is "none", skip this service if it's
+					host has children */
+				if(NULL == child_host) {
+					for(temp_host2 = host_list; temp_host2 != NULL;
+					    temp_host2 = temp_host2->next) {
+						if(TRUE == is_host_immediate_child_of_host(temp_host,
+						        temp_host2)) {
+							return 0;
+						}
+					}
+				}
+				/* Otherwise, skip this service if it's host does not have the
+					specified host as a child */
+				else if(FALSE == is_host_immediate_child_of_host(temp_host,
+				        child_host)) {
+					return 0;
+				}
+			}
+		}
+		break;
 	}
 
-json_object * json_archive_notification_selectors(unsigned format_options, 
-		int start, int count, time_t start_time, time_t end_time, 
-		int match_object_types, char *match_host, char *match_service, 
-		int use_parent_host, host *parent_host, int use_child_host, 
-		host *child_host, hostgroup *match_hostgroup, 
-		servicegroup *match_servicegroup, char *match_contact, 
-		contactgroup *match_contactgroup, 
-		unsigned match_host_notification_types, 
-		unsigned match_service_notification_types,
-		char *match_notification_method) {
+	return 1;
+}
+
+json_object * json_archive_notification_selectors(unsigned format_options,
+        int start, int count, time_t start_time, time_t end_time,
+        int match_object_types, char *match_host, char *match_service,
+        int use_parent_host, host *parent_host, int use_child_host,
+        host *child_host, hostgroup *match_hostgroup,
+        servicegroup *match_servicegroup, char *match_contact,
+        contactgroup *match_contactgroup,
+        unsigned match_host_notification_types,
+        unsigned match_service_notification_types,
+        char *match_notification_method)
+{
 
 	json_object *json_selectors;
 
@@ -2618,95 +2690,96 @@ json_object * json_archive_notification_selectors(unsigned format_options,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 
 	if(match_object_types != AU_OBJTYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "objecttypes", 
-				match_object_types, valid_object_types);
-		}
+		json_bitmask(json_selectors, format_options, "objecttypes",
+		             match_object_types, valid_object_types);
+	}
 
-	if((match_object_types & AU_OBJTYPE_HOST) && 
-			(match_host_notification_types != AU_NOTIFICATION_HOST_ALL)) {
-		json_bitmask(json_selectors, format_options, "hostnotificationtypes", 
-				match_host_notification_types, 
-				valid_host_notification_types);
-		}
+	if((match_object_types & AU_OBJTYPE_HOST) &&
+	   (match_host_notification_types != AU_NOTIFICATION_HOST_ALL)) {
+		json_bitmask(json_selectors, format_options, "hostnotificationtypes",
+		             match_host_notification_types,
+		             valid_host_notification_types);
+	}
 
-	if((match_object_types & AU_OBJTYPE_SERVICE) && 
-			(match_service_notification_types != AU_NOTIFICATION_SERVICE_ALL)) {
+	if((match_object_types & AU_OBJTYPE_SERVICE) &&
+	   (match_service_notification_types != AU_NOTIFICATION_SERVICE_ALL)) {
 		json_bitmask(json_selectors, format_options, "servicenotificationtypes",
-				match_service_notification_types, 
-				valid_service_notification_types);
-		}
+		             match_service_notification_types,
+		             valid_service_notification_types);
+	}
 
 	if(NULL != match_host) {
 		json_object_append_string(json_selectors, "hostname", match_host);
-		}
+	}
 
 	if(NULL != match_service) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				match_service);
-		}
+		json_object_append_string(json_selectors, "servicedescription",
+		                          match_service);
+	}
 
 	if(1 == use_parent_host) {
-		json_object_append_string(json_selectors, "parenthost", 
-				( NULL == parent_host ? "none" : parent_host->name));
-		}
+		json_object_append_string(json_selectors, "parenthost",
+		                          ( NULL == parent_host ? "none" : parent_host->name));
+	}
 
 	if( 1 == use_child_host) {
-		json_object_append_string(json_selectors, "childhost", 
-				( NULL == child_host ? "none" : child_host->name));
-		}
+		json_object_append_string(json_selectors, "childhost",
+		                          ( NULL == child_host ? "none" : child_host->name));
+	}
 
 	if(NULL != match_hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				match_hostgroup->group_name);
-		}
+		json_object_append_string(json_selectors, "hostgroup",
+		                          match_hostgroup->group_name);
+	}
 
-	if((match_object_types & AU_OBJTYPE_SERVICE) && 
-			(NULL != match_servicegroup)) {
-		json_object_append_string(json_selectors, "servicegroup", 
-				match_servicegroup->group_name);
-		}
+	if((match_object_types & AU_OBJTYPE_SERVICE) &&
+	   (NULL != match_servicegroup)) {
+		json_object_append_string(json_selectors, "servicegroup",
+		                          match_servicegroup->group_name);
+	}
 
 	if(NULL != match_contact) {
 		json_object_append_string(json_selectors, "contact", match_contact);
-		}
-
-	if(NULL != match_contactgroup) {
-		json_object_append_string(json_selectors, "contactgroup", 
-				match_contactgroup->group_name);
-		}
-
-	if(NULL != match_notification_method) {
-		json_object_append_string(json_selectors, "notificationmethod", 
-				match_notification_method);
-		}
-
-	return json_selectors;
 	}
 
-json_object * json_archive_notificationcount(unsigned format_options, 
-		time_t start_time, time_t end_time, int match_object_types, 
-		char *match_host, char *match_service, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup, 
-		char *match_contact, contactgroup *match_contactgroup, 
-		unsigned match_host_notification_types, 
-		unsigned match_service_notification_types, 
-		char *match_notification_method, au_log *log) {
+	if(NULL != match_contactgroup) {
+		json_object_append_string(json_selectors, "contactgroup",
+		                          match_contactgroup->group_name);
+	}
+
+	if(NULL != match_notification_method) {
+		json_object_append_string(json_selectors, "notificationmethod",
+		                          match_notification_method);
+	}
+
+	return json_selectors;
+}
+
+json_object * json_archive_notificationcount(unsigned format_options,
+        time_t start_time, time_t end_time, int match_object_types,
+        char *match_host, char *match_service, int use_parent_host,
+        host *parent_host, int use_child_host, host *child_host,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        char *match_contact, contactgroup *match_contactgroup,
+        unsigned match_host_notification_types,
+        unsigned match_service_notification_types,
+        char *match_notification_method, au_log *log)
+{
 
 	json_object *json_data;
 	au_node *temp_node;
@@ -2717,16 +2790,16 @@ json_object * json_archive_notificationcount(unsigned format_options,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_archive_notification_selectors(format_options, 0, 0, 
-			start_time, end_time, match_object_types, match_host, 
-			match_service, use_parent_host, parent_host, use_child_host, 
-			child_host, match_hostgroup, match_servicegroup, match_contact, 
-			match_contactgroup, match_host_notification_types, 
-			match_service_notification_types, match_notification_method));
+	json_object_append_object(json_data, "selectors",
+	                          json_archive_notification_selectors(format_options, 0, 0,
+	                                  start_time, end_time, match_object_types, match_host,
+	                                  match_service, use_parent_host, parent_host, use_child_host,
+	                                  child_host, match_hostgroup, match_servicegroup, match_contact,
+	                                  match_contactgroup, match_host_notification_types,
+	                                  match_service_notification_types, match_notification_method));
 
-	for(temp_node = log->entry_list->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log->entry_list->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 
 		temp_entry = (au_log_entry *)temp_node->data;
 
@@ -2744,38 +2817,39 @@ json_object * json_archive_notificationcount(unsigned format_options,
 			temp_host = NULL;
 			temp_service = (au_service *)temp_notification_log->object;
 			break;
-			}
+		}
 
-		/* Skip anything that does not pass the notification selection 
+		/* Skip anything that does not pass the notification selection
 			criteria */
-		if(json_archive_notification_passes_selection(temp_entry->timestamp, 
-				start_time, end_time, temp_notification_log->obj_type,
-				match_object_types, temp_host, match_host, temp_service,
-				match_service, use_parent_host, parent_host, use_child_host, 
-				child_host, match_hostgroup, match_servicegroup, 
-				temp_notification_log->contact, match_contact, 
-				match_contactgroup, temp_notification_log->notification_type, 
-				match_host_notification_types, 
-				match_service_notification_types, temp_notification_log->method,				match_notification_method) == 0) {
+		if(json_archive_notification_passes_selection(temp_entry->timestamp,
+		        start_time, end_time, temp_notification_log->obj_type,
+		        match_object_types, temp_host, match_host, temp_service,
+		        match_service, use_parent_host, parent_host, use_child_host,
+		        child_host, match_hostgroup, match_servicegroup,
+		        temp_notification_log->contact, match_contact,
+		        match_contactgroup, temp_notification_log->notification_type,
+		        match_host_notification_types,
+		        match_service_notification_types, temp_notification_log->method,				match_notification_method) == 0) {
 			continue;
-			}
+		}
 
 		count++;
-		}
+	}
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object * json_archive_notificationlist(unsigned format_options, int start, 
-		int count, time_t start_time, time_t end_time, int match_object_types, 
-		char *match_host, char *match_service, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup, 
-		char *match_contact, contactgroup *match_contactgroup, 
-		unsigned match_host_notification_types, 
-		unsigned match_service_notification_types, 
-		char *match_notification_method, au_log *log) {
+json_object * json_archive_notificationlist(unsigned format_options, int start,
+        int count, time_t start_time, time_t end_time, int match_object_types,
+        char *match_host, char *match_service, int use_parent_host,
+        host *parent_host, int use_child_host, host *child_host,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        char *match_contact, contactgroup *match_contactgroup,
+        unsigned match_host_notification_types,
+        unsigned match_service_notification_types,
+        char *match_notification_method, au_log *log)
+{
 
 	json_object *json_data;
 	json_array *json_notificationlist;
@@ -2789,18 +2863,18 @@ json_object * json_archive_notificationlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_archive_notification_selectors(format_options, start, count, 
-			start_time, end_time, match_object_types, match_host, 
-			match_service, use_parent_host, parent_host, use_child_host, 
-			child_host, match_hostgroup, match_servicegroup, match_contact, 
-			match_contactgroup, match_host_notification_types, 
-			match_service_notification_types, match_notification_method));
+	json_object_append_object(json_data, "selectors",
+	                          json_archive_notification_selectors(format_options, start, count,
+	                                  start_time, end_time, match_object_types, match_host,
+	                                  match_service, use_parent_host, parent_host, use_child_host,
+	                                  child_host, match_hostgroup, match_servicegroup, match_contact,
+	                                  match_contactgroup, match_host_notification_types,
+	                                  match_service_notification_types, match_notification_method));
 
 	json_notificationlist = json_new_array();
 
-	for(temp_node = log->entry_list->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log->entry_list->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 
 		temp_entry = (au_log_entry *)temp_node->data;
 
@@ -2818,54 +2892,55 @@ json_object * json_archive_notificationlist(unsigned format_options, int start,
 			temp_host = NULL;
 			temp_service = (au_service *)temp_notification_log->object;
 			break;
-			}
+		}
 
-		/* Skip anything that does not pass the notification selection 
+		/* Skip anything that does not pass the notification selection
 				criteria */
-		if(json_archive_notification_passes_selection(temp_entry->timestamp, 
-				start_time, end_time, temp_notification_log->obj_type, 
-				match_object_types, temp_host, match_host, temp_service, 
-				match_service, use_parent_host, parent_host, use_child_host, 
-				child_host, match_hostgroup, match_servicegroup, 
-				temp_notification_log->contact, match_contact, 
-				match_contactgroup, temp_notification_log->notification_type, 
-				match_host_notification_types, 
-				match_service_notification_types, temp_notification_log->method,
-				match_notification_method) == 0) {
+		if(json_archive_notification_passes_selection(temp_entry->timestamp,
+		        start_time, end_time, temp_notification_log->obj_type,
+		        match_object_types, temp_host, match_host, temp_service,
+		        match_service, use_parent_host, parent_host, use_child_host,
+		        child_host, match_hostgroup, match_servicegroup,
+		        temp_notification_log->contact, match_contact,
+		        match_contactgroup, temp_notification_log->notification_type,
+		        match_host_notification_types,
+		        match_service_notification_types, temp_notification_log->method,
+		        match_notification_method) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			json_notification_details = json_new_object();
-			json_archive_notification_details(json_notification_details, 
-					format_options, temp_entry->timestamp, 
-					(au_log_notification *)temp_entry->entry);
-			json_array_append_object(json_notificationlist, 
-					json_notification_details);
+			json_archive_notification_details(json_notification_details,
+			                                  format_options, temp_entry->timestamp,
+			                                  (au_log_notification *)temp_entry->entry);
+			json_array_append_object(json_notificationlist,
+			                         json_notification_details);
 			counted++;
-			}
-		current++; 
 		}
-
-	json_object_append_array(json_data, "notificationlist", 
-			json_notificationlist);
-
-	return json_data;
+		current++;
 	}
 
-void json_archive_notification_details(json_object *json_details, 
-		unsigned format_options, time_t timestamp, 
-		au_log_notification *temp_notification) {
+	json_object_append_array(json_data, "notificationlist",
+	                         json_notificationlist);
+
+	return json_data;
+}
+
+void json_archive_notification_details(json_object *json_details,
+                                       unsigned format_options, time_t timestamp,
+                                       au_log_notification *temp_notification)
+{
 
 	au_host *temp_host;
 	au_service *temp_service;
 
 	json_object_append_time_t(json_details, "timestamp", timestamp);
 
-	json_enumeration(json_details, format_options, "object_type", 
-			temp_notification->obj_type, 
-			svm_au_object_types);
+	json_enumeration(json_details, format_options, "object_type",
+	                 temp_notification->obj_type,
+	                 svm_au_object_types);
 
 	switch(temp_notification->obj_type) {
 	case AU_OBJTYPE_HOST:
@@ -2874,59 +2949,60 @@ void json_archive_notification_details(json_object *json_details,
 		break;
 	case AU_OBJTYPE_SERVICE:
 		temp_service = (au_service *)temp_notification->object;
-		json_object_append_string(json_details, "host_name", 
-				temp_service->host_name);
-		json_object_append_string(json_details, "description", 
-				temp_service->description);
+		json_object_append_string(json_details, "host_name",
+		                          temp_service->host_name);
+		json_object_append_string(json_details, "description",
+		                          temp_service->description);
 		break;
-		}
-
-	json_object_append_string(json_details, "contact", 
-			temp_notification->contact->name);
-	json_enumeration(json_details, format_options, "notification_type", 
-			temp_notification->notification_type, 
-			svm_au_notification_types);
-	json_object_append_string(json_details, "method", 
-			temp_notification->method);
-	json_object_append_string(json_details, "message", 
-			temp_notification->message);
 	}
 
+	json_object_append_string(json_details, "contact",
+	                          temp_notification->contact->name);
+	json_enumeration(json_details, format_options, "notification_type",
+	                 temp_notification->notification_type,
+	                 svm_au_notification_types);
+	json_object_append_string(json_details, "method",
+	                          temp_notification->method);
+	json_object_append_string(json_details, "message",
+	                          temp_notification->message);
+}
+
 int json_archive_statechange_passes_selection(time_t timestamp,
-		time_t end_time, int current_object_type, 
-		int match_object_type, au_host *current_host, char *match_host, 
-		au_service *current_service, char *match_service, 
-		unsigned current_state_type, unsigned match_state_types) {
+        time_t end_time, int current_object_type,
+        int match_object_type, au_host *current_host, char *match_host,
+        au_service *current_service, char *match_service,
+        unsigned current_state_type, unsigned match_state_types)
+{
 
 	if((end_time > 0) && (timestamp > end_time)) {
 		return 0;
-		}
+	}
 
 	/* Skip if we're not interested in the current state type */
 	if(!(current_state_type & match_state_types)) {
 		return 0;
-		}
+	}
 
 	switch(current_object_type) {
 	case AU_OBJTYPE_HOST:
 		/* Skip if we're not interested in hosts */
 		if(match_object_type != AU_OBJTYPE_HOST) {
 			return 0;
-			}
+		}
 
 		/* Skip if user is not authorized for this host */
-		if((NULL != current_host->hostp) && (FALSE == 
-				is_authorized_for_host(current_host->hostp, 
-				&current_authdata))) {
+		if((NULL != current_host->hostp) && (FALSE ==
+		                                     is_authorized_for_host(current_host->hostp,
+		                                             &current_authdata))) {
 			return 0;
-			}
+		}
 
-		/* If a specific host name was specified, skip this host if it's 
+		/* If a specific host name was specified, skip this host if it's
 			name does not match the one specified */
-		if((NULL != match_host) && (NULL != current_host) && 
-				strcmp(current_host->name, match_host)) {
+		if((NULL != match_host) && (NULL != current_host) &&
+		   strcmp(current_host->name, match_host)) {
 			return 0;
-			}
+		}
 
 		break;
 
@@ -2934,34 +3010,35 @@ int json_archive_statechange_passes_selection(time_t timestamp,
 		/* Skip if we're not interested in services */
 		if(match_object_type != AU_OBJTYPE_SERVICE) {
 			return 0;
-			}
-
-		/* Skip if user is not authorized for this service */
-		if((NULL != current_service->servicep) && (FALSE == 
-				is_authorized_for_service(current_service->servicep, 
-				&current_authdata))) {
-			return 0;
-			}
-
-		/* If a specific service was specified, skip this service if it's 
-			host name and service description do not match the one specified */
-		if((NULL != match_host) && (NULL != match_service) && 
-				(NULL != current_service) && 
-				( strcmp(current_service->host_name, match_host) ||
-				strcmp(current_service->description, match_service))) {
-			return 0;
-			}
-
-		break;
 		}
 
-	return 1;
+		/* Skip if user is not authorized for this service */
+		if((NULL != current_service->servicep) && (FALSE ==
+		        is_authorized_for_service(current_service->servicep,
+		                                  &current_authdata))) {
+			return 0;
+		}
+
+		/* If a specific service was specified, skip this service if it's
+			host name and service description do not match the one specified */
+		if((NULL != match_host) && (NULL != match_service) &&
+		   (NULL != current_service) &&
+		   ( strcmp(current_service->host_name, match_host) ||
+		     strcmp(current_service->description, match_service))) {
+			return 0;
+		}
+
+		break;
 	}
 
-json_object *json_archive_statechange_selectors(unsigned format_options, 
-		int start, int count, time_t start_time, time_t end_time, 
-		int object_type, char *host_name, char *service_description,
-		unsigned state_types) {
+	return 1;
+}
+
+json_object *json_archive_statechange_selectors(unsigned format_options,
+        int start, int count, time_t start_time, time_t end_time,
+        int object_type, char *host_name, char *service_description,
+        unsigned state_types)
+{
 
 	json_object *json_selectors;
 
@@ -2969,42 +3046,43 @@ json_object *json_archive_statechange_selectors(unsigned format_options,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 
 	if(NULL != host_name) {
 		json_object_append_string(json_selectors, "hostname", host_name);
-		}
-
-	if(NULL != service_description) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				service_description);
-		}
-
-	if(state_types != AU_STATETYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "statetypes", state_types, 
-				valid_state_types);
-		}
-
-	return json_selectors;
 	}
 
-json_object *json_archive_statechangelist(unsigned format_options, 
-		int start, int count, time_t start_time, time_t end_time, 
-		int object_type, char *host_name, char *service_description, 
-		int assumed_initial_host_state, int assumed_initial_service_state, 
-		unsigned state_types, au_log *log) {
+	if(NULL != service_description) {
+		json_object_append_string(json_selectors, "servicedescription",
+		                          service_description);
+	}
+
+	if(state_types != AU_STATETYPE_ALL) {
+		json_bitmask(json_selectors, format_options, "statetypes", state_types,
+		             valid_state_types);
+	}
+
+	return json_selectors;
+}
+
+json_object *json_archive_statechangelist(unsigned format_options,
+        int start, int count, time_t start_time, time_t end_time,
+        int object_type, char *host_name, char *service_description,
+        int assumed_initial_host_state, int assumed_initial_service_state,
+        unsigned state_types, au_log *log)
+{
 
 	json_object *json_data;
 	json_array *json_statechangelist;
@@ -3027,28 +3105,28 @@ json_object *json_archive_statechangelist(unsigned format_options,
 
 	if(assumed_initial_host_state != AU_STATE_NO_DATA) {
 		last_host_state = initial_host_state = assumed_initial_host_state;
-		}
+	}
 	if(assumed_initial_service_state != AU_STATE_NO_DATA) {
-		last_service_state = initial_service_state = 
-				assumed_initial_service_state;
-		}
+		last_service_state = initial_service_state =
+		                         assumed_initial_service_state;
+	}
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_archive_statechange_selectors(format_options, start, count, 
-			start_time, end_time, object_type, host_name, service_description,
-			state_types));
+	json_object_append_object(json_data, "selectors",
+	                          json_archive_statechange_selectors(format_options, start, count,
+	                                  start_time, end_time, object_type, host_name, service_description,
+	                                  state_types));
 
 	json_statechangelist = json_new_array();
 
-	for(temp_node = log->entry_list->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log->entry_list->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 
 		/* Skip all but notification type messages */
 		temp_entry = (au_log_entry *)temp_node->data;
 		if(!(temp_entry->entry_type & (AU_LOGTYPE_STATE | AU_LOGTYPE_ALERT))) {
 			continue;
-			}
+		}
 
 		/* Get the host/service object */
 		temp_state_log = (au_log_alert *)temp_entry->entry;
@@ -3063,16 +3141,16 @@ json_object *json_archive_statechangelist(unsigned format_options,
 			temp_service = (au_service *)temp_state_log->object;
 			object = (void *)temp_service;
 			break;
-			}
+		}
 
 		/* Skip any entries not passing the selectors */
-		if(json_archive_statechange_passes_selection(temp_entry->timestamp, 
-				end_time, temp_state_log->obj_type, 
-				object_type, temp_host, host_name, temp_service, 
-				service_description, temp_state_log->state_type, 
-				state_types) == 0) {
+		if(json_archive_statechange_passes_selection(temp_entry->timestamp,
+		        end_time, temp_state_log->obj_type,
+		        object_type, temp_host, host_name, temp_service,
+		        service_description, temp_state_log->state_type,
+		        state_types) == 0) {
 			continue;
-			}
+		}
 
 		if((start_time > 0) && (temp_entry->timestamp < start_time)) {
 			/* If we're before the start time and no initial assumed state
@@ -3081,124 +3159,124 @@ json_object *json_archive_statechangelist(unsigned format_options,
 			switch(temp_state_log->obj_type) {
 			case AU_OBJTYPE_HOST:
 				if(AU_STATE_NO_DATA == assumed_initial_host_state) {
-					last_host_state = initial_host_state = 
-							temp_state_log->state;
-					}
+					last_host_state = initial_host_state =
+					                      temp_state_log->state;
+				}
 				break;
 			case AU_OBJTYPE_SERVICE:
 				if(AU_STATE_NO_DATA == assumed_initial_service_state) {
-					last_service_state = initial_service_state = 
-							temp_state_log->state;
-					}
-				break;
+					last_service_state = initial_service_state =
+					                         temp_state_log->state;
 				}
-			continue;
+				break;
 			}
-		else if(0 == have_seen_first_entry) {
-			/* When we get to the first entry after the start, inject a 
+			continue;
+		} else if(0 == have_seen_first_entry) {
+			/* When we get to the first entry after the start, inject a
 				pseudo entry with the initial state */
 			switch(object_type) {
 			case AU_OBJTYPE_HOST:
-				start_log = au_create_alert_or_state_log(object_type, 
-						temp_host, AU_STATETYPE_HARD, initial_host_state, 
-						"Initial Host Pseudo-State");
+				start_log = au_create_alert_or_state_log(object_type,
+				            temp_host, AU_STATETYPE_HARD, initial_host_state,
+				            "Initial Host Pseudo-State");
 				break;
 			case AU_OBJTYPE_SERVICE:
-				start_log = au_create_alert_or_state_log(object_type, 
-						temp_service, AU_STATETYPE_HARD, initial_service_state, 
-						"Initial Service Pseudo-State");
+				start_log = au_create_alert_or_state_log(object_type,
+				            temp_service, AU_STATETYPE_HARD, initial_service_state,
+				            "Initial Service Pseudo-State");
 				break;
-				}
+			}
 			if(start_log != NULL) {
 				json_statechange_details = json_new_object();
-				json_archive_alert_details(json_statechange_details, 
-						format_options, start_time, start_log);
-				json_array_append_object(json_statechangelist, 
-						json_statechange_details);
+				json_archive_alert_details(json_statechange_details,
+				                           format_options, start_time, start_log);
+				json_array_append_object(json_statechangelist,
+				                         json_statechange_details);
 				au_free_alert_log(start_log);
-				}
-			have_seen_first_entry = 1;
 			}
+			have_seen_first_entry = 1;
+		}
 #if 0
 		else {
 			/* Ignore ALERT logs if their state is not different from the
 				previous state */
 			switch(object_type) {
 			case AU_OBJTYPE_HOST:
-//				if((temp_entry->entry_type & (AU_LOGTYPE_ALERT | 
-//						AU_LOGTYPE_STATE_INITIAL)) && 
+//				if((temp_entry->entry_type & (AU_LOGTYPE_ALERT |
+//						AU_LOGTYPE_STATE_INITIAL)) &&
 				if((temp_entry->entry_type & AU_LOGTYPE_ALERT) &&
-						(last_host_state == temp_state_log->state)) {
+				   (last_host_state == temp_state_log->state)) {
 					continue;
-					}
+				}
 				last_host_state = temp_state_log->state;
 				break;
 			case AU_OBJTYPE_SERVICE:
-//				if((temp_entry->entry_type & (AU_LOGTYPE_ALERT | 
-//						AU_LOGTYPE_STATE_INITIAL)) && 
+//				if((temp_entry->entry_type & (AU_LOGTYPE_ALERT |
+//						AU_LOGTYPE_STATE_INITIAL)) &&
 				if((temp_entry->entry_type & AU_LOGTYPE_ALERT) &&
-						(last_service_state == temp_state_log->state)) {
+				   (last_service_state == temp_state_log->state)) {
 					continue;
-					}
+				}
 				last_service_state = temp_state_log->state;
 				break;
-				}
 			}
+		}
 #endif
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			json_statechange_details = json_new_object();
-			json_archive_alert_details(json_statechange_details, 
-					format_options, temp_entry->timestamp, temp_state_log);
-			json_array_append_object(json_statechangelist, 
-					json_statechange_details);
+			json_archive_alert_details(json_statechange_details,
+			                           format_options, temp_entry->timestamp, temp_state_log);
+			json_array_append_object(json_statechangelist,
+			                         json_statechange_details);
 			counted++;
-			}
-		current++; 
 		}
+		current++;
+	}
 
 	/* Inject a pseudo entry with the final state */
 	switch(object_type) {
 	case AU_OBJTYPE_HOST:
-		end_log = au_create_alert_or_state_log(object_type, 
-				temp_host, AU_STATETYPE_HARD, temp_state_log->state, 
-				"Final Host Pseudo-State");
+		end_log = au_create_alert_or_state_log(object_type,
+		                                       temp_host, AU_STATETYPE_HARD, temp_state_log->state,
+		                                       "Final Host Pseudo-State");
 		break;
 	case AU_OBJTYPE_SERVICE:
-		end_log = au_create_alert_or_state_log(object_type, 
-				temp_service, AU_STATETYPE_HARD, temp_state_log->state, 
-				"Final Service Pseudo-State");
+		end_log = au_create_alert_or_state_log(object_type,
+		                                       temp_service, AU_STATETYPE_HARD, temp_state_log->state,
+		                                       "Final Service Pseudo-State");
 		break;
-		}
+	}
 	if(end_log != NULL) {
 		json_statechange_details = json_new_object();
-		json_archive_alert_details(json_statechange_details, format_options, 
-				end_time, end_log);
-		json_array_append_object(json_statechangelist, 
-				json_statechange_details);
+		json_archive_alert_details(json_statechange_details, format_options,
+		                           end_time, end_log);
+		json_array_append_object(json_statechangelist,
+		                         json_statechange_details);
 		au_free_alert_log(end_log);
-		}
+	}
 
-	json_object_append_array(json_data, "statechangelist", 
-			json_statechangelist);
+	json_object_append_array(json_data, "statechangelist",
+	                         json_statechangelist);
 
 	return json_data;
-	}
+}
 
 /*
 	Return the initial state of Nagios itself.
  */
-int get_initial_nagios_state(au_linked_list *log_entries, time_t start_time, 
-		time_t end_time) {
+int get_initial_nagios_state(au_linked_list *log_entries, time_t start_time,
+                             time_t end_time)
+{
 
 	au_node *temp_node;
 	au_log_entry *current_log_entry;
 	au_log_nagios *temp_nagios_log;
 	int initial_state = AU_STATE_NO_DATA;
 
-	for(temp_node = log_entries->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log_entries->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 		current_log_entry = (au_log_entry *)temp_node->data;
 		if(current_log_entry->timestamp < start_time) {
 			/* Any log entries prior to the start time tell us something
@@ -3214,20 +3292,18 @@ int get_initial_nagios_state(au_linked_list *log_entries, time_t start_time,
 				/* Any other log indicates that Nagios is running */
 				initial_state = AU_STATE_PROGRAM_START;
 				break;
-				}
 			}
-		else {
+		} else {
 			if(AU_STATE_NO_DATA != initial_state) {
 				/* Once we cross the threshold of the start time, if we have
 					an intial state, that is THE initial state */
 				return initial_state;
-				}
-			else {
+			} else {
 				/* Otherwise the first log encountered tells us the initial
 					state of Nagios */
 				switch(current_log_entry->entry_type) {
 				case AU_LOGTYPE_NAGIOS:
-					/* If the log is a Nagios start or stop log, that is 
+					/* If the log is a Nagios start or stop log, that is
 						opposite the initial state */
 					temp_nagios_log = (au_log_nagios *)current_log_entry->entry;
 					switch(temp_nagios_log->type) {
@@ -3237,52 +3313,51 @@ int get_initial_nagios_state(au_linked_list *log_entries, time_t start_time,
 					case AU_STATE_PROGRAM_END:
 						return AU_STATE_PROGRAM_START;
 						break;
-						}
+					}
 					break;
 				default:
 					/* Any other log indicates that Nagios was running at
 						the start time */
 					return AU_STATE_PROGRAM_START;
 					break;
-					}
 				}
 			}
 		}
-		/* If we reach this point, we are in bad shape because we had nothing
-			in the logs and the initial state should still be AU_STATE_NO_DATA,
-			which we return as an error indication */
-		return initial_state;
 	}
+	/* If we reach this point, we are in bad shape because we had nothing
+		in the logs and the initial state should still be AU_STATE_NO_DATA,
+		which we return as an error indication */
+	return initial_state;
+}
 
 /*
 	Return the initial downtime state of the host or service.
  */
-int get_initial_downtime_state(au_linked_list *log_entries, time_t start_time, 
-		time_t end_time) {
+int get_initial_downtime_state(au_linked_list *log_entries, time_t start_time,
+                               time_t end_time)
+{
 
 	au_node *temp_node;
 	au_log_entry *current_log_entry;
 	au_log_downtime *temp_downtime_log;
 	int initial_state = AU_STATE_NO_DATA;
 
-	for(temp_node = log_entries->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log_entries->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 		current_log_entry = (au_log_entry *)temp_node->data;
 		if(current_log_entry->timestamp < start_time) {
-			/* Any downtime log prior to the start time may indicate the 
+			/* Any downtime log prior to the start time may indicate the
 				initial downtime state so look at all of them */
 			if(AU_LOGTYPE_DOWNTIME == current_log_entry->entry_type) {
 				temp_downtime_log = (au_log_downtime *)current_log_entry->entry;
 				initial_state = temp_downtime_log->downtime_type;
-				}
 			}
-		else if(current_log_entry->timestamp <= end_time) {
+		} else if(current_log_entry->timestamp <= end_time) {
 			if(AU_STATE_NO_DATA != initial_state) {
 				/* Once we cross the start time, if we have a downtime state,
 					we have THE initial downtime state */
 				return initial_state;
-				}
-			else {
+			} else {
 				/* If we dont' have a downtime state yet, the first downtime
 					state we encounter will be opposite the initial downtime
 					state */
@@ -3295,32 +3370,33 @@ int get_initial_downtime_state(au_linked_list *log_entries, time_t start_time,
 					case AU_STATE_DOWNTIME_END:
 						return AU_STATE_DOWNTIME_START;
 						break;
-						}
 					}
 				}
 			}
 		}
-		/* If we haven't encountered any indication of downtime yet, assume
-			we were not initially in downtime */
-		if(AU_STATE_NO_DATA == initial_state) {
-			initial_state = AU_STATE_DOWNTIME_END;
-			}
-
-		return initial_state;
 	}
+	/* If we haven't encountered any indication of downtime yet, assume
+		we were not initially in downtime */
+	if(AU_STATE_NO_DATA == initial_state) {
+		initial_state = AU_STATE_DOWNTIME_END;
+	}
+
+	return initial_state;
+}
 
 /*
 	Return the initial state of the host or service.
  */
-int get_initial_subject_state(au_linked_list *log_entries, time_t start_time, 
-		time_t end_time) {
+int get_initial_subject_state(au_linked_list *log_entries, time_t start_time,
+                              time_t end_time)
+{
 
 	au_node *temp_node;
 	au_log_entry *current_log_entry;
 	int initial_state = AU_STATE_NO_DATA;
 
-	for(temp_node = log_entries->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log_entries->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 		current_log_entry = (au_log_entry *)temp_node->data;
 		if(current_log_entry->timestamp < start_time) {
 			/* Any state log prior to the start time may indicate the
@@ -3331,13 +3407,14 @@ int get_initial_subject_state(au_linked_list *log_entries, time_t start_time,
 			case AU_LOGTYPE_STATE_CURRENT:
 				initial_state = get_log_entry_state(current_log_entry);
 				break;
-				}
 			}
 		}
-		return initial_state;
 	}
+	return initial_state;
+}
 
-int get_log_entry_state(au_log_entry *log_entry) {
+int get_log_entry_state(au_log_entry *log_entry)
+{
 
 	switch(log_entry->entry_type) {
 	case AU_LOGTYPE_ALERT:
@@ -3357,28 +3434,30 @@ int get_log_entry_state(au_log_entry *log_entry) {
 	default:
 		return AU_STATE_NO_DATA;
 		break;
-		}
 	}
+}
 
 #define have_real_data(a)	have_data((a), \
 	~(AU_STATE_NO_DATA | AU_STATE_PROGRAM_START | AU_STATE_PROGRAM_END))
 #define have_state_data(a)	have_data((a), AU_STATE_ALL)
 
-int have_data(au_linked_list *log_entries, int mask) {
+int have_data(au_linked_list *log_entries, int mask)
+{
 
 	au_node *temp_node;
 	int state;
 
-	for(temp_node = log_entries->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log_entries->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 		state = get_log_entry_state((au_log_entry *)temp_node->data);
 		if(state & mask) return TRUE;
-		}
-	return FALSE;
 	}
+	return FALSE;
+}
 
-unsigned long calculate_window_duration(time_t start_time, time_t end_time, 
-		timeperiod *report_timeperiod) {
+unsigned long calculate_window_duration(time_t start_time, time_t end_time,
+                                        timeperiod *report_timeperiod)
+{
 
 	struct tm *t;
 	unsigned long state_duration;
@@ -3410,19 +3489,19 @@ unsigned long calculate_window_duration(time_t start_time, time_t end_time,
 			temp_start = 0;
 			if(start_time > midnight) {
 				temp_start = start_time - midnight;
-				}
+			}
 #ifdef DEBUG
-			printf("Matching: %ld -> %ld. (%ld -> %ld)\n", temp_start, 
-					temp_end, midnight + temp_start, midnight + temp_end);
+			printf("Matching: %ld -> %ld. (%ld -> %ld)\n", temp_start,
+			       temp_end, midnight + temp_start, midnight + temp_end);
 #endif
 			/* check all time ranges for this day of the week */
-			for(temp_timerange = report_timeperiod->days[weekday]; 
-					temp_timerange != NULL; 
-					temp_timerange = temp_timerange->next) {
+			for(temp_timerange = report_timeperiod->days[weekday];
+			    temp_timerange != NULL;
+			    temp_timerange = temp_timerange->next) {
 #ifdef DEBUG
-				printf("Matching in timerange[%d]: %lu -> %lu (%lu -> %lu)\n", 
-						weekday, temp_timerange->range_start, 
-						temp_timerange->range_end, temp_start, temp_end);
+				printf("Matching in timerange[%d]: %lu -> %lu (%lu -> %lu)\n",
+				       weekday, temp_timerange->range_start,
+				       temp_timerange->range_end, temp_start, temp_end);
 #endif
 
 				start = max(temp_timerange->range_start, temp_start);
@@ -3431,91 +3510,93 @@ unsigned long calculate_window_duration(time_t start_time, time_t end_time,
 				if(start < end) {
 					temp_duration += end - start;
 #ifdef DEBUG
-					printf("Matched time: %ld -> %ld = %lu\n", start, end, 
-							temp_duration);
+					printf("Matched time: %ld -> %ld = %lu\n", start, end,
+					       temp_duration);
 #endif
-					}
+				}
 #ifdef DEBUG
 				else {
 					printf("Ignored time: %ld -> %ld\n", start, end);
-					}
-#endif
 				}
+#endif
+			}
 			state_duration += temp_duration;
 			temp_start = 0;
 			midnight += 86400;
 			if(++weekday > 6) weekday = 0;
-			}
 		}
+	}
 
 	/* No report timeperiod was requested; assume 24x7 */
 	else {
 		/* Calculate time in this state */
 		state_duration = (unsigned long)(end_time - start_time);
-		}
+	}
 
 	return state_duration;
-	}
+}
 
 #ifdef DEBUG
-void print_availability(au_availability *availability, const char *padding) {
+void print_availability(au_availability *availability, const char *padding)
+{
 
 	printf("%sAll::           up:          %10lu\n", padding,
-			availability->time_up);
+	       availability->time_up);
 	printf("%s                down:        %10lu\n", padding,
-			availability->time_down);
+	       availability->time_down);
 	printf("%s                unreachable: %10lu\n", padding,
-			availability->time_unreachable);
+	       availability->time_unreachable);
 	printf("%s                ok:          %10lu\n", padding,
-			availability->time_ok);
+	       availability->time_ok);
 	printf("%s                warning:     %10lu\n", padding,
-			availability->time_warning);
+	       availability->time_warning);
 	printf("%s                critical:    %10lu\n", padding,
-			availability->time_critical);
+	       availability->time_critical);
 	printf("%s                unknown:     %10lu\n", padding,
-			availability->time_unknown); 
+	       availability->time_unknown);
 	printf("%sScheduled::     up:          %10lu\n", padding,
-			availability->scheduled_time_up);
+	       availability->scheduled_time_up);
 	printf("%s                down:        %10lu\n", padding,
-			availability->scheduled_time_down);
+	       availability->scheduled_time_down);
 	printf("%s                unreachable: %10lu\n", padding,
-			availability->scheduled_time_unreachable);
+	       availability->scheduled_time_unreachable);
 	printf("%s                ok:          %10lu\n", padding,
-			availability->scheduled_time_ok);
+	       availability->scheduled_time_ok);
 	printf("%s                warning:     %10lu\n", padding,
-			availability->scheduled_time_warning);
+	       availability->scheduled_time_warning);
 	printf("%s                critical:    %10lu\n", padding,
-			availability->scheduled_time_critical);
+	       availability->scheduled_time_critical);
 	printf("%s                unknown:     %10lu\n", padding,
-			availability->scheduled_time_unknown); 
+	       availability->scheduled_time_unknown);
 	printf("%sIndeterminate:: scheduled:   %10lu\n", padding,
-			availability->scheduled_time_indeterminate);
+	       availability->scheduled_time_indeterminate);
 	printf("%s                nodata:      %10lu\n", padding,
-			availability->time_indeterminate_nodata);
+	       availability->time_indeterminate_nodata);
 	printf("%s                notrunning:  %10lu\n", padding,
-			availability->time_indeterminate_notrunning); 
-	}
+	       availability->time_indeterminate_notrunning);
+}
 #endif
 
-void compute_window_availability(time_t start_time, time_t end_time, 
-		int last_subject_state, int last_downtime_state, int last_nagios_state,
-		timeperiod *report_timeperiod, au_availability *availability, 
-		int assume_state_during_nagios_downtime, int object_type, 
-		int assume_state_retention) {
+void compute_window_availability(time_t start_time, time_t end_time,
+                                 int last_subject_state, int last_downtime_state, int last_nagios_state,
+                                 timeperiod *report_timeperiod, au_availability *availability,
+                                 int assume_state_during_nagios_downtime, int object_type,
+                                 int assume_state_retention)
+{
 
 	unsigned long state_duration;
 
 #ifdef DEBUG
-printf( "    %lu to %lu (%lus): %s/%s/%s\n", start_time, end_time, 
-		(end_time - start_time),
-		svm_get_string_from_value(last_subject_state, svm_au_states),
-		svm_get_string_from_value(last_downtime_state, svm_au_states),
-		svm_get_string_from_value(last_nagios_state, svm_au_states));
+	printf( "    %lu to %lu (%lus): %s/%s/%s\n", start_time, end_time,
+	        (end_time - start_time),
+	        svm_get_string_from_value(last_subject_state, svm_au_states),
+	        svm_get_string_from_value(last_downtime_state, svm_au_states),
+	        svm_get_string_from_value(last_nagios_state, svm_au_states));
 #endif
 
 	/* Get the duration of this window as adjusted for the report timeperiod */
-	state_duration = calculate_window_duration(start_time, end_time, 
-			report_timeperiod);
+	state_duration = calculate_window_duration(start_time, end_time,
+	                 report_timeperiod);
 
 	/* Deterime the appropriate state */
 	switch(last_nagios_state) {
@@ -3547,7 +3628,7 @@ printf( "    %lu to %lu (%lus): %s/%s/%s\n", start_time, end_time,
 			case AU_STATE_SERVICE_CRITICAL:
 				availability->scheduled_time_critical += state_duration;
 				break;
-				}
+			}
 			break;
 		case AU_STATE_DOWNTIME_END:
 			switch(last_subject_state) {
@@ -3575,9 +3656,9 @@ printf( "    %lu to %lu (%lus): %s/%s/%s\n", start_time, end_time,
 			case AU_STATE_SERVICE_CRITICAL:
 				availability->time_critical += state_duration;
 				break;
-				}
-			break;
 			}
+			break;
+		}
 		break;
 	case AU_STATE_PROGRAM_END:
 		if(assume_state_during_nagios_downtime) {
@@ -3608,7 +3689,7 @@ printf( "    %lu to %lu (%lus): %s/%s/%s\n", start_time, end_time,
 				case AU_STATE_SERVICE_CRITICAL:
 					availability->scheduled_time_critical += state_duration;
 					break;
-					}
+				}
 				break;
 			case AU_STATE_DOWNTIME_END:
 				switch(last_subject_state) {
@@ -3636,28 +3717,28 @@ printf( "    %lu to %lu (%lus): %s/%s/%s\n", start_time, end_time,
 				case AU_STATE_SERVICE_CRITICAL:
 					availability->time_critical += state_duration;
 					break;
-					}
-				break;
 				}
+				break;
 			}
-		else {
+		} else {
 			availability->time_indeterminate_notrunning += state_duration;
-			}
-		break;
 		}
+		break;
+	}
 
 #ifdef DEBUG
 	print_availability(availability, "    ");
 #endif
 
 	return;
-	}
+}
 
 static void compute_availability(au_linked_list *log_entries, time_t query_time,
-		time_t start_time, time_t end_time, timeperiod *report_timeperiod, 
-		au_availability *availability, int initial_subject_state,
-		int assume_state_during_nagios_downtime, int object_type,
-		int assume_state_retention) {
+                                 time_t start_time, time_t end_time, timeperiod *report_timeperiod,
+                                 au_availability *availability, int initial_subject_state,
+                                 int assume_state_during_nagios_downtime, int object_type,
+                                 int assume_state_retention)
+{
 
 	int current_nagios_state;
 	int last_nagios_state;
@@ -3676,48 +3757,48 @@ static void compute_availability(au_linked_list *log_entries, time_t query_time,
 
 #ifdef DEBUG
 	printf("  initial state: %s\n",
-			svm_get_string_from_value(initial_subject_state, valid_states));
+	       svm_get_string_from_value(initial_subject_state, valid_states));
 #endif
 
 	/* Determine the initial Nagios state */
-	if((last_nagios_state = current_nagios_state = 
-			get_initial_nagios_state(log_entries, start_time, end_time)) 
-			== AU_STATE_NO_DATA) {
+	if((last_nagios_state = current_nagios_state =
+	                            get_initial_nagios_state(log_entries, start_time, end_time))
+	   == AU_STATE_NO_DATA) {
 		/* This is bad; I'm giving up. */
 		return;
-		}
+	}
 
 #ifdef DEBUG
 	printf("  initial nagios state: %s\n",
-			svm_get_string_from_value(last_nagios_state, valid_states));
+	       svm_get_string_from_value(last_nagios_state, valid_states));
 #endif
 
 	/* Determine the initial downtime state */
-	if((last_downtime_state = current_downtime_state = 
-			get_initial_downtime_state(log_entries, start_time, end_time)) 
-			== AU_STATE_NO_DATA) {
+	if((last_downtime_state = current_downtime_state =
+	                              get_initial_downtime_state(log_entries, start_time, end_time))
+	   == AU_STATE_NO_DATA) {
 		/* This is bad; I'm giving up. */
 		return;
-		}
+	}
 
 #ifdef DEBUG
 	printf("  initial downtime state: %s\n",
-			svm_get_string_from_value(last_downtime_state, valid_states));
+	       svm_get_string_from_value(last_downtime_state, valid_states));
 #endif
 
 
 	/* Process all entry pairs */
-	for(temp_node = log_entries->head; temp_node != NULL; 
-			temp_node = temp_node->next) {
+	for(temp_node = log_entries->head; temp_node != NULL;
+	    temp_node = temp_node->next) {
 		current_log_entry = (au_log_entry *)temp_node->data;
 
 		/* Skip everything before the start of the requested query window */
 		if(current_log_entry->timestamp < start_time) continue;
 
 #ifdef DEBUG
-		printf("  Got log of type \"%s\" at %lu\n", 
-				svm_get_string_from_value(current_log_entry->entry_type, 
-				svm_au_log_types), current_log_entry->timestamp);
+		printf("  Got log of type \"%s\" at %lu\n",
+		       svm_get_string_from_value(current_log_entry->entry_type,
+		                                 svm_au_log_types), current_log_entry->timestamp);
 #endif
 
 		/* Update states */
@@ -3732,33 +3813,33 @@ static void compute_availability(au_linked_list *log_entries, time_t query_time,
 			temp_alert_log = (au_log_alert *)current_log_entry->entry;
 			current_subject_state = temp_alert_log->state;
 #ifdef DEBUG
-			printf("  Current alert state: \"%s\"\n", 
-					svm_get_string_from_value(current_subject_state, 
-					valid_states));
+			printf("  Current alert state: \"%s\"\n",
+			       svm_get_string_from_value(current_subject_state,
+			                                 valid_states));
 #endif
 			break;
 		case AU_LOGTYPE_DOWNTIME:
 			temp_downtime_log = (au_log_downtime *)current_log_entry->entry;
 			current_downtime_state = temp_downtime_log->downtime_type;
 #ifdef DEBUG
-			printf("  Current downtime state: \"%s\"\n", 
-					svm_get_string_from_value(current_downtime_state, 
-					valid_states));
+			printf("  Current downtime state: \"%s\"\n",
+			       svm_get_string_from_value(current_downtime_state,
+			                                 valid_states));
 #endif
 			break;
 		case AU_LOGTYPE_NAGIOS:
 			temp_nagios_log = (au_log_nagios *)current_log_entry->entry;
 			current_nagios_state = temp_nagios_log->type;
 #ifdef DEBUG
-			printf("  Current nagios state: \"%s\"\n", 
-					svm_get_string_from_value(current_nagios_state, 
-					valid_states));
+			printf("  Current nagios state: \"%s\"\n",
+			       svm_get_string_from_value(current_nagios_state,
+			                                 valid_states));
 #endif
 			break;
 		default:
 			continue;
 			break;
-			}
+		}
 
 		/* Record the time ranges for the current log pair */
 		if(NULL != last_log_entry) last_time = last_log_entry->timestamp;
@@ -3772,26 +3853,26 @@ static void compute_availability(au_linked_list *log_entries, time_t query_time,
 			time range */
 		if(current_time > end_time) current_time = end_time;
 
-		/* Clip first time if it precedes the start of the requested 
+		/* Clip first time if it precedes the start of the requested
 			time range */
 		if(last_time < start_time) last_time = start_time;
 
 		/* compute availability times for this chunk */
 		compute_window_availability(last_time, current_time, last_subject_state,
-				last_downtime_state, last_nagios_state, report_timeperiod, 
-				availability, assume_state_during_nagios_downtime, object_type, 
-				assume_state_retention);
+		                            last_downtime_state, last_nagios_state, report_timeperiod,
+		                            availability, assume_state_during_nagios_downtime, object_type,
+		                            assume_state_retention);
 
-		/* Return if we've reached the end of the requested time 
+		/* Return if we've reached the end of the requested time
 			range */
 		if(current_time >= end_time) {
 			last_log_entry = current_log_entry;
 			break;
-			}
+		}
 
 		/* Keep track of the last item */
 		last_log_entry = current_log_entry;
-		}
+	}
 
 	/* Process the last entry */
 	if(last_log_entry != NULL) {
@@ -3810,29 +3891,29 @@ static void compute_availability(au_linked_list *log_entries, time_t query_time,
 			if(last_time < start_time) last_time = start_time;
 
 			/* compute availability times for last state */
-			compute_window_availability(last_time, current_time, 
-					last_subject_state, last_downtime_state, last_nagios_state, 
-					report_timeperiod, availability, 
-					assume_state_during_nagios_downtime, object_type, 
-					assume_state_retention);
-			}
+			compute_window_availability(last_time, current_time,
+			                            last_subject_state, last_downtime_state, last_nagios_state,
+			                            report_timeperiod, availability,
+			                            assume_state_during_nagios_downtime, object_type,
+			                            assume_state_retention);
 		}
-	else {
+	} else {
 		/* There were no log entries for the entire queried time, therefore
 			the whole query window was the same state */
 		compute_window_availability(start_time, end_time, initial_subject_state,
-				last_downtime_state, last_nagios_state, report_timeperiod,
-				availability, assume_state_during_nagios_downtime, object_type, 
-				assume_state_retention);
-		}
+		                            last_downtime_state, last_nagios_state, report_timeperiod,
+		                            availability, assume_state_during_nagios_downtime, object_type,
+		                            assume_state_retention);
 	}
+}
 
 
-void compute_host_availability(time_t query_time, time_t start_time, 
-		time_t end_time, au_log *log, au_host *host, 
-		timeperiod *report_timeperiod, int assume_initial_state, 
-		int assumed_initial_host_state, 
-		int assume_state_during_nagios_downtime, int assume_state_retention) {
+void compute_host_availability(time_t query_time, time_t start_time,
+                               time_t end_time, au_log *log, au_host *host,
+                               timeperiod *report_timeperiod, int assume_initial_state,
+                               int assumed_initial_host_state,
+                               int assume_state_during_nagios_downtime, int assume_state_retention)
+{
 
 	hoststatus *host_status = NULL;
 	int	last_known_state = AU_STATE_NO_DATA;
@@ -3840,7 +3921,7 @@ void compute_host_availability(time_t query_time, time_t start_time,
 
 #ifdef DEBUG
 	printf("Computing availability for host %s\n    from %lu to %lu\n",
-			host->name, start_time, end_time);
+	       host->name, start_time, end_time);
 #endif
 
 	/* If the start time is in the future, we can't compute anything */
@@ -3850,12 +3931,12 @@ void compute_host_availability(time_t query_time, time_t start_time,
 	host_status = find_hoststatus(host->name);
 
 	/* If we don't have any data, the query time falls within the requested
-		query window, and we have the current host status, insert the 
+		query window, and we have the current host status, insert the
 		current state as the pseudo state at the start of the requested
 		query window. */
-	if((have_state_data(host->log_entries) == FALSE) && 
-			(query_time > start_time) && (query_time <= end_time) && 
-			(host_status != NULL)) {
+	if((have_state_data(host->log_entries) == FALSE) &&
+	   (query_time > start_time) && (query_time <= end_time) &&
+	   (host_status != NULL)) {
 		switch(host_status->status) {
 		case HOST_DOWN:
 			last_known_state = AU_STATE_HOST_DOWN;
@@ -3869,31 +3950,31 @@ void compute_host_availability(time_t query_time, time_t start_time,
 		default:
 			last_known_state = AU_STATE_NO_DATA;
 			break;
-			}
+		}
 
 		if(last_known_state != AU_STATE_NO_DATA) {
 			/* Add a dummy current state item */
 #ifdef DEBUG
 			printf("  Inserting %s as current service pseudo-state\n",
-					svm_get_string_from_value(last_known_state, valid_states));
+			       svm_get_string_from_value(last_known_state, valid_states));
 #endif
-			(void)au_add_alert_or_state_log(log, start_time, 
-					AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_HOST, host, 
-					AU_STATETYPE_HARD, last_known_state, 
-					"Current Host Pseudo-State");
-			}
+			(void)au_add_alert_or_state_log(log, start_time,
+			                                AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_HOST, host,
+			                                AU_STATETYPE_HARD, last_known_state,
+			                                "Current Host Pseudo-State");
 		}
+	}
 
 	/* Next determine the initial state of the host */
-	initial_host_state = get_initial_subject_state(host->log_entries, 
-			start_time, end_time);
+	initial_host_state = get_initial_subject_state(host->log_entries,
+	                     start_time, end_time);
 #ifdef DEBUG
 	printf("  Initial state from logs: %s\n",
-			svm_get_string_from_value(initial_host_state, valid_states));
+	       svm_get_string_from_value(initial_host_state, valid_states));
 #endif
 
-	if((AU_STATE_NO_DATA == initial_host_state) && 
-			(1 == assume_initial_state)) {
+	if((AU_STATE_NO_DATA == initial_host_state) &&
+	   (1 == assume_initial_state)) {
 		switch(assumed_initial_host_state) {
 		case AU_STATE_HOST_UP:
 		case AU_STATE_HOST_DOWN:
@@ -3912,31 +3993,32 @@ void compute_host_availability(time_t query_time, time_t start_time,
 				case HOST_UP:
 					initial_host_state = AU_STATE_HOST_UP;
 					break;
-					}
 				}
-			break;
 			}
+			break;
 		}
+	}
 
 	/* At this point, if we still don't have any real data, we can't compute
 		anything, so return */
-	if((have_real_data(host->log_entries) != TRUE) && 
-			(AU_STATE_NO_DATA == initial_host_state)) return;
+	if((have_real_data(host->log_entries) != TRUE) &&
+	   (AU_STATE_NO_DATA == initial_host_state)) return;
 
 	/* Compute the availability for every entry in the host's list of log
 		entries */
-	compute_availability(host->log_entries, query_time, start_time, end_time, 
-			report_timeperiod, host->availability, initial_host_state,
-			assume_state_during_nagios_downtime, AU_OBJTYPE_HOST,
-			assume_state_retention);
+	compute_availability(host->log_entries, query_time, start_time, end_time,
+	                     report_timeperiod, host->availability, initial_host_state,
+	                     assume_state_during_nagios_downtime, AU_OBJTYPE_HOST,
+	                     assume_state_retention);
 
-	}
+}
 
-void compute_service_availability(time_t query_time, time_t start_time, 
-		time_t end_time, au_log *log, au_service *service, 
-		timeperiod *report_timeperiod, int assume_initial_state, 
-		int assumed_initial_service_state, 
-		int assume_state_during_nagios_downtime, int assume_state_retention) {
+void compute_service_availability(time_t query_time, time_t start_time,
+                                  time_t end_time, au_log *log, au_service *service,
+                                  timeperiod *report_timeperiod, int assume_initial_state,
+                                  int assumed_initial_service_state,
+                                  int assume_state_during_nagios_downtime, int assume_state_retention)
+{
 
 	servicestatus *service_status = NULL;
 	int	last_known_state = AU_STATE_NO_DATA;
@@ -3944,23 +4026,23 @@ void compute_service_availability(time_t query_time, time_t start_time,
 
 #ifdef DEBUG
 	printf("Computing availability for service %s:%s\n    from %lu to %lu\n",
-			service->host_name, service->description, start_time, end_time);
+	       service->host_name, service->description, start_time, end_time);
 #endif
 
 	/* If the start time is in the future, we can't compute anything */
 	if(start_time > query_time) return;
 
 	/* Get current service status if possible */
-	service_status = find_servicestatus(service->host_name, 
-			service->description);
+	service_status = find_servicestatus(service->host_name,
+	                                    service->description);
 
 	/* If we don't have any data, the query time falls within the requested
-		query window, and we have the current service status, insert the 
+		query window, and we have the current service status, insert the
 		current state as the pseudo state at the start of the requested
 		query window. */
-	if((have_state_data(service->log_entries) == FALSE) && 
-			(query_time > start_time) && (query_time <= end_time) && 
-			(service_status != NULL)) {
+	if((have_state_data(service->log_entries) == FALSE) &&
+	   (query_time > start_time) && (query_time <= end_time) &&
+	   (service_status != NULL)) {
 		switch(service_status->status) {
 		case SERVICE_OK:
 			last_known_state = AU_STATE_SERVICE_OK;
@@ -3977,30 +4059,30 @@ void compute_service_availability(time_t query_time, time_t start_time,
 		default:
 			last_known_state = AU_STATE_NO_DATA;
 			break;
-			}
+		}
 
 		if(last_known_state != AU_STATE_NO_DATA) {
 			/* Add a dummy current state item */
 #ifdef DEBUG
 			printf("  Inserting %s as current service pseudo-state\n",
-					svm_get_string_from_value(last_known_state, valid_states));
+			       svm_get_string_from_value(last_known_state, valid_states));
 #endif
-			(void)au_add_alert_or_state_log(log, start_time, 
-					AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_SERVICE, service, 
-					AU_STATETYPE_HARD, last_known_state, 
-					"Current Service Pseudo-State");
-			}
+			(void)au_add_alert_or_state_log(log, start_time,
+			                                AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_SERVICE, service,
+			                                AU_STATETYPE_HARD, last_known_state,
+			                                "Current Service Pseudo-State");
 		}
+	}
 
 	/* Next determine the initial state of the service */
-	initial_service_state = get_initial_subject_state(service->log_entries, 
-			start_time, end_time);
+	initial_service_state = get_initial_subject_state(service->log_entries,
+	                        start_time, end_time);
 #ifdef DEBUG
 	printf("  Initial state from logs: %s\n",
-			svm_get_string_from_value(initial_service_state, valid_states));
+	       svm_get_string_from_value(initial_service_state, valid_states));
 #endif
-	if((AU_STATE_NO_DATA == initial_service_state) && 
-			(1 == assume_initial_state)) {
+	if((AU_STATE_NO_DATA == initial_service_state) &&
+	   (1 == assume_initial_state)) {
 		switch(assumed_initial_service_state) {
 		case AU_STATE_SERVICE_OK:
 		case AU_STATE_SERVICE_WARNING:
@@ -4023,110 +4105,112 @@ void compute_service_availability(time_t query_time, time_t start_time,
 				case SERVICE_CRITICAL:
 					initial_service_state = AU_STATE_SERVICE_CRITICAL;
 					break;
-					}
 				}
-			break;
 			}
+			break;
 		}
+	}
 
 	/* At this point, if we still don't have any real data, we can't compute
 		anything, so return */
-	if((have_real_data(service->log_entries) != TRUE) && 
-			(AU_STATE_NO_DATA == initial_service_state)) return;
+	if((have_real_data(service->log_entries) != TRUE) &&
+	   (AU_STATE_NO_DATA == initial_service_state)) return;
 
 	/* Compute the availability for every entry in the service's list of log
 		entries */
 	compute_availability(service->log_entries, query_time, start_time, end_time,
-			report_timeperiod, service->availability, initial_service_state,
-			assume_state_during_nagios_downtime, AU_OBJTYPE_SERVICE,
-			assume_state_retention);
+	                     report_timeperiod, service->availability, initial_service_state,
+	                     assume_state_during_nagios_downtime, AU_OBJTYPE_SERVICE,
+	                     assume_state_retention);
 
-	}
+}
 
-json_object *json_archive_availability_selectors(unsigned format_options, 
-		time_t start_time, time_t end_time, int availability_object_type, 
-		char *host_name, char *service_description, hostgroup *hostgroup,
-		servicegroup *servicegroup, timeperiod *report_timeperiod,
-		int assume_initial_state, int assume_state_retention, 
-		int assume_state_during_nagios_downtime, 
-		int assumed_initial_host_state, int assumed_initial_service_state, 
-		unsigned state_types) {
+json_object *json_archive_availability_selectors(unsigned format_options,
+        time_t start_time, time_t end_time, int availability_object_type,
+        char *host_name, char *service_description, hostgroup *hostgroup,
+        servicegroup *servicegroup, timeperiod *report_timeperiod,
+        int assume_initial_state, int assume_state_retention,
+        int assume_state_during_nagios_downtime,
+        int assumed_initial_host_state, int assumed_initial_service_state,
+        unsigned state_types)
+{
 
 	json_object *json_selectors;
 
 	json_selectors = json_new_object();
 
-	json_enumeration(json_selectors, format_options, "availabilityobjecttype", 
-			availability_object_type, valid_availability_object_types);
+	json_enumeration(json_selectors, format_options, "availabilityobjecttype",
+	                 availability_object_type, valid_availability_object_types);
 
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 
 	if(NULL != host_name) {
 		json_object_append_string(json_selectors, "hostname", host_name);
-		}
-
-	if(NULL != service_description) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				service_description);
-		}
-
-	if(NULL != hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				hostgroup->group_name);
-		}
-
-	if(NULL != servicegroup) {
-		json_object_append_string(json_selectors, "servicegroup", 
-				servicegroup->group_name);
-		}
-
-	if(NULL != report_timeperiod) {
-		json_object_append_string(json_selectors, "timeperiod", 
-				report_timeperiod->name);
-		}
-
-	json_object_append_boolean(json_selectors, "assumeinitialstate", 
-			assume_initial_state);
-	json_object_append_boolean(json_selectors, "assumestateretention", 
-			assume_state_retention);
-	json_object_append_boolean(json_selectors, 
-			"assumestateduringnagiosdowntime", 
-			assume_state_during_nagios_downtime); 
-	if(assumed_initial_host_state != AU_STATE_NO_DATA) {
-		json_enumeration(json_selectors, format_options, 
-			"assumedinitialhoststate", assumed_initial_host_state, 
-			valid_initial_host_states);
-		}
-
-	if(assumed_initial_service_state != AU_STATE_NO_DATA) {
-		json_enumeration(json_selectors, format_options, 
-			"assumedinitialservicestate", assumed_initial_service_state, 
-			valid_initial_service_states);
-		}
-
-	if(state_types != AU_STATETYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "statetypes", state_types, 
-				valid_state_types);
-		}
-
-	return json_selectors;
 	}
 
-json_object *json_archive_availability(unsigned format_options, 
-		time_t query_time, time_t start_time, time_t end_time, 
-		int availability_object_type, char *host_name, 
-		char *service_description, hostgroup *hostgroup_selector, 
-		servicegroup *servicegroup_selector, timeperiod *report_timeperiod, 
-		int assume_initial_state, int assume_state_retention, 
-		int assume_state_during_nagios_downtime, 
-		int assumed_initial_host_state, int assumed_initial_service_state, 
-		unsigned state_types, au_log *log) {
+	if(NULL != service_description) {
+		json_object_append_string(json_selectors, "servicedescription",
+		                          service_description);
+	}
+
+	if(NULL != hostgroup) {
+		json_object_append_string(json_selectors, "hostgroup",
+		                          hostgroup->group_name);
+	}
+
+	if(NULL != servicegroup) {
+		json_object_append_string(json_selectors, "servicegroup",
+		                          servicegroup->group_name);
+	}
+
+	if(NULL != report_timeperiod) {
+		json_object_append_string(json_selectors, "timeperiod",
+		                          report_timeperiod->name);
+	}
+
+	json_object_append_boolean(json_selectors, "assumeinitialstate",
+	                           assume_initial_state);
+	json_object_append_boolean(json_selectors, "assumestateretention",
+	                           assume_state_retention);
+	json_object_append_boolean(json_selectors,
+	                           "assumestateduringnagiosdowntime",
+	                           assume_state_during_nagios_downtime);
+	if(assumed_initial_host_state != AU_STATE_NO_DATA) {
+		json_enumeration(json_selectors, format_options,
+		                 "assumedinitialhoststate", assumed_initial_host_state,
+		                 valid_initial_host_states);
+	}
+
+	if(assumed_initial_service_state != AU_STATE_NO_DATA) {
+		json_enumeration(json_selectors, format_options,
+		                 "assumedinitialservicestate", assumed_initial_service_state,
+		                 valid_initial_service_states);
+	}
+
+	if(state_types != AU_STATETYPE_ALL) {
+		json_bitmask(json_selectors, format_options, "statetypes", state_types,
+		             valid_state_types);
+	}
+
+	return json_selectors;
+}
+
+json_object *json_archive_availability(unsigned format_options,
+                                       time_t query_time, time_t start_time, time_t end_time,
+                                       int availability_object_type, char *host_name,
+                                       char *service_description, hostgroup *hostgroup_selector,
+                                       servicegroup *servicegroup_selector, timeperiod *report_timeperiod,
+                                       int assume_initial_state, int assume_state_retention,
+                                       int assume_state_during_nagios_downtime,
+                                       int assumed_initial_host_state, int assumed_initial_service_state,
+                                       unsigned state_types, au_log *log)
+{
 
 	json_object *json_data;
 
@@ -4149,314 +4233,309 @@ json_object *json_archive_availability(unsigned format_options,
 	servicesmember *temp_servicegroup_member;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_archive_availability_selectors(format_options, start_time, 
-			end_time, availability_object_type, host_name, service_description, 
-			hostgroup_selector, servicegroup_selector, report_timeperiod, 
-			assume_initial_state, assume_state_retention, 
-			assume_state_during_nagios_downtime, assumed_initial_host_state, 
-			assumed_initial_service_state, state_types));
+	json_object_append_object(json_data, "selectors",
+	                          json_archive_availability_selectors(format_options, start_time,
+	                                  end_time, availability_object_type, host_name, service_description,
+	                                  hostgroup_selector, servicegroup_selector, report_timeperiod,
+	                                  assume_initial_state, assume_state_retention,
+	                                  assume_state_during_nagios_downtime, assumed_initial_host_state,
+	                                  assumed_initial_service_state, state_types));
 
 	/* First compute the availability */
 	switch(availability_object_type) {
-		case AU_OBJTYPE_HOST:
-			if(NULL == host_name) {		/* compute for all hosts */
-				json_host_list = json_new_array();
-				for(temp_host = host_list; temp_host != NULL; 
-						temp_host = temp_host->next) {
-					if(FALSE == is_authorized_for_host(temp_host, 
-							&current_authdata)) {
-						continue;
-						}
-					json_host_object = 
-							json_archive_single_host_availability(
-							format_options, query_time, start_time, end_time, 
-							temp_host->name, report_timeperiod, 
-							assume_initial_state, assume_state_retention, 
-							assume_state_during_nagios_downtime, 
-							assumed_initial_host_state, state_types, log);
-					if(NULL != json_host_object) {
-						json_array_append_object(json_host_list, 
-								json_host_object);
-						}
-					}
-				json_object_append_array(json_data, "hosts", json_host_list);
+	case AU_OBJTYPE_HOST:
+		if(NULL == host_name) {		/* compute for all hosts */
+			json_host_list = json_new_array();
+			for(temp_host = host_list; temp_host != NULL;
+			    temp_host = temp_host->next) {
+				if(FALSE == is_authorized_for_host(temp_host,
+				                                   &current_authdata)) {
+					continue;
 				}
-			else {
-				temp_host = find_host(host_name);
-				if((NULL != temp_host) && 
-						(TRUE == is_authorized_for_host(temp_host, 
-						&current_authdata))) {
-					json_host_object = 
-							json_archive_single_host_availability(format_options, 
-							query_time, start_time, end_time, host_name, 
-							report_timeperiod, assume_initial_state, 
-							assume_state_retention, 
-							assume_state_during_nagios_downtime, 
-							assumed_initial_host_state, state_types, log);
-					if(NULL != json_host_object) {
-						json_object_append_object(json_data, "host", 
-								json_host_object);
-						}
-					}
+				json_host_object =
+				    json_archive_single_host_availability(
+				        format_options, query_time, start_time, end_time,
+				        temp_host->name, report_timeperiod,
+				        assume_initial_state, assume_state_retention,
+				        assume_state_during_nagios_downtime,
+				        assumed_initial_host_state, state_types, log);
+				if(NULL != json_host_object) {
+					json_array_append_object(json_host_list,
+					                         json_host_object);
 				}
-			break;
-		case AU_OBJTYPE_SERVICE:
-			if((NULL == host_name) && (NULL == service_description)) {	
-				/* compute for all services on all hosts */
-				json_service_list = json_new_array();
-				for(temp_service = service_list; temp_service != NULL; 
-						temp_service = temp_service->next) {
-					if(FALSE == is_authorized_for_service(temp_service,
-							&current_authdata)) {
-						continue;
-						}
-					json_service_object = 
-							json_archive_single_service_availability(
-							format_options, query_time, start_time, end_time, 
-							temp_service->host_name, temp_service->description, 
-							report_timeperiod, assume_initial_state, 
-							assume_state_retention, 
-							assume_state_during_nagios_downtime, 
-							assumed_initial_service_state, state_types, log);
+			}
+			json_object_append_array(json_data, "hosts", json_host_list);
+		} else {
+			temp_host = find_host(host_name);
+			if((NULL != temp_host) &&
+			   (TRUE == is_authorized_for_host(temp_host,
+			                                   &current_authdata))) {
+				json_host_object =
+				    json_archive_single_host_availability(format_options,
+				            query_time, start_time, end_time, host_name,
+				            report_timeperiod, assume_initial_state,
+				            assume_state_retention,
+				            assume_state_during_nagios_downtime,
+				            assumed_initial_host_state, state_types, log);
+				if(NULL != json_host_object) {
+					json_object_append_object(json_data, "host",
+					                          json_host_object);
+				}
+			}
+		}
+		break;
+	case AU_OBJTYPE_SERVICE:
+		if((NULL == host_name) && (NULL == service_description)) {
+			/* compute for all services on all hosts */
+			json_service_list = json_new_array();
+			for(temp_service = service_list; temp_service != NULL;
+			    temp_service = temp_service->next) {
+				if(FALSE == is_authorized_for_service(temp_service,
+				                                      &current_authdata)) {
+					continue;
+				}
+				json_service_object =
+				    json_archive_single_service_availability(
+				        format_options, query_time, start_time, end_time,
+				        temp_service->host_name, temp_service->description,
+				        report_timeperiod, assume_initial_state,
+				        assume_state_retention,
+				        assume_state_during_nagios_downtime,
+				        assumed_initial_service_state, state_types, log);
+				if(NULL != json_service_object) {
+					json_array_append_object(json_service_list,
+					                         json_service_object);
+				}
+			}
+			json_object_append_array(json_data, "services",
+			                         json_service_list);
+		} else if(NULL == service_description) {
+			/* compute for all services on the specified host */
+			json_service_list = json_new_array();
+			for(temp_service = service_list; temp_service != NULL;
+			    temp_service = temp_service->next) {
+				if(!strcmp(temp_service->host_name, host_name) &&
+				   (TRUE == is_authorized_for_service(temp_service,
+				                                      &current_authdata))) {
+					json_service_object =
+					    json_archive_single_service_availability(
+					        format_options, query_time, start_time,
+					        end_time, temp_service->host_name,
+					        temp_service->description, report_timeperiod,
+					        assume_initial_state, assume_state_retention,
+					        assume_state_during_nagios_downtime,
+					        assumed_initial_service_state, state_types,
+					        log);
 					if(NULL != json_service_object) {
-						json_array_append_object(json_service_list, 
-								json_service_object);
-						}
+						json_array_append_object(json_service_list,
+						                         json_service_object);
 					}
-				json_object_append_array(json_data, "services", 
-						json_service_list);
 				}
-			else if(NULL == service_description) {	
-				/* compute for all services on the specified host */
-				json_service_list = json_new_array();
-				for(temp_service = service_list; temp_service != NULL; 
-						temp_service = temp_service->next) {
-					if(!strcmp(temp_service->host_name, host_name) &&
-							(TRUE == is_authorized_for_service(temp_service,
-							&current_authdata))) {
-						json_service_object = 
-								json_archive_single_service_availability(
-								format_options, query_time, start_time, 
-								end_time, temp_service->host_name, 
-								temp_service->description, report_timeperiod, 
-								assume_initial_state, assume_state_retention, 
-								assume_state_during_nagios_downtime, 
-								assumed_initial_service_state, state_types, 
-								log);
-						if(NULL != json_service_object) {
-							json_array_append_object(json_service_list, 
-									json_service_object);
-							}
-						}
-					}
-				json_object_append_array(json_data, "services", 
-						json_service_list);
-				}
-			else if(NULL == host_name) {	
-				/* compute for all services on the specified host */
-				json_service_list = json_new_array();
-				for(temp_service = service_list; temp_service != NULL; 
-						temp_service = temp_service->next) {
-					if(!strcmp(temp_service->description, 
-							service_description) &&
-							(TRUE == is_authorized_for_service(temp_service,
-							&current_authdata))) {
-						json_service_object = 
-								json_archive_single_service_availability(
-								format_options, query_time, start_time, 
-								end_time, temp_service->host_name, 
-								temp_service->description, report_timeperiod, 
-								assume_initial_state, assume_state_retention, 
-								assume_state_during_nagios_downtime, 
-								assumed_initial_service_state, state_types, 
-								log);
-						if(NULL != json_service_object) {
-							json_array_append_object(json_service_list, 
-									json_service_object);
-							}
-						}
-					}
-				json_object_append_array(json_data, "services", 
-						json_service_list);
-				}
-			else {
-				temp_service = find_service(host_name, service_description);
-				if((NULL != temp_service) && 
-						(TRUE == is_authorized_for_service(temp_service,
-						&current_authdata))) {
-					json_service_object = 
-							json_archive_single_service_availability(format_options,
-							query_time, start_time, end_time, host_name, 
-							service_description, report_timeperiod, 
-							assume_initial_state, assume_state_retention, 
-							assume_state_during_nagios_downtime, 
-							assumed_initial_service_state, state_types, log);
+			}
+			json_object_append_array(json_data, "services",
+			                         json_service_list);
+		} else if(NULL == host_name) {
+			/* compute for all services on the specified host */
+			json_service_list = json_new_array();
+			for(temp_service = service_list; temp_service != NULL;
+			    temp_service = temp_service->next) {
+				if(!strcmp(temp_service->description,
+				           service_description) &&
+				   (TRUE == is_authorized_for_service(temp_service,
+				                                      &current_authdata))) {
+					json_service_object =
+					    json_archive_single_service_availability(
+					        format_options, query_time, start_time,
+					        end_time, temp_service->host_name,
+					        temp_service->description, report_timeperiod,
+					        assume_initial_state, assume_state_retention,
+					        assume_state_during_nagios_downtime,
+					        assumed_initial_service_state, state_types,
+					        log);
 					if(NULL != json_service_object) {
-						json_object_append_object(json_data, "service", 
-								json_service_object);
-						}
+						json_array_append_object(json_service_list,
+						                         json_service_object);
 					}
 				}
-			break;
-		case AU_OBJTYPE_HOSTGROUP:
-			if(NULL == hostgroup_selector) {
-				/* compute for all hosts in all hostgroups */
-				json_hostgroup_list = json_new_array();
-				for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; 
-						temp_hostgroup = temp_hostgroup->next) {
-					json_host_list = json_new_array();
-					for(temp_hostgroup_member = temp_hostgroup->members; 
-							temp_hostgroup_member != NULL; 
-							temp_hostgroup_member = 
-							temp_hostgroup_member->next) {
-						if(FALSE == is_authorized_for_host(temp_hostgroup_member->host_ptr, 
-								&current_authdata)) {
-							continue;
-							}
-						json_host_object = 
-								json_archive_single_host_availability(
-								format_options, query_time, start_time, 
-								end_time, temp_hostgroup_member->host_name, 
-								report_timeperiod, assume_initial_state, 
-								assume_state_retention, 
-								assume_state_during_nagios_downtime, 
-								assumed_initial_host_state, state_types, log);
-						if(NULL != json_host_object) {
-							json_array_append_object(json_host_list, 
-									json_host_object);
-							}
-						}
-					json_hostgroup_object = json_new_object();
-					json_object_append_string(json_hostgroup_object, "name",
-							temp_hostgroup->group_name);
-					json_object_append_array(json_hostgroup_object, "hosts", 
-							json_host_list);
-					json_array_append_object(json_hostgroup_list, 
-							json_hostgroup_object);
-					}
-				json_object_append_array(json_data, "hostgroups", 
-						json_hostgroup_list);
+			}
+			json_object_append_array(json_data, "services",
+			                         json_service_list);
+		} else {
+			temp_service = find_service(host_name, service_description);
+			if((NULL != temp_service) &&
+			   (TRUE == is_authorized_for_service(temp_service,
+			                                      &current_authdata))) {
+				json_service_object =
+				    json_archive_single_service_availability(format_options,
+				            query_time, start_time, end_time, host_name,
+				            service_description, report_timeperiod,
+				            assume_initial_state, assume_state_retention,
+				            assume_state_during_nagios_downtime,
+				            assumed_initial_service_state, state_types, log);
+				if(NULL != json_service_object) {
+					json_object_append_object(json_data, "service",
+					                          json_service_object);
 				}
-			else {
-				/* compute for all hosts in the specified hostgroup */
+			}
+		}
+		break;
+	case AU_OBJTYPE_HOSTGROUP:
+		if(NULL == hostgroup_selector) {
+			/* compute for all hosts in all hostgroups */
+			json_hostgroup_list = json_new_array();
+			for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL;
+			    temp_hostgroup = temp_hostgroup->next) {
 				json_host_list = json_new_array();
-				for(temp_hostgroup_member = hostgroup_selector->members; 
-						temp_hostgroup_member != NULL; 
-						temp_hostgroup_member = temp_hostgroup_member->next) {
-					if(FALSE == is_authorized_for_host(temp_hostgroup_member->host_ptr, 
-							&current_authdata)) {
+				for(temp_hostgroup_member = temp_hostgroup->members;
+				    temp_hostgroup_member != NULL;
+				    temp_hostgroup_member =
+				        temp_hostgroup_member->next) {
+					if(FALSE == is_authorized_for_host(temp_hostgroup_member->host_ptr,
+					                                   &current_authdata)) {
 						continue;
-						}
-					json_host_object = 
-							json_archive_single_host_availability(
-							format_options, query_time, start_time, end_time, 
-							temp_hostgroup_member->host_name, report_timeperiod, 
-							assume_initial_state, assume_state_retention, 
-							assume_state_during_nagios_downtime, 
-							assumed_initial_host_state, state_types, log);
-					if(NULL != json_host_object) {
-						json_array_append_object(json_host_list, 
-								json_host_object);
-						}
 					}
+					json_host_object =
+					    json_archive_single_host_availability(
+					        format_options, query_time, start_time,
+					        end_time, temp_hostgroup_member->host_name,
+					        report_timeperiod, assume_initial_state,
+					        assume_state_retention,
+					        assume_state_during_nagios_downtime,
+					        assumed_initial_host_state, state_types, log);
+					if(NULL != json_host_object) {
+						json_array_append_object(json_host_list,
+						                         json_host_object);
+					}
+				}
 				json_hostgroup_object = json_new_object();
 				json_object_append_string(json_hostgroup_object, "name",
-						hostgroup_selector->group_name);
-				json_object_append_array(json_hostgroup_object, "hosts", 
-						json_host_list);
-				json_object_append_object(json_data, "hostgroup", 
-						json_hostgroup_object);
+				                          temp_hostgroup->group_name);
+				json_object_append_array(json_hostgroup_object, "hosts",
+				                         json_host_list);
+				json_array_append_object(json_hostgroup_list,
+				                         json_hostgroup_object);
+			}
+			json_object_append_array(json_data, "hostgroups",
+			                         json_hostgroup_list);
+		} else {
+			/* compute for all hosts in the specified hostgroup */
+			json_host_list = json_new_array();
+			for(temp_hostgroup_member = hostgroup_selector->members;
+			    temp_hostgroup_member != NULL;
+			    temp_hostgroup_member = temp_hostgroup_member->next) {
+				if(FALSE == is_authorized_for_host(temp_hostgroup_member->host_ptr,
+				                                   &current_authdata)) {
+					continue;
 				}
-			break;
-		case AU_OBJTYPE_SERVICEGROUP:
-			if(NULL == servicegroup_selector) {
-				/* compute for all hosts in all hostgroups */
-				json_servicegroup_list = json_new_array();
-				for(temp_servicegroup = servicegroup_list; 
-						temp_servicegroup != NULL; 
-						temp_servicegroup = temp_servicegroup->next) {
-					json_service_list = json_new_array();
-					for(temp_servicegroup_member = temp_servicegroup->members; 
-							temp_servicegroup_member != NULL; 
-							temp_servicegroup_member = 
-							temp_servicegroup_member->next) {
-						if(FALSE == is_authorized_for_service(temp_servicegroup_member->service_ptr,
-								&current_authdata)) {
-							continue;
-							}
-						json_service_object = 
-								json_archive_single_service_availability(
-								format_options, query_time, start_time, 
-								end_time, temp_servicegroup_member->host_name, 
-								temp_servicegroup_member->service_description, 
-								report_timeperiod, assume_initial_state, 
-								assume_state_retention, 
-								assume_state_during_nagios_downtime, 
-								assumed_initial_service_state, state_types, 
-								log);
-						if(NULL != json_service_object) {
-							json_array_append_object(json_service_list, 
-									json_service_object);
-							}
-						}
-					json_servicegroup_object = json_new_object();
-					json_object_append_string(json_servicegroup_object, "name",
-							temp_servicegroup->group_name);
-					json_object_append_array(json_servicegroup_object, "hosts", 
-							json_service_list);
-					json_array_append_object(json_servicegroup_list, 
-							json_servicegroup_object);
-					}
-				json_object_append_array(json_data, "servicegroups", 
-						json_servicegroup_list);
+				json_host_object =
+				    json_archive_single_host_availability(
+				        format_options, query_time, start_time, end_time,
+				        temp_hostgroup_member->host_name, report_timeperiod,
+				        assume_initial_state, assume_state_retention,
+				        assume_state_during_nagios_downtime,
+				        assumed_initial_host_state, state_types, log);
+				if(NULL != json_host_object) {
+					json_array_append_object(json_host_list,
+					                         json_host_object);
 				}
-			else {
-				/* compute for all services in the specified servicegroup */
+			}
+			json_hostgroup_object = json_new_object();
+			json_object_append_string(json_hostgroup_object, "name",
+			                          hostgroup_selector->group_name);
+			json_object_append_array(json_hostgroup_object, "hosts",
+			                         json_host_list);
+			json_object_append_object(json_data, "hostgroup",
+			                          json_hostgroup_object);
+		}
+		break;
+	case AU_OBJTYPE_SERVICEGROUP:
+		if(NULL == servicegroup_selector) {
+			/* compute for all hosts in all hostgroups */
+			json_servicegroup_list = json_new_array();
+			for(temp_servicegroup = servicegroup_list;
+			    temp_servicegroup != NULL;
+			    temp_servicegroup = temp_servicegroup->next) {
 				json_service_list = json_new_array();
-				for(temp_servicegroup_member = servicegroup_selector->members; 
-						temp_servicegroup_member != NULL; 
-						temp_servicegroup_member = 
-						temp_servicegroup_member->next) {
+				for(temp_servicegroup_member = temp_servicegroup->members;
+				    temp_servicegroup_member != NULL;
+				    temp_servicegroup_member =
+				        temp_servicegroup_member->next) {
 					if(FALSE == is_authorized_for_service(temp_servicegroup_member->service_ptr,
-							&current_authdata)) {
+					                                      &current_authdata)) {
 						continue;
-						}
-					json_service_object = 
-							json_archive_single_service_availability(
-							format_options, query_time, start_time, end_time, 
-							temp_servicegroup_member->host_name, 
-							temp_servicegroup_member->service_description, 
-							report_timeperiod, assume_initial_state, 
-							assume_state_retention, 
-							assume_state_during_nagios_downtime, 
-							assumed_initial_service_state, state_types, log);
-					if(NULL != json_service_object) {
-						json_array_append_object(json_service_list, 
-								json_service_object);
-						}
 					}
+					json_service_object =
+					    json_archive_single_service_availability(
+					        format_options, query_time, start_time,
+					        end_time, temp_servicegroup_member->host_name,
+					        temp_servicegroup_member->service_description,
+					        report_timeperiod, assume_initial_state,
+					        assume_state_retention,
+					        assume_state_during_nagios_downtime,
+					        assumed_initial_service_state, state_types,
+					        log);
+					if(NULL != json_service_object) {
+						json_array_append_object(json_service_list,
+						                         json_service_object);
+					}
+				}
 				json_servicegroup_object = json_new_object();
 				json_object_append_string(json_servicegroup_object, "name",
-						servicegroup_selector->group_name);
-				json_object_append_array(json_servicegroup_object, "services", 
-						json_service_list);
-				json_object_append_object(json_data, "servicegroup", 
-						json_servicegroup_object);
+				                          temp_servicegroup->group_name);
+				json_object_append_array(json_servicegroup_object, "hosts",
+				                         json_service_list);
+				json_array_append_object(json_servicegroup_list,
+				                         json_servicegroup_object);
+			}
+			json_object_append_array(json_data, "servicegroups",
+			                         json_servicegroup_list);
+		} else {
+			/* compute for all services in the specified servicegroup */
+			json_service_list = json_new_array();
+			for(temp_servicegroup_member = servicegroup_selector->members;
+			    temp_servicegroup_member != NULL;
+			    temp_servicegroup_member =
+			        temp_servicegroup_member->next) {
+				if(FALSE == is_authorized_for_service(temp_servicegroup_member->service_ptr,
+				                                      &current_authdata)) {
+					continue;
 				}
-			break;
-		default:
-			break;
+				json_service_object =
+				    json_archive_single_service_availability(
+				        format_options, query_time, start_time, end_time,
+				        temp_servicegroup_member->host_name,
+				        temp_servicegroup_member->service_description,
+				        report_timeperiod, assume_initial_state,
+				        assume_state_retention,
+				        assume_state_during_nagios_downtime,
+				        assumed_initial_service_state, state_types, log);
+				if(NULL != json_service_object) {
+					json_array_append_object(json_service_list,
+					                         json_service_object);
+				}
+			}
+			json_servicegroup_object = json_new_object();
+			json_object_append_string(json_servicegroup_object, "name",
+			                          servicegroup_selector->group_name);
+			json_object_append_array(json_servicegroup_object, "services",
+			                         json_service_list);
+			json_object_append_object(json_data, "servicegroup",
+			                          json_servicegroup_object);
 		}
-
-	return json_data;
+		break;
+	default:
+		break;
 	}
 
-json_object *json_archive_single_host_availability(unsigned format_options, 
-		time_t query_time, time_t start_time, time_t end_time, char *host_name, 
-		timeperiod *report_timeperiod, int assume_initial_state, 
-		int assume_state_retention, int assume_state_during_nagios_downtime, 
-		int assumed_initial_host_state, unsigned state_types, au_log *log) {
+	return json_data;
+}
+
+json_object *json_archive_single_host_availability(unsigned format_options,
+        time_t query_time, time_t start_time, time_t end_time, char *host_name,
+        timeperiod *report_timeperiod, int assume_initial_state,
+        int assume_state_retention, int assume_state_during_nagios_downtime,
+        int assumed_initial_host_state, unsigned state_types, au_log *log)
+{
 
 	au_host *host = NULL;
 	au_node *temp_entry = NULL;
@@ -4464,38 +4543,39 @@ json_object *json_archive_single_host_availability(unsigned format_options,
 	json_object	*json_host_availability = NULL;
 
 	host = au_find_host(log->hosts, host_name);
-	if(NULL == host) { 
+	if(NULL == host) {
 		/* host has no log entries, so create the host */
 		host = au_add_host(log->hosts, host_name);
 		/* Add global events to this new host */
 		global_host = au_find_host(log->hosts, "*");
-		for(temp_entry = global_host->log_entries->head; NULL != temp_entry; 
-				temp_entry = temp_entry->next) {
-			if(au_list_add_node(host->log_entries, temp_entry->data, 
-					au_cmp_log_entries) == 0) {
+		for(temp_entry = global_host->log_entries->head; NULL != temp_entry;
+		    temp_entry = temp_entry->next) {
+			if(au_list_add_node(host->log_entries, temp_entry->data,
+			                    au_cmp_log_entries) == 0) {
 				break;
-				}
 			}
 		}
-
-	if((host->availability = calloc(1, sizeof(au_availability))) != NULL) {
-		compute_host_availability(query_time, start_time, end_time, log, host, 
-				report_timeperiod, assume_initial_state, 
-				assumed_initial_host_state, 
-				assume_state_during_nagios_downtime, assume_state_retention);
-		json_host_availability = json_archive_host_availability(format_options, 
-				host->name, host->availability);
-		}
-
-	return json_host_availability;
 	}
 
-json_object *json_archive_single_service_availability(unsigned format_options, 
-		time_t query_time, time_t start_time, time_t end_time, char *host_name, 
-		char *service_description, timeperiod *report_timeperiod, 
-		int assume_initial_state, int assume_state_retention, 
-		int assume_state_during_nagios_downtime, 
-		int assumed_initial_service_state, unsigned state_types, au_log *log) {
+	if((host->availability = calloc(1, sizeof(au_availability))) != NULL) {
+		compute_host_availability(query_time, start_time, end_time, log, host,
+		                          report_timeperiod, assume_initial_state,
+		                          assumed_initial_host_state,
+		                          assume_state_during_nagios_downtime, assume_state_retention);
+		json_host_availability = json_archive_host_availability(format_options,
+		                         host->name, host->availability);
+	}
+
+	return json_host_availability;
+}
+
+json_object *json_archive_single_service_availability(unsigned format_options,
+        time_t query_time, time_t start_time, time_t end_time, char *host_name,
+        char *service_description, timeperiod *report_timeperiod,
+        int assume_initial_state, int assume_state_retention,
+        int assume_state_during_nagios_downtime,
+        int assumed_initial_service_state, unsigned state_types, au_log *log)
+{
 
 	au_service *service = NULL;
 	au_node *temp_entry = NULL;
@@ -4508,31 +4588,32 @@ json_object *json_archive_single_service_availability(unsigned format_options,
 		service = au_add_service(log->services, host_name, service_description);
 		/* Add global events to this new service */
 		global_host = au_find_host(log->hosts, "*");
-		for(temp_entry = global_host->log_entries->head; NULL != temp_entry; 
-				temp_entry = temp_entry->next) {
-			if(au_list_add_node(service->log_entries, temp_entry->data, 
-					au_cmp_log_entries) == 0) {
+		for(temp_entry = global_host->log_entries->head; NULL != temp_entry;
+		    temp_entry = temp_entry->next) {
+			if(au_list_add_node(service->log_entries, temp_entry->data,
+			                    au_cmp_log_entries) == 0) {
 				break;
-				}
 			}
 		}
-
-	if((service->availability = calloc(1, sizeof(au_availability))) != NULL) {
-		compute_service_availability(query_time, start_time, end_time, log, 
-				service, report_timeperiod, assume_initial_state, 
-				assumed_initial_service_state, 
-				assume_state_during_nagios_downtime, assume_state_retention);
-		json_service_availability = 
-				json_archive_service_availability(format_options, 
-						service->host_name, service->description, 
-						service->availability);
-		}
-
-	return json_service_availability;
 	}
 
-json_object *json_archive_host_availability(unsigned format_options, 
-		char *name, au_availability *availability) {
+	if((service->availability = calloc(1, sizeof(au_availability))) != NULL) {
+		compute_service_availability(query_time, start_time, end_time, log,
+		                             service, report_timeperiod, assume_initial_state,
+		                             assumed_initial_service_state,
+		                             assume_state_during_nagios_downtime, assume_state_retention);
+		json_service_availability =
+		    json_archive_service_availability(format_options,
+		                                      service->host_name, service->description,
+		                                      service->availability);
+	}
+
+	return json_service_availability;
+}
+
+json_object *json_archive_host_availability(unsigned format_options,
+        char *name, au_availability *availability)
+{
 
 	json_object *json_host_availability;
 
@@ -4542,67 +4623,68 @@ json_object *json_archive_host_availability(unsigned format_options,
 		json_object_append_string(json_host_availability, "name", name);
 	}
 
-	json_object_append_duration(json_host_availability, "time_up", 
-			availability->time_up);
-	json_object_append_duration(json_host_availability, "time_down", 
-			availability->time_down);
-	json_object_append_duration(json_host_availability, "time_unreachable", 
-			availability->time_unreachable);
-	json_object_append_duration(json_host_availability, "scheduled_time_up", 
-			availability->scheduled_time_up);
-	json_object_append_duration(json_host_availability, "scheduled_time_down", 
-			availability->scheduled_time_down);
-	json_object_append_duration(json_host_availability, 
-			"scheduled_time_unreachable", 
-			availability->scheduled_time_unreachable);
-	json_object_append_duration(json_host_availability, 
-			"time_indeterminate_nodata", 
-			availability->time_indeterminate_nodata);
-	json_object_append_duration(json_host_availability, 
-			"time_indeterminate_notrunning", 
-			availability->time_indeterminate_notrunning);
+	json_object_append_duration(json_host_availability, "time_up",
+	                            availability->time_up);
+	json_object_append_duration(json_host_availability, "time_down",
+	                            availability->time_down);
+	json_object_append_duration(json_host_availability, "time_unreachable",
+	                            availability->time_unreachable);
+	json_object_append_duration(json_host_availability, "scheduled_time_up",
+	                            availability->scheduled_time_up);
+	json_object_append_duration(json_host_availability, "scheduled_time_down",
+	                            availability->scheduled_time_down);
+	json_object_append_duration(json_host_availability,
+	                            "scheduled_time_unreachable",
+	                            availability->scheduled_time_unreachable);
+	json_object_append_duration(json_host_availability,
+	                            "time_indeterminate_nodata",
+	                            availability->time_indeterminate_nodata);
+	json_object_append_duration(json_host_availability,
+	                            "time_indeterminate_notrunning",
+	                            availability->time_indeterminate_notrunning);
 
 	return json_host_availability;
-	}
+}
 
-json_object *json_archive_service_availability(unsigned format_options, 
-		char *host_name, char *description, au_availability *availability) {
+json_object *json_archive_service_availability(unsigned format_options,
+        char *host_name, char *description, au_availability *availability)
+{
 
 	json_object *json_service_availability;
 
 	json_service_availability = json_new_object();
 
 	if(host_name != NULL) {
-		json_object_append_string(json_service_availability, "host_name", 
-				host_name);
+		json_object_append_string(json_service_availability, "host_name",
+		                          host_name);
 	}
 	if(description != NULL) {
-		json_object_append_string(json_service_availability, "description", 
-				description);
+		json_object_append_string(json_service_availability, "description",
+		                          description);
 	}
 
-	json_object_append_duration(json_service_availability, "time_ok", 
-			availability->time_ok);
-	json_object_append_duration(json_service_availability, "time_warning", 
-			availability->time_warning);
-	json_object_append_duration(json_service_availability, "time_critical", 
-			availability->time_critical);
-	json_object_append_duration(json_service_availability, "time_unknown", 
-			availability->time_unknown);
-	json_object_append_duration(json_service_availability, "scheduled_time_ok", 
-			availability->scheduled_time_up);
-	json_object_append_duration(json_service_availability, 
-			"scheduled_time_warning", availability->scheduled_time_warning);
-	json_object_append_duration(json_service_availability, 
-			"scheduled_time_critical", availability->scheduled_time_critical);
-	json_object_append_duration(json_service_availability, 
-			"scheduled_time_unknown", availability->scheduled_time_unknown);
-	json_object_append_duration(json_service_availability, 
-			"time_indeterminate_nodata", 
-			availability->time_indeterminate_nodata);
-	json_object_append_duration(json_service_availability, 
-			"time_indeterminate_notrunning", 
-			availability->time_indeterminate_notrunning);
+	json_object_append_duration(json_service_availability, "time_ok",
+	                            availability->time_ok);
+	json_object_append_duration(json_service_availability, "time_warning",
+	                            availability->time_warning);
+	json_object_append_duration(json_service_availability, "time_critical",
+	                            availability->time_critical);
+	json_object_append_duration(json_service_availability, "time_unknown",
+	                            availability->time_unknown);
+	json_object_append_duration(json_service_availability, "scheduled_time_ok",
+	                            availability->scheduled_time_up);
+	json_object_append_duration(json_service_availability,
+	                            "scheduled_time_warning", availability->scheduled_time_warning);
+	json_object_append_duration(json_service_availability,
+	                            "scheduled_time_critical", availability->scheduled_time_critical);
+	json_object_append_duration(json_service_availability,
+	                            "scheduled_time_unknown", availability->scheduled_time_unknown);
+	json_object_append_duration(json_service_availability,
+	                            "time_indeterminate_nodata",
+	                            availability->time_indeterminate_nodata);
+	json_object_append_duration(json_service_availability,
+	                            "time_indeterminate_notrunning",
+	                            availability->time_indeterminate_notrunning);
 
 	return json_service_availability;
-	}
+}

--- a/cgi/archiveutils.c
+++ b/cgi/archiveutils.c
@@ -38,14 +38,14 @@ const string_value_mapping svm_au_object_types[] = {
 	{ "host", AU_OBJTYPE_HOST, "Host" },
 	{ "service", AU_OBJTYPE_SERVICE, "Service" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_au_state_types[] = {
 	{ "hard", AU_STATETYPE_HARD, "Hard" },
 	{ "soft", AU_STATETYPE_SOFT, "Soft" },
 	{ "nodata", AU_STATETYPE_NO_DATA, "No Data" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_au_states[] = {
 	{ "nodata", AU_STATE_NO_DATA, "No Data" },
@@ -62,7 +62,7 @@ const string_value_mapping svm_au_states[] = {
 	{ "downtimeend", AU_STATE_DOWNTIME_END, "Downtime End"},
 	{ "currentstate", AU_STATE_CURRENT_STATE, "Current State"},
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_au_log_types[] = {
 	{ "alert", AU_LOGTYPE_ALERT, "Alert" },
@@ -72,43 +72,75 @@ const string_value_mapping svm_au_log_types[] = {
 	{ "downtime", AU_LOGTYPE_DOWNTIME, "Downtime" },
 	{ "nagios", AU_LOGTYPE_NAGIOS, "Nagios" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_au_notification_types[] = {
-	{ "nodata", AU_NOTIFICATION_NO_DATA, 
-			"No Data" },
-	{ "down", AU_NOTIFICATION_HOST_DOWN, 
-			"Host Down" },
-	{ "unreachable", AU_NOTIFICATION_HOST_UNREACHABLE, 
-			"Host Unreachable" },
-	{ "recovery", AU_NOTIFICATION_HOST_RECOVERY, 
-			"Host Recovery" },
-	{ "hostcustom", AU_NOTIFICATION_HOST_CUSTOM, 
-			"Host Custom" },
-	{ "hostack", AU_NOTIFICATION_HOST_ACK, 
-			"Host Acknowlegement" },
-	{ "hostflapstart", AU_NOTIFICATION_HOST_FLAPPING_START, 
-			"Host Flapping Start" },
-	{ "hostflapstop", AU_NOTIFICATION_HOST_FLAPPING_STOP, 
-			"Host Flapping Stop" },
-	{ "critical", AU_NOTIFICATION_SERVICE_CRITICAL, 
-			"Service Critical" },
-	{ "warning", AU_NOTIFICATION_SERVICE_WARNING, 
-			"Service Warning" },
-	{ "recovery", AU_NOTIFICATION_SERVICE_RECOVERY, 
-			"Service Recovery" },
-	{ "custom", AU_NOTIFICATION_SERVICE_CUSTOM, 
-			"Service Custom" },
-	{ "serviceack", AU_NOTIFICATION_SERVICE_ACK, 
-			"Service Acknowlegement" },
-	{ "serviceflapstart", AU_NOTIFICATION_SERVICE_FLAPPING_START, 
-			"Service Flapping Start" },
-	{ "serviceflapstop", AU_NOTIFICATION_SERVICE_FLAPPING_STOP, 
-			"Service Flapping Stop" },
-	{ "unknown", AU_NOTIFICATION_SERVICE_UNKNOWN, 
-			"Service Unknown" },
+	{
+		"nodata", AU_NOTIFICATION_NO_DATA,
+		"No Data"
+	},
+	{
+		"down", AU_NOTIFICATION_HOST_DOWN,
+		"Host Down"
+	},
+	{
+		"unreachable", AU_NOTIFICATION_HOST_UNREACHABLE,
+		"Host Unreachable"
+	},
+	{
+		"recovery", AU_NOTIFICATION_HOST_RECOVERY,
+		"Host Recovery"
+	},
+	{
+		"hostcustom", AU_NOTIFICATION_HOST_CUSTOM,
+		"Host Custom"
+	},
+	{
+		"hostack", AU_NOTIFICATION_HOST_ACK,
+		"Host Acknowlegement"
+	},
+	{
+		"hostflapstart", AU_NOTIFICATION_HOST_FLAPPING_START,
+		"Host Flapping Start"
+	},
+	{
+		"hostflapstop", AU_NOTIFICATION_HOST_FLAPPING_STOP,
+		"Host Flapping Stop"
+	},
+	{
+		"critical", AU_NOTIFICATION_SERVICE_CRITICAL,
+		"Service Critical"
+	},
+	{
+		"warning", AU_NOTIFICATION_SERVICE_WARNING,
+		"Service Warning"
+	},
+	{
+		"recovery", AU_NOTIFICATION_SERVICE_RECOVERY,
+		"Service Recovery"
+	},
+	{
+		"custom", AU_NOTIFICATION_SERVICE_CUSTOM,
+		"Service Custom"
+	},
+	{
+		"serviceack", AU_NOTIFICATION_SERVICE_ACK,
+		"Service Acknowlegement"
+	},
+	{
+		"serviceflapstart", AU_NOTIFICATION_SERVICE_FLAPPING_START,
+		"Service Flapping Start"
+	},
+	{
+		"serviceflapstop", AU_NOTIFICATION_SERVICE_FLAPPING_STOP,
+		"Service Flapping Stop"
+	},
+	{
+		"unknown", AU_NOTIFICATION_SERVICE_UNKNOWN,
+		"Service Unknown"
+	},
 	{ NULL, -1, NULL },
-	};
+};
 
 /* Function prototypes */
 int read_log_file(char *, unsigned, unsigned, unsigned, au_log *);
@@ -119,8 +151,8 @@ int parse_downtime_alerts(char *, time_t, unsigned, au_log *);
 int au_add_downtime_log(au_log *, time_t, int, void *, int);
 void au_free_downtime_log(au_log_downtime *);
 int parse_notification_log(char *, time_t, int, au_log *);
-int au_add_notification_log(au_log *, time_t, int, void *, au_contact *, int, 
-		char *, char *);
+int au_add_notification_log(au_log *, time_t, int, void *, au_contact *, int,
+                            char *, char *);
 void au_free_notification_log(au_log_notification *);
 au_log_entry *au_add_log_entry(au_log *, time_t, int, void *);
 void au_free_log_entry_void(void *);
@@ -140,8 +172,8 @@ void au_free_contact(au_contact *);
 int	au_cmp_contacts(const void *, const void *);
 au_contact *au_find_contact(au_array *, char *);
 void au_sort_array(au_array *, int(*cmp)(const void *, const void *));
-void *au_find_in_array(au_array *, void *, 
-		int(*cmp)(const void *, const void *));
+void *au_find_in_array(au_array *, void *,
+                       int(*cmp)(const void *, const void *));
 au_linked_list *au_init_list(char *);
 void au_empty_list(au_linked_list *, void(*)(void *));
 void au_free_list(au_linked_list *, void(*)(void *));
@@ -150,80 +182,83 @@ void au_free_list(au_linked_list *, void(*)(void *));
 extern int log_rotation_method;
 
 /* Initialize log structure */
-au_log *au_init_log(void) {
+au_log *au_init_log(void)
+{
 	au_log *log;
 
 	/* Initialize the log structure itself */
 	if((log = calloc(1, sizeof( au_log))) == NULL) {
 		return NULL;
-		}
+	}
 
 	/* Initialize the host subjects */
 	if((log->host_subjects = au_init_array("host_subjects")) == NULL) {
 		au_free_log(log);
 		return NULL;
-		}
+	}
 
 	/* Initialize the service subjects */
 	if((log->service_subjects = au_init_array("service_subjects")) == NULL) {
 		au_free_log(log);
 		return NULL;
-		}
+	}
 
 	/* Initialize the log entry list */
 	if((log->entry_list = au_init_list("global log entries")) == NULL) {
 		au_free_log(log);
 		return NULL;
-		}
+	}
 
 	/* Initialize the host list */
 	if((log->hosts = au_init_array("hosts")) == NULL) {
 		au_free_log(log);
 		return NULL;
-		}
+	}
 
 	/* Initialize the service list */
 	if((log->services = au_init_array("services")) == NULL) {
 		au_free_log(log);
 		return NULL;
-		}
+	}
 
 	/* Initialize the contact list */
 	if((log->contacts = au_init_array("contacts")) == NULL) {
 		au_free_log(log);
 		return NULL;
-		}
-
-	return log;
 	}
 
-void au_free_log(au_log *log) {
+	return log;
+}
+
+void au_free_log(au_log *log)
+{
 	if(NULL == log) return;
 	if(NULL != log->host_subjects) {
 		au_free_array(log->host_subjects, au_free_host_void);
-		}
+	}
 	if(NULL != log->service_subjects) {
 		au_free_array(log->service_subjects, au_free_service_void);
-		}
+	}
 	if(NULL != log->hosts) {
 		au_free_array(log->hosts, au_free_host_void);
-		}
+	}
 	if(NULL != log->services) {
 		au_free_array(log->services, au_free_service_void);
-		}
+	}
 	if(NULL != log->contacts) {
 		au_free_array(log->contacts, au_free_contact_void);
-		}
+	}
 	if(NULL != log->entry_list) {
 		au_free_list(log->entry_list, au_free_log_entry_void);
-		}
-	free(log);
 	}
+	free(log);
+}
 
 /* reads log files for archived data */
-int read_archived_data(time_t start_time, time_t end_time, 
-		int backtrack_archives, unsigned obj_types, unsigned state_types, 
-		unsigned log_types, au_log *log, time_t *last_archive_data_update) {
+int read_archived_data(time_t start_time, time_t end_time,
+                       int backtrack_archives, unsigned obj_types, unsigned state_types,
+                       unsigned log_types, au_log *log, time_t *last_archive_data_update)
+{
 
 	char filename[MAX_FILENAME_LENGTH];
 	int oldest_archive = 0;
@@ -237,23 +272,23 @@ int read_archived_data(time_t start_time, time_t end_time,
 	au_node *temp_entry;
 	struct stat adstat;
 
-	/* Determine oldest archive to use when scanning for data 
+	/* Determine oldest archive to use when scanning for data
 		(include backtracked archives as well) */
 	oldest_archive = determine_archive_to_use_from_time(start_time);
 	if(log_rotation_method != LOG_ROTATION_NONE) {
 		oldest_archive += backtrack_archives;
-		}
+	}
 
 	/* determine most recent archive to use when scanning for data */
 	newest_archive = determine_archive_to_use_from_time(end_time);
 
 	if(oldest_archive < newest_archive) {
 		oldest_archive = newest_archive;
-		}
+	}
 
 	/* read in all the necessary archived logs (from most recent to earliest) */
-	for(current_archive = newest_archive; current_archive <= oldest_archive; 
-			current_archive++) {
+	for(current_archive = newest_archive; current_archive <= oldest_archive;
+	    current_archive++) {
 
 #ifdef DEBUG
 		printf("Reading archive #%d... ", current_archive);
@@ -268,56 +303,56 @@ int read_archived_data(time_t start_time, time_t end_time,
 
 		/* Record the last modification time of the the archive file */
 		if(stat(filename, &adstat) < 0) {
-			/* ENOENT is OK because Nagios may have been down when the 
+			/* ENOENT is OK because Nagios may have been down when the
 				logs were being rotated */
 			if(ENOENT != errno) return -1;
-			}
-		else {
+		} else {
 			if(*last_archive_data_update < adstat.st_mtime) {
 				*last_archive_data_update = adstat.st_mtime;
-				}
+			}
 
 			/* scan the log file for archived state data */
-			if(read_log_file(filename, obj_types, state_types, log_types, 
-					log) == 0) {
+			if(read_log_file(filename, obj_types, state_types, log_types,
+			                 log) == 0) {
 				return 0;	/* Memory allocation error */
-				}
 			}
 		}
+	}
 
 	/* Add Nagios log events to all hosts and services found */
 	global_host = au_find_host(log->hosts, "*");
 	if(NULL != global_host) {
-		for(temp_entry = global_host->log_entries->head; NULL != temp_entry; 
-				temp_entry = temp_entry->next) {
+		for(temp_entry = global_host->log_entries->head; NULL != temp_entry;
+		    temp_entry = temp_entry->next) {
 			for(x = 0; x < log->hosts->count; x++) {
 				temp_host = log->hosts->members[x];
 				if(temp_host == global_host) continue;
-				if(au_list_add_node(temp_host->log_entries, 
-						temp_entry->data, au_cmp_log_entries) == 0) {
+				if(au_list_add_node(temp_host->log_entries,
+				                    temp_entry->data, au_cmp_log_entries) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 			if(0 == retval) break;
 			for(x = 0; x < log->services->count; x++) {
 				temp_service = log->services->members[x];
-				if(au_list_add_node(temp_service->log_entries, 
-							temp_entry->data, au_cmp_log_entries) == 0) {
+				if(au_list_add_node(temp_service->log_entries,
+				                    temp_entry->data, au_cmp_log_entries) == 0) {
 					retval = 0;
 					break;
-					}
 				}
-			if(0 == retval) break;
 			}
+			if(0 == retval) break;
 		}
-
-	return 1;
 	}
 
+	return 1;
+}
+
 /* grabs archives state data from a log file */
-int read_log_file(char *filename, unsigned obj_types, unsigned state_types, 
-		unsigned log_types, au_log *log) {
+int read_log_file(char *filename, unsigned obj_types, unsigned state_types,
+                  unsigned log_types, au_log *log)
+{
 	char *input = NULL;
 	char *input2 = NULL;
 	char *temp_buffer = NULL;
@@ -327,7 +362,7 @@ int read_log_file(char *filename, unsigned obj_types, unsigned state_types,
 
 	if((thefile = mmap_fopen(filename)) == NULL) {
 		return 1;
-		}
+	}
 
 	while(1) {
 
@@ -345,160 +380,161 @@ int read_log_file(char *filename, unsigned obj_types, unsigned state_types,
 		if((input2 = strdup(input)) == NULL) continue;
 
 		temp_buffer = my_strtok(input2, "]");
-		time_stamp = (temp_buffer == NULL) ? (time_t)0 : 
-				(time_t)strtoul(temp_buffer + 1, NULL, 10);
+		time_stamp = (temp_buffer == NULL) ? (time_t)0 :
+		             (time_t)strtoul(temp_buffer + 1, NULL, 10);
 
 		/* program starts/restarts */
 		if(strstr(input, " starting...")) {
-			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_START, 
-					"Program start") == 0) {
+			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_START,
+			                     "Program start") == 0) {
 				retval = 0;
 				break;
-				}
 			}
+		}
 		if(strstr(input, " restarting...")) {
-			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_START, 
-					"Program restart") == 0) {
+			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_START,
+			                     "Program restart") == 0) {
 				retval = 0;
 				break;
-				}
 			}
+		}
 
 		/* program stops */
 		if(strstr(input, " shutting down...")) {
-			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_END, 
-					"Normal program termination") == 0) {
+			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_END,
+			                     "Normal program termination") == 0) {
 				retval = 0;
 				break;
-				}
 			}
+		}
 		if(strstr(input, "Bailing out")) {
-			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_END, 
-					"Abnormal program termination") == 0) {
+			if(au_add_nagios_log(log, time_stamp, AU_STATE_PROGRAM_END,
+			                     "Abnormal program termination") == 0) {
 				retval = 0;
 				break;
-				}
 			}
+		}
 
 		if(obj_types & AU_OBJTYPE_HOST) {
 
 			/* normal host alerts */
 			if((log_types & AU_LOGTYPE_ALERT) && strstr(input, "HOST ALERT:")) {
-				if(parse_states_and_alerts(input, time_stamp, AU_LOGTYPE_ALERT, 
-						AU_OBJTYPE_HOST, state_types, log) == 0) {
+				if(parse_states_and_alerts(input, time_stamp, AU_LOGTYPE_ALERT,
+				                           AU_OBJTYPE_HOST, state_types, log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* host initial states */
-			else if((log_types & AU_LOGTYPE_STATE) && 
-					strstr(input, "INITIAL HOST STATE:")) {
-				if(parse_states_and_alerts(input, time_stamp, 
-						AU_LOGTYPE_STATE_INITIAL, AU_OBJTYPE_HOST, state_types, 
-						log) == 0) {
+			else if((log_types & AU_LOGTYPE_STATE) &&
+			        strstr(input, "INITIAL HOST STATE:")) {
+				if(parse_states_and_alerts(input, time_stamp,
+				                           AU_LOGTYPE_STATE_INITIAL, AU_OBJTYPE_HOST, state_types,
+				                           log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* host current states */
-			else if((log_types & AU_LOGTYPE_STATE) && 
-					strstr(input, "CURRENT HOST STATE:")) {
-				if(parse_states_and_alerts(input, time_stamp, 
-						AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_HOST, state_types, 
-						log) == 0) {
+			else if((log_types & AU_LOGTYPE_STATE) &&
+			        strstr(input, "CURRENT HOST STATE:")) {
+				if(parse_states_and_alerts(input, time_stamp,
+				                           AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_HOST, state_types,
+				                           log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* scheduled downtime notices */
-			else if((log_types & AU_LOGTYPE_DOWNTIME) && 
-					strstr(input, "HOST DOWNTIME ALERT:")) {
-				if(parse_downtime_alerts(input, time_stamp, AU_OBJTYPE_HOST, 
-						log) == 0) {
+			else if((log_types & AU_LOGTYPE_DOWNTIME) &&
+			        strstr(input, "HOST DOWNTIME ALERT:")) {
+				if(parse_downtime_alerts(input, time_stamp, AU_OBJTYPE_HOST,
+				                         log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* host notifications */
-			else if((log_types & AU_LOGTYPE_NOTIFICATION) && 
-					strstr(input, "HOST NOTIFICATION:")) {
-				if(parse_notification_log(input, time_stamp, AU_OBJTYPE_HOST, 
-						log) ==0) {
+			else if((log_types & AU_LOGTYPE_NOTIFICATION) &&
+			        strstr(input, "HOST NOTIFICATION:")) {
+				if(parse_notification_log(input, time_stamp, AU_OBJTYPE_HOST,
+				                          log) ==0) {
 					retval = 0;
 					break;
-					}
 				}
-	
 			}
+
+		}
 
 		if(obj_types & AU_OBJTYPE_SERVICE) {
 
 			/* normal service alerts */
-			if((log_types & AU_LOGTYPE_ALERT) && 
-					strstr(input, "SERVICE ALERT:")) {
-				if(parse_states_and_alerts(input, time_stamp, AU_LOGTYPE_ALERT, 
-						AU_OBJTYPE_SERVICE, state_types, log) == 0) {
+			if((log_types & AU_LOGTYPE_ALERT) &&
+			   strstr(input, "SERVICE ALERT:")) {
+				if(parse_states_and_alerts(input, time_stamp, AU_LOGTYPE_ALERT,
+				                           AU_OBJTYPE_SERVICE, state_types, log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* service initial states */
-			else if((log_types & AU_LOGTYPE_STATE) && 
-					strstr(input, "INITIAL SERVICE STATE:")) {
-				if(parse_states_and_alerts(input, time_stamp, 
-						AU_LOGTYPE_STATE_INITIAL, AU_OBJTYPE_SERVICE, 
-						state_types, log) == 0) {
+			else if((log_types & AU_LOGTYPE_STATE) &&
+			        strstr(input, "INITIAL SERVICE STATE:")) {
+				if(parse_states_and_alerts(input, time_stamp,
+				                           AU_LOGTYPE_STATE_INITIAL, AU_OBJTYPE_SERVICE,
+				                           state_types, log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* service current states */
-			else if((log_types & AU_LOGTYPE_STATE) && 
-					strstr(input, "CURRENT SERVICE STATE:")) {
-				if(parse_states_and_alerts(input, time_stamp, 
-						AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_SERVICE, 
-						state_types, log) == 0) {
+			else if((log_types & AU_LOGTYPE_STATE) &&
+			        strstr(input, "CURRENT SERVICE STATE:")) {
+				if(parse_states_and_alerts(input, time_stamp,
+				                           AU_LOGTYPE_STATE_CURRENT, AU_OBJTYPE_SERVICE,
+				                           state_types, log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* scheduled service downtime notices */
-			else if((log_types & AU_LOGTYPE_DOWNTIME) && 
-					strstr(input, "SERVICE DOWNTIME ALERT:")) {
-				if(parse_downtime_alerts(input, time_stamp, AU_OBJTYPE_SERVICE, 
-						log) == 0) {
+			else if((log_types & AU_LOGTYPE_DOWNTIME) &&
+			        strstr(input, "SERVICE DOWNTIME ALERT:")) {
+				if(parse_downtime_alerts(input, time_stamp, AU_OBJTYPE_SERVICE,
+				                         log) == 0) {
 					retval = 0;
 					break;
-					}
 				}
+			}
 
 			/* service notifications */
-			else if((log_types & AU_LOGTYPE_NOTIFICATION) && 
-					strstr(input, "SERVICE NOTIFICATION:")) {
-				if(parse_notification_log(input, time_stamp, 
-						AU_OBJTYPE_SERVICE, log) ==0) {
+			else if((log_types & AU_LOGTYPE_NOTIFICATION) &&
+			        strstr(input, "SERVICE NOTIFICATION:")) {
+				if(parse_notification_log(input, time_stamp,
+				                          AU_OBJTYPE_SERVICE, log) ==0) {
 					retval = 0;
 					break;
-					}
 				}
 			}
 		}
+	}
 
 	/* free memory and close the file */
 	free(input);
 	free(input2);
 	mmap_fclose(thefile);
 	return retval;
-	}
+}
 
-int	au_cmp_log_entries(const void *a, const void *b) {
+int	au_cmp_log_entries(const void *a, const void *b)
+{
 
 	au_log_entry *lea = *(au_log_entry **)a;
 	au_log_entry *leb = *(au_log_entry **)b;
@@ -506,10 +542,11 @@ int	au_cmp_log_entries(const void *a, const void *b) {
 	if(lea->timestamp == leb->timestamp) return 0;
 	else if(lea->timestamp < leb->timestamp) return -1;
 	else return 1;
-	}
+}
 
-int au_add_nagios_log(au_log *log, time_t timestamp, int type, 
-		char *description) {
+int au_add_nagios_log(au_log *log, time_t timestamp, int type,
+                      char *description)
+{
 
 	au_log_nagios *nagios_log;
 	au_log_entry *new_log_entry;
@@ -518,19 +555,19 @@ int au_add_nagios_log(au_log *log, time_t timestamp, int type,
 	/* Create the au_log_nagios */
 	if((nagios_log = calloc(1, sizeof(au_log_nagios))) == NULL) {
 		return 0;
-		}
+	}
 	nagios_log->type = type;
 	if((nagios_log->description = strdup(description)) == NULL) {
 		au_free_nagios_log(nagios_log);
 		return 0;
-		}
+	}
 
 	/* Create the log entry */
-	if((new_log_entry = au_add_log_entry(log, timestamp, AU_LOGTYPE_NAGIOS, 
-			(void *)nagios_log)) == NULL) {
+	if((new_log_entry = au_add_log_entry(log, timestamp, AU_LOGTYPE_NAGIOS,
+	                                     (void *)nagios_log)) == NULL) {
 		au_free_nagios_log(nagios_log);
 		return 0;
-		}
+	}
 
 	/* Find the au_host object associated with the global host */
 	global_host = au_find_host(log->hosts, "*");
@@ -538,27 +575,29 @@ int au_add_nagios_log(au_log *log, time_t timestamp, int type,
 		global_host = au_add_host_and_sort(log->hosts, "*");
 		if(NULL == global_host) { /* Could not allocate memory */
 			return 0;
-			}
 		}
-
-	/* Add the entry to the global host */
-	if(au_list_add_node(global_host->log_entries, new_log_entry, 
-			au_cmp_log_entries) == 0) {
-		return 0;
-		}
-
-	return 1;
 	}
 
-void au_free_nagios_log(au_log_nagios *nagios_log) {
+	/* Add the entry to the global host */
+	if(au_list_add_node(global_host->log_entries, new_log_entry,
+	                    au_cmp_log_entries) == 0) {
+		return 0;
+	}
+
+	return 1;
+}
+
+void au_free_nagios_log(au_log_nagios *nagios_log)
+{
 	if(NULL == nagios_log) return;
 	if(NULL != nagios_log->description) free(nagios_log->description);
 	free(nagios_log);
-	}
+}
 
 /* parse state and alert log entries */
-int parse_states_and_alerts(char *input, time_t timestamp, int log_type, 
-		unsigned obj_type, unsigned state_types, au_log *log) {
+int parse_states_and_alerts(char *input, time_t timestamp, int log_type,
+                            unsigned obj_type, unsigned state_types, au_log *log)
+{
 
 	char *temp_buffer = NULL;
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -574,18 +613,18 @@ int parse_states_and_alerts(char *input, time_t timestamp, int log_type,
 	/* get host name */
 	temp_buffer = my_strtok(NULL, ":");
 	temp_buffer = my_strtok(NULL, ";");
-	strncpy(entry_host_name, (temp_buffer == NULL) ? "" : 
-			temp_buffer + 1, sizeof(entry_host_name));
+	strncpy(entry_host_name, (temp_buffer == NULL) ? "" :
+	        temp_buffer + 1, sizeof(entry_host_name));
 	entry_host_name[sizeof(entry_host_name) - 1] = '\x0';
 
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(log->host_subjects->count > 0) {
 			/* see if there is a corresponding subject for this host */
-			temp_host_subject = au_find_host(log->host_subjects, 
-					entry_host_name);
+			temp_host_subject = au_find_host(log->host_subjects,
+			                                 entry_host_name);
 			if(temp_host_subject == NULL) return 1;
-			}
+		}
 
 		/* Find the au_host object associated with the host name */
 		temp_host = au_find_host(log->hosts, entry_host_name);
@@ -593,47 +632,47 @@ int parse_states_and_alerts(char *input, time_t timestamp, int log_type,
 			temp_host = au_add_host_and_sort(log->hosts, entry_host_name);
 			if(NULL == temp_host) { /* Could not allocate memory */
 				return 0;
-				}
 			}
+		}
 
 		break;
 	case AU_OBJTYPE_SERVICE:
 		/* get service description */
 		temp_buffer = my_strtok(NULL, ";");
-		strncpy(entry_svc_description, (temp_buffer == NULL) ? "" : 
-				temp_buffer, sizeof(entry_svc_description));
+		strncpy(entry_svc_description, (temp_buffer == NULL) ? "" :
+		        temp_buffer, sizeof(entry_svc_description));
 		entry_svc_description[sizeof(entry_svc_description) - 1] = '\x0';
 
 		if(log->service_subjects->count > 0) {
 			/* see if there is a corresponding subject for this service */
-			temp_service_subject = au_find_service(log->service_subjects, 
-					entry_host_name, entry_svc_description);
+			temp_service_subject = au_find_service(log->service_subjects,
+			                                       entry_host_name, entry_svc_description);
 			if(temp_service_subject == NULL) return 1;
-			}
+		}
 
 		/* Find the au_service object associated with the service */
-		temp_service = au_find_service(log->services, entry_host_name, 
-				entry_svc_description);
+		temp_service = au_find_service(log->services, entry_host_name,
+		                               entry_svc_description);
 		if(NULL == temp_service) {
-			temp_service = au_add_service_and_sort(log->services, 
-					entry_host_name, entry_svc_description);
+			temp_service = au_add_service_and_sort(log->services,
+			                                       entry_host_name, entry_svc_description);
 			if(NULL == temp_service) { /* Could not allocate memory */
 				return 0;
-				}
 			}
+		}
 
 		break;
-		}
+	}
 
 	/* state types */
 	if(strstr(input, ";SOFT;")) {
 		if(!(state_types & AU_STATETYPE_SOFT)) return 1;
 		state_type = AU_STATETYPE_SOFT;
-		}
+	}
 	if(strstr(input, ";HARD;")) {
 		if(!(state_types & AU_STATETYPE_HARD)) return 1;
 		state_type = AU_STATETYPE_HARD;
-		}
+	}
 
 	/* get the plugin output */
 	temp_buffer = my_strtok(NULL, ";");
@@ -645,98 +684,93 @@ int parse_states_and_alerts(char *input, time_t timestamp, int log_type,
 	case AU_OBJTYPE_HOST:
 		if(strstr(input, ";DOWN;")) {
 			state = AU_STATE_HOST_DOWN;
-			}
-		else if(strstr(input, ";UNREACHABLE;")) {
+		} else if(strstr(input, ";UNREACHABLE;")) {
 			state = AU_STATE_HOST_UNREACHABLE;
-			}
-		else if(strstr(input, ";RECOVERY") || strstr(input, ";UP;")) {
+		} else if(strstr(input, ";RECOVERY") || strstr(input, ";UP;")) {
 			state = AU_STATE_HOST_UP;
-			}
-		else {
+		} else {
 			state = AU_STATE_NO_DATA;
 			state_type = AU_STATETYPE_NO_DATA;
-			}
-		if(au_add_alert_or_state_log(log, timestamp, log_type, AU_OBJTYPE_HOST, 
-				(void *)temp_host, state_type, state, plugin_output) == 0) {
+		}
+		if(au_add_alert_or_state_log(log, timestamp, log_type, AU_OBJTYPE_HOST,
+		                             (void *)temp_host, state_type, state, plugin_output) == 0) {
 			return 0;
-			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
 		if(strstr(input, ";CRITICAL;")) {
 			state = AU_STATE_SERVICE_CRITICAL;
-			}
-		else if(strstr(input, ";WARNING;")) {
+		} else if(strstr(input, ";WARNING;")) {
 			state = AU_STATE_SERVICE_WARNING;
-			}
-		else if(strstr(input, ";UNKNOWN;")) {
+		} else if(strstr(input, ";UNKNOWN;")) {
 			state = AU_STATE_SERVICE_UNKNOWN;
-			}
-		else if(strstr(input, ";RECOVERY;") || strstr(input, ";OK;")) {
+		} else if(strstr(input, ";RECOVERY;") || strstr(input, ";OK;")) {
 			state = AU_STATE_SERVICE_OK;
-			}
-		else {
+		} else {
 			state = AU_STATE_NO_DATA;
 			state_type = AU_STATETYPE_NO_DATA;
-			}
-		if(au_add_alert_or_state_log(log, timestamp, log_type, 
-				AU_OBJTYPE_SERVICE, (void *)temp_service, state_type, state, 
-				plugin_output) == 0) {
-			return 0;
-			}
-		break;
 		}
-
-	return 1;
+		if(au_add_alert_or_state_log(log, timestamp, log_type,
+		                             AU_OBJTYPE_SERVICE, (void *)temp_service, state_type, state,
+		                             plugin_output) == 0) {
+			return 0;
+		}
+		break;
 	}
 
+	return 1;
+}
+
 int au_add_alert_or_state_log(au_log *log, time_t timestamp, int log_type,
-		int obj_type, void *object, int state_type, int state, 
-		char *plugin_output) {
+                              int obj_type, void *object, int state_type, int state,
+                              char *plugin_output)
+{
 
 	au_log_alert *alert_log;
 	au_log_entry *new_log_entry;
 
 	/* Create the au_log_alert */
-	if((alert_log = au_create_alert_or_state_log(obj_type, object, state_type, 
-			state, plugin_output)) == NULL) {
+	if((alert_log = au_create_alert_or_state_log(obj_type, object, state_type,
+	                state, plugin_output)) == NULL) {
 		return 0;
-		}
+	}
 
 	/* Create the log entry */
-	if((new_log_entry = au_add_log_entry(log, timestamp, log_type, 
-			(void *)alert_log)) == NULL) {
+	if((new_log_entry = au_add_log_entry(log, timestamp, log_type,
+	                                     (void *)alert_log)) == NULL) {
 		au_free_alert_log(alert_log);
 		return 0;
-		}
+	}
 
 	/* Add the log entry to the logs for the object supplied */
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(au_list_add_node(((au_host *)object)->log_entries,
-				new_log_entry, au_cmp_log_entries) == 0) {
+		                    new_log_entry, au_cmp_log_entries) == 0) {
 			return 0;
-			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
-		if(au_list_add_node(((au_service *)object)->log_entries, 
-				new_log_entry, au_cmp_log_entries) == 0) {
+		if(au_list_add_node(((au_service *)object)->log_entries,
+		                    new_log_entry, au_cmp_log_entries) == 0) {
 			return 0;
-			}
-		break;
 		}
-
-	return 1;
+		break;
 	}
 
-au_log_alert *au_create_alert_or_state_log(int obj_type, void *object, 
-		int state_type, int state, char *plugin_output) {
+	return 1;
+}
+
+au_log_alert *au_create_alert_or_state_log(int obj_type, void *object,
+        int state_type, int state, char *plugin_output)
+{
 
 	au_log_alert *alert_log;
 
 	/* Create the au_log_alert */
 	if((alert_log = calloc(1, sizeof(au_log_alert))) == NULL) {
 		return NULL;
-		}
+	}
 	alert_log->obj_type = obj_type;
 	alert_log->object = object;
 	alert_log->state_type = state_type;
@@ -744,20 +778,22 @@ au_log_alert *au_create_alert_or_state_log(int obj_type, void *object,
 	if((alert_log->plugin_output = strdup(plugin_output)) == NULL) {
 		au_free_alert_log(alert_log);
 		return NULL;
-		}
-
-	return alert_log;
 	}
 
-void au_free_alert_log(au_log_alert *alert_log) {
+	return alert_log;
+}
+
+void au_free_alert_log(au_log_alert *alert_log)
+{
 	if(NULL == alert_log) return;
 	if(NULL != alert_log->plugin_output) free(alert_log->plugin_output);
 	free(alert_log);
-	}
+}
 
 /* parse archive log downtime notifications */
-int parse_downtime_alerts(char *input, time_t timestamp, unsigned obj_type, 
-		au_log *log) {
+int parse_downtime_alerts(char *input, time_t timestamp, unsigned obj_type,
+                          au_log *log)
+{
 
 	char *temp_buffer = NULL;
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -770,18 +806,18 @@ int parse_downtime_alerts(char *input, time_t timestamp, unsigned obj_type,
 	/* get host name */
 	temp_buffer = my_strtok(NULL, ":");
 	temp_buffer = my_strtok(NULL, ";");
-	strncpy(entry_host_name, (temp_buffer == NULL) ? "" : 
-			temp_buffer + 1, sizeof(entry_host_name));
+	strncpy(entry_host_name, (temp_buffer == NULL) ? "" :
+	        temp_buffer + 1, sizeof(entry_host_name));
 	entry_host_name[sizeof(entry_host_name) - 1] = '\x0';
 
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(log->host_subjects->count > 0) {
 			/* see if there is a corresponding subject for this host */
-			temp_host_subject = au_find_host(log->host_subjects, 
-					entry_host_name);
+			temp_host_subject = au_find_host(log->host_subjects,
+			                                 entry_host_name);
 			if(temp_host_subject == NULL) return 1;
-			}
+		}
 
 		/* Find the au_host object associated with the host name */
 		temp_host = au_find_host(log->hosts, entry_host_name);
@@ -789,74 +825,73 @@ int parse_downtime_alerts(char *input, time_t timestamp, unsigned obj_type,
 			temp_host = au_add_host_and_sort(log->hosts, entry_host_name);
 			if(NULL == temp_host) { /* Could not allocate memory */
 				return 0;
-				}
 			}
+		}
 
 		break;
 	case AU_OBJTYPE_SERVICE:
 		/* get service description */
 		temp_buffer = my_strtok(NULL, ";");
-		strncpy(entry_svc_description, (temp_buffer == NULL) ? "" : 
-				temp_buffer, sizeof(entry_svc_description));
+		strncpy(entry_svc_description, (temp_buffer == NULL) ? "" :
+		        temp_buffer, sizeof(entry_svc_description));
 		entry_svc_description[sizeof(entry_svc_description) - 1] = '\x0';
 
 		if(log->service_subjects->count > 0) {
 			/* see if there is a corresponding subject for this service */
-			temp_service_subject = au_find_service(log->service_subjects, 
-					entry_host_name, entry_svc_description);
+			temp_service_subject = au_find_service(log->service_subjects,
+			                                       entry_host_name, entry_svc_description);
 			if(temp_service_subject == NULL) return 1;
-			}
+		}
 
 		/* Find the au_service object associated with the service */
-		temp_service = au_find_service(log->services, entry_host_name, 
-				entry_svc_description);
+		temp_service = au_find_service(log->services, entry_host_name,
+		                               entry_svc_description);
 		if(NULL == temp_service) {
-			temp_service = au_add_service_and_sort(log->services, 
-					entry_host_name, entry_svc_description);
+			temp_service = au_add_service_and_sort(log->services,
+			                                       entry_host_name, entry_svc_description);
 			if(NULL == temp_service) { /* Could not allocate memory */
 				return 0;
-				}
 			}
+		}
 
 		break;
-		}
+	}
 
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(strstr(input, ";STARTED;")) {
-			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_HOST, 
-					(void *)temp_host, AU_STATE_DOWNTIME_START) == 0) {
+			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_HOST,
+			                       (void *)temp_host, AU_STATE_DOWNTIME_START) == 0) {
 				return 0;
-				}
 			}
-		else {
-			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_HOST, 
-					(void *)temp_host, AU_STATE_DOWNTIME_END) == 0) {
+		} else {
+			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_HOST,
+			                       (void *)temp_host, AU_STATE_DOWNTIME_END) == 0) {
 				return 0;
-				}
 			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
 		if(strstr(input, ";STARTED;")) {
-			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_SERVICE, 
-					(void *)temp_service, AU_STATE_DOWNTIME_START) == 0) {
+			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_SERVICE,
+			                       (void *)temp_service, AU_STATE_DOWNTIME_START) == 0) {
 				return 0;
-				}
 			}
-		else {
-			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_SERVICE, 
-					(void *)temp_service, AU_STATE_DOWNTIME_END) == 0) {
+		} else {
+			if(au_add_downtime_log(log, timestamp, AU_OBJTYPE_SERVICE,
+			                       (void *)temp_service, AU_STATE_DOWNTIME_END) == 0) {
 				return 0;
-				}
 			}
-		break;
 		}
-
-	return 1;
+		break;
 	}
 
-int au_add_downtime_log(au_log *log, time_t timestamp, int obj_type, 
-		void *object, int downtime_type) {
+	return 1;
+}
+
+int au_add_downtime_log(au_log *log, time_t timestamp, int obj_type,
+                        void *object, int downtime_type)
+{
 
 	au_log_downtime *downtime_log;
 	au_log_entry *new_log_entry;
@@ -864,44 +899,46 @@ int au_add_downtime_log(au_log *log, time_t timestamp, int obj_type,
 	/* Create the au_log_downtime */
 	if((downtime_log = calloc(1, sizeof(au_log_downtime))) == NULL) {
 		return 0;
-		}
+	}
 	downtime_log->obj_type = obj_type;
 	downtime_log->object = object;
 	downtime_log->downtime_type = downtime_type;
 
 	/* Create the log entry */
-	if((new_log_entry = au_add_log_entry(log, timestamp, AU_LOGTYPE_DOWNTIME, 
-			(void *)downtime_log)) == NULL) {
+	if((new_log_entry = au_add_log_entry(log, timestamp, AU_LOGTYPE_DOWNTIME,
+	                                     (void *)downtime_log)) == NULL) {
 		au_free_downtime_log(downtime_log);
 		return 0;
-		}
+	}
 
 	/* Add the log entry to the logs for the object supplied */
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(au_list_add_node(((au_host *)object)->log_entries,
-				new_log_entry, au_cmp_log_entries) == 0) {
+		                    new_log_entry, au_cmp_log_entries) == 0) {
 			return 0;
-			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
-		if(au_list_add_node(((au_service *)object)->log_entries, 
-				new_log_entry, au_cmp_log_entries) == 0) {
+		if(au_list_add_node(((au_service *)object)->log_entries,
+		                    new_log_entry, au_cmp_log_entries) == 0) {
 			return 0;
-			}
-		break;
 		}
+		break;
+	}
 
 	return 1;
-	}
+}
 
-void au_free_downtime_log(au_log_downtime *downtime_log) {
+void au_free_downtime_log(au_log_downtime *downtime_log)
+{
 	if(NULL == downtime_log) return;
 	free(downtime_log);
-	}
+}
 
-int parse_notification_log(char *input, time_t timestamp, int obj_type, 
-		au_log *log) {
+int parse_notification_log(char *input, time_t timestamp, int obj_type,
+                           au_log *log)
+{
 
 	char entry_contact_name[MAX_INPUT_BUFFER];
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -919,34 +956,34 @@ int parse_notification_log(char *input, time_t timestamp, int obj_type,
 	/* get the contact name */
 	temp_buffer = my_strtok(NULL, ":");
 	temp_buffer = my_strtok(NULL, ";");
-	strncpy(entry_contact_name, (temp_buffer == NULL) ? "" : 
-			temp_buffer + 1, sizeof(entry_contact_name));
+	strncpy(entry_contact_name, (temp_buffer == NULL) ? "" :
+	        temp_buffer + 1, sizeof(entry_contact_name));
 	entry_contact_name[sizeof(entry_contact_name) - 1] = '\x0';
 
 	/* Find the au_contact object associated with the contact name */
 	temp_contact = au_find_contact(log->contacts, entry_contact_name);
 	if(NULL == temp_contact) {
-		temp_contact = au_add_contact_and_sort(log->contacts, 
-				entry_contact_name);
+		temp_contact = au_add_contact_and_sort(log->contacts,
+		                                       entry_contact_name);
 		if(NULL == temp_contact) { /* Could not allocate memory */
 			return 0;
-			}
 		}
+	}
 
 	/* get the host name */
 	temp_buffer = (char *)my_strtok(NULL, ";");
-	snprintf(entry_host_name, sizeof(entry_host_name), "%s", 
-			(temp_buffer == NULL) ? "" : temp_buffer);
+	snprintf(entry_host_name, sizeof(entry_host_name), "%s",
+	         (temp_buffer == NULL) ? "" : temp_buffer);
 	entry_host_name[sizeof(entry_host_name) - 1] = '\x0';
 
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(log->host_subjects->count > 0) {
 			/* see if there is a corresponding subject for this host */
-			temp_host_subject = au_find_host(log->host_subjects, 
-					entry_host_name);
+			temp_host_subject = au_find_host(log->host_subjects,
+			                                 entry_host_name);
 			if(temp_host_subject == NULL) return 1;
-			}
+		}
 
 		/* Find the au_host object associated with the host name */
 		temp_host = au_find_host(log->hosts, entry_host_name);
@@ -954,102 +991,89 @@ int parse_notification_log(char *input, time_t timestamp, int obj_type,
 			temp_host = au_add_host_and_sort(log->hosts, entry_host_name);
 			if(NULL == temp_host) { /* Could not allocate memory */
 				return 0;
-				}
 			}
+		}
 
 		break;
 	case AU_OBJTYPE_SERVICE:
 		/* get service description */
 		temp_buffer = my_strtok(NULL, ";");
-		strncpy(entry_svc_description, (temp_buffer == NULL) ? "" : 
-				temp_buffer, sizeof(entry_svc_description));
+		strncpy(entry_svc_description, (temp_buffer == NULL) ? "" :
+		        temp_buffer, sizeof(entry_svc_description));
 		entry_svc_description[sizeof(entry_svc_description) - 1] = '\x0';
 
 		if(log->service_subjects->count > 0) {
 			/* see if there is a corresponding subject for this service */
-			temp_service_subject = au_find_service(log->service_subjects, 
-					entry_host_name, entry_svc_description);
+			temp_service_subject = au_find_service(log->service_subjects,
+			                                       entry_host_name, entry_svc_description);
 			if(temp_service_subject == NULL) return 1;
-			}
+		}
 
 		/* Find the au_service object associated with the service */
-		temp_service = au_find_service(log->services, entry_host_name, 
-				entry_svc_description);
+		temp_service = au_find_service(log->services, entry_host_name,
+		                               entry_svc_description);
 		if(NULL == temp_service) {
-			temp_service = au_add_service_and_sort(log->services, 
-					entry_host_name, entry_svc_description);
+			temp_service = au_add_service_and_sort(log->services,
+			                                       entry_host_name, entry_svc_description);
 			if(NULL == temp_service) { /* Could not allocate memory */
 				return 0;
-				}
 			}
+		}
 
 		break;
-		}
+	}
 
 	/* get the alert level */
 	temp_buffer = (char *)my_strtok(NULL, ";");
-	snprintf(alert_level, sizeof(alert_level), "%s", 
-			(temp_buffer == NULL) ? "" : temp_buffer);
+	snprintf(alert_level, sizeof(alert_level), "%s",
+	         (temp_buffer == NULL) ? "" : temp_buffer);
 	alert_level[sizeof(alert_level) - 1] = '\x0';
 
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(!strcmp(alert_level, "DOWN")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_DOWN;
-			}
-		else if(!strcmp(alert_level, "UNREACHABLE")) {
+		} else if(!strcmp(alert_level, "UNREACHABLE")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_UNREACHABLE;
-			}
-		else if(!strcmp(alert_level, "RECOVERY") || 
-				!strcmp(alert_level, "UP")) {
+		} else if(!strcmp(alert_level, "RECOVERY") ||
+		          !strcmp(alert_level, "UP")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_RECOVERY;
-			}
-		else if(strstr(alert_level, "CUSTOM (")) {
+		} else if(strstr(alert_level, "CUSTOM (")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_CUSTOM;
-			}
-		else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
+		} else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_ACK;
-			}
-		else if(strstr(alert_level, "FLAPPINGSTART (")) {
+		} else if(strstr(alert_level, "FLAPPINGSTART (")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_FLAPPING_START;
-			}
-		else if(strstr(alert_level, "FLAPPINGSTOP (")) {
+		} else if(strstr(alert_level, "FLAPPINGSTOP (")) {
 			notification_detail_type = AU_NOTIFICATION_HOST_FLAPPING_STOP;
-			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
 		if(!strcmp(alert_level, "CRITICAL")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_CRITICAL;
-			}
-		else if(!strcmp(alert_level, "WARNING")) {
+		} else if(!strcmp(alert_level, "WARNING")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_WARNING;
-			}
-		else if(!strcmp(alert_level, "RECOVERY") || 
-				!strcmp(alert_level, "OK")) {
+		} else if(!strcmp(alert_level, "RECOVERY") ||
+		          !strcmp(alert_level, "OK")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_RECOVERY;
-			}
-		else if(strstr(alert_level, "CUSTOM (")) {
+		} else if(strstr(alert_level, "CUSTOM (")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_CUSTOM;
-			}
-		else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
+		} else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_ACK;
-			}
-		else if(strstr(alert_level, "FLAPPINGSTART (")) {
+		} else if(strstr(alert_level, "FLAPPINGSTART (")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_FLAPPING_START;
-			}
-		else if(strstr(alert_level, "FLAPPINGSTOP (")) {
+		} else if(strstr(alert_level, "FLAPPINGSTOP (")) {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_FLAPPING_STOP;
-			}
-		else {
+		} else {
 			notification_detail_type = AU_NOTIFICATION_SERVICE_UNKNOWN;
-			}
-		break;
 		}
+		break;
+	}
 
 	/* get the method name */
 	temp_buffer = (char *)my_strtok(NULL, ";");
-	snprintf(method_name, sizeof(method_name), "%s", 
-			(temp_buffer == NULL) ? "" : temp_buffer);
+	snprintf(method_name, sizeof(method_name), "%s",
+	         (temp_buffer == NULL) ? "" : temp_buffer);
 	method_name[sizeof(method_name) - 1] = '\x0';
 
 	/* move to the informational message */
@@ -1058,27 +1082,28 @@ int parse_notification_log(char *input, time_t timestamp, int obj_type,
 	/* Create the log entry */
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
-		if(au_add_notification_log(log, timestamp, AU_OBJTYPE_HOST, 
-				(void *)temp_host, temp_contact, notification_detail_type, 
-				method_name, temp_buffer) == 0) {
+		if(au_add_notification_log(log, timestamp, AU_OBJTYPE_HOST,
+		                           (void *)temp_host, temp_contact, notification_detail_type,
+		                           method_name, temp_buffer) == 0) {
 			return 0;
-			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
-		if(au_add_notification_log(log, timestamp, AU_OBJTYPE_SERVICE, 
-				(void *)temp_service, temp_contact, notification_detail_type, 
-				method_name, temp_buffer) == 0) {
+		if(au_add_notification_log(log, timestamp, AU_OBJTYPE_SERVICE,
+		                           (void *)temp_service, temp_contact, notification_detail_type,
+		                           method_name, temp_buffer) == 0) {
 			return 0;
-			}
-		break;
 		}
-
-	return 1;
+		break;
 	}
 
-int au_add_notification_log(au_log *log, time_t timestamp, int obj_type, 
-		void *object, au_contact *contact, int notification_type, 
-		char *method, char *message) {
+	return 1;
+}
+
+int au_add_notification_log(au_log *log, time_t timestamp, int obj_type,
+                            void *object, au_contact *contact, int notification_type,
+                            char *method, char *message)
+{
 
 	au_log_notification *notification_log;
 	au_log_entry *new_log_entry;
@@ -1086,81 +1111,85 @@ int au_add_notification_log(au_log *log, time_t timestamp, int obj_type,
 	/* Create the au_log_downtime */
 	if((notification_log = calloc(1, sizeof(au_log_notification))) == NULL) {
 		return 0;
-		}
+	}
 	notification_log->obj_type = obj_type;
 	notification_log->object = object;
 	notification_log->contact = contact;
 	notification_log->notification_type = notification_type;
-	if((notification_log->method = strdup(method)) 
-			== NULL) {
+	if((notification_log->method = strdup(method))
+	   == NULL) {
 		au_free_notification_log(notification_log);
 		return 0;
-		}
+	}
 	if((notification_log->message = strdup(message)) == NULL) {
 		au_free_notification_log(notification_log);
 		return 0;
-		}
+	}
 
 	/* Create the log entry */
-	if((new_log_entry = au_add_log_entry(log, timestamp, 
-			AU_LOGTYPE_NOTIFICATION, (void *)notification_log)) == NULL) {
+	if((new_log_entry = au_add_log_entry(log, timestamp,
+	                                     AU_LOGTYPE_NOTIFICATION, (void *)notification_log)) == NULL) {
 		au_free_notification_log(notification_log);
 		return 0;
-		}
+	}
 
 	/* Add the log entry to the logs for the object supplied */
 	switch(obj_type) {
 	case AU_OBJTYPE_HOST:
 		if(au_list_add_node((void *)((au_host *)object)->log_entries,
-				new_log_entry, au_cmp_log_entries) == 0) {
+		                    new_log_entry, au_cmp_log_entries) == 0) {
 			return 0;
-			}
+		}
 		break;
 	case AU_OBJTYPE_SERVICE:
-		if(au_list_add_node((void *)((au_service *)object)->log_entries, 
-				new_log_entry, au_cmp_log_entries) == 0) {
+		if(au_list_add_node((void *)((au_service *)object)->log_entries,
+		                    new_log_entry, au_cmp_log_entries) == 0) {
 			return 0;
-			}
-		break;
 		}
-
-	return 1;
+		break;
 	}
 
-void au_free_notification_log(au_log_notification *notification_log) {
+	return 1;
+}
+
+void au_free_notification_log(au_log_notification *notification_log)
+{
 	if(NULL == notification_log) return;
 	if(NULL != notification_log->method) free(notification_log->method);
 	if(NULL != notification_log->message) free(notification_log->message);
 	free(notification_log);
-	}
+}
 
-au_log_entry *au_add_log_entry(au_log *log, time_t timestamp, int entry_type, 
-		void *entry) {
+au_log_entry *au_add_log_entry(au_log *log, time_t timestamp, int entry_type,
+                               void *entry)
+{
 
 	au_log_entry *new_log_entry;
 
 	/* Create the au_log_entry */
 	if((new_log_entry = calloc(1, sizeof(au_log_entry))) == NULL) {
 		return NULL;
-		}
+	}
 	new_log_entry->timestamp = timestamp;
 	new_log_entry->entry_type = entry_type;
 	new_log_entry->entry = entry;
 
-	if(au_list_add_node(log->entry_list, (void *)new_log_entry, 
-			au_cmp_log_entries) == NULL) {
+	if(au_list_add_node(log->entry_list, (void *)new_log_entry,
+	                    au_cmp_log_entries) == NULL) {
 		au_free_log_entry(new_log_entry);
 		return NULL;
-		}
+	}
 
 	return new_log_entry;
-	}
+}
 
-void au_free_log_entry_void(void *log_entry) {
+void au_free_log_entry_void(void *log_entry)
+{
 	au_free_log_entry((au_log_entry *)log_entry);
-	}
+}
 
-void au_free_log_entry(au_log_entry *log_entry) {
+void au_free_log_entry(au_log_entry *log_entry)
+{
 	if(NULL == log_entry) return;
 	switch(log_entry->entry_type) {
 	case AU_LOGTYPE_ALERT:
@@ -1176,25 +1205,27 @@ void au_free_log_entry(au_log_entry *log_entry) {
 	case AU_LOGTYPE_NAGIOS:
 		au_free_nagios_log((au_log_nagios *)log_entry->entry);
 		break;
-		}
-	free(log_entry);
 	}
+	free(log_entry);
+}
 
 /* Add a host to a host list and sort the list */
-au_host *au_add_host_and_sort(au_array *host_list, char *name) {
+au_host *au_add_host_and_sort(au_array *host_list, char *name)
+{
 
 	au_host *temp_host;
 
 	temp_host = au_add_host(host_list, name);
 	if(NULL != temp_host) {
 		au_sort_array(host_list, au_cmp_hosts);
-		}
-
-	return temp_host;
 	}
 
+	return temp_host;
+}
+
 /* Add a host to a host list */
-au_host *au_add_host(au_array *host_list, char *name) {
+au_host *au_add_host(au_array *host_list, char *name)
+{
 
 	au_host	*new_host;
 	char	buf[8192];
@@ -1202,38 +1233,40 @@ au_host *au_add_host(au_array *host_list, char *name) {
 	/* Should have been allocated during au_log_init() */
 	if(NULL == host_list) {
 		return NULL;
-		}
+	}
 
 	/* Create the host */
 	if((new_host = calloc(1, sizeof(au_host))) == NULL) {
 		return NULL;
-		}
+	}
 	if((new_host->name = strdup(name)) == NULL) {
 		au_free_host(new_host);
 		return NULL;
-		}
+	}
 	new_host->hostp = find_host(name);
 	new_host->availability = NULL;
 	snprintf(buf, sizeof(buf) - 1, "Host %s log entries", name);
 	if((new_host->log_entries = au_init_list(buf)) == NULL) {
 		au_free_host(new_host);
 		return NULL;
-		}
+	}
 
 	/* Add it to the list of hosts */
 	if(0 == au_array_append_member(host_list, (void *)new_host)) {
 		au_free_host(new_host);
 		return NULL;
-		}
+	}
 
 	return new_host;
-	}
+}
 
-void au_free_host_void(void *host) {
+void au_free_host_void(void *host)
+{
 	au_free_host((au_host *)host);
-	}
+}
 
-void au_free_host(au_host *host) {
+void au_free_host(au_host *host)
+{
 	if(NULL == host) return;
 	if(NULL != host->name) free(host->name);
 	/* Do not free the log entry data here because they are freed when the
@@ -1242,16 +1275,18 @@ void au_free_host(au_host *host) {
 	if(NULL != host->availability) free(host->availability);
 	free(host);
 	return;
-	}
+}
 
-int	au_cmp_hosts(const void *a, const void *b) {
+int	au_cmp_hosts(const void *a, const void *b)
+{
 	au_host *hosta = *(au_host **)a;
 	au_host *hostb = *(au_host **)b;
 
 	return strcmp(hosta->name, hostb->name);
-	}
+}
 
-au_host *au_find_host(au_array *host_list, char *name) {
+au_host *au_find_host(au_array *host_list, char *name)
+{
 
 	au_host	key;
 	void *found;
@@ -1261,23 +1296,25 @@ au_host *au_find_host(au_array *host_list, char *name) {
 	found = au_find_in_array(host_list, (void *)&key, au_cmp_hosts);
 	if(NULL == found) return NULL;
 	return *(au_host **)found;
-	}
+}
 
-au_service *au_add_service_and_sort(au_array *service_list, char *host_name, 
-		char *description) {
+au_service *au_add_service_and_sort(au_array *service_list, char *host_name,
+                                    char *description)
+{
 
 	au_service *temp_service;
 
 	temp_service = au_add_service(service_list, host_name, description);
 	if(NULL != temp_service) {
 		au_sort_array(service_list, au_cmp_services);
-		}
-
-	return temp_service;
 	}
 
-au_service *au_add_service(au_array *service_list, char *host_name, 
-		char *description) {
+	return temp_service;
+}
+
+au_service *au_add_service(au_array *service_list, char *host_name,
+                           char *description)
+{
 
 	au_service	*new_service;
 	char	buf[8192];
@@ -1285,43 +1322,45 @@ au_service *au_add_service(au_array *service_list, char *host_name,
 	/* Should have been allocated during au_log_init() */
 	if(NULL == service_list) {
 		return NULL;
-		}
+	}
 
 	/* Create the service */
 	if((new_service = calloc(1, sizeof(au_service))) == NULL) {
 		return NULL;
-		}
+	}
 	if((new_service->host_name = strdup(host_name)) == NULL) {
 		au_free_service(new_service);
 		return NULL;
-		}
+	}
 	if((new_service->description = strdup(description)) == NULL) {
 		au_free_service(new_service);
 		return NULL;
-		}
+	}
 	new_service->servicep = find_service(host_name, description);
 	new_service->availability = NULL;
-	snprintf(buf, sizeof(buf) - 1, "Service %s:%s log entries", host_name, 
-			description);
+	snprintf(buf, sizeof(buf) - 1, "Service %s:%s log entries", host_name,
+	         description);
 	if((new_service->log_entries = au_init_list(buf)) == NULL) {
 		au_free_service(new_service);
 		return NULL;
-		}
+	}
 
 	/* Add it to the list of services */
 	if(0 == au_array_append_member(service_list, (void *)new_service)) {
 		au_free_service(new_service);
 		return NULL;
-		}
-	
+	}
+
 	return new_service;
-	}
+}
 
-void au_free_service_void(void *service) {
+void au_free_service_void(void *service)
+{
 	au_free_service((au_service *)service);
-	}
+}
 
-void au_free_service(au_service *service) {
+void au_free_service(au_service *service)
+{
 	if(NULL == service) return;
 	if(NULL != service->host_name) free(service->host_name);
 	if(NULL != service->description) free(service->description);
@@ -1331,10 +1370,11 @@ void au_free_service(au_service *service) {
 	if(NULL != service->availability) free(service->availability);
 	free(service);
 	return;
-	}
+}
 
 au_service *au_find_service(au_array *service_list, char *host_name,
-		char *description) {
+                            char *description)
+{
 
 	au_service	key;
 	void *found;
@@ -1343,12 +1383,13 @@ au_service *au_find_service(au_array *service_list, char *host_name,
 	key.host_name = host_name;
 	key.description = description;
 	found = (au_service *)au_find_in_array(service_list, (void *)&key,
-			au_cmp_services);
+	                                       au_cmp_services);
 	if(NULL == found) return NULL;
 	return *(au_service **)found;
-	}
+}
 
-int	au_cmp_services(const void *a, const void *b) {
+int	au_cmp_services(const void *a, const void *b)
+{
 
 	au_service *servicea = *(au_service **)a;
 	au_service *serviceb = *(au_service **)b;
@@ -1357,72 +1398,77 @@ int	au_cmp_services(const void *a, const void *b) {
 	host_result = strcmp(servicea->host_name, serviceb->host_name);
 	if(0 == host_result) {
 		return strcmp(servicea->description, serviceb->description);
-		}
-	else {
+	} else {
 		return host_result;
-		}
 	}
+}
 
 /* Add a contact to a contact list and sort the list */
-au_contact *au_add_contact_and_sort(au_array *contact_list, char *name) {
+au_contact *au_add_contact_and_sort(au_array *contact_list, char *name)
+{
 
 	au_contact *temp_contact;
 
 	temp_contact = au_add_contact(contact_list, name);
 	if(NULL != temp_contact) {
 		au_sort_array(contact_list, au_cmp_contacts);
-		}
-	return temp_contact;
 	}
+	return temp_contact;
+}
 
 /* Add a contact to a contact list */
-au_contact *au_add_contact(au_array *contact_list, char *name) {
+au_contact *au_add_contact(au_array *contact_list, char *name)
+{
 
 	au_contact	*new_contact;
 
 	/* Should have been allocated during au_log_init() */
 	if(NULL == contact_list) {
 		return NULL;
-		}
+	}
 
 	/* Create the contact */
 	if((new_contact = calloc(1, sizeof(au_contact))) == NULL) {
 		return NULL;
-		}
+	}
 	if((new_contact->name = strdup(name)) == NULL) {
 		au_free_contact(new_contact);
 		return NULL;
-		}
+	}
 
 	/* Add it to the list of contacts */
 	if(0 == au_array_append_member(contact_list, (void *)new_contact)) {
 		au_free_contact(new_contact);
 		return NULL;
-		}
+	}
 
 	return new_contact;
-	}
+}
 
-void au_free_contact_void(void *contact) {
+void au_free_contact_void(void *contact)
+{
 	au_free_contact((au_contact *)contact);
-	}
+}
 
-void au_free_contact(au_contact *contact) {
+void au_free_contact(au_contact *contact)
+{
 	if(NULL == contact) return;
 	if(NULL != contact->name) free(contact->name);
 	free(contact);
 	return;
-	}
+}
 
-int	au_cmp_contacts(const void *a, const void *b) {
+int	au_cmp_contacts(const void *a, const void *b)
+{
 
 	au_contact *contacta = (au_contact *)a;
 	au_contact *contactb = (au_contact *)b;
 
 	return strcmp(contacta->name, contactb->name);
-	}
+}
 
-au_contact *au_find_contact(au_array *contact_list, char *name) {
+au_contact *au_find_contact(au_array *contact_list, char *name)
+{
 
 	au_contact	key;
 	void *found;
@@ -1430,33 +1476,35 @@ au_contact *au_find_contact(au_array *contact_list, char *name) {
 	if(NULL == contact_list) return NULL;
 	key.name = name;
 	found = (au_contact *)au_find_in_array(contact_list, (void *)&key,
-			au_cmp_contacts);
+	                                       au_cmp_contacts);
 	if(NULL == found) return NULL;
 	return *(au_contact **)found;
-	}
+}
 
-au_array *au_init_array(char *label) {
+au_array *au_init_array(char *label)
+{
 	au_array *array;
 
 	if((array = calloc(1, sizeof(au_array))) == NULL) {
 		return NULL;
-		}
+	}
 	array->label = NULL;
 	if(NULL != label) {
 		if((array->label = strdup(label)) == NULL) {
 			free(array);
 			return NULL;
-			}
 		}
+	}
 	array->size = 0;
 	array->count = 0;
 	array->members = (void **)NULL;
 	array->new = 0;
 
 	return array;
-	}
+}
 
-void au_free_array(au_array *array, void(*datafree)(void *)) {
+void au_free_array(au_array *array, void(*datafree)(void *))
+{
 
 	int x;
 
@@ -1465,79 +1513,83 @@ void au_free_array(au_array *array, void(*datafree)(void *)) {
 	for(x = 0; x < array->count; x++) {
 		if((NULL != datafree) && (NULL != array->members[x])) {
 			datafree(array->members[x]);
-			}
 		}
+	}
 	if(NULL != array->members) free(array->members);
 	free(array);
 	return;
-	}
+}
 
-int au_array_append_member(au_array *array, void *member) {
+int au_array_append_member(au_array *array, void *member)
+{
 
 	/* Check whether the list needs to be grown before adding the member */
-	if(array->count == array->size) { 
+	if(array->count == array->size) {
 		/* Need to grow the list */
 		if(0 == array->count) {
 			/* Never had any members */
-			if((array->members = (void **)calloc(AU_INITIAL_LIST_SIZE, 
-					sizeof(void *))) == NULL) {
+			if((array->members = (void **)calloc(AU_INITIAL_LIST_SIZE,
+			                                     sizeof(void *))) == NULL) {
 				return 0;
-				}
+			}
 			array->size = AU_INITIAL_LIST_SIZE;
-			}
-		else {
+		} else {
 			/* Double the size of the list */
-			if((array->members = (void **)realloc(array->members, 
-					sizeof(void *) * array->size * 2)) == NULL) {
+			if((array->members = (void **)realloc(array->members,
+			                                      sizeof(void *) * array->size * 2)) == NULL) {
 				return 0;
-				}
-			array->size *= 2;
 			}
+			array->size *= 2;
 		}
+	}
 
 	array->members[array->count] = member;
 	array->new++;		/* Number of appends since last sort */
 	array->count++;
 
 	return 1;
-	}
+}
 
-void au_sort_array(au_array *array, int(*cmp)(const void *, const void *)) {
+void au_sort_array(au_array *array, int(*cmp)(const void *, const void *))
+{
 
-	/* TODO: Use array->new to determine whether to do a quick sort or a 
+	/* TODO: Use array->new to determine whether to do a quick sort or a
 		bubble sort */
 	qsort(array->members, array->count, sizeof(void *), cmp);
 	array->new = 0;
-	}
+}
 
-void *au_find_in_array(au_array *array, void *key, 
-		int(*cmp)(const void *, const void *)) {
+void *au_find_in_array(au_array *array, void *key,
+                       int(*cmp)(const void *, const void *))
+{
 
 	return bsearch(&key, array->members, array->count, sizeof(void *), cmp);
-	}
+}
 
-au_linked_list *au_init_list(char *label) {
+au_linked_list *au_init_list(char *label)
+{
 
 	au_linked_list *list;
 
 	if((list = calloc(1, sizeof(au_linked_list))) == NULL) {
 		return NULL;
-		}
+	}
 	list->label = NULL;
 	if(NULL != label) {
 		if((list->label = strdup(label)) == NULL) {
 			free(list);
 			return NULL;
-			}
 		}
+	}
 	list->head = (au_node *)0;
 	list->last_new = (au_node *)0;
 
 	return list;
-	}
+}
 
-au_node *au_list_add_node(au_linked_list *list, void *data, 
-		int(*cmp)(const void *, const void *)) {
+au_node *au_list_add_node(au_linked_list *list, void *data,
+                          int(*cmp)(const void *, const void *))
+{
 
 	au_node *new_node;
 	au_node *temp_node;
@@ -1545,7 +1597,7 @@ au_node *au_list_add_node(au_linked_list *list, void *data,
 	/* Create the new node */
 	if((new_node = calloc(1, sizeof(au_node))) == NULL) {
 		return NULL;
-		}
+	}
 	new_node->data = data;
 	new_node->next = NULL;
 
@@ -1553,74 +1605,68 @@ au_node *au_list_add_node(au_linked_list *list, void *data,
 	if(NULL == list->head) {
 		/* If the list is empty, add this node as the only item in the list */
 		list->head = new_node;
-		}
-	else if(cmp(&(list->last_new->data), &(new_node->data)) <= 0) {
+	} else if(cmp(&(list->last_new->data), &(new_node->data)) <= 0) {
 		/* The new node goes somewhere on the list downstream of the most
 			recently added node */
 		if(NULL == list->last_new->next) {
-			/* If the most recently added node is the last one on the list, 
+			/* If the most recently added node is the last one on the list,
 				append the list with this node */
 			list->last_new->next = new_node;
-			}
-		else if(cmp(&(list->last_new->next->data), &(new_node->data)) > 0) {
-			/* If the next node is "greater than" the new node, the new 
+		} else if(cmp(&(list->last_new->next->data), &(new_node->data)) > 0) {
+			/* If the next node is "greater than" the new node, the new
 				node goes here */
 			new_node->next = list->last_new->next;
 			list->last_new->next = new_node;
-			}
-		else {
-			/* Visit each node downstream in the list until we reach the 
+		} else {
+			/* Visit each node downstream in the list until we reach the
 				end of the list or until we find a node whose next
 				node is "greater than" the new node */
 			temp_node = list->last_new;
 			while((NULL != temp_node->next) && (cmp(&(temp_node->next->data),
-					&(new_node->data)) <= 0)) {
+			                                        &(new_node->data)) <= 0)) {
 				temp_node = temp_node->next;
-				}
+			}
 			if(NULL == temp_node->next) {
 				/* If we reach the end of the list, the new node gets
 					appended */
 				temp_node->next = new_node;
-				}
-			else {
+			} else {
 				/* Otherwise, the new node gets inserted here */
 				new_node->next = temp_node->next;
 				temp_node->next = new_node;
-				}
 			}
 		}
-	else {
-		/* The new node is "less than" the last new node.  Visit each node 
-			starting at the beginning of the list until we reach the end of 
-			the list (which shouldn't happen because that case was covered 
+	} else {
+		/* The new node is "less than" the last new node.  Visit each node
+			starting at the beginning of the list until we reach the end of
+			the list (which shouldn't happen because that case was covered
 			earlier) or we find a node whose next node is is "greater than"
 			the new node. */
 		temp_node = list->head;
-		while((NULL != temp_node->next) && (cmp(&(temp_node->next->data), 
-				&(new_node->data)) <= 0)) {
+		while((NULL != temp_node->next) && (cmp(&(temp_node->next->data),
+		                                        &(new_node->data)) <= 0)) {
 			temp_node = temp_node->next;
-			}
+		}
 		if(temp_node == list->head) {
 			/* We insert at the beginning of the list */
 			new_node->next = list->head;
 			list->head = new_node;
-			}
-		else if(NULL == temp_node->next) {
+		} else if(NULL == temp_node->next) {
 			/* If we reach the end of the list, the new node gets appended */
 			temp_node->next = new_node;
-			}
-		else {
+		} else {
 			/* Otherwise, the new node gets inserted here */
 			new_node->next = temp_node->next;
 			temp_node->next = new_node;
-			}
 		}
+	}
 	list->last_new = new_node;
 
 	return new_node;
-	}
+}
 
-void au_empty_list(au_linked_list *list, void(*datafree)(void *)) {
+void au_empty_list(au_linked_list *list, void(*datafree)(void *))
+{
 
 	au_node *temp_node1;
 	au_node *temp_node2;
@@ -1630,18 +1676,19 @@ void au_empty_list(au_linked_list *list, void(*datafree)(void *)) {
 		temp_node2 = temp_node1->next;
 		if((NULL != datafree) && (NULL != temp_node1->data)) {
 			datafree(temp_node1->data);
-			}
+		}
 		free(temp_node1);
 		temp_node1 = temp_node2;
-		}
+	}
 	list->head = NULL;
 	list->last_new = NULL;
-	}
+}
 
-void au_free_list(au_linked_list *list, void(*datafree)(void *)) {
+void au_free_list(au_linked_list *list, void(*datafree)(void *))
+{
 
 	if(NULL == list) return;
 	if(NULL != list->label) free(list->label);
 	au_empty_list(list, datafree);
 	free(list);
-	}
+}

--- a/cgi/avail.c
+++ b/cgi/avail.c
@@ -115,7 +115,7 @@ typedef struct archived_state_struct {
 	int     processed_state;
 	struct archived_state_struct *misc_ptr;
 	struct archived_state_struct *next;
-	} archived_state;
+} archived_state;
 
 typedef struct avail_subject_struct {
 	int type;
@@ -151,7 +151,7 @@ typedef struct avail_subject_struct {
 	unsigned long time_indeterminate_notrunning;
 
 	struct avail_subject_struct *next;
-	} avail_subject;
+} avail_subject;
 
 avail_subject *subject_list = NULL;
 
@@ -256,7 +256,8 @@ int output_format = HTML_OUTPUT;
 
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char start_timestring[MAX_DATETIME_LENGTH];
 	char end_timestring[MAX_DATETIME_LENGTH];
@@ -286,22 +287,22 @@ int main(int argc, char **argv) {
 
 	/* default number of backtracked archives */
 	switch(log_rotation_method) {
-		case LOG_ROTATION_MONTHLY:
-			backtrack_archives = 1;
-			break;
-		case LOG_ROTATION_WEEKLY:
-			backtrack_archives = 2;
-			break;
-		case LOG_ROTATION_DAILY:
-			backtrack_archives = 4;
-			break;
-		case LOG_ROTATION_HOURLY:
-			backtrack_archives = 8;
-			break;
-		default:
-			backtrack_archives = 2;
-			break;
-		}
+	case LOG_ROTATION_MONTHLY:
+		backtrack_archives = 1;
+		break;
+	case LOG_ROTATION_WEEKLY:
+		backtrack_archives = 2;
+		break;
+	case LOG_ROTATION_DAILY:
+		backtrack_archives = 4;
+		break;
+	case LOG_ROTATION_HOURLY:
+		backtrack_archives = 8;
+		break;
+	default:
+		backtrack_archives = 2;
+		break;
+	}
 
 	/* get the arguments passed in the URL */
 	process_cgivars();
@@ -320,14 +321,14 @@ int main(int argc, char **argv) {
 		t3 = t2;
 		t2 = t1;
 		t1 = t3;
-		}
+	}
 
 	/* don't let user create reports in the future */
 	if(t2 > current_time) {
 		t2 = current_time;
 		if(t1 > t2)
 			t1 = t2 - (60 * 60 * 24);
-		}
+	}
 
 	if(display_header == TRUE) {
 
@@ -339,22 +340,22 @@ int main(int argc, char **argv) {
 		printf("<td align=left valign=top width=33%%>\n");
 
 		switch(display_type) {
-			case DISPLAY_HOST_AVAIL:
-				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Host Availability Report");
-				break;
-			case DISPLAY_SERVICE_AVAIL:
-				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Service Availability Report");
-				break;
-			case DISPLAY_HOSTGROUP_AVAIL:
-				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Hostgroup Availability Report");
-				break;
-			case DISPLAY_SERVICEGROUP_AVAIL:
-				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Servicegroup Availability Report");
-				break;
-			default:
-				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Availability Report");
-				break;
-			}
+		case DISPLAY_HOST_AVAIL:
+			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Host Availability Report");
+			break;
+		case DISPLAY_SERVICE_AVAIL:
+			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Service Availability Report");
+			break;
+		case DISPLAY_HOSTGROUP_AVAIL:
+			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Hostgroup Availability Report");
+			break;
+		case DISPLAY_SERVICEGROUP_AVAIL:
+			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Servicegroup Availability Report");
+			break;
+		default:
+			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Availability Report");
+			break;
+		}
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		display_info_table(temp_buffer, FALSE, &current_authdata);
 
@@ -375,8 +376,7 @@ int main(int argc, char **argv) {
 				printf("<a href='%s?host=%s'>View Status Detail For This Host</a><BR>\n", STATUS_CGI, url_encode(host_name));
 				printf("<a href='%s?host=%s'>View Alert History For This Host</a><BR>\n", HISTORY_CGI, url_encode(host_name));
 				printf("<a href='%s?host=%s'>View Notifications For This Host</a><BR>\n", NOTIFICATIONS_CGI, url_encode(host_name));
-				}
-			else if(display_type == DISPLAY_SERVICE_AVAIL && show_all_services == FALSE) {
+			} else if(display_type == DISPLAY_SERVICE_AVAIL && show_all_services == FALSE) {
 				host_report_url(host_name, "View Availability Report For This Host");
 				printf("<BR>\n");
 				service_report_url("null", "all", "View Availability Report For All Services");
@@ -393,11 +393,11 @@ int main(int argc, char **argv) {
 				printf("service=%s'>View Alert History For This Service</A><BR>\n", url_encode(svc_description));
 				printf("<A HREF='%s?host=%s&", NOTIFICATIONS_CGI, url_encode(host_name));
 				printf("service=%s'>View Notifications For This Service</A><BR>\n", url_encode(svc_description));
-				}
+			}
 
 			printf("</TD></TR>\n");
 			printf("</TABLE>\n");
-			}
+		}
 
 		printf("</td>\n");
 
@@ -412,25 +412,22 @@ int main(int argc, char **argv) {
 					printf("All Hosts");
 				else
 					printf("Host '%s'", host_name);
-				}
-			else if(display_type == DISPLAY_SERVICE_AVAIL) {
+			} else if(display_type == DISPLAY_SERVICE_AVAIL) {
 				if(show_all_services == TRUE)
 					printf("All Services");
 				else
 					printf("Service '%s' On Host '%s'", svc_description, host_name);
-				}
-			else if(display_type == DISPLAY_HOSTGROUP_AVAIL) {
+			} else if(display_type == DISPLAY_HOSTGROUP_AVAIL) {
 				if(show_all_hostgroups == TRUE)
 					printf("All Hostgroups");
 				else
 					printf("Hostgroup '%s'", hostgroup_name);
-				}
-			else if(display_type == DISPLAY_SERVICEGROUP_AVAIL) {
+			} else if(display_type == DISPLAY_SERVICEGROUP_AVAIL) {
 				if(show_all_servicegroups == TRUE)
 					printf("All Servicegroups");
 				else
 					printf("Servicegroup '%s'", servicegroup_name);
-				}
+			}
 			printf("</DIV>\n");
 
 			printf("<BR>\n");
@@ -445,7 +442,7 @@ int main(int argc, char **argv) {
 
 			get_time_breakdown((time_t)(t2 - t1), &days, &hours, &minutes, &seconds);
 			printf("<div align=center class='reportDuration'>Duration: %dd %dh %dm %ds</div>\n", days, hours, minutes, seconds);
-			}
+		}
 
 		printf("</td>\n");
 
@@ -489,8 +486,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Host Down\n", AS_HOST_DOWN, (initial_assumed_host_state == AS_HOST_DOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host Unreachable\n", AS_HOST_UNREACHABLE, (initial_assumed_host_state == AS_HOST_UNREACHABLE) ? "SELECTED" : "");
 				printf("</select>\n");
-				}
-			else {
+			} else {
 				printf("<input type='hidden' name='initialassumedhoststate' value='%d'>", initial_assumed_host_state);
 				printf("<select name='initialassumedservicestate'>\n");
 				printf("<option value=%d %s>Unspecified\n", AS_NO_DATA, (initial_assumed_service_state == AS_NO_DATA) ? "SELECTED" : "");
@@ -500,7 +496,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Service Unknown\n", AS_SVC_UNKNOWN, (initial_assumed_service_state == AS_SVC_UNKNOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service Critical\n", AS_SVC_CRITICAL, (initial_assumed_service_state == AS_SVC_CRITICAL) ? "SELECTED" : "");
 				printf("</select>\n");
-				}
+			}
 			printf("</td>\n");
 			printf("<td CLASS='optBoxItem'>\n");
 			if(display_type == DISPLAY_HOST_AVAIL || display_type == DISPLAY_HOSTGROUP_AVAIL || display_type == DISPLAY_SERVICEGROUP_AVAIL) {
@@ -512,7 +508,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Service Unknown\n", AS_SVC_UNKNOWN, (initial_assumed_service_state == AS_SVC_UNKNOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service Critical\n", AS_SVC_CRITICAL, (initial_assumed_service_state == AS_SVC_CRITICAL) ? "SELECTED" : "");
 				printf("</select>\n");
-				}
+			}
 			printf("</td>\n");
 			printf("</tr>\n");
 
@@ -544,7 +540,7 @@ int main(int argc, char **argv) {
 			printf("<input type='submit' value='Update'>\n");
 			printf("</td>\n");
 			printf("</tr>\n");
-			}
+		}
 
 		/* display context-sensitive help */
 		printf("<tr><td></td><td align=right valign=bottom>\n");
@@ -576,7 +572,7 @@ int main(int argc, char **argv) {
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 
 
@@ -739,7 +735,7 @@ int main(int argc, char **argv) {
 			printf("<option value=%d>Host Unreachable\n", AS_HOST_UNREACHABLE);
 			printf("</select>\n");
 			printf("</td></tr>\n");
-			}
+		}
 
 		printf("<tr><td class='reportSelectSubTitle' align=right>First Assumed Service State:</td>\n");
 		printf("<td class='reportSelectItem'>\n");
@@ -765,7 +761,7 @@ int main(int argc, char **argv) {
 			printf("<input type='checkbox' name='csvoutput' value=''>\n");
 			printf("</td>\n");
 			printf("</tr>\n");
-			}
+		}
 
 		printf("<tr><td></td><td align=left class='dateSelectItem'><input type='submit' value='Create Availability Report!'></td></tr>\n");
 
@@ -773,7 +769,7 @@ int main(int argc, char **argv) {
 
 		printf("</form>\n");
 		printf("</DIV></P>\n");
-		}
+	}
 
 
 	/* step 2 - the user wants to select a hostgroup */
@@ -793,7 +789,7 @@ int main(int argc, char **argv) {
 		for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
 			if(is_authorized_for_hostgroup(temp_hostgroup, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s\n", escape_string(temp_hostgroup->group_name), temp_hostgroup->group_name);
-			}
+		}
 		printf("</select>\n");
 		printf("</td></tr>\n");
 
@@ -804,7 +800,7 @@ int main(int argc, char **argv) {
 		printf("</form>\n");
 
 		printf("</div></p>\n");
-		}
+	}
 
 	/* step 2 - the user wants to select a host */
 	else if(select_hosts == TRUE) {
@@ -823,7 +819,7 @@ int main(int argc, char **argv) {
 		for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 			if(is_authorized_for_host(temp_host, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s\n", escape_string(temp_host->name), temp_host->name);
-			}
+		}
 		printf("</select>\n");
 		printf("</td></tr>\n");
 
@@ -836,7 +832,7 @@ int main(int argc, char **argv) {
 		printf("</div></p>\n");
 
 		printf("<div align=center class='helpfulHint'>Tip: If you want to have the option of getting the availability data in CSV format, select '<b>** ALL HOSTS **</b>' from the pull-down menu.\n");
-		}
+	}
 
 	/* step 2 - the user wants to select a servicegroup */
 	else if(select_servicegroups == TRUE) {
@@ -855,7 +851,7 @@ int main(int argc, char **argv) {
 		for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next) {
 			if(is_authorized_for_servicegroup(temp_servicegroup, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s\n", escape_string(temp_servicegroup->group_name), temp_servicegroup->group_name);
-			}
+		}
 		printf("</select>\n");
 		printf("</td></tr>\n");
 
@@ -866,7 +862,7 @@ int main(int argc, char **argv) {
 		printf("</form>\n");
 
 		printf("</div></p>\n");
-		}
+	}
 
 	/* step 2 - the user wants to select a service */
 	else if(select_services == TRUE) {
@@ -881,8 +877,8 @@ int main(int argc, char **argv) {
 				if(!firsthostpointer)
 					firsthostpointer = temp_service->host_name;
 				printf(", \"%s\"", temp_service->host_name);
-				}
 			}
+		}
 
 		printf(" ]\n");
 		printf("return hostnames[hostindex];\n");
@@ -905,7 +901,7 @@ int main(int argc, char **argv) {
 		for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 			if(is_authorized_for_service(temp_service, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s;%s\n", escape_string(temp_service->description), temp_service->host_name, temp_service->description);
-			}
+		}
 
 		printf("</select>\n");
 		printf("</td></tr>\n");
@@ -919,7 +915,7 @@ int main(int argc, char **argv) {
 		printf("</div></p>\n");
 
 		printf("<div align=center class='helpfulHint'>Tip: If you want to have the option of getting the availability data in CSV format, select '<b>** ALL SERVICES **</b>' from the pull-down menu.\n");
-		}
+	}
 
 
 	/* generate availability report */
@@ -933,7 +929,7 @@ int main(int argc, char **argv) {
 				is_authorized = is_authorized_for_host(find_host(host_name), &current_authdata);
 			else
 				is_authorized = is_authorized_for_service(find_service(host_name, svc_description), &current_authdata);
-			}
+		}
 
 		if(is_authorized == FALSE)
 			printf("<P><DIV ALIGN=CENTER CLASS='errorMessage'>It appears as though you are not authorized to view information for the specified %s...</DIV></P>\n", (display_type == DISPLAY_HOST_AVAIL) ? "host" : "service");
@@ -957,7 +953,7 @@ int main(int argc, char **argv) {
 				get_time_breakdown((time_t)(report_end_time - report_start_time), &days, &hours, &minutes, &seconds);
 				printf("<div align=center class='reportTime'>[ Availability report completed in %d min %d sec ]</div>\n", minutes, seconds);
 				printf("<BR><BR>\n");
-				}
+			}
 
 			/* display availability data */
 			if(display_type == DISPLAY_HOST_AVAIL)
@@ -971,8 +967,8 @@ int main(int argc, char **argv) {
 
 			/* free memory allocated to availability data */
 			free_availability_data();
-			}
 		}
+	}
 
 
 	/* step 1 - ask the user what kind of report they want */
@@ -1003,7 +999,7 @@ int main(int argc, char **argv) {
 		printf("</form>\n");
 
 		printf("</div></p>\n");
-		}
+	}
 
 
 	document_footer();
@@ -1012,11 +1008,12 @@ int main(int argc, char **argv) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -1037,7 +1034,7 @@ void document_header(int use_stylesheet) {
 	else {
 		printf("Content-type: text/csv\r\n\r\n");
 		return;
-		}
+	}
 
 	if(embedded == TRUE || output_format == CSV_OUTPUT)
 		return;
@@ -1052,7 +1049,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, AVAIL_CSS);
-		}
+	}
 
 	printf("</head>\n");
 
@@ -1062,11 +1059,12 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(AVAIL_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(output_format != HTML_OUTPUT)
 		return;
@@ -1081,11 +1079,12 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -1097,7 +1096,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the hostgroup argument */
 		else if(!strcmp(variables[x], "hostgroup")) {
@@ -1105,7 +1104,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((hostgroup_name = (char *)strdup(variables[x])) == NULL)
 				hostgroup_name = "";
@@ -1113,7 +1112,7 @@ int process_cgivars(void) {
 
 			display_type = DISPLAY_HOSTGROUP_AVAIL;
 			show_all_hostgroups = (strcmp(hostgroup_name, "all")) ? FALSE : TRUE;
-			}
+		}
 
 		/* we found the servicegroup argument */
 		else if(!strcmp(variables[x], "servicegroup")) {
@@ -1121,7 +1120,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((servicegroup_name = (char *)strdup(variables[x])) == NULL)
 				servicegroup_name = "";
@@ -1129,7 +1128,7 @@ int process_cgivars(void) {
 
 			display_type = DISPLAY_SERVICEGROUP_AVAIL;
 			show_all_servicegroups = (strcmp(servicegroup_name, "all")) ? FALSE : TRUE;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -1137,7 +1136,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "";
@@ -1145,7 +1144,7 @@ int process_cgivars(void) {
 
 			display_type = DISPLAY_HOST_AVAIL;
 			show_all_hosts = (strcmp(host_name, "all")) ? FALSE : TRUE;
-			}
+		}
 
 		/* we found the service description argument */
 		else if(!strcmp(variables[x], "service")) {
@@ -1153,7 +1152,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((svc_description = (char *)strdup(variables[x])) == NULL)
 				svc_description = "";
@@ -1161,7 +1160,7 @@ int process_cgivars(void) {
 
 			display_type = DISPLAY_SERVICE_AVAIL;
 			show_all_services = (strcmp(svc_description, "all")) ? FALSE : TRUE;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t1")) {
@@ -1169,12 +1168,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t1 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = FALSE;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t2")) {
@@ -1182,12 +1181,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t2 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = FALSE;
-			}
+		}
 
 		/* we found the assume initial states option */
 		else if(!strcmp(variables[x], "assumeinitialstates")) {
@@ -1195,13 +1194,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_initial_states = TRUE;
 			else
 				assume_initial_states = FALSE;
-			}
+		}
 
 		/* we found the assume state during program not running option */
 		else if(!strcmp(variables[x], "assumestatesduringnotrunning")) {
@@ -1209,13 +1208,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_states_during_notrunning = TRUE;
 			else
 				assume_states_during_notrunning = FALSE;
-			}
+		}
 
 		/* we found the initial assumed host state option */
 		else if(!strcmp(variables[x], "initialassumedhoststate")) {
@@ -1223,10 +1222,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			initial_assumed_host_state = atoi(variables[x]);
-			}
+		}
 
 		/* we found the initial assumed service state option */
 		else if(!strcmp(variables[x], "initialassumedservicestate")) {
@@ -1234,10 +1233,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			initial_assumed_service_state = atoi(variables[x]);
-			}
+		}
 
 		/* we found the assume state retention option */
 		else if(!strcmp(variables[x], "assumestateretention")) {
@@ -1245,13 +1244,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_state_retention = TRUE;
 			else
 				assume_state_retention = FALSE;
-			}
+		}
 
 		/* we found the include soft states option */
 		else if(!strcmp(variables[x], "includesoftstates")) {
@@ -1259,13 +1258,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				include_soft_states = TRUE;
 			else
 				include_soft_states = FALSE;
-			}
+		}
 
 		/* we found the backtrack archives argument */
 		else if(!strcmp(variables[x], "backtrack")) {
@@ -1273,7 +1272,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			backtrack_archives = atoi(variables[x]);
 			if(backtrack_archives < 0)
@@ -1284,7 +1283,7 @@ int process_cgivars(void) {
 #ifdef DEBUG
 			printf("BACKTRACK ARCHIVES: %d\n", backtrack_archives);
 #endif
-			}
+		}
 
 		/* we found the standard timeperiod argument */
 		else if(!strcmp(variables[x], "timeperiod")) {
@@ -1292,7 +1291,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "today"))
 				timeperiod_type = TIMEPERIOD_TODAY;
@@ -1327,7 +1326,7 @@ int process_cgivars(void) {
 
 			convert_timeperiod_to_times(timeperiod_type);
 			compute_time_from_parts = FALSE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -1341,7 +1340,7 @@ int process_cgivars(void) {
 		else if(!strcmp(variables[x], "csvoutput")) {
 			display_header = FALSE;
 			output_format = CSV_OUTPUT;
-			}
+		}
 
 		/* we found the log entries option  */
 		else if(!strcmp(variables[x], "show_log_entries"))
@@ -1361,7 +1360,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			if(!strcmp(variables[x], "hostgroups"))
 				select_hostgroups = TRUE;
 			else if(!strcmp(variables[x], "servicegroups"))
@@ -1370,7 +1369,7 @@ int process_cgivars(void) {
 				select_hosts = TRUE;
 			else
 				select_services = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smon")) {
@@ -1378,7 +1377,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1386,7 +1385,7 @@ int process_cgivars(void) {
 			start_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "sday")) {
@@ -1394,7 +1393,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1402,7 +1401,7 @@ int process_cgivars(void) {
 			start_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "syear")) {
@@ -1410,7 +1409,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1418,7 +1417,7 @@ int process_cgivars(void) {
 			start_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smin")) {
@@ -1426,7 +1425,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1434,7 +1433,7 @@ int process_cgivars(void) {
 			start_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ssec")) {
@@ -1442,7 +1441,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1450,7 +1449,7 @@ int process_cgivars(void) {
 			start_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "shour")) {
@@ -1458,7 +1457,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1466,7 +1465,7 @@ int process_cgivars(void) {
 			start_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 
 		/* we found time argument */
@@ -1475,7 +1474,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1483,7 +1482,7 @@ int process_cgivars(void) {
 			end_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eday")) {
@@ -1491,7 +1490,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1499,7 +1498,7 @@ int process_cgivars(void) {
 			end_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eyear")) {
@@ -1507,7 +1506,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1515,7 +1514,7 @@ int process_cgivars(void) {
 			end_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "emin")) {
@@ -1523,7 +1522,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1531,7 +1530,7 @@ int process_cgivars(void) {
 			end_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "esec")) {
@@ -1539,7 +1538,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1547,7 +1546,7 @@ int process_cgivars(void) {
 			end_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ehour")) {
@@ -1555,7 +1554,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1563,7 +1562,7 @@ int process_cgivars(void) {
 			end_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found the show scheduled downtime option */
 		else if(!strcmp(variables[x], "showscheduleddowntime")) {
@@ -1571,13 +1570,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				show_scheduled_downtime = TRUE;
 			else
 				show_scheduled_downtime = FALSE;
-			}
+		}
 
 		/* we found the report timeperiod option */
 		else if(!strcmp(variables[x], "rpttimeperiod")) {
@@ -1586,28 +1585,29 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			for(temp_timeperiod = timeperiod_list; temp_timeperiod != NULL; temp_timeperiod = temp_timeperiod->next) {
 				if(!strcmp(url_encode(temp_timeperiod->name), variables[x])) {
 					current_timeperiod = temp_timeperiod;
 					break;
-					}
 				}
 			}
-
 		}
+
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* computes availability data for all subjects */
-void compute_availability(void) {
+void compute_availability(void)
+{
 	avail_subject *temp_subject;
 	time_t current_time;
 
@@ -1616,15 +1616,16 @@ void compute_availability(void) {
 	for(temp_subject = subject_list; temp_subject != NULL; temp_subject = temp_subject->next) {
 		compute_subject_availability(temp_subject, current_time);
 		compute_subject_downtime(temp_subject, current_time);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* computes availability data for a given subject */
-void compute_subject_availability(avail_subject *subject, time_t current_time) {
+void compute_subject_availability(avail_subject *subject, time_t current_time)
+{
 	archived_state *temp_as;
 	archived_state *last_as;
 	time_t a;
@@ -1676,10 +1677,9 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 
 					/* add a dummy archived state item, so something can get graphed */
 					add_archived_state(subject->last_known_state, AS_HARD_STATE, t1, "Current Host State Assumed (Faked Log Entry)", subject);
-					}
 				}
 			}
-		else {
+		} else {
 			if(svcstatus != NULL) {
 
 				if(svcstatus->status == SERVICE_OK)
@@ -1697,10 +1697,10 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 
 					/* add a dummy archived state item, so something can get graphed */
 					add_archived_state(subject->last_known_state, AS_HARD_STATE, t1, "Current Service State Assumed (Faked Log Entry)", subject);
-					}
 				}
 			}
 		}
+	}
 
 
 
@@ -1719,54 +1719,52 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 				initial_assumed_state = initial_assumed_service_state;
 			if(initial_assumed_service_state == AS_CURRENT_STATE && svcstatus == NULL)
 				error = TRUE;
-			}
-		else {
+		} else {
 			if(initial_assumed_host_state != AS_HOST_UP && initial_assumed_host_state != AS_HOST_DOWN && initial_assumed_host_state != AS_HOST_UNREACHABLE && initial_assumed_host_state != AS_CURRENT_STATE)
 				error = TRUE;
 			else
 				initial_assumed_state = initial_assumed_host_state;
 			if(initial_assumed_host_state == AS_CURRENT_STATE && hststatus == NULL)
 				error = TRUE;
-			}
+		}
 
 		/* get the current state if applicable */
 		if(((subject->type == HOST_SUBJECT && initial_assumed_host_state == AS_CURRENT_STATE) || (subject->type == SERVICE_SUBJECT && initial_assumed_service_state == AS_CURRENT_STATE)) && error == FALSE) {
 			if(subject->type == SERVICE_SUBJECT) {
 				switch(svcstatus->status) {
-					case SERVICE_OK:
-						initial_assumed_state = AS_SVC_OK;
-						break;
-					case SERVICE_WARNING:
-						initial_assumed_state = AS_SVC_WARNING;
-						break;
-					case SERVICE_UNKNOWN:
-						initial_assumed_state = AS_SVC_UNKNOWN;
-						break;
-					case SERVICE_CRITICAL:
-						initial_assumed_state = AS_SVC_CRITICAL;
-						break;
-					default:
-						error = TRUE;
-						break;
-					}
+				case SERVICE_OK:
+					initial_assumed_state = AS_SVC_OK;
+					break;
+				case SERVICE_WARNING:
+					initial_assumed_state = AS_SVC_WARNING;
+					break;
+				case SERVICE_UNKNOWN:
+					initial_assumed_state = AS_SVC_UNKNOWN;
+					break;
+				case SERVICE_CRITICAL:
+					initial_assumed_state = AS_SVC_CRITICAL;
+					break;
+				default:
+					error = TRUE;
+					break;
 				}
-			else {
+			} else {
 				switch(hststatus->status) {
-					case SD_HOST_DOWN:
-						initial_assumed_state = AS_HOST_DOWN;
-						break;
-					case SD_HOST_UNREACHABLE:
-						initial_assumed_state = AS_HOST_UNREACHABLE;
-						break;
-					case SD_HOST_UP:
-						initial_assumed_state = AS_HOST_UP;
-						break;
-					default:
-						error = TRUE;
-						break;
-					}
+				case SD_HOST_DOWN:
+					initial_assumed_state = AS_HOST_DOWN;
+					break;
+				case SD_HOST_UNREACHABLE:
+					initial_assumed_state = AS_HOST_UNREACHABLE;
+					break;
+				case SD_HOST_UP:
+					initial_assumed_state = AS_HOST_UP;
+					break;
+				default:
+					error = TRUE;
+					break;
 				}
 			}
+		}
 
 		if(error == FALSE) {
 
@@ -1782,8 +1780,8 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 				add_archived_state(initial_assumed_state, AS_HARD_STATE, initial_assumed_time, "First Host State Assumed (Faked Log Entry)", subject);
 			else
 				add_archived_state(initial_assumed_state, AS_HARD_STATE, initial_assumed_time, "First Service State Assumed (Faked Log Entry)", subject);
-			}
 		}
+	}
 
 
 
@@ -1797,8 +1795,8 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 		if(temp_as->entry_type != AS_NO_DATA && temp_as->entry_type != AS_PROGRAM_START && temp_as->entry_type != AS_PROGRAM_END) {
 			have_some_real_data = TRUE;
 			break;
-			}
 		}
+	}
 	if(have_some_real_data == FALSE)
 		return;
 
@@ -1826,7 +1824,7 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 #ifdef DEBUG
 			printf("SETTING LAST KNOWN STATE=%d<br>\n", subject->last_known_state);
 #endif
-			}
+		}
 
 		/* skip this entry if it occurs before the starting point of the graph */
 		if(temp_as->time_stamp <= t1) {
@@ -1835,7 +1833,7 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 #endif
 			last_as = temp_as;
 			continue;
-			}
+		}
 
 		/* graph this span if we're not on the first item */
 		if(last_as != NULL) {
@@ -1862,13 +1860,13 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 				if(a < subject->earliest_time) {
 					subject->earliest_time = a;
 					subject->earliest_state = last_as->entry_type;
-					}
+				}
 
 				/* save this time if its the latest we've graphed */
 				if(b > subject->latest_time) {
 					subject->latest_time = b;
 					subject->latest_state = last_as->entry_type;
-					}
+				}
 
 				/* compute availability times for this chunk */
 				compute_subject_availability_times(last_as->entry_type, temp_as->entry_type, last_as->time_stamp, a, b, subject, temp_as);
@@ -1877,14 +1875,14 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 				if(b >= t2) {
 					last_as = temp_as;
 					break;
-					}
 				}
 			}
+		}
 
 
 		/* keep track of the last item */
 		last_as = temp_as;
-		}
+	}
 
 
 #ifdef DEBUG
@@ -1917,16 +1915,17 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 
 			/* compute availability times for last state */
 			compute_subject_availability_times(last_as->entry_type, current_state, last_as->time_stamp, a, b, subject, last_as);
-			}
 		}
-
-
-	return;
 	}
 
 
+	return;
+}
+
+
 /* computes availability times */
-void compute_subject_availability_times(int first_state, int last_state, time_t real_start_time, time_t start_time, time_t end_time, avail_subject *subject, archived_state *as) {
+void compute_subject_availability_times(int first_state, int last_state, time_t real_start_time, time_t start_time, time_t end_time, avail_subject *subject, archived_state *as)
+{
 	int start_state;
 	unsigned long state_duration;
 	struct tm *t;
@@ -1996,48 +1995,47 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 #ifdef DEBUG
 					printf("<li>Matched time: %ld -> %ld = %d<br>\n", start, end, temp_duration);
 #endif
-					}
+				}
 #ifdef DEBUG
 				else
 					printf("<li>Ignored time: %ld -> %ld<br>\n", start, end);
 #endif
-				}
+			}
 			state_duration += temp_duration;
 			temp_start = 0;
 			midnight_today += 86400;
 			if(++weekday > 6)
 				weekday = 0;
-			}
 		}
+	}
 
 	/* no report timeperiod was selected (assume 24x7) */
 	else {
 		/* calculate time in this state */
 		state_duration = (unsigned long)(end_time - start_time);
-		}
+	}
 
 	/* can't graph if we don't have data... */
 	if(first_state == AS_NO_DATA || last_state == AS_NO_DATA) {
 		subject->time_indeterminate_nodata += state_duration;
 		return;
-		}
+	}
 	if(first_state == AS_PROGRAM_START && (last_state == AS_PROGRAM_END || last_state == AS_PROGRAM_START)) {
 		if(assume_initial_states == FALSE) {
 			subject->time_indeterminate_nodata += state_duration;
 			return;
-			}
 		}
+	}
 	if(first_state == AS_PROGRAM_END) {
 
 		/* added 7/24/03 */
 		if(assume_states_during_notrunning == TRUE) {
 			first_state = subject->last_known_state;
-			}
-		else {
+		} else {
 			subject->time_indeterminate_notrunning += state_duration;
 			return;
-			}
 		}
+	}
 
 	/* special case if first entry was program start */
 	if(first_state == AS_PROGRAM_START) {
@@ -2052,15 +2050,13 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 					start_state = AS_HOST_UP;
 				else
 					start_state = AS_SVC_OK;
-				}
 			}
-		else
+		} else
 			return;
-		}
-	else {
+	} else {
 		start_state = first_state;
 		subject->last_known_state = first_state;
-		}
+	}
 
 	/* save "processed state" info */
 	as->processed_state = start_state;
@@ -2072,37 +2068,38 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 
 	/* add time in this state to running totals */
 	switch(start_state) {
-		case AS_HOST_UP:
-			subject->time_up += state_duration;
-			break;
-		case AS_HOST_DOWN:
-			subject->time_down += state_duration;
-			break;
-		case AS_HOST_UNREACHABLE:
-			subject->time_unreachable += state_duration;
-			break;
-		case AS_SVC_OK:
-			subject->time_ok += state_duration;
-			break;
-		case AS_SVC_WARNING:
-			subject->time_warning += state_duration;
-			break;
-		case AS_SVC_UNKNOWN:
-			subject->time_unknown += state_duration;
-			break;
-		case AS_SVC_CRITICAL:
-			subject->time_critical += state_duration;
-			break;
-		default:
-			break;
-		}
+	case AS_HOST_UP:
+		subject->time_up += state_duration;
+		break;
+	case AS_HOST_DOWN:
+		subject->time_down += state_duration;
+		break;
+	case AS_HOST_UNREACHABLE:
+		subject->time_unreachable += state_duration;
+		break;
+	case AS_SVC_OK:
+		subject->time_ok += state_duration;
+		break;
+	case AS_SVC_WARNING:
+		subject->time_warning += state_duration;
+		break;
+	case AS_SVC_UNKNOWN:
+		subject->time_unknown += state_duration;
+		break;
+	case AS_SVC_CRITICAL:
+		subject->time_critical += state_duration;
+		break;
+	default:
+		break;
+	}
 
 	return;
-	}
+}
 
 
 /* computes downtime data for a given subject */
-void compute_subject_downtime(avail_subject *subject, time_t current_time) {
+void compute_subject_downtime(avail_subject *subject, time_t current_time)
+{
 	archived_state *temp_sd;
 	time_t start_time;
 	time_t end_time;
@@ -2139,7 +2136,7 @@ void compute_subject_downtime(avail_subject *subject, time_t current_time) {
 		end_time = (temp_sd->time_stamp > t2) ? t2 : temp_sd->time_stamp;
 		compute_subject_downtime_times(start_time, end_time, subject, NULL);
 		temp_sd = temp_sd->next;
-		}
+	}
 
 	/* process all periods of scheduled downtime */
 	for(; temp_sd != NULL; temp_sd = temp_sd->next) {
@@ -2186,16 +2183,17 @@ void compute_subject_downtime(avail_subject *subject, time_t current_time) {
 				end_time = t2;
 
 			compute_subject_downtime_times(start_time, end_time, subject, temp_sd);
-			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* computes downtime times */
-void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_subject *subject, archived_state *sd) {
+void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_subject *subject, archived_state *sd)
+{
 	archived_state *temp_as = NULL;
 	time_t part_subject_state = 0L;
 	int saved_status = 0;
@@ -2220,25 +2218,22 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 		printf("<P>TEMP_AS=SUBJECT->AS_LIST </P>");
 #endif
 		temp_as = subject->as_list;
-		}
-	else if(sd->misc_ptr == NULL) {
+	} else if(sd->misc_ptr == NULL) {
 #ifdef DEBUG2
 		printf("<P>TEMP_AS=SUBJECT->AS_LIST</P>");
 #endif
 		temp_as = subject->as_list;
-		}
-	else if(sd->misc_ptr->next == NULL) {
+	} else if(sd->misc_ptr->next == NULL) {
 #ifdef DEBUG2
 		printf("<P>TEMP_AS=SD->MISC_PTR</P>");
 #endif
 		temp_as = sd->misc_ptr;
-		}
-	else {
+	} else {
 #ifdef DEBUG2
 		printf("<P>TEMP_AS=SD->MISC_PTR->NEXT</P>");
 #endif
 		temp_as = sd->misc_ptr->next;
-		}
+	}
 
 	/* initialize values */
 	if(temp_as == NULL)
@@ -2248,13 +2243,12 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 		printf("<P>ENTRY TYPE #1: %d</P>", temp_as->entry_type);
 #endif
 		part_subject_state = AS_NO_DATA;
-		}
-	else {
+	} else {
 #ifdef DEBUG2
 		printf("<P>ENTRY TYPE #2: %d</P>", temp_as->entry_type);
 #endif
 		part_subject_state = temp_as->processed_state;
-		}
+	}
 
 #ifdef DEBUG2
 	printf("<P>TEMP_AS=%s</P>", (temp_as == NULL) ? "NULL" : "Not NULL");
@@ -2272,7 +2266,7 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 					compute_subject_downtime_part_times(start_time, end_time, part_subject_state, subject);
 				else
 					compute_subject_downtime_part_times(start_time, last->time_stamp, part_subject_state, subject);
-				}
+			}
 			temp_before = temp_as;
 			saved_status = temp_as->entry_type;
 			saved_stamp = temp_as->time_stamp;
@@ -2282,7 +2276,7 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 				saved_stamp = start_time;
 
 			continue;
-			}
+		}
 
 		/* if status changed, we have to calculate */
 		if(saved_status != temp_as->entry_type) {
@@ -2293,17 +2287,16 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 					compute_subject_downtime_part_times(start_time, end_time, saved_status, subject);
 				else
 					compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
-				}
-			else {
+			} else {
 				if(saved_stamp < start_time)
 					compute_subject_downtime_part_times(start_time, temp_as->time_stamp, saved_status, subject);
 				else
 					compute_subject_downtime_part_times(saved_stamp, temp_as->time_stamp, saved_status, subject);
-				}
+			}
 			saved_status = temp_as->entry_type;
 			saved_stamp = temp_as->time_stamp;
-			}
 		}
+	}
 
 	/* just one entry inside the scheduled downtime */
 	if(count == 0)
@@ -2314,15 +2307,16 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 			compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
 		else
 			compute_subject_downtime_part_times(saved_stamp, last->time_stamp, saved_status, subject);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* computes downtime times */
-void compute_subject_downtime_part_times(time_t start_time, time_t end_time, int subject_state, avail_subject *subject) {
+void compute_subject_downtime_part_times(time_t start_time, time_t end_time, int subject_state, avail_subject *subject)
+{
 	unsigned long state_duration;
 
 #ifdef DEBUG2
@@ -2336,43 +2330,44 @@ void compute_subject_downtime_part_times(time_t start_time, time_t end_time, int
 	state_duration = (unsigned long)(end_time - start_time);
 
 	switch(subject_state) {
-		case AS_HOST_UP:
-			subject->scheduled_time_up += state_duration;
-			break;
-		case AS_HOST_DOWN:
-			subject->scheduled_time_down += state_duration;
-			break;
-		case AS_HOST_UNREACHABLE:
-			subject->scheduled_time_unreachable += state_duration;
-			break;
-		case AS_SVC_OK:
-			subject->scheduled_time_ok += state_duration;
-			break;
-		case AS_SVC_WARNING:
-			subject->scheduled_time_warning += state_duration;
-			break;
-		case AS_SVC_UNKNOWN:
-			subject->scheduled_time_unknown += state_duration;
-			break;
-		case AS_SVC_CRITICAL:
-			subject->scheduled_time_critical += state_duration;
-			break;
-		default:
-			subject->scheduled_time_indeterminate += state_duration;
-			break;
-		}
+	case AS_HOST_UP:
+		subject->scheduled_time_up += state_duration;
+		break;
+	case AS_HOST_DOWN:
+		subject->scheduled_time_down += state_duration;
+		break;
+	case AS_HOST_UNREACHABLE:
+		subject->scheduled_time_unreachable += state_duration;
+		break;
+	case AS_SVC_OK:
+		subject->scheduled_time_ok += state_duration;
+		break;
+	case AS_SVC_WARNING:
+		subject->scheduled_time_warning += state_duration;
+		break;
+	case AS_SVC_UNKNOWN:
+		subject->scheduled_time_unknown += state_duration;
+		break;
+	case AS_SVC_CRITICAL:
+		subject->scheduled_time_critical += state_duration;
+		break;
+	default:
+		subject->scheduled_time_indeterminate += state_duration;
+		break;
+	}
 
 #ifdef DEBUG2
 	printf("\tSUBJECT DOWNTIME: Host '%s', Service '%s', State=%d, Duration=%lu, Start=%lu\n", subject->host_name, (subject->service_description == NULL) ? "NULL" : subject->service_description, subject_state, state_duration, start_time);
 #endif
 
 	return;
-	}
+}
 
 
 
 /* convert current host state to archived state value */
-int convert_host_state_to_archived_state(int current_status) {
+int convert_host_state_to_archived_state(int current_status)
+{
 
 	if(current_status == SD_HOST_UP)
 		return AS_HOST_UP;
@@ -2382,11 +2377,12 @@ int convert_host_state_to_archived_state(int current_status) {
 		return AS_HOST_UNREACHABLE;
 
 	return AS_NO_DATA;
-	}
+}
 
 
 /* convert current service state to archived state value */
-int convert_service_state_to_archived_state(int current_status) {
+int convert_service_state_to_archived_state(int current_status)
+{
 
 	if(current_status == SERVICE_OK)
 		return AS_SVC_OK;
@@ -2398,12 +2394,13 @@ int convert_service_state_to_archived_state(int current_status) {
 		return AS_SVC_CRITICAL;
 
 	return AS_NO_DATA;
-	}
+}
 
 
 
 /* create list of subjects to collect availability data for */
-void create_subject_list(void) {
+void create_subject_list(void)
+{
 	hostgroup *temp_hostgroup;
 	hostsmember *temp_hgmember;
 	servicegroup *temp_servicegroup;
@@ -2421,15 +2418,15 @@ void create_subject_list(void) {
 			for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 				if(!strcmp(temp_service->host_name, host_name))
 					add_subject(SERVICE_SUBJECT, host_name, temp_service->description);
-				}
 			}
+		}
 
 		/* we're displaying all hosts */
 		else {
 			for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next)
 				add_subject(HOST_SUBJECT, temp_host->name, NULL);
-			}
 		}
+	}
 
 	/* we're displaying a specific service */
 	else if(display_type == DISPLAY_SERVICE_AVAIL && svc_description && strcmp(svc_description, "")) {
@@ -2442,8 +2439,8 @@ void create_subject_list(void) {
 		else {
 			for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next)
 				add_subject(SERVICE_SUBJECT, temp_service->host_name, temp_service->description);
-			}
 		}
+	}
 
 	/* we're displaying one or more hostgroups (the host members of the groups) */
 	else if(display_type == DISPLAY_HOSTGROUP_AVAIL && hostgroup_name && strcmp(hostgroup_name, "")) {
@@ -2453,17 +2450,17 @@ void create_subject_list(void) {
 			for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
 				for(temp_hgmember = temp_hostgroup->members; temp_hgmember != NULL; temp_hgmember = temp_hgmember->next)
 					add_subject(HOST_SUBJECT, temp_hgmember->host_name, NULL);
-				}
 			}
+		}
 		/* we're only displaying a specific hostgroup */
 		else {
 			temp_hostgroup = find_hostgroup(hostgroup_name);
 			if(temp_hostgroup != NULL) {
 				for(temp_hgmember = temp_hostgroup->members; temp_hgmember != NULL; temp_hgmember = temp_hgmember->next)
 					add_subject(HOST_SUBJECT, temp_hgmember->host_name, NULL);
-				}
 			}
 		}
+	}
 
 	/* we're displaying one or more servicegroups (the host and service members of the groups) */
 	else if(display_type == DISPLAY_SERVICEGROUP_AVAIL && servicegroup_name && strcmp(servicegroup_name, "")) {
@@ -2476,9 +2473,9 @@ void create_subject_list(void) {
 					if(strcmp(last_host_name, temp_sgmember->host_name))
 						add_subject(HOST_SUBJECT, temp_sgmember->host_name, NULL);
 					last_host_name = temp_sgmember->host_name;
-					}
 				}
 			}
+		}
 		/* we're only displaying a specific servicegroup */
 		else {
 			temp_servicegroup = find_servicegroup(servicegroup_name);
@@ -2488,18 +2485,19 @@ void create_subject_list(void) {
 					if(strcmp(last_host_name, temp_sgmember->host_name))
 						add_subject(HOST_SUBJECT, temp_sgmember->host_name, NULL);
 					last_host_name = temp_sgmember->host_name;
-					}
 				}
 			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* adds a subject */
-void add_subject(int subject_type, char *hn, char *sd) {
+void add_subject(int subject_type, char *hn, char *sd)
+{
 	avail_subject *last_subject = NULL;
 	avail_subject *temp_subject = NULL;
 	avail_subject *new_subject = NULL;
@@ -2527,8 +2525,7 @@ void add_subject(int subject_type, char *hn, char *sd) {
 		new_subject->host_name = (char *)malloc(strlen(hn) + 1);
 		if(new_subject->host_name != NULL)
 			strcpy(new_subject->host_name, hn);
-		}
-	else
+	} else
 		new_subject->host_name = NULL;
 
 	/* allocate memory for the service description */
@@ -2536,8 +2533,7 @@ void add_subject(int subject_type, char *hn, char *sd) {
 		new_subject->service_description = (char *)malloc(strlen(sd) + 1);
 		if(new_subject->service_description != NULL)
 			strcpy(new_subject->service_description, sd);
-		}
-	else
+	} else
 		new_subject->service_description = NULL;
 
 	new_subject->type = subject_type;
@@ -2575,26 +2571,25 @@ void add_subject(int subject_type, char *hn, char *sd) {
 			else
 				last_subject->next = new_subject;
 			break;
-			}
-		else
+		} else
 			last_subject = temp_subject;
-		}
+	}
 	if(subject_list == NULL) {
 		new_subject->next = NULL;
 		subject_list = new_subject;
-		}
-	else if(temp_subject == NULL) {
+	} else if(temp_subject == NULL) {
 		new_subject->next = NULL;
 		last_subject->next = new_subject;
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* finds a specific subject */
-avail_subject *find_subject(int type, char *hn, char *sd) {
+avail_subject *find_subject(int type, char *hn, char *sd)
+{
 	avail_subject *temp_subject;
 
 	if(hn == NULL)
@@ -2611,28 +2606,30 @@ avail_subject *find_subject(int type, char *hn, char *sd) {
 		if(type == SERVICE_SUBJECT && strcmp(sd, temp_subject->service_description))
 			continue;
 		return temp_subject;
-		}
+	}
 
 	return NULL;
-	}
+}
 
 
 
 /* adds an archived state entry to all subjects */
-void add_global_archived_state(int entry_type, int state_type, time_t time_stamp, const char *state_info) {
+void add_global_archived_state(int entry_type, int state_type, time_t time_stamp, const char *state_info)
+{
 	avail_subject *temp_subject;
 
 	for(temp_subject = subject_list; temp_subject != NULL; temp_subject = temp_subject->next)
 		add_archived_state(entry_type, state_type, time_stamp, state_info, temp_subject);
 
 	return;
-	}
+}
 
 
 
 
 /* adds an archived state entry to a specific subject */
-void add_archived_state(int entry_type, int state_type, time_t time_stamp, const char *state_info, avail_subject *subject) {
+void add_archived_state(int entry_type, int state_type, time_t time_stamp, const char *state_info, avail_subject *subject)
+{
 	archived_state *last_as = NULL;
 	archived_state *temp_as = NULL;
 	archived_state *new_as = NULL;
@@ -2647,8 +2644,7 @@ void add_archived_state(int entry_type, int state_type, time_t time_stamp, const
 		new_as->state_info = (char *)malloc(strlen(state_info) + 1);
 		if(new_as->state_info != NULL)
 			strcpy(new_as->state_info, state_info);
-		}
-	else new_as->state_info = NULL;
+	} else new_as->state_info = NULL;
 
 	/* initialize the "processed state" value - this gets modified later for most entries */
 	if(entry_type != AS_PROGRAM_START && entry_type != AS_PROGRAM_END && entry_type != AS_NO_DATA)
@@ -2671,28 +2667,27 @@ void add_archived_state(int entry_type, int state_type, time_t time_stamp, const
 			else
 				last_as->next = new_as;
 			break;
-			}
-		else
+		} else
 			last_as = temp_as;
-		}
+	}
 	if(subject->as_list == NULL) {
 		new_as->next = NULL;
 		subject->as_list = new_as;
-		}
-	else if(temp_as == NULL) {
+	} else if(temp_as == NULL) {
 		new_as->next = NULL;
 		last_as->next = new_as;
-		}
+	}
 
 	/* update "tail" of the list - not really the tail, just last item added */
 	subject->as_list_tail = new_as;
 
 	return;
-	}
+}
 
 
 /* adds a scheduled downtime entry to a specific subject */
-void add_scheduled_downtime(int state_type, time_t time_stamp, avail_subject *subject) {
+void add_scheduled_downtime(int state_type, time_t time_stamp, avail_subject *subject)
+{
 	archived_state *last_sd = NULL;
 	archived_state *temp_sd = NULL;
 	archived_state *new_sd = NULL;
@@ -2718,25 +2713,24 @@ void add_scheduled_downtime(int state_type, time_t time_stamp, avail_subject *su
 			else
 				last_sd->next = new_sd;
 			break;
-			}
-		else
+		} else
 			last_sd = temp_sd;
-		}
+	}
 	if(subject->sd_list == NULL) {
 		new_sd->next = NULL;
 		subject->sd_list = new_sd;
-		}
-	else if(temp_sd == NULL) {
+	} else if(temp_sd == NULL) {
 		new_sd->next = NULL;
 		last_sd->next = new_sd;
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* frees memory allocated to all availability data */
-void free_availability_data(void) {
+void free_availability_data(void)
+{
 	avail_subject *this_subject;
 	avail_subject *next_subject;
 
@@ -2750,13 +2744,14 @@ void free_availability_data(void) {
 		free_archived_state_list(this_subject->sd_list);
 		free(this_subject);
 		this_subject = next_subject;
-		}
-
-	return;
 	}
 
+	return;
+}
+
 /* frees memory allocated to the archived state list */
-void free_archived_state_list(archived_state *as_list) {
+void free_archived_state_list(archived_state *as_list)
+{
 	archived_state *this_as = NULL;
 	archived_state *next_as = NULL;
 
@@ -2766,17 +2761,18 @@ void free_archived_state_list(archived_state *as_list) {
 			free(this_as->state_info);
 		free(this_as);
 		this_as = next_as;
-		}
+	}
 
 	as_list = NULL;
 
 	return;
-	}
+}
 
 
 
 /* reads log files for archived state data */
-void read_archived_state_data(void) {
+void read_archived_state_data(void)
+{
 	char filename[MAX_FILENAME_LENGTH];
 	int oldest_archive = 0;
 	int newest_archive = 0;
@@ -2809,15 +2805,16 @@ void read_archived_state_data(void) {
 
 		/* scan the log file for archived state data */
 		scan_log_file_for_archived_state_data(filename);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* grabs archives state data from a log file */
-void scan_log_file_for_archived_state_data(char *filename) {
+void scan_log_file_for_archived_state_data(char *filename)
+{
 	char *input = NULL;
 	char *input2 = NULL;
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -2885,7 +2882,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					if(include_soft_states == FALSE)
 						continue;
 					state_type = AS_SOFT_STATE;
-					}
+				}
 				if(strstr(input, ";HARD;"))
 					state_type = AS_HARD_STATE;
 
@@ -2903,7 +2900,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					add_archived_state(AS_HOST_UP, state_type, time_stamp, plugin_output, temp_subject);
 				else
 					add_archived_state(AS_NO_DATA, AS_NO_DATA, time_stamp, plugin_output, temp_subject);
-				}
+			}
 
 			/* scheduled downtime notices */
 			else if(strstr(input, "HOST DOWNTIME ALERT:")) {
@@ -2927,8 +2924,8 @@ void scan_log_file_for_archived_state_data(char *filename) {
 				else
 					add_scheduled_downtime(AS_HOST_DOWNTIME_END, time_stamp, temp_subject);
 
-				}
 			}
+		}
 
 		if(display_type == DISPLAY_SERVICE_AVAIL || display_type == DISPLAY_HOST_AVAIL || display_type == DISPLAY_SERVICEGROUP_AVAIL) {
 
@@ -2956,7 +2953,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					if(include_soft_states == FALSE)
 						continue;
 					state_type = AS_SOFT_STATE;
-					}
+				}
 				if(strstr(input, ";HARD;"))
 					state_type = AS_HARD_STATE;
 
@@ -2977,7 +2974,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 				else
 					add_archived_state(AS_NO_DATA, AS_NO_DATA, time_stamp, plugin_output, temp_subject);
 
-				}
+			}
 
 			/* scheduled service downtime notices */
 			else if(strstr(input, "SERVICE DOWNTIME ALERT:")) {
@@ -3005,7 +3002,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					add_scheduled_downtime(AS_SVC_DOWNTIME_START, time_stamp, temp_subject);
 				else
 					add_scheduled_downtime(AS_SVC_DOWNTIME_END, time_stamp, temp_subject);
-				}
+			}
 
 			/* scheduled host downtime notices */
 			else if(strstr(input, "HOST DOWNTIME ALERT:")) {
@@ -3032,11 +3029,11 @@ void scan_log_file_for_archived_state_data(char *filename) {
 						add_scheduled_downtime(AS_HOST_DOWNTIME_START, time_stamp, temp_subject);
 					else
 						add_scheduled_downtime(AS_HOST_DOWNTIME_END, time_stamp, temp_subject);
-					}
 				}
 			}
-
 		}
+
+	}
 
 	/* free memory and close the file */
 	free(input);
@@ -3044,12 +3041,13 @@ void scan_log_file_for_archived_state_data(char *filename) {
 	mmap_fclose(thefile);
 
 	return;
-	}
+}
 
 
 
 
-void convert_timeperiod_to_times(int type) {
+void convert_timeperiod_to_times(int type)
+{
 	time_t current_time;
 	struct tm *t;
 
@@ -3064,79 +3062,79 @@ void convert_timeperiod_to_times(int type) {
 	t->tm_isdst = -1;
 
 	switch(type) {
-		case TIMEPERIOD_LAST24HOURS:
-			t1 = current_time - (60 * 60 * 24);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_TODAY:
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_YESTERDAY:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24));
-			t2 = (time_t)mktime(t);
-			break;
-		case TIMEPERIOD_THISWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
-			t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			break;
-		case TIMEPERIOD_THISMONTH:
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTMONTH:
-			t->tm_mday = 1;
-			t2 = mktime(t);
-			if(t->tm_mon == 0) {
-				t->tm_mon = 11;
-				t->tm_year--;
-				}
-			else
-				t->tm_mon--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_THISQUARTER:
-			/* not implemented */
-			break;
-		case TIMEPERIOD_LASTQUARTER:
-			/* not implemented */
-			break;
-		case TIMEPERIOD_THISYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t2 = mktime(t);
+	case TIMEPERIOD_LAST24HOURS:
+		t1 = current_time - (60 * 60 * 24);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_TODAY:
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_YESTERDAY:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24));
+		t2 = (time_t)mktime(t);
+		break;
+	case TIMEPERIOD_THISWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
+		t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		break;
+	case TIMEPERIOD_THISMONTH:
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTMONTH:
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		if(t->tm_mon == 0) {
+			t->tm_mon = 11;
 			t->tm_year--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_LAST7DAYS:
-			t2 = current_time;
-			t1 = current_time - (7 * 24 * 60 * 60);
-			break;
-		case TIMEPERIOD_LAST31DAYS:
-			t2 = current_time;
-			t1 = current_time - (31 * 24 * 60 * 60);
-			break;
-		default:
-			break;
-		}
-
-	return;
+		} else
+			t->tm_mon--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_THISQUARTER:
+		/* not implemented */
+		break;
+	case TIMEPERIOD_LASTQUARTER:
+		/* not implemented */
+		break;
+	case TIMEPERIOD_THISYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		t->tm_year--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_LAST7DAYS:
+		t2 = current_time;
+		t1 = current_time - (7 * 24 * 60 * 60);
+		break;
+	case TIMEPERIOD_LAST31DAYS:
+		t2 = current_time;
+		t1 = current_time - (31 * 24 * 60 * 60);
+		break;
+	default:
+		break;
 	}
 
+	return;
+}
 
 
-void compute_report_times(void) {
+
+void compute_report_times(void)
+{
 	time_t current_time;
 	struct tm *st;
 	struct tm *et;
@@ -3167,11 +3165,12 @@ void compute_report_times(void) {
 	et->tm_isdst = -1;
 
 	t2 = mktime(et);
-	}
+}
 
 
 /* writes log entries to screen */
-void write_log_entries(avail_subject *subject) {
+void write_log_entries(avail_subject *subject)
+{
 	archived_state *temp_as;
 	archived_state *temp_sd;
 	time_t current_time;
@@ -3203,20 +3202,20 @@ void write_log_entries(avail_subject *subject) {
 	/* inject all scheduled downtime entries into the main list for display purposes */
 	for(temp_sd = subject->sd_list; temp_sd != NULL; temp_sd = temp_sd->next) {
 		switch(temp_sd->entry_type) {
-			case AS_SVC_DOWNTIME_START:
-			case AS_HOST_DOWNTIME_START:
-				entry_type = "Start of scheduled downtime";
-				break;
-			case AS_SVC_DOWNTIME_END:
-			case AS_HOST_DOWNTIME_END:
-				entry_type = "End of scheduled downtime";
-				break;
-			default:
-				entry_type = "?";
-				break;
-			}
-		add_archived_state(temp_sd->entry_type, AS_NO_DATA, temp_sd->time_stamp, entry_type, subject);
+		case AS_SVC_DOWNTIME_START:
+		case AS_HOST_DOWNTIME_START:
+			entry_type = "Start of scheduled downtime";
+			break;
+		case AS_SVC_DOWNTIME_END:
+		case AS_HOST_DOWNTIME_END:
+			entry_type = "End of scheduled downtime";
+			break;
+		default:
+			entry_type = "?";
+			break;
 		}
+		add_archived_state(temp_sd->entry_type, AS_NO_DATA, temp_sd->time_stamp, entry_type, subject);
+	}
 
 
 	printf("<BR><BR>\n");
@@ -3231,15 +3230,14 @@ void write_log_entries(avail_subject *subject) {
 		else
 			service_report_url(subject->host_name, subject->service_description, "[ View condensed log entries ]");
 		full_log_entries = TRUE;
-		}
-	else {
+	} else {
 		full_log_entries = TRUE;
 		if(subject->type == HOST_SUBJECT)
 			host_report_url(subject->host_name, "[ View full log entries ]");
 		else
 			service_report_url(subject->host_name, subject->service_description, "[ View full log entries ]");
 		full_log_entries = FALSE;
-		}
+	}
 	printf("</DIV>\n");
 
 	printf("<DIV ALIGN=CENTER>\n");
@@ -3258,95 +3256,93 @@ void write_log_entries(avail_subject *subject) {
 			state_type = "";
 
 		switch(temp_as->entry_type) {
-			case AS_NO_DATA:
-				if(full_log_entries == FALSE)
-					continue;
-				entry_type = "NO DATA";
-				ebgclass = "INDETERMINATE";
-				break;
-			case AS_PROGRAM_END:
-				if(full_log_entries == FALSE)
-					continue;
-				entry_type = "PROGRAM END";
-				ebgclass = "INDETERMINATE";
-				break;
-			case AS_PROGRAM_START:
-				if(full_log_entries == FALSE)
-					continue;
-				entry_type = "PROGRAM (RE)START";
-				ebgclass = "INDETERMINATE";
-				break;
-			case AS_HOST_UP:
-				entry_type = "HOST UP";
-				ebgclass = "UP";
-				break;
-			case AS_HOST_DOWN:
-				entry_type = "HOST DOWN";
-				ebgclass = "DOWN";
-				break;
-			case AS_HOST_UNREACHABLE:
-				entry_type = "HOST UNREACHABLE";
-				ebgclass = "UNREACHABLE";
-				break;
-			case AS_SVC_OK:
-				entry_type = "SERVICE OK";
-				ebgclass = "OK";
-				break;
-			case AS_SVC_UNKNOWN:
-				entry_type = "SERVICE UNKNOWN";
-				ebgclass = "UNKNOWN";
-				break;
-			case AS_SVC_WARNING:
-				entry_type = "SERVICE WARNING";
-				ebgclass = "WARNING";
-				break;
-			case AS_SVC_CRITICAL:
-				entry_type = "SERVICE CRITICAL";
-				ebgclass = "CRITICAL";
-				break;
-			case AS_SVC_DOWNTIME_START:
-				entry_type = "SERVICE DOWNTIME START";
-				ebgclass = "INDETERMINATE";
-				break;
-			case AS_SVC_DOWNTIME_END:
-				entry_type = "SERVICE DOWNTIME END";
-				ebgclass = "INDETERMINATE";
-				break;
-			case AS_HOST_DOWNTIME_START:
-				entry_type = "HOST DOWNTIME START";
-				ebgclass = "INDETERMINATE";
-				break;
-			case AS_HOST_DOWNTIME_END:
-				entry_type = "HOST DOWNTIME END";
-				ebgclass = "INDETERMINATE";
-				break;
-			default:
-				if(full_log_entries == FALSE)
-					continue;
-				entry_type = "?";
-				ebgclass = "INDETERMINATE";
-			}
+		case AS_NO_DATA:
+			if(full_log_entries == FALSE)
+				continue;
+			entry_type = "NO DATA";
+			ebgclass = "INDETERMINATE";
+			break;
+		case AS_PROGRAM_END:
+			if(full_log_entries == FALSE)
+				continue;
+			entry_type = "PROGRAM END";
+			ebgclass = "INDETERMINATE";
+			break;
+		case AS_PROGRAM_START:
+			if(full_log_entries == FALSE)
+				continue;
+			entry_type = "PROGRAM (RE)START";
+			ebgclass = "INDETERMINATE";
+			break;
+		case AS_HOST_UP:
+			entry_type = "HOST UP";
+			ebgclass = "UP";
+			break;
+		case AS_HOST_DOWN:
+			entry_type = "HOST DOWN";
+			ebgclass = "DOWN";
+			break;
+		case AS_HOST_UNREACHABLE:
+			entry_type = "HOST UNREACHABLE";
+			ebgclass = "UNREACHABLE";
+			break;
+		case AS_SVC_OK:
+			entry_type = "SERVICE OK";
+			ebgclass = "OK";
+			break;
+		case AS_SVC_UNKNOWN:
+			entry_type = "SERVICE UNKNOWN";
+			ebgclass = "UNKNOWN";
+			break;
+		case AS_SVC_WARNING:
+			entry_type = "SERVICE WARNING";
+			ebgclass = "WARNING";
+			break;
+		case AS_SVC_CRITICAL:
+			entry_type = "SERVICE CRITICAL";
+			ebgclass = "CRITICAL";
+			break;
+		case AS_SVC_DOWNTIME_START:
+			entry_type = "SERVICE DOWNTIME START";
+			ebgclass = "INDETERMINATE";
+			break;
+		case AS_SVC_DOWNTIME_END:
+			entry_type = "SERVICE DOWNTIME END";
+			ebgclass = "INDETERMINATE";
+			break;
+		case AS_HOST_DOWNTIME_START:
+			entry_type = "HOST DOWNTIME START";
+			ebgclass = "INDETERMINATE";
+			break;
+		case AS_HOST_DOWNTIME_END:
+			entry_type = "HOST DOWNTIME END";
+			ebgclass = "INDETERMINATE";
+			break;
+		default:
+			if(full_log_entries == FALSE)
+				continue;
+			entry_type = "?";
+			ebgclass = "INDETERMINATE";
+		}
 
 		get_time_string(&(temp_as->time_stamp), start_date_time, sizeof(start_date_time) - 1, SHORT_DATE_TIME);
 		if(temp_as->next == NULL) {
 			get_time_string(&t2, end_date_time, sizeof(end_date_time) - 1, SHORT_DATE_TIME);
 			get_time_breakdown((time_t)(t2 - temp_as->time_stamp), &days, &hours, &minutes, &seconds);
 			snprintf(duration, sizeof(duration) - 1, "%dd %dh %dm %ds+", days, hours, minutes, seconds);
-			}
-		else {
+		} else {
 			get_time_string(&(temp_as->next->time_stamp), end_date_time, sizeof(end_date_time) - 1, SHORT_DATE_TIME);
 			get_time_breakdown((time_t)(temp_as->next->time_stamp - temp_as->time_stamp), &days, &hours, &minutes, &seconds);
 			snprintf(duration, sizeof(duration) - 1, "%dd %dh %dm %ds", days, hours, minutes, seconds);
-			}
+		}
 
 		if(odd) {
 			bgclass = "Odd";
 			odd = 0;
-			}
-		else {
+		} else {
 			bgclass = "Even";
 			odd = 1;
-			}
+		}
 
 		printf("<tr class='logEntries%s'>", bgclass);
 		printf("<td class='logEntries%s'>%s</td>", bgclass, start_date_time);
@@ -3355,40 +3351,42 @@ void write_log_entries(avail_subject *subject) {
 		printf("<td class='logEntries%s'>%s%s</td>", ebgclass, entry_type, state_type);
 		printf("<td class='logEntries%s'>%s</td>", bgclass, (temp_as->state_info == NULL) ? "" : html_encode(temp_as->state_info, FALSE));
 		printf("</tr>\n");
-		}
+	}
 
 	printf("</table>\n");
 
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 
 /* display hostgroup availability */
-void display_hostgroup_availability(void) {
+void display_hostgroup_availability(void)
+{
 	hostgroup *temp_hostgroup;
 
 	/* display data for a specific hostgroup */
 	if(show_all_hostgroups == FALSE) {
 		temp_hostgroup = find_hostgroup(hostgroup_name);
 		display_specific_hostgroup_availability(temp_hostgroup);
-		}
+	}
 
 	/* display data for all hostgroups */
 	else {
 		for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next)
 			display_specific_hostgroup_availability(temp_hostgroup);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* display availability for a specific hostgroup */
-void display_specific_hostgroup_availability(hostgroup *hg) {
+void display_specific_hostgroup_availability(hostgroup *hg)
+{
 	unsigned long total_time;
 	unsigned long time_determinate;
 	unsigned long time_indeterminate;
@@ -3467,17 +3465,16 @@ void display_specific_hostgroup_availability(hostgroup *hg) {
 				percent_time_up_known = (double)(((double)temp_subject->time_up * 100.0) / (double)time_determinate);
 				percent_time_down_known = (double)(((double)temp_subject->time_down * 100.0) / (double)time_determinate);
 				percent_time_unreachable_known = (double)(((double)temp_subject->time_unreachable * 100.0) / (double)time_determinate);
-				}
 			}
+		}
 
 		if(odd) {
 			odd = 0;
 			bgclass = "Odd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Even";
-			}
+		}
 
 		printf("<tr CLASS='data%s'><td CLASS='data%s'>", bgclass, bgclass);
 		host_report_url(temp_subject->host_name, temp_subject->host_name);
@@ -3490,49 +3487,50 @@ void display_specific_hostgroup_availability(hostgroup *hg) {
 		get_running_average(&average_percent_time_unreachable, percent_time_unreachable, current_subject);
 		get_running_average(&average_percent_time_unreachable_known, percent_time_unreachable_known, current_subject);
 		get_running_average(&average_percent_time_indeterminate, percent_time_indeterminate, current_subject);
-		}
+	}
 
 	/* average statistics */
 	if(odd) {
 		odd = 0;
 		bgclass = "Odd";
-		}
-	else {
+	} else {
 		odd = 1;
 		bgclass = "Even";
-		}
+	}
 	printf("<tr CLASS='data%s'><td CLASS='data%s'>Average</td><td CLASS='hostUP'>%2.3f%% (%2.3f%%)</td><td CLASS='hostDOWN'>%2.3f%% (%2.3f%%)</td><td CLASS='hostUNREACHABLE'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>", bgclass, bgclass, average_percent_time_up, average_percent_time_up_known, average_percent_time_down, average_percent_time_down_known, average_percent_time_unreachable, average_percent_time_unreachable_known, bgclass, average_percent_time_indeterminate);
 
 	printf("</table>\n");
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 /* display servicegroup availability */
-void display_servicegroup_availability(void) {
+void display_servicegroup_availability(void)
+{
 	servicegroup *temp_servicegroup;
 
 	/* display data for a specific servicegroup */
 	if(show_all_servicegroups == FALSE) {
 		temp_servicegroup = find_servicegroup(servicegroup_name);
 		display_specific_servicegroup_availability(temp_servicegroup);
-		}
+	}
 
 	/* display data for all servicegroups */
 	else {
 		for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next)
 			display_specific_servicegroup_availability(temp_servicegroup);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* display availability for a specific servicegroup */
-void display_specific_servicegroup_availability(servicegroup *sg) {
+void display_specific_servicegroup_availability(servicegroup *sg)
+{
 	unsigned long total_time;
 	unsigned long time_determinate;
 	unsigned long time_indeterminate;
@@ -3629,17 +3627,16 @@ void display_specific_servicegroup_availability(servicegroup *sg) {
 				percent_time_up_known = (double)(((double)temp_subject->time_up * 100.0) / (double)time_determinate);
 				percent_time_down_known = (double)(((double)temp_subject->time_down * 100.0) / (double)time_determinate);
 				percent_time_unreachable_known = (double)(((double)temp_subject->time_unreachable * 100.0) / (double)time_determinate);
-				}
 			}
+		}
 
 		if(odd) {
 			odd = 0;
 			bgclass = "Odd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Even";
-			}
+		}
 
 		printf("<tr CLASS='data%s'><td CLASS='data%s'>", bgclass, bgclass);
 		host_report_url(temp_subject->host_name, temp_subject->host_name);
@@ -3652,17 +3649,16 @@ void display_specific_servicegroup_availability(servicegroup *sg) {
 		get_running_average(&average_percent_time_unreachable, percent_time_unreachable, current_subject);
 		get_running_average(&average_percent_time_unreachable_known, percent_time_unreachable_known, current_subject);
 		get_running_average(&average_percent_time_indeterminate, percent_time_indeterminate, current_subject);
-		}
+	}
 
 	/* average statistics */
 	if(odd) {
 		odd = 0;
 		bgclass = "Odd";
-		}
-	else {
+	} else {
 		odd = 1;
 		bgclass = "Even";
-		}
+	}
 	printf("<tr CLASS='data%s'><td CLASS='data%s'>Average</td><td CLASS='hostUP'>%2.3f%% (%2.3f%%)</td><td CLASS='hostDOWN'>%2.3f%% (%2.3f%%)</td><td CLASS='hostUNREACHABLE'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>", bgclass, bgclass, average_percent_time_up, average_percent_time_up_known, average_percent_time_down, average_percent_time_down_known, average_percent_time_unreachable, average_percent_time_unreachable_known, bgclass, average_percent_time_indeterminate);
 
 	printf("</table>\n");
@@ -3720,17 +3716,16 @@ void display_specific_servicegroup_availability(servicegroup *sg) {
 				percent_time_warning_known = (double)(((double)temp_subject->time_warning * 100.0) / (double)time_determinate);
 				percent_time_unknown_known = (double)(((double)temp_subject->time_unknown * 100.0) / (double)time_determinate);
 				percent_time_critical_known = (double)(((double)temp_subject->time_critical * 100.0) / (double)time_determinate);
-				}
 			}
+		}
 
 		if(odd) {
 			odd = 0;
 			bgclass = "Odd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Even";
-			}
+		}
 
 		printf("<tr CLASS='data%s'><td CLASS='data%s'>", bgclass, bgclass);
 		if(strcmp(temp_subject->host_name, last_host))
@@ -3751,17 +3746,16 @@ void display_specific_servicegroup_availability(servicegroup *sg) {
 		get_running_average(&average_percent_time_critical, percent_time_critical, current_subject);
 		get_running_average(&average_percent_time_critical_known, percent_time_critical_known, current_subject);
 		get_running_average(&average_percent_time_indeterminate, percent_time_indeterminate, current_subject);
-		}
+	}
 
 	/* display average stats */
 	if(odd) {
 		odd = 0;
 		bgclass = "Odd";
-		}
-	else {
+	} else {
 		odd = 1;
 		bgclass = "Even";
-		}
+	}
 
 	printf("<tr CLASS='data%s'><td CLASS='data%s' colspan='2'>Average</td><td CLASS='serviceOK'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceWARNING'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceUNKNOWN'>%2.3f%% (%2.3f%%)</td><td class='serviceCRITICAL'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>\n", bgclass, bgclass, average_percent_time_ok, average_percent_time_ok_known, average_percent_time_warning, average_percent_time_warning_known, average_percent_time_unknown, average_percent_time_unknown_known, average_percent_time_critical, average_percent_time_critical_known, bgclass, average_percent_time_indeterminate);
 
@@ -3769,11 +3763,12 @@ void display_specific_servicegroup_availability(servicegroup *sg) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 /* display host availability */
-void display_host_availability(void) {
+void display_host_availability(void)
+{
 	unsigned long total_time;
 	unsigned long time_determinate;
 	unsigned long time_indeterminate;
@@ -3944,8 +3939,8 @@ void display_host_availability(void) {
 				percent_time_unreachable_known = (double)(((double)temp_subject->time_unreachable * 100.0) / (double)time_determinate);
 				percent_time_unreachable_scheduled_known = (double)(((double)temp_subject->scheduled_time_unreachable * 100.0) / (double)time_determinate);
 				percent_time_unreachable_unscheduled_known = percent_time_unreachable_known - percent_time_unreachable_scheduled_known;
-				}
 			}
+		}
 
 		printf("<DIV ALIGN=CENTER CLASS='dataTitle'>Host State Breakdowns:</DIV>\n");
 
@@ -4021,11 +4016,10 @@ void display_host_availability(void) {
 			if(odd) {
 				odd = 0;
 				bgclass = "Odd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bgclass = "Even";
-				}
+			}
 
 			/* reset variables */
 			percent_time_ok = 0.0;
@@ -4052,8 +4046,8 @@ void display_host_availability(void) {
 					percent_time_warning_known = (double)(((double)temp_subject->time_warning * 100.0) / (double)time_determinate);
 					percent_time_unknown_known = (double)(((double)temp_subject->time_unknown * 100.0) / (double)time_determinate);
 					percent_time_critical_known = (double)(((double)temp_subject->time_critical * 100.0) / (double)time_determinate);
-					}
 				}
+			}
 
 			printf("<tr CLASS='data%s'><td CLASS='data%s'>", bgclass, bgclass);
 			service_report_url(temp_subject->host_name, temp_subject->service_description, temp_subject->service_description);
@@ -4068,17 +4062,16 @@ void display_host_availability(void) {
 			get_running_average(&average_percent_time_critical, percent_time_critical, current_subject);
 			get_running_average(&average_percent_time_critical_known, percent_time_critical_known, current_subject);
 			get_running_average(&average_percent_time_indeterminate, percent_time_indeterminate, current_subject);
-			}
+		}
 
 		/* display average stats */
 		if(odd) {
 			odd = 0;
 			bgclass = "Odd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Even";
-			}
+		}
 
 		printf("<tr CLASS='data%s'><td CLASS='data%s'>Average</td><td CLASS='serviceOK'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceWARNING'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceUNKNOWN'>%2.3f%% (%2.3f%%)</td><td class='serviceCRITICAL'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>\n", bgclass, bgclass, average_percent_time_ok, average_percent_time_ok_known, average_percent_time_warning, average_percent_time_warning_known, average_percent_time_unknown, average_percent_time_unknown_known, average_percent_time_critical, average_percent_time_critical_known, bgclass, average_percent_time_indeterminate);
 
@@ -4089,7 +4082,7 @@ void display_host_availability(void) {
 		/* write log entries for the host */
 		temp_subject = find_subject(HOST_SUBJECT, host_name, NULL);
 		write_log_entries(temp_subject);
-		}
+	}
 
 
 	/* display data for all hosts */
@@ -4103,7 +4096,7 @@ void display_host_availability(void) {
 			printf("<DIV ALIGN=CENTER>\n");
 			printf("<TABLE BORDER=0 CLASS='data'>\n");
 			printf("<TR><TH CLASS='data'>Host</TH><TH CLASS='data'>%% Time Up</TH><TH CLASS='data'>%% Time Down</TH><TH CLASS='data'>%% Time Unreachable</TH><TH CLASS='data'>%% Time Undetermined</TH></TR>\n");
-			}
+		}
 
 		else if(output_format == CSV_OUTPUT) {
 			printf("HOST_NAME,");
@@ -4115,7 +4108,7 @@ void display_host_availability(void) {
 			printf(" TIME_UNREACHABLE_SCHEDULED, PERCENT_TIME_UNREACHABLE_SCHEDULED, PERCENT_KNOWN_TIME_UNREACHABLE_SCHEDULED, TIME_UNREACHABLE_UNSCHEDULED, PERCENT_TIME_UNREACHABLE_UNSCHEDULED, PERCENT_KNOWN_TIME_UNREACHABLE_UNSCHEDULED, TOTAL_TIME_UNREACHABLE, PERCENT_TOTAL_TIME_UNREACHABLE, PERCENT_KNOWN_TIME_UNREACHABLE,");
 
 			printf(" TIME_UNDETERMINED_NOT_RUNNING, PERCENT_TIME_UNDETERMINED_NOT_RUNNING, TIME_UNDETERMINED_NO_DATA, PERCENT_TIME_UNDETERMINED_NO_DATA, TOTAL_TIME_UNDETERMINED, PERCENT_TOTAL_TIME_UNDETERMINED\n");
-			}
+		}
 
 
 		for(temp_subject = subject_list; temp_subject != NULL; temp_subject = temp_subject->next) {
@@ -4185,25 +4178,23 @@ void display_host_availability(void) {
 					percent_time_unreachable_known = (double)(((double)temp_subject->time_unreachable * 100.0) / (double)time_determinate);
 					percent_time_unreachable_scheduled_known = (double)(((double)temp_subject->scheduled_time_unreachable * 100.0) / (double)time_determinate);
 					percent_time_unreachable_unscheduled_known = percent_time_unreachable_known - percent_time_unreachable_scheduled_known;
-					}
 				}
+			}
 
 			if(output_format == HTML_OUTPUT) {
 
 				if(odd) {
 					odd = 0;
 					bgclass = "Odd";
-					}
-				else {
+				} else {
 					odd = 1;
 					bgclass = "Even";
-					}
+				}
 
 				printf("<tr CLASS='data%s'><td CLASS='data%s'>", bgclass, bgclass);
 				host_report_url(temp_subject->host_name, temp_subject->host_name);
 				printf("</td><td CLASS='hostUP'>%2.3f%% (%2.3f%%)</td><td CLASS='hostDOWN'>%2.3f%% (%2.3f%%)</td><td CLASS='hostUNREACHABLE'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>\n", percent_time_up, percent_time_up_known, percent_time_down, percent_time_down_known, percent_time_unreachable, percent_time_unreachable_known, bgclass, percent_time_indeterminate);
-				}
-			else if(output_format == CSV_OUTPUT) {
+			} else if(output_format == CSV_OUTPUT) {
 
 				/* host name */
 				printf("\"%s\",", temp_subject->host_name);
@@ -4219,7 +4210,7 @@ void display_host_availability(void) {
 
 				/* indeterminate times */
 				printf(" %lu, %2.3f%%, %lu, %2.3f%%, %lu, %2.3f%%\n", temp_subject->time_indeterminate_notrunning, percent_time_indeterminate_notrunning, temp_subject->time_indeterminate_nodata, percent_time_indeterminate_nodata, time_indeterminate, percent_time_indeterminate);
-				}
+			}
 
 			get_running_average(&average_percent_time_up, percent_time_up, current_subject);
 			get_running_average(&average_percent_time_up_known, percent_time_up_known, current_subject);
@@ -4228,7 +4219,7 @@ void display_host_availability(void) {
 			get_running_average(&average_percent_time_unreachable, percent_time_unreachable, current_subject);
 			get_running_average(&average_percent_time_unreachable_known, percent_time_unreachable_known, current_subject);
 			get_running_average(&average_percent_time_indeterminate, percent_time_indeterminate, current_subject);
-			}
+		}
 
 		if(output_format == HTML_OUTPUT) {
 
@@ -4236,24 +4227,24 @@ void display_host_availability(void) {
 			if(odd) {
 				odd = 0;
 				bgclass = "Odd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bgclass = "Even";
-				}
+			}
 			printf("<tr CLASS='data%s'><td CLASS='data%s'>Average</td><td CLASS='hostUP'>%2.3f%% (%2.3f%%)</td><td CLASS='hostDOWN'>%2.3f%% (%2.3f%%)</td><td CLASS='hostUNREACHABLE'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>", bgclass, bgclass, average_percent_time_up, average_percent_time_up_known, average_percent_time_down, average_percent_time_down_known, average_percent_time_unreachable, average_percent_time_unreachable_known, bgclass, average_percent_time_indeterminate);
 
 			printf("</table>\n");
 			printf("</DIV>\n");
-			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 /* display service availability */
-void display_service_availability(void) {
+void display_service_availability(void)
+{
 	unsigned long total_time;
 	unsigned long time_determinate;
 	unsigned long time_indeterminate;
@@ -4429,8 +4420,8 @@ void display_service_availability(void) {
 				percent_time_critical_known = (double)(((double)temp_subject->time_critical * 100.0) / (double)time_determinate);
 				percent_time_critical_scheduled_known = (double)(((double)temp_subject->scheduled_time_critical * 100.0) / (double)time_determinate);
 				percent_time_critical_unscheduled_known = percent_time_critical_known - percent_time_critical_scheduled_known;
-				}
 			}
+		}
 
 		printf("<DIV ALIGN=CENTER CLASS='dataTitle'>Service State Breakdowns:</DIV>\n");
 #ifdef USE_TRENDS
@@ -4485,7 +4476,7 @@ void display_service_availability(void) {
 
 
 		write_log_entries(temp_subject);
-		}
+	}
 
 
 	/* display data for all services */
@@ -4498,8 +4489,7 @@ void display_service_availability(void) {
 			printf("<DIV ALIGN=CENTER>\n");
 			printf("<TABLE BORDER=0 CLASS='data'>\n");
 			printf("<TR><TH CLASS='data'>Host</TH><TH CLASS='data'>Service</TH><TH CLASS='data'>%% Time OK</TH><TH CLASS='data'>%% Time Warning</TH><TH CLASS='data'>%% Time Unknown</TH><TH CLASS='data'>%% Time Critical</TH><TH CLASS='data'>%% Time Undetermined</TH></TR>\n");
-			}
-		else if(output_format == CSV_OUTPUT) {
+		} else if(output_format == CSV_OUTPUT) {
 			printf("HOST_NAME, SERVICE_DESCRIPTION,");
 
 			printf(" TIME_OK_SCHEDULED, PERCENT_TIME_OK_SCHEDULED, PERCENT_KNOWN_TIME_OK_SCHEDULED, TIME_OK_UNSCHEDULED, PERCENT_TIME_OK_UNSCHEDULED, PERCENT_KNOWN_TIME_OK_UNSCHEDULED, TOTAL_TIME_OK, PERCENT_TOTAL_TIME_OK, PERCENT_KNOWN_TIME_OK,");
@@ -4511,7 +4501,7 @@ void display_service_availability(void) {
 			printf(" TIME_CRITICAL_SCHEDULED, PERCENT_TIME_CRITICAL_SCHEDULED, PERCENT_KNOWN_TIME_CRITICAL_SCHEDULED, TIME_CRITICAL_UNSCHEDULED, PERCENT_TIME_CRITICAL_UNSCHEDULED, PERCENT_KNOWN_TIME_CRITICAL_UNSCHEDULED, TOTAL_TIME_CRITICAL, PERCENT_TOTAL_TIME_CRITICAL, PERCENT_KNOWN_TIME_CRITICAL,");
 
 			printf(" TIME_UNDETERMINED_NOT_RUNNING, PERCENT_TIME_UNDETERMINED_NOT_RUNNING, TIME_UNDETERMINED_NO_DATA, PERCENT_TIME_UNDETERMINED_NO_DATA, TOTAL_TIME_UNDETERMINED, PERCENT_TOTAL_TIME_UNDETERMINED\n");
-			}
+		}
 
 
 		for(temp_subject = subject_list; temp_subject != NULL; temp_subject = temp_subject->next) {
@@ -4593,19 +4583,18 @@ void display_service_availability(void) {
 					percent_time_critical_known = (double)(((double)temp_subject->time_critical * 100.0) / (double)time_determinate);
 					percent_time_critical_scheduled_known = (double)(((double)temp_subject->scheduled_time_critical * 100.0) / (double)time_determinate);
 					percent_time_critical_unscheduled_known = percent_time_critical_known - percent_time_critical_scheduled_known;
-					}
 				}
+			}
 
 			if(output_format == HTML_OUTPUT) {
 
 				if(odd) {
 					odd = 0;
 					bgclass = "Odd";
-					}
-				else {
+				} else {
 					odd = 1;
 					bgclass = "Even";
-					}
+				}
 
 				printf("<tr CLASS='data%s'><td CLASS='data%s'>", bgclass, bgclass);
 				if(strcmp(temp_subject->host_name, last_host))
@@ -4613,8 +4602,7 @@ void display_service_availability(void) {
 				printf("</td><td CLASS='data%s'>", bgclass);
 				service_report_url(temp_subject->host_name, temp_subject->service_description, temp_subject->service_description);
 				printf("</td><td CLASS='serviceOK'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceWARNING'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceUNKNOWN'>%2.3f%% (%2.3f%%)</td><td class='serviceCRITICAL'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>\n", percent_time_ok, percent_time_ok_known, percent_time_warning, percent_time_warning_known, percent_time_unknown, percent_time_unknown_known, percent_time_critical, percent_time_critical_known, bgclass, percent_time_indeterminate);
-				}
-			else if(output_format == CSV_OUTPUT) {
+			} else if(output_format == CSV_OUTPUT) {
 
 				/* host name and service description */
 				printf("\"%s\", \"%s\",", temp_subject->host_name, temp_subject->service_description);
@@ -4633,7 +4621,7 @@ void display_service_availability(void) {
 
 				/* indeterminate times */
 				printf(" %lu, %2.3f%%, %lu, %2.3f%%, %lu, %2.3f%%\n", temp_subject->time_indeterminate_notrunning, percent_time_indeterminate_notrunning, temp_subject->time_indeterminate_nodata, percent_time_indeterminate_nodata, time_indeterminate, percent_time_indeterminate);
-				}
+			}
 
 			strncpy(last_host, temp_subject->host_name, sizeof(last_host) - 1);
 			last_host[sizeof(last_host) - 1] = '\x0';
@@ -4647,7 +4635,7 @@ void display_service_availability(void) {
 			get_running_average(&average_percent_time_critical, percent_time_critical, current_subject);
 			get_running_average(&average_percent_time_critical_known, percent_time_critical_known, current_subject);
 			get_running_average(&average_percent_time_indeterminate, percent_time_indeterminate, current_subject);
-			}
+		}
 
 		if(output_format == HTML_OUTPUT) {
 
@@ -4655,25 +4643,25 @@ void display_service_availability(void) {
 			if(odd) {
 				odd = 0;
 				bgclass = "Odd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bgclass = "Even";
-				}
+			}
 			printf("<tr CLASS='data%s'><td CLASS='data%s' colspan='2'>Average</td><td CLASS='serviceOK'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceWARNING'>%2.3f%% (%2.3f%%)</td><td CLASS='serviceUNKNOWN'>%2.3f%% (%2.3f%%)</td><td class='serviceCRITICAL'>%2.3f%% (%2.3f%%)</td><td class='data%s'>%2.3f%%</td></tr>\n", bgclass, bgclass, average_percent_time_ok, average_percent_time_ok_known, average_percent_time_warning, average_percent_time_warning_known, average_percent_time_unknown, average_percent_time_unknown_known, average_percent_time_critical, average_percent_time_critical_known, bgclass, average_percent_time_indeterminate);
 
 			printf("</table>\n");
 			printf("</DIV>\n");
-			}
 		}
-
-	return;
 	}
 
+	return;
+}
 
 
 
-void host_report_url(const char *hn, const char *label) {
+
+void host_report_url(const char *hn, const char *label)
+{
 
 	printf("<a href='%s?host=%s", AVAIL_CGI, url_encode(hn));
 	printf("&show_log_entries");
@@ -4694,10 +4682,11 @@ void host_report_url(const char *hn, const char *label) {
 	printf("'>%s</a>", label);
 
 	return;
-	}
+}
 
 
-void service_report_url(const char *hn, const char *sd, const char *label) {
+void service_report_url(const char *hn, const char *sd, const char *label)
+{
 
 	printf("<a href='%s?host=%s", AVAIL_CGI, url_encode(hn));
 	printf("&service=%s", url_encode(sd));
@@ -4718,20 +4707,22 @@ void service_report_url(const char *hn, const char *sd, const char *label) {
 	printf("'>%s</a>", label);
 
 	return;
-	}
+}
 
 
 /* calculates running average */
-void get_running_average(double *running_average, double new_value, int current_item) {
+void get_running_average(double *running_average, double new_value, int current_item)
+{
 
 	*running_average = (((*running_average * ((double)current_item - 1.0)) + new_value) / (double)current_item);
 
 	return;
-	}
+}
 
 
 /* used in reports where a timeperiod is selected */
-unsigned long calculate_total_time(time_t start_time, time_t end_time) {
+unsigned long calculate_total_time(time_t start_time, time_t end_time)
+{
 	struct tm *t;
 	time_t midnight_today;
 	int weekday;
@@ -4774,17 +4765,17 @@ unsigned long calculate_total_time(time_t start_time, time_t end_time) {
 #endif
 				if(end > start)
 					temp_duration += end - start;
-				}
+			}
 			total_time += temp_duration;
 			temp_start = 0;
 			midnight_today += 86400;
 			if(++weekday > 6)
 				weekday = 0;
-			}
+		}
 
 		return total_time;
-		}
+	}
 
 	/* no timeperiod was selected */
 	return end_time - start_time;
-	}
+}

--- a/cgi/cgiauth.c
+++ b/cgi/cgiauth.c
@@ -35,7 +35,8 @@ extern int             use_ssl_authentication;
 
 
 /* get current authentication information */
-int get_authentication_information(authdata *authinfo) {
+int get_authentication_information(authdata *authinfo)
+{
 	mmapfile *thefile;
 	char *input = NULL;
 	char *temp_ptr = NULL;
@@ -59,15 +60,13 @@ int get_authentication_information(authdata *authinfo) {
 	if(use_ssl_authentication) {
 		/* patch by Pawl Zuzelski - 7/22/08 */
 		temp_ptr = getenv("SSL_CLIENT_S_DN_CN");
-		}
-	else {
+	} else {
 		temp_ptr = getenv("REMOTE_USER");
-		}
+	}
 	if(temp_ptr == NULL) {
 		authinfo->username = "";
 		authinfo->authenticated = FALSE;
-		}
-	else {
+	} else {
 		authinfo->username = (char *)malloc(strlen(temp_ptr) + 1);
 		if(authinfo->username == NULL)
 			authinfo->username = "";
@@ -77,7 +76,7 @@ int get_authentication_information(authdata *authinfo) {
 			authinfo->authenticated = FALSE;
 		else
 			authinfo->authenticated = TRUE;
-		}
+	}
 
 	/* read in authorization override vars from config file... */
 	if((thefile = mmap_fopen(get_cgi_config_location())) != NULL) {
@@ -106,147 +105,133 @@ int get_authentication_information(authdata *authinfo) {
 					authinfo->authenticated = FALSE;
 				else
 					authinfo->authenticated = TRUE;
-				}
+			}
 
 			else if(strstr(input, "authorized_for_all_hosts=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_all_hosts = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_all_services=") == input) {
+			} else if(strstr(input, "authorized_for_all_services=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_all_services = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_system_information=") == input) {
+			} else if(strstr(input, "authorized_for_system_information=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_system_information = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_configuration_information=") == input) {
+			} else if(strstr(input, "authorized_for_configuration_information=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_configuration_information = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_all_host_commands=") == input) {
+			} else if(strstr(input, "authorized_for_all_host_commands=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_all_host_commands = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_all_service_commands=") == input) {
+			} else if(strstr(input, "authorized_for_all_service_commands=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_all_service_commands = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_system_commands=") == input) {
+			} else if(strstr(input, "authorized_for_system_commands=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_system_commands = TRUE;
-					}
 				}
-			else if(strstr(input, "authorized_for_read_only=") == input) {
+			} else if(strstr(input, "authorized_for_read_only=") == input) {
 				temp_ptr = strtok(input, "=");
 				while((temp_ptr = strtok(NULL, ","))) {
 					if(!strcmp(temp_ptr, authinfo->username) || !strcmp(temp_ptr, "*"))
 						authinfo->authorized_for_read_only = TRUE;
-					}
 				}
-			else if((temp_contact = find_contact(authinfo->username)) != NULL) {
+			} else if((temp_contact = find_contact(authinfo->username)) != NULL) {
 				if(strstr(input, "authorized_contactgroup_for_all_hosts=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_all_hosts = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_all_services=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_all_services=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_all_services = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_system_information=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_system_information=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_system_information = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_configuration_information=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_configuration_information=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_configuration_information = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_all_host_commands=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_all_host_commands=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_all_host_commands = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_all_service_commands=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_all_service_commands=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_all_service_commands = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_system_commands=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_system_commands=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_system_commands = TRUE;
-						}
 					}
-				else if(strstr(input, "authorized_contactgroup_for_read_only=") == input) {
+				} else if(strstr(input, "authorized_contactgroup_for_read_only=") == input) {
 					temp_ptr = strtok(input, "=");
 					while((temp_ptr = strtok(NULL, ","))) {
 						temp_contactgroup = find_contactgroup(temp_ptr);
 						if(is_contact_member_of_contactgroup(temp_contactgroup, temp_contact))
 							authinfo->authorized_for_read_only = TRUE;
-						}
 					}
 				}
 			}
+		}
 
 		/* free memory and close the file */
 		free(input);
 		mmap_fclose(thefile);
-		}
+	}
 
 	if(authinfo->authenticated == TRUE)
 		return OK;
 	else
 		return ERROR;
-	}
+}
 
 
 
 /* check if user is authorized to view information about a particular host */
-int is_authorized_for_host(host *hst, authdata *authinfo) {
+int is_authorized_for_host(host *hst, authdata *authinfo)
+{
 	contact *temp_contact;
 
 	if(hst == NULL)
@@ -276,11 +261,12 @@ int is_authorized_for_host(host *hst, authdata *authinfo) {
 		return TRUE;
 
 	return FALSE;
-	}
+}
 
 
 /* check if user is authorized to view information about all hosts in a particular hostgroup */
-int is_authorized_for_hostgroup(hostgroup *hg, authdata *authinfo) {
+int is_authorized_for_hostgroup(hostgroup *hg, authdata *authinfo)
+{
 	hostsmember *temp_hostsmember;
 	host *temp_host;
 
@@ -301,16 +287,17 @@ int is_authorized_for_hostgroup(hostgroup *hg, authdata *authinfo) {
 		temp_host = find_host(temp_hostsmember->host_name);
 		if(is_authorized_for_host(temp_host, authinfo) == TRUE)
 			return TRUE;
-		}
+	}
 
 	/*return TRUE;*/
 	return FALSE;
-	}
+}
 
 
 
 /* check if user is authorized to view information about all services in a particular servicegroup */
-int is_authorized_for_servicegroup(servicegroup *sg, authdata *authinfo) {
+int is_authorized_for_servicegroup(servicegroup *sg, authdata *authinfo)
+{
 	servicesmember *temp_servicesmember;
 	service *temp_service;
 
@@ -330,14 +317,15 @@ int is_authorized_for_servicegroup(servicegroup *sg, authdata *authinfo) {
 		temp_service = find_service(temp_servicesmember->host_name, temp_servicesmember->service_description);
 		if(is_authorized_for_service(temp_service, authinfo) == TRUE)
 			return TRUE;
-		}
+	}
 
 	/*return TRUE*/;
 	return FALSE;
-	}
+}
 
 /* check if current user is restricted to read only */
-int is_authorized_for_read_only(authdata *authinfo) {
+int is_authorized_for_read_only(authdata *authinfo)
+{
 
 	/* if we're not using authentication, fake it */
 	if(use_authentication == FALSE)
@@ -348,10 +336,11 @@ int is_authorized_for_read_only(authdata *authinfo) {
 		return FALSE;
 
 	return authinfo->authorized_for_read_only;
-	}
+}
 
 /* check if user is authorized to view information about a particular service */
-int is_authorized_for_service(service *svc, authdata *authinfo) {
+int is_authorized_for_service(service *svc, authdata *authinfo)
+{
 	host *temp_host;
 	contact *temp_contact;
 
@@ -391,11 +380,12 @@ int is_authorized_for_service(service *svc, authdata *authinfo) {
 		return TRUE;
 
 	return FALSE;
-	}
+}
 
 
 /* check if current user is authorized to view information on all hosts */
-int is_authorized_for_all_hosts(authdata *authinfo) {
+int is_authorized_for_all_hosts(authdata *authinfo)
+{
 
 	/* if we're not using authentication, fake it */
 	if(use_authentication == FALSE)
@@ -406,11 +396,12 @@ int is_authorized_for_all_hosts(authdata *authinfo) {
 		return FALSE;
 
 	return authinfo->authorized_for_all_hosts;
-	}
+}
 
 
 /* check if current user is authorized to view information on all service */
-int is_authorized_for_all_services(authdata *authinfo) {
+int is_authorized_for_all_services(authdata *authinfo)
+{
 
 	/* if we're not using authentication, fake it */
 	if(use_authentication == FALSE)
@@ -421,11 +412,12 @@ int is_authorized_for_all_services(authdata *authinfo) {
 		return FALSE;
 
 	return authinfo->authorized_for_all_services;
-	}
+}
 
 
 /* check if current user is authorized to view system information */
-int is_authorized_for_system_information(authdata *authinfo) {
+int is_authorized_for_system_information(authdata *authinfo)
+{
 
 	/* if we're not using authentication, fake it */
 	if(use_authentication == FALSE)
@@ -436,11 +428,12 @@ int is_authorized_for_system_information(authdata *authinfo) {
 		return FALSE;
 
 	return authinfo->authorized_for_system_information;
-	}
+}
 
 
 /* check if current user is authorized to view configuration information */
-int is_authorized_for_configuration_information(authdata *authinfo) {
+int is_authorized_for_configuration_information(authdata *authinfo)
+{
 
 	/* if we're not using authentication, fake it */
 	if(use_authentication == FALSE)
@@ -451,11 +444,12 @@ int is_authorized_for_configuration_information(authdata *authinfo) {
 		return FALSE;
 
 	return authinfo->authorized_for_configuration_information;
-	}
+}
 
 
 /* check if current user is authorized to issue system commands */
-int is_authorized_for_system_commands(authdata *authinfo) {
+int is_authorized_for_system_commands(authdata *authinfo)
+{
 
 	/* if we're not using authentication, fake it */
 	if(use_authentication == FALSE)
@@ -466,11 +460,12 @@ int is_authorized_for_system_commands(authdata *authinfo) {
 		return FALSE;
 
 	return authinfo->authorized_for_system_commands;
-	}
+}
 
 
 /* check is the current user is authorized to issue commands relating to a particular service */
-int is_authorized_for_service_commands(service *svc, authdata *authinfo) {
+int is_authorized_for_service_commands(service *svc, authdata *authinfo)
+{
 	host *temp_host;
 	contact *temp_contact;
 
@@ -519,14 +514,15 @@ int is_authorized_for_service_commands(service *svc, authdata *authinfo) {
 		/* this user is not a contact for the host, so they must have been given explicit permissions to all service commands */
 		if(authinfo->authorized_for_all_service_commands == TRUE)
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /* check is the current user is authorized to issue commands relating to a particular host */
-int is_authorized_for_host_commands(host *hst, authdata *authinfo) {
+int is_authorized_for_host_commands(host *hst, authdata *authinfo)
+{
 	contact *temp_contact;
 
 	if(hst == NULL)
@@ -561,14 +557,15 @@ int is_authorized_for_host_commands(host *hst, authdata *authinfo) {
 		/* this user is not a contact for the host, so they must have been given explicit permissions to all host commands */
 		if(authinfo->authorized_for_all_host_commands == TRUE)
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /* check is the current user is authorized to issue commands relating to a particular servicegroup */
-int is_authorized_for_servicegroup_commands(servicegroup *sg, authdata *authinfo) {
+int is_authorized_for_servicegroup_commands(servicegroup *sg, authdata *authinfo)
+{
 	servicesmember *temp_servicesmember;
 	service *temp_service;
 
@@ -580,14 +577,15 @@ int is_authorized_for_servicegroup_commands(servicegroup *sg, authdata *authinfo
 		temp_service = find_service(temp_servicesmember->host_name, temp_servicesmember->service_description);
 		if(is_authorized_for_service_commands(temp_service, authinfo) == FALSE)
 			return FALSE;
-		}
+	}
 
 	return TRUE;
-	}
+}
 
 
 /* check is the current user is authorized to issue commands relating to a particular hostgroup */
-int is_authorized_for_hostgroup_commands(hostgroup *hg, authdata *authinfo) {
+int is_authorized_for_hostgroup_commands(hostgroup *hg, authdata *authinfo)
+{
 	hostsmember *temp_hostsmember;
 	host *temp_host;
 
@@ -599,7 +597,7 @@ int is_authorized_for_hostgroup_commands(hostgroup *hg, authdata *authinfo) {
 		temp_host = find_host(temp_hostsmember->host_name);
 		if(is_authorized_for_host_commands(temp_host, authinfo) == FALSE)
 			return FALSE;
-		}
+	}
 
 	return TRUE;
-	}
+}

--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -115,12 +115,14 @@ char *encoded_html_string = NULL;
  * source-files once. A decent linker will make the call
  * a no-op anyway, so it's not a big issue
  */
-void logit(int data_type, int display, const char *fmt, ...) {
+void logit(int data_type, int display, const char *fmt, ...)
+{
 	return;
-	}
-int log_debug_info(int leve, int verbosity, const char *fmt, ...) {
+}
+int log_debug_info(int leve, int verbosity, const char *fmt, ...)
+{
 	return 0;
-	}
+}
 
 /*** helpers ****/
 /*
@@ -152,7 +154,8 @@ static command *find_bang_command(char *name)
  **********************************************************/
 
 /* reset all variables used by the CGIs */
-void reset_cgi_vars(void) {
+void reset_cgi_vars(void)
+{
 
 	strcpy(main_config_file, "");
 
@@ -204,12 +207,13 @@ void reset_cgi_vars(void) {
 	ping_syntax = NULL;
 
 	return;
-	}
+}
 
 
 
 /* free all memory for object definitions */
-void free_memory(void) {
+void free_memory(void)
+{
 
 	/* free memory for common object definitions */
 	free_object_data();
@@ -229,7 +233,7 @@ void free_memory(void) {
 	free(ping_syntax);
 
 	return;
-	}
+}
 
 
 
@@ -239,34 +243,37 @@ void free_memory(void) {
  **********************************************************/
 
 /* read the CGI config file location from an environment variable */
-const char *get_cgi_config_location(void) {
+const char *get_cgi_config_location(void)
+{
 	static char *cgiloc = NULL;
 
 	if(!cgiloc) {
 		cgiloc = getenv("NAGIOS_CGI_CONFIG");
 		if(!cgiloc)
 			cgiloc = DEFAULT_CGI_CONFIG_FILE;
-		}
+	}
 
 	return cgiloc;
-	}
+}
 
 
 /* read the command file location from an environment variable */
-const char *get_cmd_file_location(void) {
+const char *get_cmd_file_location(void)
+{
 	static char *cmdloc = NULL;
 
 	if(!cmdloc) {
 		cmdloc = getenv("NAGIOS_COMMAND_FILE");
 		if(!cmdloc)
 			cmdloc = DEFAULT_COMMAND_FILE;
-		}
-	return cmdloc;
 	}
+	return cmdloc;
+}
 
 
 /*read the CGI configuration file */
-int read_cgi_config_file(const char *filename) {
+int read_cgi_config_file(const char *filename)
+{
 	char *input = NULL;
 	mmapfile *thefile;
 	char *var = NULL;
@@ -298,7 +305,7 @@ int read_cgi_config_file(const char *filename) {
 			strncpy(main_config_file, val, sizeof(main_config_file));
 			main_config_file[sizeof(main_config_file) - 1] = '\x0';
 			strip(main_config_file);
-			}
+		}
 
 		else if(!strcmp(var, "show_context_help"))
 			show_context_help = (atoi(val) > 0) ? TRUE : FALSE;
@@ -313,7 +320,7 @@ int read_cgi_config_file(const char *filename) {
 			strncpy(nagios_check_command, val, sizeof(nagios_check_command));
 			nagios_check_command[sizeof(nagios_check_command) - 1] = '\x0';
 			strip(nagios_check_command);
-			}
+		}
 
 		else if(!strcmp(var, "refresh_rate"))
 			refresh_rate = atoi(val);
@@ -334,7 +341,7 @@ int read_cgi_config_file(const char *filename) {
 
 			snprintf(physical_ssi_path, sizeof(physical_images_path), "%sssi/", physical_html_path);
 			physical_ssi_path[sizeof(physical_ssi_path) - 1] = '\x0';
-			}
+		}
 
 		else if(!strcmp(var, "url_html_path")) {
 
@@ -367,7 +374,7 @@ int read_cgi_config_file(const char *filename) {
 			snprintf(url_js_path, sizeof(url_js_path), "%sjs/", url_html_path);
 			url_js_path[sizeof(url_js_path) - 1] = '\x0';
 
-			}
+		}
 
 		else if(!strcmp(var, "service_critical_sound"))
 			service_critical_sound = strdup(val);
@@ -440,7 +447,7 @@ int read_cgi_config_file(const char *filename) {
 
 		else if(!strcmp(var, "navbar_search_aliases"))
 			navbar_search_aliases = (atoi(val) > 0) ? TRUE : FALSE;
-		}
+	}
 
 	for(p = illegal_output_chars; p && *p; p++)
 		illegal_output_char_map[(int)*p] = 1;
@@ -453,12 +460,13 @@ int read_cgi_config_file(const char *filename) {
 		return ERROR;
 	else
 		return OK;
-	}
+}
 
 
 
 /* read the main configuration file */
-int read_main_config_file(const char *filename) {
+int read_main_config_file(const char *filename)
+{
 	char *input = NULL;
 	char *temp_buffer;
 	mmapfile *thefile;
@@ -483,7 +491,7 @@ int read_main_config_file(const char *filename) {
 			temp_buffer = strtok(input, "=");
 			temp_buffer = strtok(NULL, "\x0");
 			interval_length = (temp_buffer == NULL) ? 60 : atoi(temp_buffer);
-			}
+		}
 
 		else if(strstr(input, "log_file=") == input) {
 			temp_buffer = strtok(input, "=");
@@ -491,18 +499,17 @@ int read_main_config_file(const char *filename) {
 			strncpy(log_file, (temp_buffer == NULL) ? "" : temp_buffer, sizeof(log_file));
 			log_file[sizeof(log_file) - 1] = '\x0';
 			strip(log_file);
-			}
+		}
 
 		else if(strstr(input, "object_cache_file=") == input) {
 			temp_buffer = strtok(input, "=");
 			temp_buffer = strtok(NULL, "\x0");
 			object_cache_file = nspath_absolute(temp_buffer, config_file_dir);
-			}
-		else if(strstr(input, "status_file=") == input) {
+		} else if(strstr(input, "status_file=") == input) {
 			temp_buffer = strtok(input, "=");
 			temp_buffer = strtok(NULL, "\x0");
 			status_file = nspath_absolute(temp_buffer, config_file_dir);
-			}
+		}
 
 		else if(strstr(input, "log_archive_path=") == input) {
 			temp_buffer = strtok(input, "=");
@@ -512,7 +519,7 @@ int read_main_config_file(const char *filename) {
 			strip(physical_html_path);
 			if(log_archive_path[strlen(log_archive_path) - 1] != '/' && (strlen(log_archive_path) < sizeof(log_archive_path) - 1))
 				strcat(log_archive_path, "/");
-			}
+		}
 
 		else if(strstr(input, "log_rotation_method=") == input) {
 			temp_buffer = strtok(input, "=");
@@ -527,7 +534,7 @@ int read_main_config_file(const char *filename) {
 				log_rotation_method = LOG_ROTATION_WEEKLY;
 			else if(!strcmp(temp_buffer, "m"))
 				log_rotation_method = LOG_ROTATION_MONTHLY;
-			}
+		}
 
 		else if(strstr(input, "command_file=") == input) {
 			temp_buffer = strtok(input, "=");
@@ -535,13 +542,13 @@ int read_main_config_file(const char *filename) {
 			strncpy(command_file, (temp_buffer == NULL) ? "" : temp_buffer, sizeof(command_file));
 			command_file[sizeof(command_file) - 1] = '\x0';
 			strip(command_file);
-			}
+		}
 
 		else if(strstr(input, "check_external_commands=") == input) {
 			temp_buffer = strtok(input, "=");
 			temp_buffer = strtok(NULL, "\x0");
 			check_external_commands = (temp_buffer == NULL) ? 0 : atoi(temp_buffer);
-			}
+		}
 
 		else if(strstr(input, "date_format=") == input) {
 			temp_buffer = strtok(input, "=");
@@ -556,20 +563,21 @@ int read_main_config_file(const char *filename) {
 				date_format = DATE_FORMAT_STRICT_ISO8601;
 			else
 				date_format = DATE_FORMAT_US;
-			}
 		}
+	}
 
 	/* free memory and close the file */
 	free(input);
 	mmap_fclose(thefile);
 
 	return OK;
-	}
+}
 
 
 
 /* read all object definitions */
-int read_all_object_configuration_data(const char *cfgfile, int options) {
+int read_all_object_configuration_data(const char *cfgfile, int options)
+{
 	int result = OK;
 	host *temp_host = NULL;
 	host *parent_host = NULL;
@@ -585,74 +593,75 @@ int read_all_object_configuration_data(const char *cfgfile, int options) {
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 		/* Find the command object for the check command */
 		temp_host->check_command_ptr =
-				find_bang_command(temp_host->check_command);
+		    find_bang_command(temp_host->check_command);
 
 		/* Find the command object for the event handler */
 		temp_host->event_handler_ptr =
-				find_bang_command(temp_host->event_handler);
+		    find_bang_command(temp_host->event_handler);
 
 		/* Resolve host child->parent relationships */
 		for(temp_hostsmember = temp_host->parent_hosts;
-				temp_hostsmember != NULL;
-				temp_hostsmember = temp_hostsmember->next) {
+		    temp_hostsmember != NULL;
+		    temp_hostsmember = temp_hostsmember->next) {
 			if((parent_host = find_host(temp_hostsmember->host_name)) == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE,
-						"Error: '%s' is not a valid parent for host '%s'!",
-						temp_hostsmember->host_name, temp_host->name);
-				}
+				      "Error: '%s' is not a valid parent for host '%s'!",
+				      temp_hostsmember->host_name, temp_host->name);
+			}
 			/* save the parent host pointer for later */
 			temp_hostsmember->host_ptr = parent_host;
 
 			/* add a reverse (child) link to make searches faster later on */
 			if(add_child_link_to_host(parent_host, temp_host) == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE,
-						"Error: Failed to add '%s' as a child host of '%s'",
-						temp_host->name, parent_host->name);
-				}
+				      "Error: Failed to add '%s' as a child host of '%s'",
+				      temp_host->name, parent_host->name);
 			}
 		}
+	}
 
 	/* Resolve objects in the service object */
 	for(temp_service = service_list; temp_service != NULL;
-			temp_service = temp_service->next) {
+	    temp_service = temp_service->next) {
 		/* Find the command object for the check command */
 		temp_service->check_command_ptr =
-				find_bang_command(temp_service->check_command);
+		    find_bang_command(temp_service->check_command);
 
 		/* Find the command object for the event handler */
 		temp_service->event_handler_ptr =
-				find_bang_command(temp_service->event_handler);
+		    find_bang_command(temp_service->event_handler);
 
 		/* Resolve service child->parent relationships */
 		for(temp_servicesmember = temp_service->parents;
-				temp_servicesmember != NULL;
-				temp_servicesmember = temp_servicesmember->next) {
+		    temp_servicesmember != NULL;
+		    temp_servicesmember = temp_servicesmember->next) {
 			/* Find the parent service */
 			if((parent_service = find_service(temp_servicesmember->host_name,
-					temp_servicesmember->service_description)) == NULL) {
+			                                  temp_servicesmember->service_description)) == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE,
-						"Error: '%s:%s' is not a valid parent for service '%s:%s'!",
-						temp_servicesmember->host_name,
-						temp_servicesmember->service_description,
-						temp_service->host_name, temp_service->description);
-				}
+				      "Error: '%s:%s' is not a valid parent for service '%s:%s'!",
+				      temp_servicesmember->host_name,
+				      temp_servicesmember->service_description,
+				      temp_service->host_name, temp_service->description);
+			}
 			/* add a reverse (child) link to make searches faster later on */
 			if(add_child_link_to_service(parent_service,
-					temp_service) == NULL) {
+			                             temp_service) == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE,
-						"Error: Failed to add '%s:%s' as a child service of '%s:%s'",
-						temp_service->host_name, temp_service->description,
-						parent_service->host_name, parent_service->description);
-				}
+				      "Error: Failed to add '%s:%s' as a child service of '%s:%s'",
+				      temp_service->host_name, temp_service->description,
+				      parent_service->host_name, parent_service->description);
 			}
 		}
+	}
 
 	return result;
-	}
+}
 
 
 /* read all status data */
-int read_all_status_data(const char *cfgfile, int options) {
+int read_all_status_data(const char *cfgfile, int options)
+{
 	int result = OK;
 
 	/* don't duplicate things we've already read in */
@@ -682,10 +691,11 @@ int read_all_status_data(const char *cfgfile, int options) {
 		service_status_has_been_read = TRUE;
 
 	return result;
-	}
+}
 
 
-void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_options, int status_options) {
+void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_options, int status_options)
+{
 	int result;
 
 	/* read the CGI configuration file */
@@ -695,7 +705,7 @@ void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_opti
 		cgi_config_file_error(get_cgi_config_location());
 		doc_footer();
 		exit(EXIT_FAILURE);
-		}
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
@@ -704,7 +714,7 @@ void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_opti
 		main_config_file_error(main_config_file);
 		doc_footer();
 		exit(EXIT_FAILURE);
-		}
+	}
 
 	/* read all object configuration data */
 	result = read_all_object_configuration_data(main_config_file, object_options);
@@ -713,7 +723,7 @@ void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_opti
 		object_data_error();
 		doc_footer();
 		exit(EXIT_FAILURE);
-		}
+	}
 
 	/* read all status data */
 	result = read_all_status_data(main_config_file, status_options);
@@ -723,8 +733,8 @@ void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_opti
 		doc_footer();
 		free_memory();
 		exit(EXIT_FAILURE);
-		}
 	}
+}
 
 
 /**********************************************************
@@ -732,7 +742,8 @@ void cgi_init(void (*doc_header)(int), void (*doc_footer)(void), int object_opti
  **********************************************************/
 
 /* reads contents of file into the lifo struct */
-int read_file_into_lifo(char *filename) {
+int read_file_into_lifo(char *filename)
+{
 	char *input = NULL;
 	mmapfile *thefile;
 	int lifo_result;
@@ -754,17 +765,18 @@ int read_file_into_lifo(char *filename) {
 			free(input);
 			mmap_fclose(thefile);
 			return lifo_result;
-			}
 		}
+	}
 
 	mmap_fclose(thefile);
 
 	return LIFO_OK;
-	}
+}
 
 
 /* frees all memory allocated to lifo */
-void free_lifo_memory(void) {
+void free_lifo_memory(void)
+{
 	lifo *temp_lifo;
 	lifo *next_lifo;
 
@@ -778,14 +790,15 @@ void free_lifo_memory(void) {
 			free((void *)temp_lifo->data);
 		free((void *)temp_lifo);
 		temp_lifo = next_lifo;
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* adds an item to lifo */
-int push_lifo(char *buffer) {
+int push_lifo(char *buffer)
+{
 	lifo *temp_lifo;
 
 	temp_lifo = (lifo *)malloc(sizeof(lifo));
@@ -799,19 +812,20 @@ int push_lifo(char *buffer) {
 	if(temp_lifo->data == NULL) {
 		free(temp_lifo);
 		return LIFO_ERROR_MEMORY;
-		}
+	}
 
 	/* add item to front of lifo... */
 	temp_lifo->next = lifo_list;
 	lifo_list = temp_lifo;
 
 	return LIFO_OK;
-	}
+}
 
 
 
 /* returns/clears an item from lifo */
-char *pop_lifo(void) {
+char *pop_lifo(void)
+{
 	lifo *temp_lifo;
 	char *buf;
 
@@ -829,7 +843,7 @@ char *pop_lifo(void) {
 	lifo_list = temp_lifo;
 
 	return buf;
-	}
+}
 
 
 
@@ -839,7 +853,8 @@ char *pop_lifo(void) {
  **********************************************************/
 
 /* unescapes newlines in a string */
-char *unescape_newlines(char *rawbuf) {
+char *unescape_newlines(char *rawbuf)
+{
 	register int x, y;
 
 	for(x = 0, y = 0; rawbuf[x] != (char)'\x0'; x++) {
@@ -850,26 +865,26 @@ char *unescape_newlines(char *rawbuf) {
 			if(rawbuf[x + 1] == 'n') {
 				rawbuf[y++] = '\n';
 				x++;
-				}
+			}
 
 			/* unescape backslashes and other stuff */
 			if(rawbuf[x + 1] != '\x0') {
 				rawbuf[y++] = rawbuf[x + 1];
 				x++;
-				}
-
 			}
-		else
+
+		} else
 			rawbuf[y++] = rawbuf[x];
-		}
+	}
 	rawbuf[y] = '\x0';
 
 	return rawbuf;
-	}
+}
 
 
 /* strips HTML and bad stuff from plugin output */
-void sanitize_plugin_output(char *buffer) {
+void sanitize_plugin_output(char *buffer)
+{
 	int x = 0;
 	int y = 0;
 	int in_html = FALSE;
@@ -889,13 +904,13 @@ void sanitize_plugin_output(char *buffer) {
 		if(buffer[x] == '<') {
 			in_html = TRUE;
 			continue;
-			}
+		}
 
 		/* end of an HTML tag */
 		else if(buffer[x] == '>') {
 			in_html = FALSE;
 			continue;
-			}
+		}
 
 		/* skip everything inside HTML tags */
 		else if(in_html == TRUE)
@@ -916,7 +931,7 @@ void sanitize_plugin_output(char *buffer) {
 		/* normal character */
 		else
 			new_buffer[y++] = buffer[x];
-		}
+	}
 
 	/* terminate sanitized buffer */
 	new_buffer[y++] = '\x0';
@@ -928,12 +943,13 @@ void sanitize_plugin_output(char *buffer) {
 	free(new_buffer);
 
 	return;
-	}
+}
 
 
 
 /* get date/time string */
-void get_time_string(time_t *raw_time, char *buffer, int buffer_length, int type) {
+void get_time_string(time_t *raw_time, char *buffer, int buffer_length, int type)
+{
 	time_t t;
 	struct tm *tm_ptr = NULL;
 	int hour = 0;
@@ -981,7 +997,7 @@ void get_time_string(time_t *raw_time, char *buffer, int buffer_length, int type
 			snprintf(buffer, buffer_length, "%04d-%02d-%02d%c%02d:%02d:%02d", tm_ptr->tm_year + 1900, tm_ptr->tm_mon + 1, tm_ptr->tm_mday, (date_format == DATE_FORMAT_STRICT_ISO8601) ? 'T' : ' ', tm_ptr->tm_hour, tm_ptr->tm_min, tm_ptr->tm_sec);
 		else
 			snprintf(buffer, buffer_length, "%02d-%02d-%04d %02d:%02d:%02d", tm_ptr->tm_mon + 1, tm_ptr->tm_mday, tm_ptr->tm_year + 1900, tm_ptr->tm_hour, tm_ptr->tm_min, tm_ptr->tm_sec);
-		}
+	}
 
 	/* short date */
 	else if(type == SHORT_DATE) {
@@ -991,7 +1007,7 @@ void get_time_string(time_t *raw_time, char *buffer, int buffer_length, int type
 			snprintf(buffer, buffer_length, "%04d-%02d-%02d", year, month, day);
 		else
 			snprintf(buffer, buffer_length, "%02d-%02d-%04d", month, day, year);
-		}
+	}
 
 	/* expiration date/time for HTTP headers */
 	else if(type == HTTP_DATE_TIME)
@@ -1004,11 +1020,12 @@ void get_time_string(time_t *raw_time, char *buffer, int buffer_length, int type
 	buffer[buffer_length - 1] = '\x0';
 
 	return;
-	}
+}
 
 
 /* get time string for an interval of time */
-void get_interval_time_string(double time_units, char *buffer, int buffer_length) {
+void get_interval_time_string(double time_units, char *buffer, int buffer_length)
+{
 	unsigned long total_seconds;
 	int hours = 0;
 	int minutes = 0;
@@ -1024,11 +1041,12 @@ void get_interval_time_string(double time_units, char *buffer, int buffer_length
 	buffer[buffer_length - 1] = '\x0';
 
 	return;
-	}
+}
 
 
 /* encodes a string in proper URL format */
-const char *url_encode(const char *input) {
+const char *url_encode(const char *input)
+{
 	int len, output_len;
 	int x, y;
 	char temp_expansion[4];
@@ -1052,19 +1070,19 @@ const char *url_encode(const char *input) {
 		if((char)input[x] == (char)'\x0') {
 			str[y] = '\x0';
 			break;
-			}
+		}
 
 		/* alpha-numeric characters and a few other characters don't get encoded */
 		else if(((char)input[x] >= '0' && (char)input[x] <= '9') || ((char)input[x] >= 'A' && (char)input[x] <= 'Z') || ((char)input[x] >= (char)'a' && (char)input[x] <= (char)'z') || (char)input[x] == (char)'.' || (char)input[x] == (char)'-' || (char)input[x] == (char)'_') {
 			str[y] = input[x];
 			y++;
-			}
+		}
 
 		/* spaces are pluses */
 		else if(input[x] == ' ') {
 			str[y] = '+';
 			y++;
-			}
+		}
 
 		/* anything else gets represented by its hex value */
 		else {
@@ -1073,41 +1091,43 @@ const char *url_encode(const char *input) {
 				sprintf(temp_expansion, "%%%02X", (unsigned char)input[x]);
 				strcat(str, temp_expansion);
 				y += 3;
-				}
 			}
 		}
+	}
 
 	str[sizeof(encoded_url_string[0]) - 1] = '\x0';
 
 	return str;
-	}
+}
 
-static char * copy_wc_to_output(wchar_t wc, char *outstp, int output_max) {
+static char * copy_wc_to_output(wchar_t wc, char *outstp, int output_max)
+{
 
 	int		wctomb_result;
 	char	mbtemp[ 10];
 
 	wctomb_result = wctomb(mbtemp, wc);
 	if(( wctomb_result > 0) &&
-			((( outstp - encoded_html_string) + wctomb_result) < output_max)) {
+	   ((( outstp - encoded_html_string) + wctomb_result) < output_max)) {
 		strncpy( outstp, mbtemp, wctomb_result);
 		outstp += wctomb_result;
-		}
-	return outstp;
 	}
+	return outstp;
+}
 
-static char * encode_character(wchar_t wc, char *outstp, int output_max) {
+static char * encode_character(wchar_t wc, char *outstp, int output_max)
+{
 
 	char	temp_expansion[11];
 
 	sprintf(temp_expansion, "&#%u;", (unsigned int)wc);
 	if(((outstp - encoded_html_string) + strlen(temp_expansion)) <
-			(unsigned int)output_max) {
+	   (unsigned int)output_max) {
 		strncpy(outstp, temp_expansion, strlen( temp_expansion));
 		outstp += strlen( temp_expansion);
-		}
-	return outstp;
 	}
+	return outstp;
+}
 
 #define WHERE_OUTSIDE_TAG				0	/* Not in an HTML tag */
 #define WHERE_IN_TAG_NAME				1	/* In HTML tag name (either opening
@@ -1122,7 +1142,8 @@ static char * encode_character(wchar_t wc, char *outstp, int output_max) {
 #define WHERE_IN_COMMENT				6	/* In an HTML comment */
 
 /* escapes a string used in HTML */
-char * html_encode(char *input, int escape_newlines) {
+char * html_encode(char *input, int escape_newlines)
+{
 	int 		len;
 	int			output_max;
 	char		*outstp;
@@ -1131,7 +1152,7 @@ char * html_encode(char *input, int escape_newlines) {
 	size_t		mbstowcs_result;
 	int			x;
 	int			where_in_tag = WHERE_OUTSIDE_TAG; /* Location in HTML tag */
-	wchar_t		attr_value_start = (wchar_t)0;	/* character that starts the 
+	wchar_t		attr_value_start = (wchar_t)0;	/* character that starts the
 													attribute value */
 	int			tag_depth = 0;					/* depth of nested HTML tags */
 
@@ -1146,20 +1167,20 @@ char * html_encode(char *input, int escape_newlines) {
 	/* Convert the string to a wide character string */
 	if(( wcinput = malloc( len * sizeof( wchar_t))) == NULL) {
 		return "";
-		}
+	}
 	if((mbstowcs_result = mbstowcs( wcinput, input, len)) == (size_t)-1) {
 		free( wcinput);
 		return "";
-		}
+	}
 
 	/* Process all converted characters */
-	for( x = 0, inwcp = wcinput; x < (int)mbstowcs_result && '\0' != *inwcp; 
-			x++, inwcp++) {
+	for( x = 0, inwcp = wcinput; x < (int)mbstowcs_result && '\0' != *inwcp;
+	     x++, inwcp++) {
 
 		/* Most ASCII characters don't get encoded */
 		if(( *inwcp  >= 0x20 && *inwcp <= 0x7e) &&
-				( !( '"' == *inwcp || '&' == *inwcp || '\'' == *inwcp ||
-				'<' == *inwcp || '>' == *inwcp))) {
+		   ( !( '"' == *inwcp || '&' == *inwcp || '\'' == *inwcp ||
+		        '<' == *inwcp || '>' == *inwcp))) {
 			outstp = copy_wc_to_output(*inwcp, outstp, output_max);
 			switch(where_in_tag) {
 			case WHERE_IN_TAG_NAME:
@@ -1170,44 +1191,43 @@ char * html_encode(char *input, int escape_newlines) {
 				case '!':
 					where_in_tag = WHERE_IN_COMMENT;
 					break;
-					}
+				}
 				break;
 			case WHERE_IN_TAG_OUTSIDE_ATTRIBUTE:
 				if(*inwcp != 0x20) {
 					where_in_tag = WHERE_IN_TAG_IN_ATTRIBUTE_NAME;
-					}
+				}
 				break;
 			case WHERE_IN_TAG_IN_ATTRIBUTE_NAME:
 				if(*inwcp == '=') {
 					where_in_tag = WHERE_IN_TAG_AT_EQUALS;
-					}
+				}
 				break;
 			case WHERE_IN_TAG_AT_EQUALS:
 				if(*inwcp != 0x20) {
 					attr_value_start = *inwcp;
 					where_in_tag = WHERE_IN_TAG_IN_ATTRIBUTE_VALUE;
-					}
+				}
 				break;
 			case WHERE_IN_TAG_IN_ATTRIBUTE_VALUE:
 				if((*inwcp == 0x20) && (attr_value_start != '"') &&
-						(attr_value_start != '\'')) {
+				   (attr_value_start != '\'')) {
 					where_in_tag = WHERE_IN_TAG_OUTSIDE_ATTRIBUTE;
-					}
-				break;
 				}
+				break;
 			}
+		}
 
 		/* Special handling for quotes */
-		else if(FALSE == escape_html_tags && 
-				('"' == *inwcp || '\'' == *inwcp)) {
+		else if(FALSE == escape_html_tags &&
+		        ('"' == *inwcp || '\'' == *inwcp)) {
 			switch(where_in_tag) {
 			case WHERE_OUTSIDE_TAG:
 				if(tag_depth >0) {
 					outstp = copy_wc_to_output(*inwcp, outstp, output_max);
-					}
-				else {
+				} else {
 					outstp = encode_character(*inwcp, outstp, output_max);
-					}
+				}
 				break;
 			case WHERE_IN_COMMENT:
 				outstp = copy_wc_to_output(*inwcp, outstp, output_max);
@@ -1222,38 +1242,36 @@ char * html_encode(char *input, int escape_newlines) {
 					/* This covers the case where the quote is backslash
 						escaped. */
 					outstp = copy_wc_to_output(*inwcp, outstp, output_max);
-					}
-				else if(attr_value_start == *inwcp) {
+				} else if(attr_value_start == *inwcp) {
 					/* If the quote is the same type of quote that started
-						the attribute value and it is not backslash 
+						the attribute value and it is not backslash
 						escaped, it signals the end of the attribute value */
 					outstp = copy_wc_to_output(*inwcp, outstp, output_max);
 					where_in_tag = WHERE_IN_TAG_OUTSIDE_ATTRIBUTE;
-					}
-				else {
+				} else {
 					/* If we encounter an quote that did not start the
-						attribute value and is not backslash escaped, 
+						attribute value and is not backslash escaped,
 						use it as is */
 					outstp = copy_wc_to_output(*inwcp, outstp, output_max);
-					}
+				}
 				break;
 			default:
 				outstp = encode_character(*inwcp, outstp, output_max);
 				break;
-				}
 			}
+		}
 
 		/* newlines turn to <BR> tags */
 		else if(escape_newlines == TRUE && '\n' == *inwcp) {
 			strncpy( outstp, "<BR>", 4);
 			outstp += 4;
-			}
+		}
 
 		else if(escape_newlines == TRUE && '\\' == *inwcp && '\n' == *( inwcp + 1)) {
 			strncpy( outstp, "<BR>", 4);
 			outstp += 4;
 			inwcp++; /* needed so loop skips two wide characters */
-			}
+		}
 
 		/* TODO - strip all but allowed HTML tags out... */
 		else if(('<' == *inwcp) && (FALSE == escape_html_tags)) {
@@ -1271,13 +1289,13 @@ char * html_encode(char *input, int escape_newlines) {
 				default:
 					tag_depth++;
 					break;
-					}
+				}
 				break;
 			default:
 				outstp = encode_character(*inwcp, outstp, output_max);
 				break;
-				}
 			}
+		}
 
 		else if(('>' == *inwcp) && (FALSE == escape_html_tags)) {
 
@@ -1292,34 +1310,34 @@ char * html_encode(char *input, int escape_newlines) {
 				if((attr_value_start != '"') && (attr_value_start != '\'')) {
 					outstp = copy_wc_to_output(*inwcp, outstp, output_max);
 					where_in_tag = WHERE_OUTSIDE_TAG;
-					}
-				else {
+				} else {
 					outstp = encode_character(*inwcp, outstp, output_max);
-					}
+				}
 				break;
 			default:
 				outstp = encode_character(*inwcp, outstp, output_max);
 				break;
-				}
 			}
+		}
 
 		/* for simplicity, all other chars represented by their numeric value */
 		else {
 			outstp = encode_character(*inwcp, outstp, output_max);
-			}
 		}
+	}
 
 	/* Null terminate the encoded string */
 	*outstp = '\x0';
 	encoded_html_string[ output_max - 1] = '\x0';
 
 	return encoded_html_string;
-	}
+}
 
 
 
 /* strip > and < from string */
-void strip_html_brackets(char *buffer) {
+void strip_html_brackets(char *buffer)
+{
 	register int x;
 	register int y;
 	register int z;
@@ -1333,15 +1351,16 @@ void strip_html_brackets(char *buffer) {
 		if(buffer[x] == '<' || buffer[x] == '>')
 			continue;
 		buffer[y++] = buffer[x];
-		}
+	}
 	buffer[y++] = '\x0';
 
 	return;
-	}
+}
 
 
 /* escape string for html form usage */
-char *escape_string(const char *input) {
+char *escape_string(const char *input)
+{
 	int			len;
 	int			output_max;
 	wchar_t		wctemp[1];
@@ -1354,7 +1373,7 @@ char *escape_string(const char *input) {
 	/* If they don't give us anything to do... */
 	if( NULL == input) {
 		return "";
-		}
+	}
 
 	/* We need up to six times the space to do the conversion */
 	len = (int)strlen(input);
@@ -1374,54 +1393,55 @@ char *escape_string(const char *input) {
 			/* No complete multibyte character found - try at next memory
 				address */
 			input++;
-			}
+		}
 
 		else if((( size_t)-1 == mbtowc_result) && ( EILSEQ == errno)) {
 			/* Invalid multibyte character found - try at next memory address */
 			input++;
-			}
+		}
 
 		/* Alpha-numeric characters and a few other characters don't get
 				encoded */
 		else if(( *wctemp  >= '0' && *wctemp <= '9') ||
-				( *wctemp >= 'A' && *wctemp <= 'Z') ||
-				( *wctemp >= 'a' && *wctemp <= 'z') ||
-				' ' == *wctemp || '-' == *wctemp || '.' == *wctemp ||
-				'_' == *wctemp || ':' == *wctemp) {
+		        ( *wctemp >= 'A' && *wctemp <= 'Z') ||
+		        ( *wctemp >= 'a' && *wctemp <= 'z') ||
+		        ' ' == *wctemp || '-' == *wctemp || '.' == *wctemp ||
+		        '_' == *wctemp || ':' == *wctemp) {
 			wctomb_result = wctomb( mbtemp, wctemp[0]);
 			if(( wctomb_result > 0) &&
-					((( stp - encoded_html_string) + wctomb_result) < output_max)) {
+			   ((( stp - encoded_html_string) + wctomb_result) < output_max)) {
 				strncpy( stp, mbtemp, wctomb_result);
 				stp += wctomb_result;
-				}
-			input += mbtowc_result;
 			}
+			input += mbtowc_result;
+		}
 
 		/* Encode everything else (this may be excessive) */
 		else {
 			sprintf( temp_expansion, "&#%u;", ( unsigned int)wctemp[ 0]);
 			if((( stp - encoded_html_string) + strlen( temp_expansion)) <
-					(unsigned int)output_max) {
+			   (unsigned int)output_max) {
 				strncpy( stp, temp_expansion, strlen( temp_expansion));
 				stp += strlen( temp_expansion);
-				}
-			input += mbtowc_result;
 			}
+			input += mbtowc_result;
+		}
 
 		/* Read the next character */
 		mbtowc_result = mbtowc( wctemp, input, MB_CUR_MAX);
-		}
+	}
 
 	/* Null terminate the encoded string */
 	*stp = '\x0';
 	encoded_html_string[ output_max - 1] = '\x0';
 
 	return encoded_html_string;
-	}
+}
 
 
 /* determines the log file we should use (from current time) */
-void get_log_archive_to_use(int archive, char *buffer, int buffer_length) {
+void get_log_archive_to_use(int archive, char *buffer, int buffer_length)
+{
 	struct tm *t;
 
 	/* determine the time at which the log was rotated for this archive # */
@@ -1432,7 +1452,7 @@ void get_log_archive_to_use(int archive, char *buffer, int buffer_length) {
 		strncpy(buffer, log_file, buffer_length);
 		buffer[buffer_length - 1] = '\x0';
 		return;
-		}
+	}
 
 	t = localtime(&this_scheduled_log_rotation);
 
@@ -1441,12 +1461,13 @@ void get_log_archive_to_use(int archive, char *buffer, int buffer_length) {
 	buffer[buffer_length - 1] = '\x0';
 
 	return;
-	}
+}
 
 
 
 /* determines log archive to use, given a specific time */
-int determine_archive_to_use_from_time(time_t target_time) {
+int determine_archive_to_use_from_time(time_t target_time)
+{
 	time_t current_time;
 	int current_archive = 0;
 
@@ -1469,15 +1490,16 @@ int determine_archive_to_use_from_time(time_t target_time) {
 		/* if the target time falls within the times encompassed by this archive, we have the right archive! */
 		if(target_time >= this_scheduled_log_rotation)
 			return current_archive - 1;
-		}
+	}
 
 	return 0;
-	}
+}
 
 
 
 /* determines the log rotation times - past, present, future */
-void determine_log_rotation_times(int archive) {
+void determine_log_rotation_times(int archive)
+{
 	struct tm *t;
 	int current_month;
 	int is_dst_now = FALSE;
@@ -1497,65 +1519,63 @@ void determine_log_rotation_times(int archive) {
 
 	switch(log_rotation_method) {
 
-		case LOG_ROTATION_HOURLY:
-			this_scheduled_log_rotation = mktime(t);
-			this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - ((archive - 1) * 3600));
-			last_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - 3600);
-			break;
+	case LOG_ROTATION_HOURLY:
+		this_scheduled_log_rotation = mktime(t);
+		this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - ((archive - 1) * 3600));
+		last_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - 3600);
+		break;
 
-		case LOG_ROTATION_DAILY:
-			t->tm_hour = 0;
-			this_scheduled_log_rotation = mktime(t);
-			this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - ((archive - 1) * 86400));
-			last_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - 86400);
-			break;
+	case LOG_ROTATION_DAILY:
+		t->tm_hour = 0;
+		this_scheduled_log_rotation = mktime(t);
+		this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - ((archive - 1) * 86400));
+		last_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - 86400);
+		break;
 
-		case LOG_ROTATION_WEEKLY:
-			t->tm_hour = 0;
-			this_scheduled_log_rotation = mktime(t);
-			this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - (86400 * t->tm_wday));
-			this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - ((archive - 1) * 604800));
-			last_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - 604800);
-			break;
+	case LOG_ROTATION_WEEKLY:
+		t->tm_hour = 0;
+		this_scheduled_log_rotation = mktime(t);
+		this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - (86400 * t->tm_wday));
+		this_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - ((archive - 1) * 604800));
+		last_scheduled_log_rotation = (time_t)(this_scheduled_log_rotation - 604800);
+		break;
 
-		case LOG_ROTATION_MONTHLY:
+	case LOG_ROTATION_MONTHLY:
 
-			t = localtime(&current_time);
-			t->tm_mon++;
-			t->tm_mday = 1;
-			t->tm_hour = 0;
-			t->tm_min = 0;
-			t->tm_sec = 0;
-			for(current_month = 0; current_month <= archive; current_month++) {
-				if(t->tm_mon == 0) {
-					t->tm_mon = 11;
-					t->tm_year--;
-					}
-				else
-					t->tm_mon--;
-				}
-			last_scheduled_log_rotation = mktime(t);
-
-			t = localtime(&current_time);
-			t->tm_mon++;
-			t->tm_mday = 1;
-			t->tm_hour = 0;
-			t->tm_min = 0;
-			t->tm_sec = 0;
-			for(current_month = 0; current_month < archive; current_month++) {
-				if(t->tm_mon == 0) {
-					t->tm_mon = 11;
-					t->tm_year--;
-					}
-				else
-					t->tm_mon--;
-				}
-			this_scheduled_log_rotation = mktime(t);
-
-			break;
-		default:
-			break;
+		t = localtime(&current_time);
+		t->tm_mon++;
+		t->tm_mday = 1;
+		t->tm_hour = 0;
+		t->tm_min = 0;
+		t->tm_sec = 0;
+		for(current_month = 0; current_month <= archive; current_month++) {
+			if(t->tm_mon == 0) {
+				t->tm_mon = 11;
+				t->tm_year--;
+			} else
+				t->tm_mon--;
 		}
+		last_scheduled_log_rotation = mktime(t);
+
+		t = localtime(&current_time);
+		t->tm_mon++;
+		t->tm_mday = 1;
+		t->tm_hour = 0;
+		t->tm_min = 0;
+		t->tm_sec = 0;
+		for(current_month = 0; current_month < archive; current_month++) {
+			if(t->tm_mon == 0) {
+				t->tm_mon = 11;
+				t->tm_year--;
+			} else
+				t->tm_mon--;
+		}
+		this_scheduled_log_rotation = mktime(t);
+
+		break;
+	default:
+		break;
+	}
 
 	/* adjust this rotation time for daylight savings time */
 	t = localtime(&this_scheduled_log_rotation);
@@ -1572,7 +1592,7 @@ void determine_log_rotation_times(int archive) {
 		last_scheduled_log_rotation = (time_t)(last_scheduled_log_rotation + 3600);
 
 	return;
-	}
+}
 
 
 
@@ -1581,7 +1601,8 @@ void determine_log_rotation_times(int archive) {
  *************** COMMON HTML FUNCTIONS ********************
  **********************************************************/
 
-void display_info_table(const char *title, int refresh, authdata *current_authdata) {
+void display_info_table(const char *title, int refresh, authdata *current_authdata)
+{
 	time_t current_time;
 	char date_time[MAX_DATETIME_LENGTH];
 	int result;
@@ -1617,17 +1638,18 @@ void display_info_table(const char *title, int refresh, authdata *current_authda
 
 		if(execute_service_checks == FALSE)
 			printf("<DIV CLASS='infoBoxBadProcStatus'>- Service checks are disabled</DIV>");
-		}
+	}
 
 	printf("</TD></TR>\n");
 	printf("</TABLE>\n");
 
 	return;
-	}
+}
 
 
 
-void display_nav_table(char *url, int archive) {
+void display_nav_table(char *url, int archive)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	char archive_file[MAX_INPUT_BUFFER];
 	char *archive_basename;
@@ -1639,11 +1661,10 @@ void display_nav_table(char *url, int archive) {
 		if(archive == 0) {
 			printf("Latest Archive<br>");
 			printf("<a href='%sarchive=1'><img src='%s%s' border=0 alt='Latest Archive' title='Latest Archive'></a>", url, url_images_path, LEFT_ARROW_ICON);
-			}
-		else {
+		} else {
 			printf("Earlier Archive<br>");
 			printf("<a href='%sarchive=%d'><img src='%s%s' border=0 alt='Earlier Archive' title='Earlier Archive'></a>", url, archive + 1, url_images_path, LEFT_ARROW_ICON);
-			}
+		}
 		printf("</td>\n");
 
 		printf("<td width=15></td>\n");
@@ -1658,7 +1679,7 @@ void display_nav_table(char *url, int archive) {
 		else {
 			get_time_string(&this_scheduled_log_rotation, date_time, (int)sizeof(date_time), LONG_DATE_TIME);
 			printf("%s", date_time);
-			}
+		}
 		printf("</td>\n");
 
 		printf("<td width=15></td>\n");
@@ -1668,20 +1689,18 @@ void display_nav_table(char *url, int archive) {
 			if(archive == 1) {
 				printf("Current Log<br>");
 				printf("<a href='%s'><img src='%s%s' border=0 alt='Current Log' title='Current Log'></a>", url, url_images_path, RIGHT_ARROW_ICON);
-				}
-			else {
+			} else {
 				printf("More Recent Archive<br>");
 				printf("<a href='%sarchive=%d'><img src='%s%s' border=0 alt='More Recent Archive' title='More Recent Archive'></a>", url, archive - 1, url_images_path, RIGHT_ARROW_ICON);
-				}
-			printf("</td>\n");
 			}
-		else
+			printf("</td>\n");
+		} else
 			printf("<td><img src='%s%s' border=0 width=75 height=1></td>\n", url_images_path, EMPTY_ICON);
 
 		printf("</tr>\n");
 
 		printf("</table>\n");
-		}
+	}
 
 	/* get archive to use */
 	get_log_archive_to_use(archive, archive_file, sizeof(archive_file) - 1);
@@ -1695,12 +1714,13 @@ void display_nav_table(char *url, int archive) {
 	printf("<BR><DIV CLASS='navBoxFile'>File: %s</DIV>\n", archive_basename);
 
 	return;
-	}
+}
 
 
 
 /* prints the additional notes or action url for a hostgroup (with macros substituted) */
-void print_extra_hostgroup_url(char *group_name, char *url) {
+void print_extra_hostgroup_url(char *group_name, char *url)
+{
 	char input_buffer[MAX_INPUT_BUFFER] = "";
 	char output_buffer[MAX_INPUT_BUFFER] = "";
 	char *temp_buffer;
@@ -1714,7 +1734,7 @@ void print_extra_hostgroup_url(char *group_name, char *url) {
 	if(temp_hostgroup == NULL) {
 		printf("%s", url);
 		return;
-		}
+	}
 
 	strncpy(input_buffer, url, sizeof(input_buffer) - 1);
 	input_buffer[sizeof(input_buffer) - 1] = '\x0';
@@ -1725,30 +1745,30 @@ void print_extra_hostgroup_url(char *group_name, char *url) {
 			if(strlen(output_buffer) + strlen(temp_buffer) < sizeof(output_buffer) - 1) {
 				strncat(output_buffer, temp_buffer, sizeof(output_buffer) - strlen(output_buffer) - 1);
 				output_buffer[sizeof(output_buffer) - 1] = '\x0';
-				}
-			in_macro = TRUE;
 			}
-		else {
+			in_macro = TRUE;
+		} else {
 
 			if(strlen(output_buffer) + strlen(temp_buffer) < sizeof(output_buffer) - 1) {
 
 				if(!strcmp(temp_buffer, "HOSTGROUPNAME"))
 					strncat(output_buffer, url_encode(temp_hostgroup->group_name), sizeof(output_buffer) - strlen(output_buffer) - 1);
-				}
+			}
 
 			in_macro = FALSE;
-			}
 		}
+	}
 
 	printf("%s", output_buffer);
 
 	return;
-	}
+}
 
 
 
 /* prints the additional notes or action url for a servicegroup (with macros substituted) */
-void print_extra_servicegroup_url(char *group_name, char *url) {
+void print_extra_servicegroup_url(char *group_name, char *url)
+{
 	char input_buffer[MAX_INPUT_BUFFER] = "";
 	char output_buffer[MAX_INPUT_BUFFER] = "";
 	char *temp_buffer;
@@ -1762,7 +1782,7 @@ void print_extra_servicegroup_url(char *group_name, char *url) {
 	if(temp_servicegroup == NULL) {
 		printf("%s", url);
 		return;
-		}
+	}
 
 	strncpy(input_buffer, url, sizeof(input_buffer) - 1);
 	input_buffer[sizeof(input_buffer) - 1] = '\x0';
@@ -1773,30 +1793,30 @@ void print_extra_servicegroup_url(char *group_name, char *url) {
 			if(strlen(output_buffer) + strlen(temp_buffer) < sizeof(output_buffer) - 1) {
 				strncat(output_buffer, temp_buffer, sizeof(output_buffer) - strlen(output_buffer) - 1);
 				output_buffer[sizeof(output_buffer) - 1] = '\x0';
-				}
-			in_macro = TRUE;
 			}
-		else {
+			in_macro = TRUE;
+		} else {
 
 			if(strlen(output_buffer) + strlen(temp_buffer) < sizeof(output_buffer) - 1) {
 
 				if(!strcmp(temp_buffer, "SERVICEGROUPNAME"))
 					strncat(output_buffer, url_encode(temp_servicegroup->group_name), sizeof(output_buffer) - strlen(output_buffer) - 1);
-				}
+			}
 
 			in_macro = FALSE;
-			}
 		}
+	}
 
 	printf("%s", output_buffer);
 
 	return;
-	}
+}
 
 
 
 /* include user-defined SSI footers or headers */
-void include_ssi_files(const char *cgi_name, int type) {
+void include_ssi_files(const char *cgi_name, int type)
+{
 	char common_ssi_file[MAX_INPUT_BUFFER];
 	char cgi_ssi_file[MAX_INPUT_BUFFER];
 	char raw_cgi_name[MAX_INPUT_BUFFER];
@@ -1817,20 +1837,20 @@ void include_ssi_files(const char *cgi_name, int type) {
 		printf("\n<!-- Produced by Nagios (http://www.nagios.org).  Copyright (c) 1999-2007 Ethan Galstad. -->\n");
 		include_ssi_file(common_ssi_file);
 		include_ssi_file(cgi_ssi_file);
-		}
-	else {
+	} else {
 		include_ssi_file(cgi_ssi_file);
 		include_ssi_file(common_ssi_file);
 		printf("\n<!-- Produced by Nagios (http://www.nagios.org).  Copyright (c) 1999-2007 Ethan Galstad. -->\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* include user-defined SSI footer or header */
-void include_ssi_file(const char *filename) {
+void include_ssi_file(const char *filename)
+{
 	char buffer[MAX_INPUT_BUFFER];
 	FILE *fp;
 	struct stat stat_result;
@@ -1853,29 +1873,29 @@ void include_ssi_file(const char *filename) {
 		call_return = system(filename);
 
 		return;
-		}
+	}
 
 	/* an error occurred trying to stat() the file */
 	else if(call_return != 0) {
 
 		/* Handle error conditions. Assume that standard posix error codes and errno are available. If not, comment this section out. */
 		switch(errno) {
-			case ENOTDIR: /* - A component of the path is not a directory. */
-			case ELOOP: /* Too many symbolic links encountered while traversing the path. */
-			case EFAULT: /* Bad address. */
-			case ENOMEM: /* Out of memory (i.e. kernel memory). */
-			case ENAMETOOLONG: /* File name too long. */
-				printf("<br /> A stat call returned %d while looking for the file %s.<br />", errno, filename);
-				return;
-			case EACCES: /* Permission denied. -- The file should be accessible by nagios. */
-				printf("<br /> A stat call returned a permissions error(%d) while looking for the file %s.<br />", errno, filename);
-				return;
-			case ENOENT: /* A component of the path file_name does not exist, or the path is an empty string. Just return if the file doesn't exist. */
-				return;
-			default:
-				return;
-			}
+		case ENOTDIR: /* - A component of the path is not a directory. */
+		case ELOOP: /* Too many symbolic links encountered while traversing the path. */
+		case EFAULT: /* Bad address. */
+		case ENOMEM: /* Out of memory (i.e. kernel memory). */
+		case ENAMETOOLONG: /* File name too long. */
+			printf("<br /> A stat call returned %d while looking for the file %s.<br />", errno, filename);
+			return;
+		case EACCES: /* Permission denied. -- The file should be accessible by nagios. */
+			printf("<br /> A stat call returned a permissions error(%d) while looking for the file %s.<br />", errno, filename);
+			return;
+		case ENOENT: /* A component of the path file_name does not exist, or the path is an empty string. Just return if the file doesn't exist. */
+			return;
+		default:
+			return;
 		}
+	}
 
 	fp = fopen(filename, "r");
 	if(fp == NULL)
@@ -1888,11 +1908,12 @@ void include_ssi_file(const char *filename) {
 	fclose(fp);
 
 	return;
-	}
+}
 
 
 /* displays an error if CGI config file could not be read */
-void cgi_config_file_error(const char *config_file) {
+void cgi_config_file_error(const char *config_file)
+{
 
 	printf("<H1>Whoops!</H1>\n");
 
@@ -1916,12 +1937,13 @@ void cgi_config_file_error(const char *config_file) {
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays an error if main config file could not be read */
-void main_config_file_error(const char *config_file) {
+void main_config_file_error(const char *config_file)
+{
 
 	printf("<H1>Whoops!</H1>\n");
 
@@ -1945,11 +1967,12 @@ void main_config_file_error(const char *config_file) {
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 /* displays an error if object data could not be read */
-void object_data_error(void) {
+void object_data_error(void)
+{
 
 	printf("<H1>Whoops!</H1>\n");
 
@@ -1973,11 +1996,12 @@ void object_data_error(void) {
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 /* displays an error if status data could not be read */
-void status_data_error(void) {
+void status_data_error(void)
+{
 
 	printf("<H1>Whoops!</H1>\n");
 
@@ -2005,13 +2029,14 @@ void status_data_error(void) {
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
 
 /* displays context-sensitive help window */
-void display_context_help(const char *chid) {
+void display_context_help(const char *chid)
+{
 	const char *icon = CONTEXT_HELP_ICON1;
 
 	if(show_context_help == FALSE)
@@ -2024,11 +2049,12 @@ void display_context_help(const char *chid) {
 	printf("<a href='%s%s.html' target='cshw' onClick='javascript:window.open(\"%s%s.html\",\"cshw\",\"width=550,height=600,toolbar=0,location=0,status=0,resizable=1,scrollbars=1\");return true'><img src='%s%s' border=0 alt='Display context-sensitive help for this screen' title='Display context-sensitive help for this screen'></a>\n", url_context_help_path, chid, url_context_help_path, chid, url_images_path, icon);
 
 	return;
-	}
+}
 
 
 
-void display_splunk_host_url(host *hst) {
+void display_splunk_host_url(host *hst)
+{
 
 	if(enable_splunk_integration == FALSE)
 		return;
@@ -2038,11 +2064,12 @@ void display_splunk_host_url(host *hst) {
 	printf("<a href='%s?q=search %s' target='_blank'><img src='%s%s' alt='Splunk It' title='Splunk It' border='0'></a>\n", splunk_url, url_encode(hst->name), url_images_path, SPLUNK_SMALL_WHITE_ICON);
 
 	return;
-	}
+}
 
 
 
-void display_splunk_service_url(service *svc) {
+void display_splunk_service_url(service *svc)
+{
 
 	if(enable_splunk_integration == FALSE)
 		return;
@@ -2053,11 +2080,12 @@ void display_splunk_service_url(service *svc) {
 	printf("%s' target='_blank'><img src='%s%s' alt='Splunk It' title='Splunk It' border='0'></a>\n", url_encode(svc->description), url_images_path, SPLUNK_SMALL_WHITE_ICON);
 
 	return;
-	}
+}
 
 
 
-void display_splunk_generic_url(char *buf, int icon) {
+void display_splunk_generic_url(char *buf, int icon)
+{
 	char *newbuf = NULL;
 
 	if(enable_splunk_integration == FALSE)
@@ -2078,11 +2106,12 @@ void display_splunk_generic_url(char *buf, int icon) {
 	free(newbuf);
 
 	return;
-	}
+}
 
 
 /* strip quotes and from string */
-void strip_splunk_query_terms(char *buffer) {
+void strip_splunk_query_terms(char *buffer)
+{
 	register int x;
 	register int y;
 	register int z;
@@ -2097,8 +2126,8 @@ void strip_splunk_query_terms(char *buffer) {
 			buffer[y++] = ' ';
 		else
 			buffer[y++] = buffer[x];
-		}
+	}
 	buffer[y++] = '\x0';
 
 	return;
-	}
+}

--- a/cgi/cmd.c
+++ b/cgi/cmd.c
@@ -107,7 +107,8 @@ int string_to_time(char *, time_t *);
 
 
 
-int main(void) {
+int main(void)
+{
 	int result = OK;
 
 	/* get the arguments passed in the URL */
@@ -126,7 +127,7 @@ int main(void) {
 			cgi_config_file_error(get_cgi_config_location());
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
@@ -138,7 +139,7 @@ int main(void) {
 			main_config_file_error(main_config_file);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* This requires the date_format parameter in the main config file */
 	if(strcmp(start_time_string, ""))
@@ -158,7 +159,7 @@ int main(void) {
 			object_data_error();
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	document_header(TRUE);
 
@@ -194,7 +195,7 @@ int main(void) {
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 	/* authorized_for_read_only should take priority */
 	if(is_authorized_for_read_only(&current_authdata) == TRUE) {
@@ -209,7 +210,7 @@ int main(void) {
 		free_object_data();
 
 		return OK;
-        }
+	}
 
 	/* if no command was specified... */
 	if(command_type == CMD_NONE) {
@@ -217,7 +218,7 @@ int main(void) {
 			printf("<p>Error: No command specified!</p>\n");
 		else
 			printf("<P><DIV CLASS='errorMessage'>Error: No command was specified</DIV></P>\n");
-		}
+	}
 
 	/* if this is the first request for a command, present option */
 	else if(command_mode == CMDMODE_REQUEST)
@@ -234,11 +235,12 @@ int main(void) {
 	free_object_data();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 
 	if(content_type == WML_CONTENT) {
 
@@ -250,7 +252,7 @@ void document_header(int use_stylesheet) {
 		printf("<wml>\n");
 
 		printf("<card id='card1' title='Command Results'>\n");
-		}
+	}
 
 	else {
 
@@ -266,7 +268,7 @@ void document_header(int use_stylesheet) {
 		if(use_stylesheet == TRUE) {
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMAND_CSS);
-			}
+		}
 
 		printf("</head>\n");
 
@@ -274,18 +276,19 @@ void document_header(int use_stylesheet) {
 
 		/* include user SSI header */
 		include_ssi_files(COMMAND_CGI, SSI_HEADER);
-		}
-
-	return;
 	}
 
+	return;
+}
 
-void document_footer(void) {
+
+void document_footer(void)
+{
 
 	if(content_type == WML_CONTENT) {
 		printf("</card>\n");
 		printf("</wml>\n");
-		}
+	}
 
 	else {
 
@@ -294,13 +297,14 @@ void document_footer(void) {
 
 		printf("</body>\n");
 		printf("</html>\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
-int process_cgivars(void) {
+
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -312,7 +316,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the command type */
 		else if(!strcmp(variables[x], "cmd_typ")) {
@@ -320,10 +324,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			command_type = atoi(variables[x]);
-			}
+		}
 
 		/* we found the command mode */
 		else if(!strcmp(variables[x], "cmd_mod")) {
@@ -331,10 +335,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			command_mode = atoi(variables[x]);
-			}
+		}
 
 		/* we found the comment id */
 		else if(!strcmp(variables[x], "com_id")) {
@@ -342,10 +346,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			comment_id = strtoul(variables[x], NULL, 10);
-			}
+		}
 
 		/* we found the downtime id */
 		else if(!strcmp(variables[x], "down_id")) {
@@ -353,10 +357,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			downtime_id = strtoul(variables[x], NULL, 10);
-			}
+		}
 
 		/* we found the notification delay */
 		else if(!strcmp(variables[x], "not_dly")) {
@@ -364,10 +368,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			notification_delay = atoi(variables[x]);
-			}
+		}
 
 		/* we found the schedule delay */
 		else if(!strcmp(variables[x], "sched_dly")) {
@@ -375,10 +379,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			schedule_delay = atoi(variables[x]);
-			}
+		}
 
 		/* we found the comment author */
 		else if(!strcmp(variables[x], "com_author")) {
@@ -386,12 +390,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((comment_author = (char *)strdup(variables[x])) == NULL)
 				comment_author = "";
 			strip_html_brackets(comment_author);
-			}
+		}
 
 		/* we found the comment data */
 		else if(!strcmp(variables[x], "com_data")) {
@@ -399,12 +403,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((comment_data = (char *)strdup(variables[x])) == NULL)
 				comment_data = "";
 			strip_html_brackets(comment_data);
-			}
+		}
 
 		/* we found the host name */
 		else if(!strcmp(variables[x], "host")) {
@@ -412,12 +416,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "";
 			strip_html_brackets(host_name);
-			}
+		}
 
 		/* we found the hostgroup name */
 		else if(!strcmp(variables[x], "hostgroup")) {
@@ -425,12 +429,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((hostgroup_name = (char *)strdup(variables[x])) == NULL)
 				hostgroup_name = "";
 			strip_html_brackets(hostgroup_name);
-			}
+		}
 
 		/* we found the service name */
 		else if(!strcmp(variables[x], "service")) {
@@ -438,12 +442,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((service_desc = (char *)strdup(variables[x])) == NULL)
 				service_desc = "";
 			strip_html_brackets(service_desc);
-			}
+		}
 
 		/* we found the servicegroup name */
 		else if(!strcmp(variables[x], "servicegroup")) {
@@ -451,12 +455,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((servicegroup_name = (char *)strdup(variables[x])) == NULL)
 				servicegroup_name = "";
 			strip_html_brackets(servicegroup_name);
-			}
+		}
 
 		/* we got the persistence option for a comment */
 		else if(!strcmp(variables[x], "persistent"))
@@ -488,10 +492,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			fixed = (atoi(variables[x]) > 0) ? TRUE : FALSE;
-			}
+		}
 
 		/* we got the triggered by downtime option */
 		else if(!strcmp(variables[x], "trigger")) {
@@ -499,10 +503,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			triggered_by = strtoul(variables[x], NULL, 10);
-			}
+		}
 
 		/* we got the child options */
 		else if(!strcmp(variables[x], "childoptions")) {
@@ -510,10 +514,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			child_options = atoi(variables[x]);
-			}
+		}
 
 		/* we found the plugin output */
 		else if(!strcmp(variables[x], "plugin_output")) {
@@ -521,16 +525,15 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			/* protect against buffer overflows */
 			if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 				error = TRUE;
 				break;
-				}
-			else
+			} else
 				strcpy(plugin_output, variables[x]);
-			}
+		}
 
 		/* we found the performance data */
 		else if(!strcmp(variables[x], "performance_data")) {
@@ -538,16 +541,15 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			/* protect against buffer overflows */
 			if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 				error = TRUE;
 				break;
-				}
-			else
+			} else
 				strcpy(performance_data, variables[x]);
-			}
+		}
 
 		/* we found the plugin state */
 		else if(!strcmp(variables[x], "plugin_state")) {
@@ -555,10 +557,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			plugin_state = atoi(variables[x]);
-			}
+		}
 
 		/* we found the hour duration */
 		else if(!strcmp(variables[x], "hours")) {
@@ -566,14 +568,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(atoi(variables[x]) < 0) {
 				error = TRUE;
 				break;
-				}
-			duration += (unsigned long)(atoi(variables[x]) * 3600);
 			}
+			duration += (unsigned long)(atoi(variables[x]) * 3600);
+		}
 
 		/* we found the minute duration */
 		else if(!strcmp(variables[x], "minutes")) {
@@ -581,14 +583,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(atoi(variables[x]) < 0) {
 				error = TRUE;
 				break;
-				}
-			duration += (unsigned long)(atoi(variables[x]) * 60);
 			}
+			duration += (unsigned long)(atoi(variables[x]) * 60);
+		}
 
 		/* we found the start time */
 		else if(!strcmp(variables[x], "start_time")) {
@@ -596,14 +598,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			start_time_string = (char *)malloc(strlen(variables[x]) + 1);
 			if(start_time_string == NULL)
 				start_time_string = "";
 			else
 				strcpy(start_time_string, variables[x]);
-			}
+		}
 
 		/* we found the end time */
 		else if(!strcmp(variables[x], "end_time")) {
@@ -611,14 +613,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			end_time_string = (char *)malloc(strlen(variables[x]) + 1);
 			if(end_time_string == NULL)
 				end_time_string = "";
 			else
 				strcpy(end_time_string, variables[x]);
-			}
+		}
 
 		/* we found the content type argument */
 		else if(!strcmp(variables[x], "content")) {
@@ -626,14 +628,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			if(!strcmp(variables[x], "wml")) {
 				content_type = WML_CONTENT;
 				display_header = FALSE;
-				}
-			else
+			} else
 				content_type = HTML_CONTENT;
-			}
+		}
 
 		/* we found the forced notification option */
 		else if(!strcmp(variables[x], "force_notification"))
@@ -643,17 +644,18 @@ int process_cgivars(void) {
 		else if(!strcmp(variables[x], "broadcast_notification"))
 			broadcast_notification = NOTIFICATION_OPTION_BROADCAST;
 
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
-void request_command_data(int cmd) {
+void request_command_data(int cmd)
+{
 	time_t t;
 	char start_time_str[MAX_DATETIME_LENGTH];
 	char buffer[MAX_INPUT_BUFFER];
@@ -673,252 +675,252 @@ void request_command_data(int cmd) {
 
 	switch(cmd) {
 
-		case CMD_ADD_HOST_COMMENT:
-		case CMD_ADD_SVC_COMMENT:
-			printf("add a %s comment", (cmd == CMD_ADD_HOST_COMMENT) ? "host" : "service");
-			break;
+	case CMD_ADD_HOST_COMMENT:
+	case CMD_ADD_SVC_COMMENT:
+		printf("add a %s comment", (cmd == CMD_ADD_HOST_COMMENT) ? "host" : "service");
+		break;
 
-		case CMD_DEL_HOST_COMMENT:
-		case CMD_DEL_SVC_COMMENT:
-			printf("delete a %s comment", (cmd == CMD_DEL_HOST_COMMENT) ? "host" : "service");
-			break;
+	case CMD_DEL_HOST_COMMENT:
+	case CMD_DEL_SVC_COMMENT:
+		printf("delete a %s comment", (cmd == CMD_DEL_HOST_COMMENT) ? "host" : "service");
+		break;
 
-		case CMD_DELAY_HOST_NOTIFICATION:
-		case CMD_DELAY_SVC_NOTIFICATION:
-			printf("delay a %s notification", (cmd == CMD_DELAY_HOST_NOTIFICATION) ? "host" : "service");
-			break;
+	case CMD_DELAY_HOST_NOTIFICATION:
+	case CMD_DELAY_SVC_NOTIFICATION:
+		printf("delay a %s notification", (cmd == CMD_DELAY_HOST_NOTIFICATION) ? "host" : "service");
+		break;
 
-		case CMD_SCHEDULE_SVC_CHECK:
-			printf("schedule a service check");
-			break;
+	case CMD_SCHEDULE_SVC_CHECK:
+		printf("schedule a service check");
+		break;
 
-		case CMD_ENABLE_SVC_CHECK:
-		case CMD_DISABLE_SVC_CHECK:
-			printf("%s active checks of a particular service", (cmd == CMD_ENABLE_SVC_CHECK) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SVC_CHECK:
+	case CMD_DISABLE_SVC_CHECK:
+		printf("%s active checks of a particular service", (cmd == CMD_ENABLE_SVC_CHECK) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_NOTIFICATIONS:
-		case CMD_DISABLE_NOTIFICATIONS:
-			printf("%s notifications", (cmd == CMD_ENABLE_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_NOTIFICATIONS:
+	case CMD_DISABLE_NOTIFICATIONS:
+		printf("%s notifications", (cmd == CMD_ENABLE_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_SHUTDOWN_PROCESS:
-		case CMD_RESTART_PROCESS:
-			printf("%s the Nagios process", (cmd == CMD_SHUTDOWN_PROCESS) ? "shutdown" : "restart");
-			break;
+	case CMD_SHUTDOWN_PROCESS:
+	case CMD_RESTART_PROCESS:
+		printf("%s the Nagios process", (cmd == CMD_SHUTDOWN_PROCESS) ? "shutdown" : "restart");
+		break;
 
-		case CMD_ENABLE_HOST_SVC_CHECKS:
-		case CMD_DISABLE_HOST_SVC_CHECKS:
-			printf("%s active checks of all services on a host", (cmd == CMD_ENABLE_HOST_SVC_CHECKS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOST_SVC_CHECKS:
+	case CMD_DISABLE_HOST_SVC_CHECKS:
+		printf("%s active checks of all services on a host", (cmd == CMD_ENABLE_HOST_SVC_CHECKS) ? "enable" : "disable");
+		break;
 
-		case CMD_SCHEDULE_HOST_SVC_CHECKS:
-			printf("schedule a check of all services for a host");
-			break;
+	case CMD_SCHEDULE_HOST_SVC_CHECKS:
+		printf("schedule a check of all services for a host");
+		break;
 
-		case CMD_DEL_ALL_HOST_COMMENTS:
-		case CMD_DEL_ALL_SVC_COMMENTS:
-			printf("delete all comments for a %s", (cmd == CMD_DEL_ALL_HOST_COMMENTS) ? "host" : "service");
-			break;
+	case CMD_DEL_ALL_HOST_COMMENTS:
+	case CMD_DEL_ALL_SVC_COMMENTS:
+		printf("delete all comments for a %s", (cmd == CMD_DEL_ALL_HOST_COMMENTS) ? "host" : "service");
+		break;
 
-		case CMD_ENABLE_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SVC_NOTIFICATIONS:
-			printf("%s notifications for a service", (cmd == CMD_ENABLE_SVC_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SVC_NOTIFICATIONS:
+		printf("%s notifications for a service", (cmd == CMD_ENABLE_SVC_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_NOTIFICATIONS:
-			printf("%s notifications for a host", (cmd == CMD_ENABLE_HOST_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_NOTIFICATIONS:
+		printf("%s notifications for a host", (cmd == CMD_ENABLE_HOST_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-			printf("%s notifications for all hosts and services beyond a host", (cmd == CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+		printf("%s notifications for all hosts and services beyond a host", (cmd == CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
-			printf("%s notifications for all services on a host", (cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
+		printf("%s notifications for all services on a host", (cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ACKNOWLEDGE_HOST_PROBLEM:
-		case CMD_ACKNOWLEDGE_SVC_PROBLEM:
-			printf("acknowledge a %s problem", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? "host" : "service");
-			break;
+	case CMD_ACKNOWLEDGE_HOST_PROBLEM:
+	case CMD_ACKNOWLEDGE_SVC_PROBLEM:
+		printf("acknowledge a %s problem", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? "host" : "service");
+		break;
 
-		case CMD_START_EXECUTING_SVC_CHECKS:
-		case CMD_STOP_EXECUTING_SVC_CHECKS:
-			printf("%s executing active service checks", (cmd == CMD_START_EXECUTING_SVC_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_START_EXECUTING_SVC_CHECKS:
+	case CMD_STOP_EXECUTING_SVC_CHECKS:
+		printf("%s executing active service checks", (cmd == CMD_START_EXECUTING_SVC_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
-			printf("%s accepting passive service checks", (cmd == CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
+		printf("%s accepting passive service checks", (cmd == CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_ENABLE_PASSIVE_SVC_CHECKS:
-		case CMD_DISABLE_PASSIVE_SVC_CHECKS:
-			printf("%s accepting passive service checks for a particular service", (cmd == CMD_ENABLE_PASSIVE_SVC_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_ENABLE_PASSIVE_SVC_CHECKS:
+	case CMD_DISABLE_PASSIVE_SVC_CHECKS:
+		printf("%s accepting passive service checks for a particular service", (cmd == CMD_ENABLE_PASSIVE_SVC_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_ENABLE_EVENT_HANDLERS:
-		case CMD_DISABLE_EVENT_HANDLERS:
-			printf("%s event handlers", (cmd == CMD_ENABLE_EVENT_HANDLERS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_EVENT_HANDLERS:
+	case CMD_DISABLE_EVENT_HANDLERS:
+		printf("%s event handlers", (cmd == CMD_ENABLE_EVENT_HANDLERS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOST_EVENT_HANDLER:
-		case CMD_DISABLE_HOST_EVENT_HANDLER:
-			printf("%s the event handler for a particular host", (cmd == CMD_ENABLE_HOST_EVENT_HANDLER) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOST_EVENT_HANDLER:
+	case CMD_DISABLE_HOST_EVENT_HANDLER:
+		printf("%s the event handler for a particular host", (cmd == CMD_ENABLE_HOST_EVENT_HANDLER) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_SVC_EVENT_HANDLER:
-		case CMD_DISABLE_SVC_EVENT_HANDLER:
-			printf("%s the event handler for a particular service", (cmd == CMD_ENABLE_SVC_EVENT_HANDLER) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SVC_EVENT_HANDLER:
+	case CMD_DISABLE_SVC_EVENT_HANDLER:
+		printf("%s the event handler for a particular service", (cmd == CMD_ENABLE_SVC_EVENT_HANDLER) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOST_CHECK:
-		case CMD_DISABLE_HOST_CHECK:
-			printf("%s active checks of a particular host", (cmd == CMD_ENABLE_HOST_CHECK) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOST_CHECK:
+	case CMD_DISABLE_HOST_CHECK:
+		printf("%s active checks of a particular host", (cmd == CMD_ENABLE_HOST_CHECK) ? "enable" : "disable");
+		break;
 
-		case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_START_OBSESSING_OVER_SVC_CHECKS:
-			printf("%s obsessing over service checks", (cmd == CMD_STOP_OBSESSING_OVER_SVC_CHECKS) ? "stop" : "start");
-			break;
+	case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_START_OBSESSING_OVER_SVC_CHECKS:
+		printf("%s obsessing over service checks", (cmd == CMD_STOP_OBSESSING_OVER_SVC_CHECKS) ? "stop" : "start");
+		break;
 
-		case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
-		case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
-			printf("remove a %s acknowledgement", (cmd == CMD_REMOVE_HOST_ACKNOWLEDGEMENT) ? "host" : "service");
-			break;
+	case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
+	case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
+		printf("remove a %s acknowledgement", (cmd == CMD_REMOVE_HOST_ACKNOWLEDGEMENT) ? "host" : "service");
+		break;
 
-		case CMD_SCHEDULE_HOST_DOWNTIME:
-		case CMD_SCHEDULE_SVC_DOWNTIME:
-			printf("schedule downtime for a particular %s", (cmd == CMD_SCHEDULE_HOST_DOWNTIME) ? "host" : "service");
-			break;
+	case CMD_SCHEDULE_HOST_DOWNTIME:
+	case CMD_SCHEDULE_SVC_DOWNTIME:
+		printf("schedule downtime for a particular %s", (cmd == CMD_SCHEDULE_HOST_DOWNTIME) ? "host" : "service");
+		break;
 
-		case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
-			printf("schedule downtime for all services for a particular host");
-			break;
+	case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
+		printf("schedule downtime for all services for a particular host");
+		break;
 
-		case CMD_PROCESS_HOST_CHECK_RESULT:
-		case CMD_PROCESS_SERVICE_CHECK_RESULT:
-			printf("submit a passive check result for a particular %s", (cmd == CMD_PROCESS_HOST_CHECK_RESULT) ? "host" : "service");
-			break;
+	case CMD_PROCESS_HOST_CHECK_RESULT:
+	case CMD_PROCESS_SERVICE_CHECK_RESULT:
+		printf("submit a passive check result for a particular %s", (cmd == CMD_PROCESS_HOST_CHECK_RESULT) ? "host" : "service");
+		break;
 
-		case CMD_ENABLE_HOST_FLAP_DETECTION:
-		case CMD_DISABLE_HOST_FLAP_DETECTION:
-			printf("%s flap detection for a particular host", (cmd == CMD_ENABLE_HOST_FLAP_DETECTION) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOST_FLAP_DETECTION:
+	case CMD_DISABLE_HOST_FLAP_DETECTION:
+		printf("%s flap detection for a particular host", (cmd == CMD_ENABLE_HOST_FLAP_DETECTION) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_SVC_FLAP_DETECTION:
-		case CMD_DISABLE_SVC_FLAP_DETECTION:
-			printf("%s flap detection for a particular service", (cmd == CMD_ENABLE_SVC_FLAP_DETECTION) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SVC_FLAP_DETECTION:
+	case CMD_DISABLE_SVC_FLAP_DETECTION:
+		printf("%s flap detection for a particular service", (cmd == CMD_ENABLE_SVC_FLAP_DETECTION) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_FLAP_DETECTION:
-		case CMD_DISABLE_FLAP_DETECTION:
-			printf("%s flap detection for hosts and services", (cmd == CMD_ENABLE_FLAP_DETECTION) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_FLAP_DETECTION:
+	case CMD_DISABLE_FLAP_DETECTION:
+		printf("%s flap detection for hosts and services", (cmd == CMD_ENABLE_FLAP_DETECTION) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-			printf("%s notifications for all services in a particular hostgroup", (cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+		printf("%s notifications for all services in a particular hostgroup", (cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-			printf("%s notifications for all hosts in a particular hostgroup", (cmd == CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+		printf("%s notifications for all hosts in a particular hostgroup", (cmd == CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
-		case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
-			printf("%s active checks of all services in a particular hostgroup", (cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
+	case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
+		printf("%s active checks of all services in a particular hostgroup", (cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS) ? "enable" : "disable");
+		break;
 
-		case CMD_DEL_HOST_DOWNTIME:
-		case CMD_DEL_SVC_DOWNTIME:
-			printf("cancel scheduled downtime for a particular %s", (cmd == CMD_DEL_HOST_DOWNTIME) ? "host" : "service");
-			break;
+	case CMD_DEL_HOST_DOWNTIME:
+	case CMD_DEL_SVC_DOWNTIME:
+		printf("cancel scheduled downtime for a particular %s", (cmd == CMD_DEL_HOST_DOWNTIME) ? "host" : "service");
+		break;
 
-		case CMD_ENABLE_PERFORMANCE_DATA:
-		case CMD_DISABLE_PERFORMANCE_DATA:
-			printf("%s performance data processing for hosts and services", (cmd == CMD_ENABLE_PERFORMANCE_DATA) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_PERFORMANCE_DATA:
+	case CMD_DISABLE_PERFORMANCE_DATA:
+		printf("%s performance data processing for hosts and services", (cmd == CMD_ENABLE_PERFORMANCE_DATA) ? "enable" : "disable");
+		break;
 
-		case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
-			printf("schedule downtime for all hosts in a particular hostgroup");
-			break;
+	case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
+		printf("schedule downtime for all hosts in a particular hostgroup");
+		break;
 
-		case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
-			printf("schedule downtime for all services in a particular hostgroup");
-			break;
+	case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
+		printf("schedule downtime for all services in a particular hostgroup");
+		break;
 
-		case CMD_START_EXECUTING_HOST_CHECKS:
-		case CMD_STOP_EXECUTING_HOST_CHECKS:
-			printf("%s executing host checks", (cmd == CMD_START_EXECUTING_HOST_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_START_EXECUTING_HOST_CHECKS:
+	case CMD_STOP_EXECUTING_HOST_CHECKS:
+		printf("%s executing host checks", (cmd == CMD_START_EXECUTING_HOST_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
-			printf("%s accepting passive host checks", (cmd == CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
+		printf("%s accepting passive host checks", (cmd == CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_ENABLE_PASSIVE_HOST_CHECKS:
-		case CMD_DISABLE_PASSIVE_HOST_CHECKS:
-			printf("%s accepting passive checks for a particular host", (cmd == CMD_ENABLE_PASSIVE_HOST_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_ENABLE_PASSIVE_HOST_CHECKS:
+	case CMD_DISABLE_PASSIVE_HOST_CHECKS:
+		printf("%s accepting passive checks for a particular host", (cmd == CMD_ENABLE_PASSIVE_HOST_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_START_OBSESSING_OVER_HOST_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
-			printf("%s obsessing over host checks", (cmd == CMD_START_OBSESSING_OVER_HOST_CHECKS) ? "start" : "stop");
-			break;
+	case CMD_START_OBSESSING_OVER_HOST_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
+		printf("%s obsessing over host checks", (cmd == CMD_START_OBSESSING_OVER_HOST_CHECKS) ? "start" : "stop");
+		break;
 
-		case CMD_SCHEDULE_HOST_CHECK:
-			printf("schedule a host check");
-			break;
+	case CMD_SCHEDULE_HOST_CHECK:
+		printf("schedule a host check");
+		break;
 
-		case CMD_START_OBSESSING_OVER_SVC:
-		case CMD_STOP_OBSESSING_OVER_SVC:
-			printf("%s obsessing over a particular service", (cmd == CMD_START_OBSESSING_OVER_SVC) ? "start" : "stop");
-			break;
+	case CMD_START_OBSESSING_OVER_SVC:
+	case CMD_STOP_OBSESSING_OVER_SVC:
+		printf("%s obsessing over a particular service", (cmd == CMD_START_OBSESSING_OVER_SVC) ? "start" : "stop");
+		break;
 
-		case CMD_START_OBSESSING_OVER_HOST:
-		case CMD_STOP_OBSESSING_OVER_HOST:
-			printf("%s obsessing over a particular host", (cmd == CMD_START_OBSESSING_OVER_HOST) ? "start" : "stop");
-			break;
+	case CMD_START_OBSESSING_OVER_HOST:
+	case CMD_STOP_OBSESSING_OVER_HOST:
+		printf("%s obsessing over a particular host", (cmd == CMD_START_OBSESSING_OVER_HOST) ? "start" : "stop");
+		break;
 
-		case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-			printf("%s notifications for all services in a particular servicegroup", (cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+		printf("%s notifications for all services in a particular servicegroup", (cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-			printf("%s notifications for all hosts in a particular servicegroup", (cmd == CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+		printf("%s notifications for all hosts in a particular servicegroup", (cmd == CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS) ? "enable" : "disable");
+		break;
 
-		case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
-			printf("%s active checks of all services in a particular servicegroup", (cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS) ? "enable" : "disable");
-			break;
+	case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
+		printf("%s active checks of all services in a particular servicegroup", (cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS) ? "enable" : "disable");
+		break;
 
-		case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
-			printf("schedule downtime for all hosts in a particular servicegroup");
-			break;
+	case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
+		printf("schedule downtime for all hosts in a particular servicegroup");
+		break;
 
-		case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
-			printf("schedule downtime for all services in a particular servicegroup");
-			break;
+	case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
+		printf("schedule downtime for all services in a particular servicegroup");
+		break;
 
-		case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
-		case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
-			printf("send a custom %s notification", (cmd == CMD_SEND_CUSTOM_HOST_NOTIFICATION) ? "host" : "service");
-			break;
+	case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
+	case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
+		printf("send a custom %s notification", (cmd == CMD_SEND_CUSTOM_HOST_NOTIFICATION) ? "host" : "service");
+		break;
 
-		default:
-			printf("execute an unknown command.  Shame on you!</DIV>");
-			return;
-		}
+	default:
+		printf("execute an unknown command.  Shame on you!</DIV>");
+		return;
+	}
 
 	printf("</DIV></p>\n");
 
@@ -940,429 +942,427 @@ void request_command_data(int cmd) {
 
 	switch(cmd) {
 
-		case CMD_ADD_HOST_COMMENT:
-		case CMD_ACKNOWLEDGE_HOST_PROBLEM:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+	case CMD_ADD_HOST_COMMENT:
+	case CMD_ACKNOWLEDGE_HOST_PROBLEM:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) {
+			printf("<tr><td CLASS='optBoxItem'>Sticky Acknowledgement:</td><td><b>");
+			printf("<INPUT TYPE='checkbox' NAME='sticky_ack' CHECKED>");
 			printf("</b></td></tr>\n");
-			if(cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) {
-				printf("<tr><td CLASS='optBoxItem'>Sticky Acknowledgement:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='sticky_ack' CHECKED>");
-				printf("</b></td></tr>\n");
-				printf("<tr><td CLASS='optBoxItem'>Send Notification:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='send_notification' CHECKED>");
-				printf("</b></td></tr>\n");
-				}
-			printf("<tr><td CLASS='optBoxItem'>Persistent%s:</td><td><b>", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? " Comment" : "");
-			printf("<INPUT TYPE='checkbox' NAME='persistent' %s>", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? "" : "CHECKED");
+			printf("<tr><td CLASS='optBoxItem'>Send Notification:</td><td><b>");
+			printf("<INPUT TYPE='checkbox' NAME='send_notification' CHECKED>");
 			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
-			printf("</b></td></tr>\n");
-			break;
+		}
+		printf("<tr><td CLASS='optBoxItem'>Persistent%s:</td><td><b>", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? " Comment" : "");
+		printf("<INPUT TYPE='checkbox' NAME='persistent' %s>", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? "" : "CHECKED");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
+		printf("</b></td></tr>\n");
+		break;
 
-		case CMD_ADD_SVC_COMMENT:
-		case CMD_ACKNOWLEDGE_SVC_PROBLEM:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+	case CMD_ADD_SVC_COMMENT:
+	case CMD_ACKNOWLEDGE_SVC_PROBLEM:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
+		if(cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) {
+			printf("<tr><td CLASS='optBoxItem'>Sticky Acknowledgement:</td><td><b>");
+			printf("<INPUT TYPE='checkbox' NAME='sticky_ack' CHECKED>");
 			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
-			if(cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) {
-				printf("<tr><td CLASS='optBoxItem'>Sticky Acknowledgement:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='sticky_ack' CHECKED>");
-				printf("</b></td></tr>\n");
-				printf("<tr><td CLASS='optBoxItem'>Send Notification:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='send_notification' CHECKED>");
-				printf("</b></td></tr>\n");
-				}
-			printf("<tr><td CLASS='optBoxItem'>Persistent%s:</td><td><b>", (cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) ? " Comment" : "");
-			printf("<INPUT TYPE='checkbox' NAME='persistent' %s>", (cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) ? "" : "CHECKED");
+			printf("<tr><td CLASS='optBoxItem'>Send Notification:</td><td><b>");
+			printf("<INPUT TYPE='checkbox' NAME='send_notification' CHECKED>");
 			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
-			printf("</b></td></tr>\n");
-			break;
+		}
+		printf("<tr><td CLASS='optBoxItem'>Persistent%s:</td><td><b>", (cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) ? " Comment" : "");
+		printf("<INPUT TYPE='checkbox' NAME='persistent' %s>", (cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) ? "" : "CHECKED");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
+		printf("</b></td></tr>\n");
+		break;
 
-		case CMD_DEL_HOST_COMMENT:
-		case CMD_DEL_SVC_COMMENT:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Comment ID:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_id' VALUE='%lu'>", comment_id);
-			printf("</b></td></tr>\n");
-			break;
+	case CMD_DEL_HOST_COMMENT:
+	case CMD_DEL_SVC_COMMENT:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Comment ID:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_id' VALUE='%lu'>", comment_id);
+		printf("</b></td></tr>\n");
+		break;
 
-		case CMD_DELAY_HOST_NOTIFICATION:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Notification Delay (minutes from now):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='not_dly' VALUE='%d'>", notification_delay);
-			printf("</b></td></tr>\n");
-			break;
+	case CMD_DELAY_HOST_NOTIFICATION:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Notification Delay (minutes from now):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='not_dly' VALUE='%d'>", notification_delay);
+		printf("</b></td></tr>\n");
+		break;
 
-		case CMD_DELAY_SVC_NOTIFICATION:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
-			printf("<tr><td CLASS='optBoxRequiredItem'>Notification Delay (minutes from now):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='not_dly' VALUE='%d'>", notification_delay);
-			printf("</b></td></tr>\n");
-			break;
+	case CMD_DELAY_SVC_NOTIFICATION:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
+		printf("<tr><td CLASS='optBoxRequiredItem'>Notification Delay (minutes from now):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='not_dly' VALUE='%d'>", notification_delay);
+		printf("</b></td></tr>\n");
+		break;
 
-		case CMD_SCHEDULE_SVC_CHECK:
-		case CMD_SCHEDULE_HOST_CHECK:
-		case CMD_SCHEDULE_HOST_SVC_CHECKS:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
-			printf("</b></td></tr>\n");
-			if(cmd == CMD_SCHEDULE_SVC_CHECK) {
-				printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
-				printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
-				printf("</b></td></tr>\n");
-				}
-			time(&t);
-			get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
-			printf("<tr><td CLASS='optBoxRequiredItem'>Check Time:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='start_time' VALUE='%s'>", buffer);
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxItem'>Force Check:</td><td><b>");
-			printf("<INPUT TYPE='checkbox' NAME='force_check' %s>", (force_check == TRUE) ? "CHECKED" : "");
-			printf("</b></td></tr>\n");
-			break;
-
-		case CMD_ENABLE_SVC_CHECK:
-		case CMD_DISABLE_SVC_CHECK:
-		case CMD_DEL_ALL_SVC_COMMENTS:
-		case CMD_ENABLE_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_PASSIVE_SVC_CHECKS:
-		case CMD_DISABLE_PASSIVE_SVC_CHECKS:
-		case CMD_ENABLE_SVC_EVENT_HANDLER:
-		case CMD_DISABLE_SVC_EVENT_HANDLER:
-		case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
-		case CMD_ENABLE_SVC_FLAP_DETECTION:
-		case CMD_DISABLE_SVC_FLAP_DETECTION:
-		case CMD_START_OBSESSING_OVER_SVC:
-		case CMD_STOP_OBSESSING_OVER_SVC:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
-			printf("</b></td></tr>\n");
+	case CMD_SCHEDULE_SVC_CHECK:
+	case CMD_SCHEDULE_HOST_CHECK:
+	case CMD_SCHEDULE_HOST_SVC_CHECKS:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_SCHEDULE_SVC_CHECK) {
 			printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
 			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
 			printf("</b></td></tr>\n");
-			break;
+		}
+		time(&t);
+		get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
+		printf("<tr><td CLASS='optBoxRequiredItem'>Check Time:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='start_time' VALUE='%s'>", buffer);
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxItem'>Force Check:</td><td><b>");
+		printf("<INPUT TYPE='checkbox' NAME='force_check' %s>", (force_check == TRUE) ? "CHECKED" : "");
+		printf("</b></td></tr>\n");
+		break;
 
-		case CMD_ENABLE_HOST_SVC_CHECKS:
-		case CMD_DISABLE_HOST_SVC_CHECKS:
-		case CMD_DEL_ALL_HOST_COMMENTS:
-		case CMD_ENABLE_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_NOTIFICATIONS:
-		case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_HOST_EVENT_HANDLER:
-		case CMD_DISABLE_HOST_EVENT_HANDLER:
-		case CMD_ENABLE_HOST_CHECK:
-		case CMD_DISABLE_HOST_CHECK:
-		case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
-		case CMD_ENABLE_HOST_FLAP_DETECTION:
-		case CMD_DISABLE_HOST_FLAP_DETECTION:
-		case CMD_ENABLE_PASSIVE_HOST_CHECKS:
-		case CMD_DISABLE_PASSIVE_HOST_CHECKS:
-		case CMD_START_OBSESSING_OVER_HOST:
-		case CMD_STOP_OBSESSING_OVER_HOST:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+	case CMD_ENABLE_SVC_CHECK:
+	case CMD_DISABLE_SVC_CHECK:
+	case CMD_DEL_ALL_SVC_COMMENTS:
+	case CMD_ENABLE_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_PASSIVE_SVC_CHECKS:
+	case CMD_DISABLE_PASSIVE_SVC_CHECKS:
+	case CMD_ENABLE_SVC_EVENT_HANDLER:
+	case CMD_DISABLE_SVC_EVENT_HANDLER:
+	case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
+	case CMD_ENABLE_SVC_FLAP_DETECTION:
+	case CMD_DISABLE_SVC_FLAP_DETECTION:
+	case CMD_START_OBSESSING_OVER_SVC:
+	case CMD_STOP_OBSESSING_OVER_SVC:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
+		printf("</b></td></tr>\n");
+		break;
+
+	case CMD_ENABLE_HOST_SVC_CHECKS:
+	case CMD_DISABLE_HOST_SVC_CHECKS:
+	case CMD_DEL_ALL_HOST_COMMENTS:
+	case CMD_ENABLE_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_NOTIFICATIONS:
+	case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_HOST_EVENT_HANDLER:
+	case CMD_DISABLE_HOST_EVENT_HANDLER:
+	case CMD_ENABLE_HOST_CHECK:
+	case CMD_DISABLE_HOST_CHECK:
+	case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
+	case CMD_ENABLE_HOST_FLAP_DETECTION:
+	case CMD_DISABLE_HOST_FLAP_DETECTION:
+	case CMD_ENABLE_PASSIVE_HOST_CHECKS:
+	case CMD_DISABLE_PASSIVE_HOST_CHECKS:
+	case CMD_START_OBSESSING_OVER_HOST:
+	case CMD_STOP_OBSESSING_OVER_HOST:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_ENABLE_HOST_SVC_CHECKS || cmd == CMD_DISABLE_HOST_SVC_CHECKS || cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS || cmd == CMD_DISABLE_HOST_SVC_NOTIFICATIONS) {
+			printf("<tr><td CLASS='optBoxItem'>%s For Host Too:</td><td><b>", (cmd == CMD_ENABLE_HOST_SVC_CHECKS || cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS) ? "Enable" : "Disable");
+			printf("<INPUT TYPE='checkbox' NAME='ahas'>");
 			printf("</b></td></tr>\n");
-			if(cmd == CMD_ENABLE_HOST_SVC_CHECKS || cmd == CMD_DISABLE_HOST_SVC_CHECKS || cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS || cmd == CMD_DISABLE_HOST_SVC_NOTIFICATIONS) {
-				printf("<tr><td CLASS='optBoxItem'>%s For Host Too:</td><td><b>", (cmd == CMD_ENABLE_HOST_SVC_CHECKS || cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS) ? "Enable" : "Disable");
-				printf("<INPUT TYPE='checkbox' NAME='ahas'>");
-				printf("</b></td></tr>\n");
-				}
-			if(cmd == CMD_ENABLE_HOST_NOTIFICATIONS || cmd == CMD_DISABLE_HOST_NOTIFICATIONS) {
-				printf("<tr><td CLASS='optBoxItem'>%s Notifications For Child Hosts Too:</td><td><b>", (cmd == CMD_ENABLE_HOST_NOTIFICATIONS) ? "Enable" : "Disable");
-				printf("<INPUT TYPE='checkbox' NAME='ptc'>");
-				printf("</b></td></tr>\n");
-				}
-			break;
-
-		case CMD_ENABLE_NOTIFICATIONS:
-		case CMD_DISABLE_NOTIFICATIONS:
-		case CMD_SHUTDOWN_PROCESS:
-		case CMD_RESTART_PROCESS:
-		case CMD_START_EXECUTING_SVC_CHECKS:
-		case CMD_STOP_EXECUTING_SVC_CHECKS:
-		case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_ENABLE_EVENT_HANDLERS:
-		case CMD_DISABLE_EVENT_HANDLERS:
-		case CMD_START_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_ENABLE_FLAP_DETECTION:
-		case CMD_DISABLE_FLAP_DETECTION:
-		case CMD_ENABLE_PERFORMANCE_DATA:
-		case CMD_DISABLE_PERFORMANCE_DATA:
-		case CMD_START_EXECUTING_HOST_CHECKS:
-		case CMD_STOP_EXECUTING_HOST_CHECKS:
-		case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_START_OBSESSING_OVER_HOST_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
-			printf("<tr><td CLASS='optBoxItem' colspan=2>There are no options for this command.<br>Click the 'Commit' button to submit the command.</td></tr>");
-			break;
-
-		case CMD_PROCESS_HOST_CHECK_RESULT:
-		case CMD_PROCESS_SERVICE_CHECK_RESULT:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		}
+		if(cmd == CMD_ENABLE_HOST_NOTIFICATIONS || cmd == CMD_DISABLE_HOST_NOTIFICATIONS) {
+			printf("<tr><td CLASS='optBoxItem'>%s Notifications For Child Hosts Too:</td><td><b>", (cmd == CMD_ENABLE_HOST_NOTIFICATIONS) ? "Enable" : "Disable");
+			printf("<INPUT TYPE='checkbox' NAME='ptc'>");
 			printf("</b></td></tr>\n");
-			if(cmd == CMD_PROCESS_SERVICE_CHECK_RESULT) {
-				printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
-				printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
-				printf("</b></td></tr>\n");
-				}
-			printf("<tr><td CLASS='optBoxRequiredItem'>Check Result:</td><td><b>");
-			printf("<SELECT NAME='plugin_state'>");
-			if(cmd == CMD_PROCESS_SERVICE_CHECK_RESULT) {
-				printf("<OPTION VALUE=%d SELECTED>OK\n", STATE_OK);
-				printf("<OPTION VALUE=%d>WARNING\n", STATE_WARNING);
-				printf("<OPTION VALUE=%d>UNKNOWN\n", STATE_UNKNOWN);
-				printf("<OPTION VALUE=%d>CRITICAL\n", STATE_CRITICAL);
-				}
-			else {
-				printf("<OPTION VALUE=0 SELECTED>UP\n");
-				printf("<OPTION VALUE=1>DOWN\n");
-				printf("<OPTION VALUE=2>UNREACHABLE\n");
-				}
+		}
+		break;
+
+	case CMD_ENABLE_NOTIFICATIONS:
+	case CMD_DISABLE_NOTIFICATIONS:
+	case CMD_SHUTDOWN_PROCESS:
+	case CMD_RESTART_PROCESS:
+	case CMD_START_EXECUTING_SVC_CHECKS:
+	case CMD_STOP_EXECUTING_SVC_CHECKS:
+	case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_ENABLE_EVENT_HANDLERS:
+	case CMD_DISABLE_EVENT_HANDLERS:
+	case CMD_START_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_ENABLE_FLAP_DETECTION:
+	case CMD_DISABLE_FLAP_DETECTION:
+	case CMD_ENABLE_PERFORMANCE_DATA:
+	case CMD_DISABLE_PERFORMANCE_DATA:
+	case CMD_START_EXECUTING_HOST_CHECKS:
+	case CMD_STOP_EXECUTING_HOST_CHECKS:
+	case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_START_OBSESSING_OVER_HOST_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
+		printf("<tr><td CLASS='optBoxItem' colspan=2>There are no options for this command.<br>Click the 'Commit' button to submit the command.</td></tr>");
+		break;
+
+	case CMD_PROCESS_HOST_CHECK_RESULT:
+	case CMD_PROCESS_SERVICE_CHECK_RESULT:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_PROCESS_SERVICE_CHECK_RESULT) {
+			printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
+			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
+			printf("</b></td></tr>\n");
+		}
+		printf("<tr><td CLASS='optBoxRequiredItem'>Check Result:</td><td><b>");
+		printf("<SELECT NAME='plugin_state'>");
+		if(cmd == CMD_PROCESS_SERVICE_CHECK_RESULT) {
+			printf("<OPTION VALUE=%d SELECTED>OK\n", STATE_OK);
+			printf("<OPTION VALUE=%d>WARNING\n", STATE_WARNING);
+			printf("<OPTION VALUE=%d>UNKNOWN\n", STATE_UNKNOWN);
+			printf("<OPTION VALUE=%d>CRITICAL\n", STATE_CRITICAL);
+		} else {
+			printf("<OPTION VALUE=0 SELECTED>UP\n");
+			printf("<OPTION VALUE=1>DOWN\n");
+			printf("<OPTION VALUE=2>UNREACHABLE\n");
+		}
+		printf("</SELECT>\n");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Check Output:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='plugin_output' VALUE=''>");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxItem'>Performance Data:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='performance_data' VALUE=''>");
+		printf("</b></td></tr>\n");
+		break;
+
+	case CMD_SCHEDULE_HOST_DOWNTIME:
+	case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
+	case CMD_SCHEDULE_SVC_DOWNTIME:
+
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_SCHEDULE_SVC_DOWNTIME) {
+			printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
+			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
+		}
+		printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
+		printf("</b></td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'>Triggered By:</td><td>\n");
+		printf("<select name='trigger'>\n");
+		printf("<option value='0'>N/A\n");
+
+		for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; temp_downtime = temp_downtime->next) {
+			if(temp_downtime->type != HOST_DOWNTIME)
+				continue;
+			printf("<option value='%lu'>", temp_downtime->downtime_id);
+			get_time_string(&temp_downtime->start_time, start_time_str, sizeof(start_time_str), SHORT_DATE_TIME);
+			printf("ID: %lu, Host '%s' starting @ %s\n", temp_downtime->downtime_id, temp_downtime->host_name, start_time_str);
+		}
+		for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; temp_downtime = temp_downtime->next) {
+			if(temp_downtime->type != SERVICE_DOWNTIME)
+				continue;
+			printf("<option value='%lu'>", temp_downtime->downtime_id);
+			get_time_string(&temp_downtime->start_time, start_time_str, sizeof(start_time_str), SHORT_DATE_TIME);
+			printf("ID: %lu, Service '%s' on host '%s' starting @ %s \n", temp_downtime->downtime_id, temp_downtime->service_description, temp_downtime->host_name, start_time_str);
+		}
+
+		printf("</select>\n");
+		printf("</td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
+
+		time(&t);
+		get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
+		printf("<tr><td CLASS='optBoxRequiredItem'>Start Time:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='start_time' VALUE='%s'>", buffer);
+		printf("</b></td></tr>\n");
+		t += (unsigned long)7200;
+		get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
+		printf("<tr><td CLASS='optBoxRequiredItem'>End Time:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='end_time' VALUE='%s'>", buffer);
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxItem'>Type:</td><td><b>");
+		printf("<SELECT NAME='fixed'>");
+		printf("<OPTION VALUE=1>Fixed\n");
+		printf("<OPTION VALUE=0>Flexible\n");
+		printf("</SELECT>\n");
+		printf("</b></td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'>If Flexible, Duration:</td><td>");
+		printf("<table border=0><tr>\n");
+		printf("<td align=right><INPUT TYPE='TEXT' NAME='hours' VALUE='2' SIZE=2 MAXLENGTH=2></td>\n");
+		printf("<td align=left>Hours</td>\n");
+		printf("<td align=right><INPUT TYPE='TEXT' NAME='minutes' VALUE='0' SIZE=2 MAXLENGTH=2></td>\n");
+		printf("<td align=left>Minutes</td>\n");
+		printf("</tr></table>\n");
+		printf("</td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
+
+		if(cmd == CMD_SCHEDULE_HOST_DOWNTIME) {
+			printf("<tr><td CLASS='optBoxItem'>Child Hosts:</td><td><b>");
+			printf("<SELECT name='childoptions'>");
+			printf("<option value='0'>Do nothing with child hosts\n");
+			printf("<option value='1'>Schedule triggered downtime for all child hosts\n");
+			printf("<option value='2'>Schedule non-triggered downtime for all child hosts\n");
 			printf("</SELECT>\n");
 			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Check Output:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='plugin_output' VALUE=''>");
+		}
+
+		printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
+
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+	case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
+	case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Hostgroup Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='hostgroup' VALUE='%s'>", escape_string(hostgroup_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS || cmd == CMD_DISABLE_HOSTGROUP_SVC_CHECKS || cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS || cmd == CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS) {
+			printf("<tr><td CLASS='optBoxItem'>%s For Hosts Too:</td><td><b>", (cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS || cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS) ? "Enable" : "Disable");
+			printf("<INPUT TYPE='checkbox' NAME='ahas'>");
 			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxItem'>Performance Data:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='performance_data' VALUE=''>");
+		}
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+	case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Servicegroup Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='servicegroup' VALUE='%s'>", escape_string(servicegroup_name));
+		printf("</b></td></tr>\n");
+		if(cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS || cmd == CMD_DISABLE_SERVICEGROUP_SVC_CHECKS || cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS || cmd == CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS) {
+			printf("<tr><td CLASS='optBoxItem'>%s For Hosts Too:</td><td><b>", (cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS || cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS) ? "Enable" : "Disable");
+			printf("<INPUT TYPE='checkbox' NAME='ahas'>");
 			printf("</b></td></tr>\n");
-			break;
+		}
+		break;
 
-		case CMD_SCHEDULE_HOST_DOWNTIME:
-		case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
-		case CMD_SCHEDULE_SVC_DOWNTIME:
+	case CMD_DEL_HOST_DOWNTIME:
+	case CMD_DEL_SVC_DOWNTIME:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Scheduled Downtime ID:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='down_id' VALUE='%lu'>", downtime_id);
+		printf("</b></td></tr>\n");
+		break;
 
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
-			printf("</b></td></tr>\n");
-			if(cmd == CMD_SCHEDULE_SVC_DOWNTIME) {
-				printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
-				printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
-				}
-			printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
-			printf("</b></td></tr>\n");
 
-			printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
+	case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
+	case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
+	case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
+	case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
 
-			printf("<tr><td CLASS='optBoxItem'>Triggered By:</td><td>\n");
-			printf("<select name='trigger'>\n");
-			printf("<option value='0'>N/A\n");
-
-			for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; temp_downtime = temp_downtime->next) {
-				if(temp_downtime->type != HOST_DOWNTIME)
-					continue;
-				printf("<option value='%lu'>", temp_downtime->downtime_id);
-				get_time_string(&temp_downtime->start_time, start_time_str, sizeof(start_time_str), SHORT_DATE_TIME);
-				printf("ID: %lu, Host '%s' starting @ %s\n", temp_downtime->downtime_id, temp_downtime->host_name, start_time_str);
-				}
-			for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; temp_downtime = temp_downtime->next) {
-				if(temp_downtime->type != SERVICE_DOWNTIME)
-					continue;
-				printf("<option value='%lu'>", temp_downtime->downtime_id);
-				get_time_string(&temp_downtime->start_time, start_time_str, sizeof(start_time_str), SHORT_DATE_TIME);
-				printf("ID: %lu, Service '%s' on host '%s' starting @ %s \n", temp_downtime->downtime_id, temp_downtime->service_description, temp_downtime->host_name, start_time_str);
-				}
-
-			printf("</select>\n");
-			printf("</td></tr>\n");
-
-			printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
-
-			time(&t);
-			get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
-			printf("<tr><td CLASS='optBoxRequiredItem'>Start Time:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='start_time' VALUE='%s'>", buffer);
-			printf("</b></td></tr>\n");
-			t += (unsigned long)7200;
-			get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
-			printf("<tr><td CLASS='optBoxRequiredItem'>End Time:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='end_time' VALUE='%s'>", buffer);
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxItem'>Type:</td><td><b>");
-			printf("<SELECT NAME='fixed'>");
-			printf("<OPTION VALUE=1>Fixed\n");
-			printf("<OPTION VALUE=0>Flexible\n");
-			printf("</SELECT>\n");
-			printf("</b></td></tr>\n");
-
-			printf("<tr><td CLASS='optBoxItem'>If Flexible, Duration:</td><td>");
-			printf("<table border=0><tr>\n");
-			printf("<td align=right><INPUT TYPE='TEXT' NAME='hours' VALUE='2' SIZE=2 MAXLENGTH=2></td>\n");
-			printf("<td align=left>Hours</td>\n");
-			printf("<td align=right><INPUT TYPE='TEXT' NAME='minutes' VALUE='0' SIZE=2 MAXLENGTH=2></td>\n");
-			printf("<td align=left>Minutes</td>\n");
-			printf("</tr></table>\n");
-			printf("</td></tr>\n");
-
-			printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
-
-			if(cmd == CMD_SCHEDULE_HOST_DOWNTIME) {
-				printf("<tr><td CLASS='optBoxItem'>Child Hosts:</td><td><b>");
-				printf("<SELECT name='childoptions'>");
-				printf("<option value='0'>Do nothing with child hosts\n");
-				printf("<option value='1'>Schedule triggered downtime for all child hosts\n");
-				printf("<option value='2'>Schedule non-triggered downtime for all child hosts\n");
-				printf("</SELECT>\n");
-				printf("</b></td></tr>\n");
-				}
-
-			printf("<tr><td CLASS='optBoxItem'><br></td></tr>\n");
-
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-		case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
-		case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
+		if(cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) {
 			printf("<tr><td CLASS='optBoxRequiredItem'>Hostgroup Name:</td><td><b>");
 			printf("<INPUT TYPE='TEXT' NAME='hostgroup' VALUE='%s'>", escape_string(hostgroup_name));
 			printf("</b></td></tr>\n");
-			if(cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS || cmd == CMD_DISABLE_HOSTGROUP_SVC_CHECKS || cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS || cmd == CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS) {
-				printf("<tr><td CLASS='optBoxItem'>%s For Hosts Too:</td><td><b>", (cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS || cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS) ? "Enable" : "Disable");
-				printf("<INPUT TYPE='checkbox' NAME='ahas'>");
-				printf("</b></td></tr>\n");
-				}
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-		case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
+		} else {
 			printf("<tr><td CLASS='optBoxRequiredItem'>Servicegroup Name:</td><td><b>");
 			printf("<INPUT TYPE='TEXT' NAME='servicegroup' VALUE='%s'>", escape_string(servicegroup_name));
 			printf("</b></td></tr>\n");
-			if(cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS || cmd == CMD_DISABLE_SERVICEGROUP_SVC_CHECKS || cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS || cmd == CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS) {
-				printf("<tr><td CLASS='optBoxItem'>%s For Hosts Too:</td><td><b>", (cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS || cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS) ? "Enable" : "Disable");
-				printf("<INPUT TYPE='checkbox' NAME='ahas'>");
-				printf("</b></td></tr>\n");
-				}
-			break;
-
-		case CMD_DEL_HOST_DOWNTIME:
-		case CMD_DEL_SVC_DOWNTIME:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Scheduled Downtime ID:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='down_id' VALUE='%lu'>", downtime_id);
-			printf("</b></td></tr>\n");
-			break;
-
-
-		case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
-		case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
-		case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
-		case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
-
-			if(cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) {
-				printf("<tr><td CLASS='optBoxRequiredItem'>Hostgroup Name:</td><td><b>");
-				printf("<INPUT TYPE='TEXT' NAME='hostgroup' VALUE='%s'>", escape_string(hostgroup_name));
-				printf("</b></td></tr>\n");
-				}
-			else {
-				printf("<tr><td CLASS='optBoxRequiredItem'>Servicegroup Name:</td><td><b>");
-				printf("<INPUT TYPE='TEXT' NAME='servicegroup' VALUE='%s'>", escape_string(servicegroup_name));
-				printf("</b></td></tr>\n");
-				}
-			printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
-			printf("</b></td></tr>\n");
-			time(&t);
-			get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
-			printf("<tr><td CLASS='optBoxRequiredItem'>Start Time:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='start_time' VALUE='%s'>", buffer);
-			printf("</b></td></tr>\n");
-			t += (unsigned long)7200;
-			get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
-			printf("<tr><td CLASS='optBoxRequiredItem'>End Time:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='end_time' VALUE='%s'>", buffer);
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxItem'>Type:</td><td><b>");
-			printf("<SELECT NAME='fixed'>");
-			printf("<OPTION VALUE=1>Fixed\n");
-			printf("<OPTION VALUE=0>Flexible\n");
-			printf("</SELECT>\n");
-			printf("</b></td></tr>\n");
-
-			printf("<tr><td CLASS='optBoxItem'>If Flexible, Duration:</td><td>");
-			printf("<table border=0><tr>\n");
-			printf("<td align=right><INPUT TYPE='TEXT' NAME='hours' VALUE='2' SIZE=2 MAXLENGTH=2></td>\n");
-			printf("<td align=left>Hours</td>\n");
-			printf("<td align=right><INPUT TYPE='TEXT' NAME='minutes' VALUE='0' SIZE=2 MAXLENGTH=2></td>\n");
-			printf("<td align=left>Minutes</td>\n");
-			printf("</tr></table>\n");
-			printf("</td></tr>\n");
-			if(cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME || cmd == CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME) {
-				printf("<tr><td CLASS='optBoxItem'>Schedule Downtime For Hosts Too:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='ahas'>");
-				printf("</b></td></tr>\n");
-				}
-			break;
-
-		case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
-		case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
-			printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
-			printf("</b></td></tr>\n");
-
-			if(cmd == CMD_SEND_CUSTOM_SVC_NOTIFICATION) {
-				printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
-				printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
-				printf("</b></td></tr>\n");
-				}
-
-			printf("<tr><td CLASS='optBoxItem'>Forced:</td><td><b>");
-			printf("<INPUT TYPE='checkbox' NAME='force_notification' ");
-			printf("</b></td></tr>\n");
-
-			printf("<tr><td CLASS='optBoxItem'>Broadcast:</td><td><b>");
-			printf("<INPUT TYPE='checkbox' NAME='broadcast_notification' ");
-			printf("</b></td></tr>\n");
-
-			printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
-			printf("</b></td></tr>\n");
-			printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
-			printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
-			printf("</b></td></tr>\n");
-			break;
-
-		default:
-			printf("<tr><td CLASS='optBoxItem'>This should not be happening... :-(</td><td></td></tr>\n");
 		}
+		printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
+		printf("</b></td></tr>\n");
+		time(&t);
+		get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
+		printf("<tr><td CLASS='optBoxRequiredItem'>Start Time:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='start_time' VALUE='%s'>", buffer);
+		printf("</b></td></tr>\n");
+		t += (unsigned long)7200;
+		get_time_string(&t, buffer, sizeof(buffer) - 1, SHORT_DATE_TIME);
+		printf("<tr><td CLASS='optBoxRequiredItem'>End Time:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='end_time' VALUE='%s'>", buffer);
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxItem'>Type:</td><td><b>");
+		printf("<SELECT NAME='fixed'>");
+		printf("<OPTION VALUE=1>Fixed\n");
+		printf("<OPTION VALUE=0>Flexible\n");
+		printf("</SELECT>\n");
+		printf("</b></td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'>If Flexible, Duration:</td><td>");
+		printf("<table border=0><tr>\n");
+		printf("<td align=right><INPUT TYPE='TEXT' NAME='hours' VALUE='2' SIZE=2 MAXLENGTH=2></td>\n");
+		printf("<td align=left>Hours</td>\n");
+		printf("<td align=right><INPUT TYPE='TEXT' NAME='minutes' VALUE='0' SIZE=2 MAXLENGTH=2></td>\n");
+		printf("<td align=left>Minutes</td>\n");
+		printf("</tr></table>\n");
+		printf("</td></tr>\n");
+		if(cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME || cmd == CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME) {
+			printf("<tr><td CLASS='optBoxItem'>Schedule Downtime For Hosts Too:</td><td><b>");
+			printf("<INPUT TYPE='checkbox' NAME='ahas'>");
+			printf("</b></td></tr>\n");
+		}
+		break;
+
+	case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
+	case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
+		printf("<tr><td CLASS='optBoxRequiredItem'>Host Name:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='host' VALUE='%s'>", escape_string(host_name));
+		printf("</b></td></tr>\n");
+
+		if(cmd == CMD_SEND_CUSTOM_SVC_NOTIFICATION) {
+			printf("<tr><td CLASS='optBoxRequiredItem'>Service:</td><td><b>");
+			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
+			printf("</b></td></tr>\n");
+		}
+
+		printf("<tr><td CLASS='optBoxItem'>Forced:</td><td><b>");
+		printf("<INPUT TYPE='checkbox' NAME='force_notification' ");
+		printf("</b></td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxItem'>Broadcast:</td><td><b>");
+		printf("<INPUT TYPE='checkbox' NAME='broadcast_notification' ");
+		printf("</b></td></tr>\n");
+
+		printf("<tr><td CLASS='optBoxRequiredItem'>Author (Your Name):</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_author' VALUE='%s' %s>", escape_string(comment_author), (lock_author_names == TRUE) ? "READONLY DISABLED" : "");
+		printf("</b></td></tr>\n");
+		printf("<tr><td CLASS='optBoxRequiredItem'>Comment:</td><td><b>");
+		printf("<INPUT TYPE='TEXT' NAME='com_data' VALUE='%s' SIZE=40>", escape_string(comment_data));
+		printf("</b></td></tr>\n");
+		break;
+
+	default:
+		printf("<tr><td CLASS='optBoxItem'>This should not be happening... :-(</td><td></td></tr>\n");
+	}
 
 
 	printf("<tr><td CLASS='optBoxItem' COLSPAN=2></td></tr>\n");
@@ -1390,10 +1390,11 @@ void request_command_data(int cmd) {
 	printf("<P><DIV CLASS='infoMessage'>Please enter all required information before committing the command.<br>Required fields are marked in red.<br>Failure to supply all required values will result in an error.</DIV></P>");
 
 	return;
-	}
+}
 
 
-void commit_command_data(int cmd) {
+void commit_command_data(int cmd)
+{
 	char *error_string = NULL;
 	int result = OK;
 	int authorized = FALSE;
@@ -1416,395 +1417,389 @@ void commit_command_data(int cmd) {
 			comment_author = temp_contact->alias;
 		else
 			comment_author = current_authdata.username;
-		}
+	}
 
 	switch(cmd) {
-		case CMD_ADD_HOST_COMMENT:
-		case CMD_ACKNOWLEDGE_HOST_PROBLEM:
+	case CMD_ADD_HOST_COMMENT:
+	case CMD_ACKNOWLEDGE_HOST_PROBLEM:
 
-			/* make sure we have author name, and comment data... */
-			if(!strcmp(comment_author, "")) {
-				if(!error_string)
-					error_string = strdup("Author was not entered");
-				}
-			if(!strcmp(comment_data, "")) {
-				if(!error_string)
-					error_string = strdup("Comment was not entered");
-				}
-
-			/* clean up the comment data */
-			clean_comment_data(comment_author);
-			clean_comment_data(comment_data);
-
-			/* see if the user is authorized to issue a command... */
-			temp_host = find_host(host_name);
-			if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
-				authorized = TRUE;
-			break;
-
-		case CMD_ADD_SVC_COMMENT:
-		case CMD_ACKNOWLEDGE_SVC_PROBLEM:
-
-			/* make sure we have author name, and comment data... */
-			if(!strcmp(comment_author, "")) {
-				if(!error_string)
-					error_string = strdup("Author was not entered");
-				}
-			if(!strcmp(comment_data, "")) {
-				if(!error_string)
-					error_string = strdup("Comment was not entered");
-				}
-
-			/* clean up the comment data */
-			clean_comment_data(comment_author);
-			clean_comment_data(comment_data);
-
-			/* see if the user is authorized to issue a command... */
-			temp_service = find_service(host_name, service_desc);
-			if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
-				authorized = TRUE;
-			break;
-
-		case CMD_DEL_HOST_COMMENT:
-		case CMD_DEL_SVC_COMMENT:
-
-			/* check the sanity of the comment id */
-			if(comment_id == 0) {
-				if(!error_string)
-					error_string = strdup("Comment id cannot be 0");
-				}
-
-			/* find the comment */
-			if(cmd == CMD_DEL_HOST_COMMENT)
-				temp_comment = find_host_comment(comment_id);
-			else
-				temp_comment = find_service_comment(comment_id);
-
-			/* see if the user is authorized to issue a command... */
-			if(cmd == CMD_DEL_HOST_COMMENT && temp_comment != NULL) {
-				temp_host = find_host(temp_comment->host_name);
-				if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
-					authorized = TRUE;
-				}
-			if(cmd == CMD_DEL_SVC_COMMENT && temp_comment != NULL) {
-				temp_service = find_service(temp_comment->host_name, temp_comment->service_description);
-				if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
-					authorized = TRUE;
-				}
-
-			/* free comment data */
-			free_comment_data();
-
-			break;
-
-		case CMD_DEL_HOST_DOWNTIME:
-		case CMD_DEL_SVC_DOWNTIME:
-
-			/* check the sanity of the downtime id */
-			if(downtime_id == 0) {
-				if(!error_string)
-					error_string = strdup("Downtime id cannot be 0");
-				}
-
-			/* find the downtime entry */
-			if(cmd == CMD_DEL_HOST_DOWNTIME)
-				temp_downtime = find_host_downtime(downtime_id);
-			else
-				temp_downtime = find_service_downtime(downtime_id);
-
-			/* see if the user is authorized to issue a command... */
-			if(cmd == CMD_DEL_HOST_DOWNTIME && temp_downtime != NULL) {
-				temp_host = find_host(temp_downtime->host_name);
-				if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
-					authorized = TRUE;
-				}
-			if(cmd == CMD_DEL_SVC_DOWNTIME && temp_downtime != NULL) {
-				temp_service = find_service(temp_downtime->host_name, temp_downtime->service_description);
-				if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
-					authorized = TRUE;
-				}
-
-			/* free downtime data */
-			free_downtime_data();
-
-			break;
-
-		case CMD_SCHEDULE_SVC_CHECK:
-		case CMD_ENABLE_SVC_CHECK:
-		case CMD_DISABLE_SVC_CHECK:
-		case CMD_DEL_ALL_SVC_COMMENTS:
-		case CMD_ENABLE_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_PASSIVE_SVC_CHECKS:
-		case CMD_DISABLE_PASSIVE_SVC_CHECKS:
-		case CMD_ENABLE_SVC_EVENT_HANDLER:
-		case CMD_DISABLE_SVC_EVENT_HANDLER:
-		case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
-		case CMD_PROCESS_SERVICE_CHECK_RESULT:
-		case CMD_SCHEDULE_SVC_DOWNTIME:
-		case CMD_DELAY_SVC_NOTIFICATION:
-		case CMD_ENABLE_SVC_FLAP_DETECTION:
-		case CMD_DISABLE_SVC_FLAP_DETECTION:
-		case CMD_START_OBSESSING_OVER_SVC:
-		case CMD_STOP_OBSESSING_OVER_SVC:
-
-			/* make sure we have author name and comment data... */
-			if(cmd == CMD_SCHEDULE_SVC_DOWNTIME) {
-				if(!strcmp(comment_data, "")) {
-					if(!error_string)
-						error_string = strdup("Comment was not entered");
-					}
-				else if(!strcmp(comment_author, "")) {
-					if(!error_string)
-						error_string = strdup("Author was not entered");
-					}
-				}
-
-			/* see if the user is authorized to issue a command... */
-			temp_service = find_service(host_name, service_desc);
-			if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
-				authorized = TRUE;
-
-			/* make sure we have passive check info (if necessary) */
-			if(cmd == CMD_PROCESS_SERVICE_CHECK_RESULT && !strcmp(plugin_output, "")) {
-				if(!error_string)
-					error_string = strdup("Plugin output cannot be blank");
-				}
-
-			/* make sure we have a notification delay (if necessary) */
-			if(cmd == CMD_DELAY_SVC_NOTIFICATION && notification_delay <= 0) {
-				if(!error_string)
-					error_string = strdup("Notification delay must be greater than 0");
-				}
-
-			/* clean up the comment data if scheduling downtime */
-			if(cmd == CMD_SCHEDULE_SVC_DOWNTIME) {
-				clean_comment_data(comment_author);
-				clean_comment_data(comment_data);
-				}
-
-			/* make sure we have check time (if necessary) */
-			if(cmd == CMD_SCHEDULE_SVC_CHECK && start_time == (time_t)0) {
-				if(!error_string)
-					error_string = strdup("Start time must be non-zero or bad format has been submitted.");
-				}
-
-			/* make sure we have start/end times for downtime (if necessary) */
-			if(cmd == CMD_SCHEDULE_SVC_DOWNTIME && (start_time == (time_t)0 || end_time == (time_t)0 || end_time < start_time)) {
-				if(!error_string)
-					error_string = strdup("Start or end time not valid");
-				}
-
-			break;
-
-		case CMD_ENABLE_NOTIFICATIONS:
-		case CMD_DISABLE_NOTIFICATIONS:
-		case CMD_SHUTDOWN_PROCESS:
-		case CMD_RESTART_PROCESS:
-		case CMD_START_EXECUTING_SVC_CHECKS:
-		case CMD_STOP_EXECUTING_SVC_CHECKS:
-		case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_ENABLE_EVENT_HANDLERS:
-		case CMD_DISABLE_EVENT_HANDLERS:
-		case CMD_START_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_ENABLE_FLAP_DETECTION:
-		case CMD_DISABLE_FLAP_DETECTION:
-		case CMD_ENABLE_PERFORMANCE_DATA:
-		case CMD_DISABLE_PERFORMANCE_DATA:
-		case CMD_START_EXECUTING_HOST_CHECKS:
-		case CMD_STOP_EXECUTING_HOST_CHECKS:
-		case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_START_OBSESSING_OVER_HOST_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
-
-			/* see if the user is authorized to issue a command... */
-			if(is_authorized_for_system_commands(&current_authdata) == TRUE)
-				authorized = TRUE;
-			break;
-
-		case CMD_ENABLE_HOST_SVC_CHECKS:
-		case CMD_DISABLE_HOST_SVC_CHECKS:
-		case CMD_DEL_ALL_HOST_COMMENTS:
-		case CMD_SCHEDULE_HOST_SVC_CHECKS:
-		case CMD_ENABLE_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_NOTIFICATIONS:
-		case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_HOST_EVENT_HANDLER:
-		case CMD_DISABLE_HOST_EVENT_HANDLER:
-		case CMD_ENABLE_HOST_CHECK:
-		case CMD_DISABLE_HOST_CHECK:
-		case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
-		case CMD_SCHEDULE_HOST_DOWNTIME:
-		case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
-		case CMD_DELAY_HOST_NOTIFICATION:
-		case CMD_ENABLE_HOST_FLAP_DETECTION:
-		case CMD_DISABLE_HOST_FLAP_DETECTION:
-		case CMD_PROCESS_HOST_CHECK_RESULT:
-		case CMD_ENABLE_PASSIVE_HOST_CHECKS:
-		case CMD_DISABLE_PASSIVE_HOST_CHECKS:
-		case CMD_SCHEDULE_HOST_CHECK:
-		case CMD_START_OBSESSING_OVER_HOST:
-		case CMD_STOP_OBSESSING_OVER_HOST:
-
-			/* make sure we have author name and comment data... */
-			if(cmd == CMD_SCHEDULE_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOST_SVC_DOWNTIME) {
-				if(!strcmp(comment_data, "")) {
-					if(!error_string)
-						error_string = strdup("Comment was not entered");
-					}
-				else if(!strcmp(comment_author, "")) {
-					if(!error_string)
-						error_string = strdup("Author was not entered");
-					}
-				}
-
-			/* see if the user is authorized to issue a command... */
-			temp_host = find_host(host_name);
-			if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
-				authorized = TRUE;
-
-			/* clean up the comment data if scheduling downtime */
-			if(cmd == CMD_SCHEDULE_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOST_SVC_DOWNTIME) {
-				clean_comment_data(comment_author);
-				clean_comment_data(comment_data);
-				}
-
-			/* make sure we have a notification delay (if necessary) */
-			if(cmd == CMD_DELAY_HOST_NOTIFICATION && notification_delay <= 0) {
-				if(!error_string)
-					error_string = strdup("Notification delay must be greater than 0");
-				}
-
-			/* make sure we have start/end times for downtime (if necessary) */
-			if((cmd == CMD_SCHEDULE_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOST_SVC_DOWNTIME) && (start_time == (time_t)0 || end_time == (time_t)0 || start_time > end_time)) {
-				if(!error_string)
-					error_string = strdup("Start or end time not valid");
-				}
-
-			/* make sure we have check time (if necessary) */
-			if((cmd == CMD_SCHEDULE_HOST_CHECK || cmd == CMD_SCHEDULE_HOST_SVC_CHECKS) && start_time == (time_t)0) {
-				if(!error_string)
-					error_string = strdup("Start time must be non-zero or bad format has been submitted.");
-				}
-
-			/* make sure we have passive check info (if necessary) */
-			if(cmd == CMD_PROCESS_HOST_CHECK_RESULT && !strcmp(plugin_output, "")) {
-				if(!error_string)
-					error_string = strdup("Plugin output cannot be blank");
-				}
-
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-		case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
-		case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
-		case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
-		case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
-
-			/* make sure we have author and comment data */
-			if(cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) {
-				if(!strcmp(comment_data, "")) {
-					if(!error_string)
-						error_string = strdup("Comment was not entered");
-					}
-				else if(!strcmp(comment_author, "")) {
-					if(!error_string)
-						error_string = strdup("Author was not entered");
-					}
-				}
-
-			/* make sure we have start/end times for downtime */
-			if((cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) && (start_time == (time_t)0 || end_time == (time_t)0 || start_time > end_time)) {
-				if(!error_string)
-					error_string = strdup("Start or end time not valid");
-				}
-
-			/* see if the user is authorized to issue a command... */
-			temp_hostgroup = find_hostgroup(hostgroup_name);
-			if(is_authorized_for_hostgroup_commands(temp_hostgroup, &current_authdata) == TRUE)
-				authorized = TRUE;
-
-			/* clean up the comment data if scheduling downtime */
-			if(cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) {
-				clean_comment_data(comment_author);
-				clean_comment_data(comment_data);
-				}
-
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-		case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
-		case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
-		case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
-
-			/* make sure we have author and comment data */
-			if(cmd == CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME) {
-				if(!strcmp(comment_data, "")) {
-					if(!error_string)
-						error_string = strdup("Comment was not entered");
-					}
-				else if(!strcmp(comment_author, "")) {
-					if(!error_string)
-						error_string = strdup("Author was not entered");
-					}
-				}
-
-			/* make sure we have start/end times for downtime */
-			if((cmd == CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME) && (start_time == (time_t)0 || end_time == (time_t)0 || start_time > end_time)) {
-				if(!error_string)
-					error_string = strdup("Start or end time not valid");
-				}
-
-			/* see if the user is authorized to issue a command... */
-
-			temp_servicegroup = find_servicegroup(servicegroup_name);
-			if(is_authorized_for_servicegroup_commands(temp_servicegroup, &current_authdata) == TRUE)
-				authorized = TRUE;
-
-			break;
-
-		case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
-		case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
-
-			/* make sure we have author and comment data */
-			if(!strcmp(comment_data, "")) {
-				if(!error_string)
-					error_string = strdup("Comment was not entered");
-				}
-			else if(!strcmp(comment_author, "")) {
-				if(!error_string)
-					error_string = strdup("Author was not entered");
-				}
-
-			/* see if the user is authorized to issue a command... */
-			if(cmd == CMD_SEND_CUSTOM_HOST_NOTIFICATION) {
-				temp_host = find_host(host_name);
-				if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
-					authorized = TRUE;
-				}
-			else {
-				temp_service = find_service(host_name, service_desc);
-				if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
-					authorized = TRUE;
-				}
-			break;
-
-		default:
-			if(!error_string) error_string = strdup("An error occurred while processing your command!");
+		/* make sure we have author name, and comment data... */
+		if(!strcmp(comment_author, "")) {
+			if(!error_string)
+				error_string = strdup("Author was not entered");
 		}
+		if(!strcmp(comment_data, "")) {
+			if(!error_string)
+				error_string = strdup("Comment was not entered");
+		}
+
+		/* clean up the comment data */
+		clean_comment_data(comment_author);
+		clean_comment_data(comment_data);
+
+		/* see if the user is authorized to issue a command... */
+		temp_host = find_host(host_name);
+		if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
+			authorized = TRUE;
+		break;
+
+	case CMD_ADD_SVC_COMMENT:
+	case CMD_ACKNOWLEDGE_SVC_PROBLEM:
+
+		/* make sure we have author name, and comment data... */
+		if(!strcmp(comment_author, "")) {
+			if(!error_string)
+				error_string = strdup("Author was not entered");
+		}
+		if(!strcmp(comment_data, "")) {
+			if(!error_string)
+				error_string = strdup("Comment was not entered");
+		}
+
+		/* clean up the comment data */
+		clean_comment_data(comment_author);
+		clean_comment_data(comment_data);
+
+		/* see if the user is authorized to issue a command... */
+		temp_service = find_service(host_name, service_desc);
+		if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
+			authorized = TRUE;
+		break;
+
+	case CMD_DEL_HOST_COMMENT:
+	case CMD_DEL_SVC_COMMENT:
+
+		/* check the sanity of the comment id */
+		if(comment_id == 0) {
+			if(!error_string)
+				error_string = strdup("Comment id cannot be 0");
+		}
+
+		/* find the comment */
+		if(cmd == CMD_DEL_HOST_COMMENT)
+			temp_comment = find_host_comment(comment_id);
+		else
+			temp_comment = find_service_comment(comment_id);
+
+		/* see if the user is authorized to issue a command... */
+		if(cmd == CMD_DEL_HOST_COMMENT && temp_comment != NULL) {
+			temp_host = find_host(temp_comment->host_name);
+			if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
+				authorized = TRUE;
+		}
+		if(cmd == CMD_DEL_SVC_COMMENT && temp_comment != NULL) {
+			temp_service = find_service(temp_comment->host_name, temp_comment->service_description);
+			if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
+				authorized = TRUE;
+		}
+
+		/* free comment data */
+		free_comment_data();
+
+		break;
+
+	case CMD_DEL_HOST_DOWNTIME:
+	case CMD_DEL_SVC_DOWNTIME:
+
+		/* check the sanity of the downtime id */
+		if(downtime_id == 0) {
+			if(!error_string)
+				error_string = strdup("Downtime id cannot be 0");
+		}
+
+		/* find the downtime entry */
+		if(cmd == CMD_DEL_HOST_DOWNTIME)
+			temp_downtime = find_host_downtime(downtime_id);
+		else
+			temp_downtime = find_service_downtime(downtime_id);
+
+		/* see if the user is authorized to issue a command... */
+		if(cmd == CMD_DEL_HOST_DOWNTIME && temp_downtime != NULL) {
+			temp_host = find_host(temp_downtime->host_name);
+			if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
+				authorized = TRUE;
+		}
+		if(cmd == CMD_DEL_SVC_DOWNTIME && temp_downtime != NULL) {
+			temp_service = find_service(temp_downtime->host_name, temp_downtime->service_description);
+			if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
+				authorized = TRUE;
+		}
+
+		/* free downtime data */
+		free_downtime_data();
+
+		break;
+
+	case CMD_SCHEDULE_SVC_CHECK:
+	case CMD_ENABLE_SVC_CHECK:
+	case CMD_DISABLE_SVC_CHECK:
+	case CMD_DEL_ALL_SVC_COMMENTS:
+	case CMD_ENABLE_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_PASSIVE_SVC_CHECKS:
+	case CMD_DISABLE_PASSIVE_SVC_CHECKS:
+	case CMD_ENABLE_SVC_EVENT_HANDLER:
+	case CMD_DISABLE_SVC_EVENT_HANDLER:
+	case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
+	case CMD_PROCESS_SERVICE_CHECK_RESULT:
+	case CMD_SCHEDULE_SVC_DOWNTIME:
+	case CMD_DELAY_SVC_NOTIFICATION:
+	case CMD_ENABLE_SVC_FLAP_DETECTION:
+	case CMD_DISABLE_SVC_FLAP_DETECTION:
+	case CMD_START_OBSESSING_OVER_SVC:
+	case CMD_STOP_OBSESSING_OVER_SVC:
+
+		/* make sure we have author name and comment data... */
+		if(cmd == CMD_SCHEDULE_SVC_DOWNTIME) {
+			if(!strcmp(comment_data, "")) {
+				if(!error_string)
+					error_string = strdup("Comment was not entered");
+			} else if(!strcmp(comment_author, "")) {
+				if(!error_string)
+					error_string = strdup("Author was not entered");
+			}
+		}
+
+		/* see if the user is authorized to issue a command... */
+		temp_service = find_service(host_name, service_desc);
+		if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
+			authorized = TRUE;
+
+		/* make sure we have passive check info (if necessary) */
+		if(cmd == CMD_PROCESS_SERVICE_CHECK_RESULT && !strcmp(plugin_output, "")) {
+			if(!error_string)
+				error_string = strdup("Plugin output cannot be blank");
+		}
+
+		/* make sure we have a notification delay (if necessary) */
+		if(cmd == CMD_DELAY_SVC_NOTIFICATION && notification_delay <= 0) {
+			if(!error_string)
+				error_string = strdup("Notification delay must be greater than 0");
+		}
+
+		/* clean up the comment data if scheduling downtime */
+		if(cmd == CMD_SCHEDULE_SVC_DOWNTIME) {
+			clean_comment_data(comment_author);
+			clean_comment_data(comment_data);
+		}
+
+		/* make sure we have check time (if necessary) */
+		if(cmd == CMD_SCHEDULE_SVC_CHECK && start_time == (time_t)0) {
+			if(!error_string)
+				error_string = strdup("Start time must be non-zero or bad format has been submitted.");
+		}
+
+		/* make sure we have start/end times for downtime (if necessary) */
+		if(cmd == CMD_SCHEDULE_SVC_DOWNTIME && (start_time == (time_t)0 || end_time == (time_t)0 || end_time < start_time)) {
+			if(!error_string)
+				error_string = strdup("Start or end time not valid");
+		}
+
+		break;
+
+	case CMD_ENABLE_NOTIFICATIONS:
+	case CMD_DISABLE_NOTIFICATIONS:
+	case CMD_SHUTDOWN_PROCESS:
+	case CMD_RESTART_PROCESS:
+	case CMD_START_EXECUTING_SVC_CHECKS:
+	case CMD_STOP_EXECUTING_SVC_CHECKS:
+	case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_ENABLE_EVENT_HANDLERS:
+	case CMD_DISABLE_EVENT_HANDLERS:
+	case CMD_START_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_ENABLE_FLAP_DETECTION:
+	case CMD_DISABLE_FLAP_DETECTION:
+	case CMD_ENABLE_PERFORMANCE_DATA:
+	case CMD_DISABLE_PERFORMANCE_DATA:
+	case CMD_START_EXECUTING_HOST_CHECKS:
+	case CMD_STOP_EXECUTING_HOST_CHECKS:
+	case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_START_OBSESSING_OVER_HOST_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
+
+		/* see if the user is authorized to issue a command... */
+		if(is_authorized_for_system_commands(&current_authdata) == TRUE)
+			authorized = TRUE;
+		break;
+
+	case CMD_ENABLE_HOST_SVC_CHECKS:
+	case CMD_DISABLE_HOST_SVC_CHECKS:
+	case CMD_DEL_ALL_HOST_COMMENTS:
+	case CMD_SCHEDULE_HOST_SVC_CHECKS:
+	case CMD_ENABLE_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_NOTIFICATIONS:
+	case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_HOST_EVENT_HANDLER:
+	case CMD_DISABLE_HOST_EVENT_HANDLER:
+	case CMD_ENABLE_HOST_CHECK:
+	case CMD_DISABLE_HOST_CHECK:
+	case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
+	case CMD_SCHEDULE_HOST_DOWNTIME:
+	case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
+	case CMD_DELAY_HOST_NOTIFICATION:
+	case CMD_ENABLE_HOST_FLAP_DETECTION:
+	case CMD_DISABLE_HOST_FLAP_DETECTION:
+	case CMD_PROCESS_HOST_CHECK_RESULT:
+	case CMD_ENABLE_PASSIVE_HOST_CHECKS:
+	case CMD_DISABLE_PASSIVE_HOST_CHECKS:
+	case CMD_SCHEDULE_HOST_CHECK:
+	case CMD_START_OBSESSING_OVER_HOST:
+	case CMD_STOP_OBSESSING_OVER_HOST:
+
+		/* make sure we have author name and comment data... */
+		if(cmd == CMD_SCHEDULE_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOST_SVC_DOWNTIME) {
+			if(!strcmp(comment_data, "")) {
+				if(!error_string)
+					error_string = strdup("Comment was not entered");
+			} else if(!strcmp(comment_author, "")) {
+				if(!error_string)
+					error_string = strdup("Author was not entered");
+			}
+		}
+
+		/* see if the user is authorized to issue a command... */
+		temp_host = find_host(host_name);
+		if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
+			authorized = TRUE;
+
+		/* clean up the comment data if scheduling downtime */
+		if(cmd == CMD_SCHEDULE_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOST_SVC_DOWNTIME) {
+			clean_comment_data(comment_author);
+			clean_comment_data(comment_data);
+		}
+
+		/* make sure we have a notification delay (if necessary) */
+		if(cmd == CMD_DELAY_HOST_NOTIFICATION && notification_delay <= 0) {
+			if(!error_string)
+				error_string = strdup("Notification delay must be greater than 0");
+		}
+
+		/* make sure we have start/end times for downtime (if necessary) */
+		if((cmd == CMD_SCHEDULE_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOST_SVC_DOWNTIME) && (start_time == (time_t)0 || end_time == (time_t)0 || start_time > end_time)) {
+			if(!error_string)
+				error_string = strdup("Start or end time not valid");
+		}
+
+		/* make sure we have check time (if necessary) */
+		if((cmd == CMD_SCHEDULE_HOST_CHECK || cmd == CMD_SCHEDULE_HOST_SVC_CHECKS) && start_time == (time_t)0) {
+			if(!error_string)
+				error_string = strdup("Start time must be non-zero or bad format has been submitted.");
+		}
+
+		/* make sure we have passive check info (if necessary) */
+		if(cmd == CMD_PROCESS_HOST_CHECK_RESULT && !strcmp(plugin_output, "")) {
+			if(!error_string)
+				error_string = strdup("Plugin output cannot be blank");
+		}
+
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+	case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
+	case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
+	case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
+	case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
+
+		/* make sure we have author and comment data */
+		if(cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) {
+			if(!strcmp(comment_data, "")) {
+				if(!error_string)
+					error_string = strdup("Comment was not entered");
+			} else if(!strcmp(comment_author, "")) {
+				if(!error_string)
+					error_string = strdup("Author was not entered");
+			}
+		}
+
+		/* make sure we have start/end times for downtime */
+		if((cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) && (start_time == (time_t)0 || end_time == (time_t)0 || start_time > end_time)) {
+			if(!error_string)
+				error_string = strdup("Start or end time not valid");
+		}
+
+		/* see if the user is authorized to issue a command... */
+		temp_hostgroup = find_hostgroup(hostgroup_name);
+		if(is_authorized_for_hostgroup_commands(temp_hostgroup, &current_authdata) == TRUE)
+			authorized = TRUE;
+
+		/* clean up the comment data if scheduling downtime */
+		if(cmd == CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME) {
+			clean_comment_data(comment_author);
+			clean_comment_data(comment_data);
+		}
+
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+	case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
+	case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
+	case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
+
+		/* make sure we have author and comment data */
+		if(cmd == CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME) {
+			if(!strcmp(comment_data, "")) {
+				if(!error_string)
+					error_string = strdup("Comment was not entered");
+			} else if(!strcmp(comment_author, "")) {
+				if(!error_string)
+					error_string = strdup("Author was not entered");
+			}
+		}
+
+		/* make sure we have start/end times for downtime */
+		if((cmd == CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME || cmd == CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME) && (start_time == (time_t)0 || end_time == (time_t)0 || start_time > end_time)) {
+			if(!error_string)
+				error_string = strdup("Start or end time not valid");
+		}
+
+		/* see if the user is authorized to issue a command... */
+
+		temp_servicegroup = find_servicegroup(servicegroup_name);
+		if(is_authorized_for_servicegroup_commands(temp_servicegroup, &current_authdata) == TRUE)
+			authorized = TRUE;
+
+		break;
+
+	case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
+	case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
+
+		/* make sure we have author and comment data */
+		if(!strcmp(comment_data, "")) {
+			if(!error_string)
+				error_string = strdup("Comment was not entered");
+		} else if(!strcmp(comment_author, "")) {
+			if(!error_string)
+				error_string = strdup("Author was not entered");
+		}
+
+		/* see if the user is authorized to issue a command... */
+		if(cmd == CMD_SEND_CUSTOM_HOST_NOTIFICATION) {
+			temp_host = find_host(host_name);
+			if(is_authorized_for_host_commands(temp_host, &current_authdata) == TRUE)
+				authorized = TRUE;
+		} else {
+			temp_service = find_service(host_name, service_desc);
+			if(is_authorized_for_service_commands(temp_service, &current_authdata) == TRUE)
+				authorized = TRUE;
+		}
+		break;
+
+	default:
+		if(!error_string) error_string = strdup("An error occurred while processing your command!");
+	}
 
 
 	/* to be safe, we are going to REQUIRE that the authentication functionality is enabled... */
@@ -1821,8 +1816,8 @@ void commit_command_data(int cmd) {
 			printf("<strong>Read the section on CGI authentication in the HTML documentation to learn how you can enable authentication and why you should want to.</strong>\n");
 			printf("</DIV>\n");
 			printf("</P>\n");
-			}
 		}
+	}
 
 	/* the user is not authorized to issue the given command */
 	else if(authorized == FALSE) {
@@ -1832,8 +1827,8 @@ void commit_command_data(int cmd) {
 			printf("<P><DIV CLASS='errorMessage'>Sorry, but you are not authorized to commit the specified command.</DIV></P>\n");
 			printf("<P><DIV CLASS='errorDescription'>Read the section of the documentation that deals with authentication and authorization in the CGIs for more information.<BR><BR>\n");
 			printf("<A HREF='javascript:window.history.go(-2)'>Return from whence you came</A></DIV></P>\n");
-			}
 		}
+	}
 
 	/* some error occurred (data was probably missing) */
 	else if(error_string) {
@@ -1844,8 +1839,8 @@ void commit_command_data(int cmd) {
 			free(error_string);
 			printf("<P><DIV CLASS='errorDescription'>Go <A HREF='javascript:window.history.go(-1)'>back</A> and verify that you entered all required information correctly.<BR>\n");
 			printf("<A HREF='javascript:window.history.go(-2)'>Return from whence you came</A></DIV></P>\n");
-			}
 		}
+	}
 
 	/* if Nagios isn't checking external commands, don't do anything... */
 	else if(check_external_commands == FALSE) {
@@ -1855,8 +1850,8 @@ void commit_command_data(int cmd) {
 			printf("<P><DIV CLASS='errorMessage'>Sorry, but Nagios is currently not checking for external commands, so your command will not be committed!</DIV></P>\n");
 			printf("<P><DIV CLASS='errorDescription'>Read the documentation for information on how to enable external commands...<BR><BR>\n");
 			printf("<A HREF='javascript:window.history.go(-2)'>Return from whence you came</A></DIV></P>\n");
-			}
 		}
+	}
 
 	/* everything looks okay, so let's go ahead and commit the command... */
 	else {
@@ -1871,23 +1866,23 @@ void commit_command_data(int cmd) {
 				printf("<P><DIV CLASS='infoMessage'>Your command request was successfully submitted to Nagios for processing.<BR><BR>\n");
 				printf("Note: It may take a while before the command is actually processed.<BR><BR>\n");
 				printf("<A HREF='javascript:window.history.go(-2)'>Done</A></DIV></P>");
-				}
 			}
-		else {
+		} else {
 			if(content_type == WML_CONTENT)
 				printf("<p>An error occurred while committing your command!</p>\n");
 			else {
 				printf("<P><DIV CLASS='errorMessage'>An error occurred while attempting to commit your command for processing.<BR><BR>\n");
 				printf("<A HREF='javascript:window.history.go(-2)'>Return from whence you came</A></DIV></P>\n");
-				}
 			}
 		}
-
-	return;
 	}
 
+	return;
+}
+
 __attribute__((format(printf, 2, 3)))
-static int cmd_submitf(int id, const char *fmt, ...) {
+static int cmd_submitf(int id, const char *fmt, ...)
+{
 	char cmd[MAX_EXTERNAL_COMMAND_LENGTH];
 	const char *command_name;
 	int len, len2;
@@ -1912,15 +1907,16 @@ static int cmd_submitf(int id, const char *fmt, ...) {
 		va_end(ap);
 		if(len2 < 0)
 			return ERROR;
-		}
+	}
 
 	return write_command_to_file(cmd);
-	}
+}
 
 
 
 /* commits a command for processing */
-int commit_command(int cmd) {
+int commit_command(int cmd)
+{
 	time_t current_time;
 	time_t scheduled_time;
 	time_t notification_time;
@@ -1954,266 +1950,267 @@ int commit_command(int cmd) {
 	/* decide how to form the command line... */
 	switch(cmd) {
 
-			/* commands without arguments */
-		case CMD_START_EXECUTING_SVC_CHECKS:
-		case CMD_STOP_EXECUTING_SVC_CHECKS:
-		case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
-		case CMD_ENABLE_EVENT_HANDLERS:
-		case CMD_DISABLE_EVENT_HANDLERS:
-		case CMD_START_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
-		case CMD_ENABLE_FLAP_DETECTION:
-		case CMD_DISABLE_FLAP_DETECTION:
-		case CMD_ENABLE_PERFORMANCE_DATA:
-		case CMD_DISABLE_PERFORMANCE_DATA:
-		case CMD_START_EXECUTING_HOST_CHECKS:
-		case CMD_STOP_EXECUTING_HOST_CHECKS:
-		case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
-		case CMD_START_OBSESSING_OVER_HOST_CHECKS:
-		case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
-			result = cmd_submitf(cmd, NULL);
-			break;
+	/* commands without arguments */
+	case CMD_START_EXECUTING_SVC_CHECKS:
+	case CMD_STOP_EXECUTING_SVC_CHECKS:
+	case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
+	case CMD_ENABLE_EVENT_HANDLERS:
+	case CMD_DISABLE_EVENT_HANDLERS:
+	case CMD_START_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
+	case CMD_ENABLE_FLAP_DETECTION:
+	case CMD_DISABLE_FLAP_DETECTION:
+	case CMD_ENABLE_PERFORMANCE_DATA:
+	case CMD_DISABLE_PERFORMANCE_DATA:
+	case CMD_START_EXECUTING_HOST_CHECKS:
+	case CMD_STOP_EXECUTING_HOST_CHECKS:
+	case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
+	case CMD_START_OBSESSING_OVER_HOST_CHECKS:
+	case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
+		result = cmd_submitf(cmd, NULL);
+		break;
 
-			/** simple host commands **/
-		case CMD_ENABLE_HOST_FLAP_DETECTION:
-		case CMD_DISABLE_HOST_FLAP_DETECTION:
-		case CMD_ENABLE_PASSIVE_HOST_CHECKS:
-		case CMD_DISABLE_PASSIVE_HOST_CHECKS:
-		case CMD_START_OBSESSING_OVER_HOST:
-		case CMD_STOP_OBSESSING_OVER_HOST:
-		case CMD_DEL_ALL_HOST_COMMENTS:
-		case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-		case CMD_ENABLE_HOST_EVENT_HANDLER:
-		case CMD_DISABLE_HOST_EVENT_HANDLER:
-		case CMD_ENABLE_HOST_CHECK:
-		case CMD_DISABLE_HOST_CHECK:
-		case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
-			result = cmd_submitf(cmd, "%s", host_name);
-			break;
+	/** simple host commands **/
+	case CMD_ENABLE_HOST_FLAP_DETECTION:
+	case CMD_DISABLE_HOST_FLAP_DETECTION:
+	case CMD_ENABLE_PASSIVE_HOST_CHECKS:
+	case CMD_DISABLE_PASSIVE_HOST_CHECKS:
+	case CMD_START_OBSESSING_OVER_HOST:
+	case CMD_STOP_OBSESSING_OVER_HOST:
+	case CMD_DEL_ALL_HOST_COMMENTS:
+	case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+	case CMD_ENABLE_HOST_EVENT_HANDLER:
+	case CMD_DISABLE_HOST_EVENT_HANDLER:
+	case CMD_ENABLE_HOST_CHECK:
+	case CMD_DISABLE_HOST_CHECK:
+	case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
+		result = cmd_submitf(cmd, "%s", host_name);
+		break;
 
-			/** simple service commands **/
-		case CMD_ENABLE_SVC_FLAP_DETECTION:
-		case CMD_DISABLE_SVC_FLAP_DETECTION:
-		case CMD_ENABLE_PASSIVE_SVC_CHECKS:
-		case CMD_DISABLE_PASSIVE_SVC_CHECKS:
-		case CMD_START_OBSESSING_OVER_SVC:
-		case CMD_STOP_OBSESSING_OVER_SVC:
-		case CMD_DEL_ALL_SVC_COMMENTS:
-		case CMD_ENABLE_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SVC_NOTIFICATIONS:
-		case CMD_ENABLE_SVC_EVENT_HANDLER:
-		case CMD_DISABLE_SVC_EVENT_HANDLER:
-		case CMD_ENABLE_SVC_CHECK:
-		case CMD_DISABLE_SVC_CHECK:
-		case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
-			result = cmd_submitf(cmd, "%s;%s", host_name, service_desc);
-			break;
+	/** simple service commands **/
+	case CMD_ENABLE_SVC_FLAP_DETECTION:
+	case CMD_DISABLE_SVC_FLAP_DETECTION:
+	case CMD_ENABLE_PASSIVE_SVC_CHECKS:
+	case CMD_DISABLE_PASSIVE_SVC_CHECKS:
+	case CMD_START_OBSESSING_OVER_SVC:
+	case CMD_STOP_OBSESSING_OVER_SVC:
+	case CMD_DEL_ALL_SVC_COMMENTS:
+	case CMD_ENABLE_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SVC_NOTIFICATIONS:
+	case CMD_ENABLE_SVC_EVENT_HANDLER:
+	case CMD_DISABLE_SVC_EVENT_HANDLER:
+	case CMD_ENABLE_SVC_CHECK:
+	case CMD_DISABLE_SVC_CHECK:
+	case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
+		result = cmd_submitf(cmd, "%s;%s", host_name, service_desc);
+		break;
 
-		case CMD_ADD_HOST_COMMENT:
-			result = cmd_submitf(cmd, "%s;%d;%s;%s", host_name, persistent_comment, comment_author, comment_data);
-			break;
+	case CMD_ADD_HOST_COMMENT:
+		result = cmd_submitf(cmd, "%s;%d;%s;%s", host_name, persistent_comment, comment_author, comment_data);
+		break;
 
-		case CMD_ADD_SVC_COMMENT:
-			result = cmd_submitf(cmd, "%s;%s;%d;%s;%s", host_name, service_desc, persistent_comment, comment_author, comment_data);
-			break;
+	case CMD_ADD_SVC_COMMENT:
+		result = cmd_submitf(cmd, "%s;%s;%d;%s;%s", host_name, service_desc, persistent_comment, comment_author, comment_data);
+		break;
 
-		case CMD_DEL_HOST_COMMENT:
-		case CMD_DEL_SVC_COMMENT:
-			result = cmd_submitf(cmd, "%lu", comment_id);
-			break;
+	case CMD_DEL_HOST_COMMENT:
+	case CMD_DEL_SVC_COMMENT:
+		result = cmd_submitf(cmd, "%lu", comment_id);
+		break;
 
-		case CMD_DELAY_HOST_NOTIFICATION:
-			result = cmd_submitf(cmd, "%s;%lu", host_name, notification_time);
-			break;
+	case CMD_DELAY_HOST_NOTIFICATION:
+		result = cmd_submitf(cmd, "%s;%lu", host_name, notification_time);
+		break;
 
-		case CMD_DELAY_SVC_NOTIFICATION:
-			result = cmd_submitf(cmd, "%s;%s;%lu", host_name, service_desc, notification_time);
-			break;
+	case CMD_DELAY_SVC_NOTIFICATION:
+		result = cmd_submitf(cmd, "%s;%s;%lu", host_name, service_desc, notification_time);
+		break;
 
-		case CMD_SCHEDULE_SVC_CHECK:
-		case CMD_SCHEDULE_FORCED_SVC_CHECK:
-			if(force_check == TRUE)
-				cmd = CMD_SCHEDULE_FORCED_SVC_CHECK;
-			result = cmd_submitf(cmd, "%s;%s;%lu", host_name, service_desc, start_time);
-			break;
+	case CMD_SCHEDULE_SVC_CHECK:
+	case CMD_SCHEDULE_FORCED_SVC_CHECK:
+		if(force_check == TRUE)
+			cmd = CMD_SCHEDULE_FORCED_SVC_CHECK;
+		result = cmd_submitf(cmd, "%s;%s;%lu", host_name, service_desc, start_time);
+		break;
 
-		case CMD_DISABLE_NOTIFICATIONS:
-		case CMD_ENABLE_NOTIFICATIONS:
-		case CMD_SHUTDOWN_PROCESS:
-		case CMD_RESTART_PROCESS:
-			result = cmd_submitf(cmd, "%lu", scheduled_time);
-			break;
+	case CMD_DISABLE_NOTIFICATIONS:
+	case CMD_ENABLE_NOTIFICATIONS:
+	case CMD_SHUTDOWN_PROCESS:
+	case CMD_RESTART_PROCESS:
+		result = cmd_submitf(cmd, "%lu", scheduled_time);
+		break;
 
-		case CMD_ENABLE_HOST_SVC_CHECKS:
-		case CMD_DISABLE_HOST_SVC_CHECKS:
-			result = cmd_submitf(cmd, "%s", host_name);
-			if(affect_host_and_services == TRUE) {
-				cmd = (cmd == CMD_ENABLE_HOST_SVC_CHECKS) ? CMD_ENABLE_HOST_CHECK : CMD_DISABLE_HOST_CHECK;
-				result |= cmd_submitf(cmd, "%s", host_name);
-				}
-			break;
-
-		case CMD_SCHEDULE_HOST_SVC_CHECKS:
-			if(force_check == TRUE)
-				cmd = CMD_SCHEDULE_FORCED_HOST_SVC_CHECKS;
-			result = cmd_submitf(cmd, "%s;%lu", host_name, scheduled_time);
-			break;
-
-		case CMD_ENABLE_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_NOTIFICATIONS:
-			if(propagate_to_children == TRUE)
-				cmd = (cmd == CMD_ENABLE_HOST_NOTIFICATIONS) ? CMD_ENABLE_HOST_AND_CHILD_NOTIFICATIONS : CMD_DISABLE_HOST_AND_CHILD_NOTIFICATIONS;
-			result = cmd_submitf(cmd, "%s", host_name);
-			break;
-
-		case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
-			result = cmd_submitf(cmd, "%s", host_name);
-			if(affect_host_and_services == TRUE) {
-				cmd = (cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS) ? CMD_ENABLE_HOST_NOTIFICATIONS : CMD_DISABLE_HOST_NOTIFICATIONS;
-				result |= cmd_submitf(cmd, "%s", host_name);
-				}
-			break;
-
-		case CMD_ACKNOWLEDGE_HOST_PROBLEM:
-			result = cmd_submitf(cmd, "%s;%d;%d;%d;%s;%s", host_name, (sticky_ack == TRUE) ? ACKNOWLEDGEMENT_STICKY : ACKNOWLEDGEMENT_NORMAL, send_notification, persistent_comment, comment_author, comment_data);
-			break;
-
-		case CMD_ACKNOWLEDGE_SVC_PROBLEM:
-			result = cmd_submitf(cmd, "%s;%s;%d;%d;%d;%s;%s", host_name, service_desc, (sticky_ack == TRUE) ? ACKNOWLEDGEMENT_STICKY : ACKNOWLEDGEMENT_NORMAL, send_notification, persistent_comment, comment_author, comment_data);
-			break;
-
-		case CMD_PROCESS_SERVICE_CHECK_RESULT:
-			result = cmd_submitf(cmd, "%s;%s;%d;%s|%s", host_name, service_desc, plugin_state, plugin_output, performance_data);
-			break;
-
-		case CMD_PROCESS_HOST_CHECK_RESULT:
-			result = cmd_submitf(cmd, "%s;%d;%s|%s", host_name, plugin_state, plugin_output, performance_data);
-			break;
-
-		case CMD_SCHEDULE_HOST_DOWNTIME:
-			if(child_options == 1)
-				cmd = CMD_SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_DOWNTIME;
-			else if(child_options == 2)
-				cmd = CMD_SCHEDULE_AND_PROPAGATE_HOST_DOWNTIME;
-
-			result = cmd_submitf(cmd, "%s;%lu;%lu;%d;%lu;%lu;%s;%s", host_name, start_time, end_time, fixed, triggered_by, duration, comment_author, comment_data);
-			break;
-
-		case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
-			result = cmd_submitf(cmd, "%s;%lu;%lu;%d;%lu;%lu;%s;%s", host_name, start_time, end_time, fixed, triggered_by, duration, comment_author, comment_data);
-			break;
-
-		case CMD_SCHEDULE_SVC_DOWNTIME:
-			result = cmd_submitf(cmd, "%s;%s;%lu;%lu;%d;%lu;%lu;%s;%s", host_name, service_desc, start_time, end_time, fixed, triggered_by, duration, comment_author, comment_data);
-			break;
-
-		case CMD_DEL_HOST_DOWNTIME:
-		case CMD_DEL_SVC_DOWNTIME:
-			result = cmd_submitf(cmd, "%lu", downtime_id);
-			break;
-
-		case CMD_SCHEDULE_HOST_CHECK:
-			if(force_check == TRUE)
-				cmd = CMD_SCHEDULE_FORCED_HOST_CHECK;
-			result = cmd_submitf(cmd, "%s;%lu", host_name, start_time);
-			break;
-
-		case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
-			result = cmd_submitf(cmd, "%s;%d;%s;%s", host_name, (force_notification | broadcast_notification), comment_author, comment_data);
-			break;
-
-		case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
-			result = cmd_submitf(cmd, "%s;%s;%d;%s;%s", host_name, service_desc, (force_notification | broadcast_notification), comment_author, comment_data);
-			break;
-
-
-			/***** HOSTGROUP COMMANDS *****/
-
-		case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-			result = cmd_submitf(cmd, "%s", hostgroup_name);
-			if(affect_host_and_services == TRUE) {
-				cmd = (cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS) ? CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS : CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS;
-				result |= cmd_submitf(cmd, "%s", hostgroup_name);
-				}
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-			result = cmd_submitf(cmd, "%s", hostgroup_name);
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
-		case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
-			result = cmd_submitf(cmd, "%s", hostgroup_name);
-			if(affect_host_and_services == TRUE) {
-				cmd = (cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS) ? CMD_ENABLE_HOSTGROUP_HOST_CHECKS : CMD_DISABLE_HOSTGROUP_HOST_CHECKS;
-				result |= cmd_submitf(cmd, "%s", hostgroup_name);
-				}
-			break;
-
-		case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
-			result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", hostgroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
-			break;
-
-		case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
-			result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", hostgroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
-			if(affect_host_and_services == TRUE)
-				result |= cmd_submitf(CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME, "%s;%lu;%lu;%d;0;%lu;%s;%s", hostgroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
-			break;
-
-
-			/***** SERVICEGROUP COMMANDS *****/
-
-		case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-			result = cmd_submitf(cmd, "%s", servicegroup_name);
-			if(affect_host_and_services == TRUE) {
-				cmd = (cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS) ? CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS : CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS;
-				result |= cmd_submitf(cmd, "%s", servicegroup_name);
-				}
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-		case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-			result = cmd_submitf(cmd, "%s", servicegroup_name);
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
-		case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
-			result = cmd_submitf(cmd, "%s", servicegroup_name);
-			if(affect_host_and_services == TRUE) {
-				cmd = (cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS) ? CMD_ENABLE_SERVICEGROUP_HOST_CHECKS : CMD_DISABLE_SERVICEGROUP_HOST_CHECKS;
-				result |= cmd_submitf(cmd, "%s", servicegroup_name);
-				}
-			break;
-
-		case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
-			result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", servicegroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
-			break;
-
-		case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
-			result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", servicegroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
-			if(affect_host_and_services == TRUE)
-				result |= cmd_submitf(CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME, "%s;%lu;%lu;%d;0;%lu;%s;%s", servicegroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
-			break;
-
-		default:
-			return ERROR;
-			break;
+	case CMD_ENABLE_HOST_SVC_CHECKS:
+	case CMD_DISABLE_HOST_SVC_CHECKS:
+		result = cmd_submitf(cmd, "%s", host_name);
+		if(affect_host_and_services == TRUE) {
+			cmd = (cmd == CMD_ENABLE_HOST_SVC_CHECKS) ? CMD_ENABLE_HOST_CHECK : CMD_DISABLE_HOST_CHECK;
+			result |= cmd_submitf(cmd, "%s", host_name);
 		}
+		break;
+
+	case CMD_SCHEDULE_HOST_SVC_CHECKS:
+		if(force_check == TRUE)
+			cmd = CMD_SCHEDULE_FORCED_HOST_SVC_CHECKS;
+		result = cmd_submitf(cmd, "%s;%lu", host_name, scheduled_time);
+		break;
+
+	case CMD_ENABLE_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_NOTIFICATIONS:
+		if(propagate_to_children == TRUE)
+			cmd = (cmd == CMD_ENABLE_HOST_NOTIFICATIONS) ? CMD_ENABLE_HOST_AND_CHILD_NOTIFICATIONS : CMD_DISABLE_HOST_AND_CHILD_NOTIFICATIONS;
+		result = cmd_submitf(cmd, "%s", host_name);
+		break;
+
+	case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
+		result = cmd_submitf(cmd, "%s", host_name);
+		if(affect_host_and_services == TRUE) {
+			cmd = (cmd == CMD_ENABLE_HOST_SVC_NOTIFICATIONS) ? CMD_ENABLE_HOST_NOTIFICATIONS : CMD_DISABLE_HOST_NOTIFICATIONS;
+			result |= cmd_submitf(cmd, "%s", host_name);
+		}
+		break;
+
+	case CMD_ACKNOWLEDGE_HOST_PROBLEM:
+		result = cmd_submitf(cmd, "%s;%d;%d;%d;%s;%s", host_name, (sticky_ack == TRUE) ? ACKNOWLEDGEMENT_STICKY : ACKNOWLEDGEMENT_NORMAL, send_notification, persistent_comment, comment_author, comment_data);
+		break;
+
+	case CMD_ACKNOWLEDGE_SVC_PROBLEM:
+		result = cmd_submitf(cmd, "%s;%s;%d;%d;%d;%s;%s", host_name, service_desc, (sticky_ack == TRUE) ? ACKNOWLEDGEMENT_STICKY : ACKNOWLEDGEMENT_NORMAL, send_notification, persistent_comment, comment_author, comment_data);
+		break;
+
+	case CMD_PROCESS_SERVICE_CHECK_RESULT:
+		result = cmd_submitf(cmd, "%s;%s;%d;%s|%s", host_name, service_desc, plugin_state, plugin_output, performance_data);
+		break;
+
+	case CMD_PROCESS_HOST_CHECK_RESULT:
+		result = cmd_submitf(cmd, "%s;%d;%s|%s", host_name, plugin_state, plugin_output, performance_data);
+		break;
+
+	case CMD_SCHEDULE_HOST_DOWNTIME:
+		if(child_options == 1)
+			cmd = CMD_SCHEDULE_AND_PROPAGATE_TRIGGERED_HOST_DOWNTIME;
+		else if(child_options == 2)
+			cmd = CMD_SCHEDULE_AND_PROPAGATE_HOST_DOWNTIME;
+
+		result = cmd_submitf(cmd, "%s;%lu;%lu;%d;%lu;%lu;%s;%s", host_name, start_time, end_time, fixed, triggered_by, duration, comment_author, comment_data);
+		break;
+
+	case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
+		result = cmd_submitf(cmd, "%s;%lu;%lu;%d;%lu;%lu;%s;%s", host_name, start_time, end_time, fixed, triggered_by, duration, comment_author, comment_data);
+		break;
+
+	case CMD_SCHEDULE_SVC_DOWNTIME:
+		result = cmd_submitf(cmd, "%s;%s;%lu;%lu;%d;%lu;%lu;%s;%s", host_name, service_desc, start_time, end_time, fixed, triggered_by, duration, comment_author, comment_data);
+		break;
+
+	case CMD_DEL_HOST_DOWNTIME:
+	case CMD_DEL_SVC_DOWNTIME:
+		result = cmd_submitf(cmd, "%lu", downtime_id);
+		break;
+
+	case CMD_SCHEDULE_HOST_CHECK:
+		if(force_check == TRUE)
+			cmd = CMD_SCHEDULE_FORCED_HOST_CHECK;
+		result = cmd_submitf(cmd, "%s;%lu", host_name, start_time);
+		break;
+
+	case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
+		result = cmd_submitf(cmd, "%s;%d;%s;%s", host_name, (force_notification | broadcast_notification), comment_author, comment_data);
+		break;
+
+	case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
+		result = cmd_submitf(cmd, "%s;%s;%d;%s;%s", host_name, service_desc, (force_notification | broadcast_notification), comment_author, comment_data);
+		break;
+
+
+	/***** HOSTGROUP COMMANDS *****/
+
+	case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+		result = cmd_submitf(cmd, "%s", hostgroup_name);
+		if(affect_host_and_services == TRUE) {
+			cmd = (cmd == CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS) ? CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS : CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS;
+			result |= cmd_submitf(cmd, "%s", hostgroup_name);
+		}
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+		result = cmd_submitf(cmd, "%s", hostgroup_name);
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
+	case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
+		result = cmd_submitf(cmd, "%s", hostgroup_name);
+		if(affect_host_and_services == TRUE) {
+			cmd = (cmd == CMD_ENABLE_HOSTGROUP_SVC_CHECKS) ? CMD_ENABLE_HOSTGROUP_HOST_CHECKS : CMD_DISABLE_HOSTGROUP_HOST_CHECKS;
+			result |= cmd_submitf(cmd, "%s", hostgroup_name);
+		}
+		break;
+
+	case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
+		result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", hostgroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
+		break;
+
+	case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
+		result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", hostgroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
+		if(affect_host_and_services == TRUE)
+			result |= cmd_submitf(CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME, "%s;%lu;%lu;%d;0;%lu;%s;%s", hostgroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
+		break;
+
+
+	/***** SERVICEGROUP COMMANDS *****/
+
+	case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+		result = cmd_submitf(cmd, "%s", servicegroup_name);
+		if(affect_host_and_services == TRUE) {
+			cmd = (cmd == CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS) ? CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS : CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS;
+			result |= cmd_submitf(cmd, "%s", servicegroup_name);
+		}
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+	case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+		result = cmd_submitf(cmd, "%s", servicegroup_name);
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
+	case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
+		result = cmd_submitf(cmd, "%s", servicegroup_name);
+		if(affect_host_and_services == TRUE) {
+			cmd = (cmd == CMD_ENABLE_SERVICEGROUP_SVC_CHECKS) ? CMD_ENABLE_SERVICEGROUP_HOST_CHECKS : CMD_DISABLE_SERVICEGROUP_HOST_CHECKS;
+			result |= cmd_submitf(cmd, "%s", servicegroup_name);
+		}
+		break;
+
+	case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
+		result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", servicegroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
+		break;
+
+	case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
+		result = cmd_submitf(cmd, "%s;%lu;%lu;%d;0;%lu;%s;%s", servicegroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
+		if(affect_host_and_services == TRUE)
+			result |= cmd_submitf(CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME, "%s;%lu;%lu;%d;0;%lu;%s;%s", servicegroup_name, start_time, end_time, fixed, duration, comment_author, comment_data);
+		break;
+
+	default:
+		return ERROR;
+		break;
+	}
 
 	return result;
-	}
+}
 
 
 
 /* write a command entry to the command file */
-int write_command_to_file(char *cmd) {
+int write_command_to_file(char *cmd)
+{
 	FILE *fp;
 	struct stat statbuf;
 
@@ -2235,10 +2232,10 @@ int write_command_to_file(char *cmd) {
 			printf("<P><DIV CLASS='errorDescription'>");
 			printf("The external command file may be missing, Nagios may not be running, and/or Nagios may not be checking external commands.\n");
 			printf("</DIV></P>\n");
-			}
+		}
 
 		return ERROR;
-		}
+	}
 
 	/* open the command for writing (since this is a pipe, it will really be appended) */
 	fp = fopen(command_file, "w");
@@ -2251,10 +2248,10 @@ int write_command_to_file(char *cmd) {
 			printf("<P><DIV CLASS='errorDescription'>");
 			printf("The permissions on the external command file and/or directory may be incorrect.  Read the FAQs on how to setup proper permissions.\n");
 			printf("</DIV></P>\n");
-			}
+		}
 
 		return ERROR;
-		}
+	}
 
 	/* write the command to file */
 	fprintf(fp, "%s\n", cmd);
@@ -2265,11 +2262,12 @@ int write_command_to_file(char *cmd) {
 	fclose(fp);
 
 	return OK;
-	}
+}
 
 
 /* strips out semicolons from comment data */
-void clean_comment_data(char *buffer) {
+void clean_comment_data(char *buffer)
+{
 	int x;
 	int y;
 
@@ -2278,14 +2276,15 @@ void clean_comment_data(char *buffer) {
 	for(x = 0; x < y; x++) {
 		if(buffer[x] == ';')
 			buffer[x] = ' ';
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* display information about a command */
-void show_command_help(int cmd) {
+void show_command_help(int cmd)
+{
 
 	printf("<DIV ALIGN=CENTER CLASS='descriptionTitle'>Command Description</DIV>\n");
 	printf("<TABLE BORDER=1 CELLSPACING=0 CELLPADDING=0 CLASS='commandDescription'>\n");
@@ -2294,463 +2293,464 @@ void show_command_help(int cmd) {
 	/* decide what information to print out... */
 	switch(cmd) {
 
-		case CMD_ADD_HOST_COMMENT:
-			printf("This command is used to add a comment for the specified host.  If you work with other administrators, you may find it useful to share information about a host\n");
-			printf("that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will be automatically be deleted\n");
-			printf("the next time Nagios is restarted.\n");
-			break;
-
-		case CMD_ADD_SVC_COMMENT:
-			printf("This command is used to add a comment for the specified service.  If you work with other administrators, you may find it useful to share information about a host\n");
-			printf("or service that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will automatically be\n");
-			printf("deleted the next time Nagios is restarted.\n");
-			break;
-
-		case CMD_DEL_HOST_COMMENT:
-			printf("This command is used to delete a specific host comment.\n");
-			break;
-
-		case CMD_DEL_SVC_COMMENT:
-			printf("This command is used to delete a specific service comment.\n");
-			break;
-
-		case CMD_DELAY_HOST_NOTIFICATION:
-			printf("This command is used to delay the next problem notification that is sent out for the specified host.  The notification delay will be disregarded if\n");
-			printf("the host changes state before the next notification is scheduled to be sent out.  This command has no effect if the host is currently UP.\n");
-			break;
-
-		case CMD_DELAY_SVC_NOTIFICATION:
-			printf("This command is used to delay the next problem notification that is sent out for the specified service.  The notification delay will be disregarded if\n");
-			printf("the service changes state before the next notification is scheduled to be sent out.  This command has no effect if the service is currently in an OK state.\n");
-			break;
-
-		case CMD_SCHEDULE_SVC_CHECK:
-			printf("This command is used to schedule the next check of a particular service.  Nagios will re-queue the service to be checked at the time you specify.\n");
-			printf("If you select the <i>force check</i> option, Nagios will force a check of the service regardless of both what time the scheduled check occurs and whether or not checks are enabled for the service.\n");
-			break;
-
-		case CMD_ENABLE_SVC_CHECK:
-			printf("This command is used to enable active checks of a service.\n");
-			break;
-
-		case CMD_DISABLE_SVC_CHECK:
-			printf("This command is used to disable active checks of a service.\n");
-			break;
-
-		case CMD_DISABLE_NOTIFICATIONS:
-			printf("This command is used to disable host and service notifications on a program-wide basis.\n");
-			break;
-
-		case CMD_ENABLE_NOTIFICATIONS:
-			printf("This command is used to enable host and service notifications on a program-wide basis.\n");
-			break;
-
-		case CMD_SHUTDOWN_PROCESS:
-			printf("This command is used to shutdown the Nagios process. Note: Once the Nagios has been shutdown, it cannot be restarted via the web interface!\n");
-			break;
-
-		case CMD_RESTART_PROCESS:
-			printf("This command is used to restart the Nagios process.   Executing a restart command is equivalent to sending the process a HUP signal.\n");
-			printf("All information will be flushed from memory, the configuration files will be re-read, and Nagios will start monitoring with the new configuration information.\n");
-			break;
-
-		case CMD_ENABLE_HOST_SVC_CHECKS:
-			printf("This command is used to enable active checks of all services associated with the specified host.  This <i>does not</i> enable checks of the host unless you check the 'Enable for host too' option.\n");
-			break;
-
-		case CMD_DISABLE_HOST_SVC_CHECKS:
-			printf("This command is used to disable active checks of all services associated with the specified host.  When a service is disabled Nagios will not monitor the service.  Doing this will prevent any notifications being sent out for\n");
-			printf("the specified service while it is disabled.  In order to have Nagios check the service in the future you will have to re-enable the service.\n");
-			printf("Note that disabling service checks may not necessarily prevent notifications from being sent out about the host which those services are associated with.  This <i>does not</i> disable checks of the host unless you check the 'Disable for host too' option.\n");
-			break;
-
-		case CMD_SCHEDULE_HOST_SVC_CHECKS:
-			printf("This command is used to scheduled the next check of all services on the specified host.  If you select the <i>force check</i> option, Nagios will force a check of all services on the host regardless of both what time the scheduled checks occur and whether or not checks are enabled for those services.\n");
-			break;
-
-		case CMD_DEL_ALL_HOST_COMMENTS:
-			printf("This command is used to delete all comments associated with the specified host.\n");
-			break;
-
-		case CMD_DEL_ALL_SVC_COMMENTS:
-			printf("This command is used to delete all comments associated with the specified service.\n");
-			break;
-
-		case CMD_ENABLE_SVC_NOTIFICATIONS:
-			printf("This command is used to enable notifications for the specified service.  Notifications will only be sent out for the\n");
-			printf("service state types you defined in your service definition.\n");
-			break;
-
-		case CMD_DISABLE_SVC_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for the specified service.  You will have to re-enable notifications\n");
-			printf("for this service before any alerts can be sent out in the future.\n");
-			break;
-
-		case CMD_ENABLE_HOST_NOTIFICATIONS:
-			printf("This command is used to enable notifications for the specified host.  Notifications will only be sent out for the\n");
-			printf("host state types you defined in your host definition.  Note that this command <i>does not</i> enable notifications\n");
-			printf("for services associated with this host.\n");
-			break;
-
-		case CMD_DISABLE_HOST_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for the specified host.  You will have to re-enable notifications for this host\n");
-			printf("before any alerts can be sent out in the future.  Note that this command <i>does not</i> disable notifications for services associated with this host.\n");
-			break;
-
-		case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-			printf("This command is used to enable notifications for all hosts and services that lie \"beyond\" the specified host\n");
-			printf("(from the view of Nagios).\n");
-			break;
-
-		case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
-			printf("This command is used to temporarily prevent notifications from being sent out for all hosts and services that lie\n");
-			printf("\"beyond\" the specified host (from the view of Nagios).\n");
-			break;
-
-		case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
-			printf("This command is used to enable notifications for all services on the specified host.  Notifications will only be sent out for the\n");
-			printf("service state types you defined in your service definition.  This <i>does not</i> enable notifications for the host unless you check the 'Enable for host too' option.\n");
-			break;
-
-		case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for all services on the specified host.  You will have to re-enable notifications for\n");
-			printf("all services associated with this host before any alerts can be sent out in the future.  This <i>does not</i> prevent notifications from being sent out about the host unless you check the 'Disable for host too' option.\n");
-			break;
-
-		case CMD_ACKNOWLEDGE_HOST_PROBLEM:
-			printf("This command is used to acknowledge a host problem.  When a host problem is acknowledged, future notifications about problems are temporarily disabled until the host changes from its current state.\n");
-			printf("If you want acknowledgement to disable notifications until the host recovers, check the 'Sticky Acknowledgement' checkbox.\n");
-			printf("Contacts for this host will receive a notification about the acknowledgement, so they are aware that someone is working on the problem.  Additionally, a comment will also be added to the host.\n");
-			printf("Make sure to enter your name and fill in a brief description of what you are doing in the comment field.  If you would like the host comment to remain once the acknowledgement is removed, check\n");
-			printf("the 'Persistent Comment' checkbox.  If you do not want an acknowledgement notification sent out to the appropriate contacts, uncheck the 'Send Notification' checkbox.\n");
-			break;
-
-		case CMD_ACKNOWLEDGE_SVC_PROBLEM:
-			printf("This command is used to acknowledge a service problem.  When a service problem is acknowledged, future notifications about problems are temporarily disabled until the service changes from its current state.\n");
-			printf("If you want acknowledgement to disable notifications until the service recovers, check the 'Sticky Acknowledgement' checkbox.\n");
-			printf("Contacts for this service will receive a notification about the acknowledgement, so they are aware that someone is working on the problem.  Additionally, a comment will also be added to the service.\n");
-			printf("Make sure to enter your name and fill in a brief description of what you are doing in the comment field.  If you would like the service comment to remain once the acknowledgement is removed, check\n");
-			printf("the 'Persistent Comment' checkbox.  If you do not want an acknowledgement notification sent out to the appropriate contacts, uncheck the 'Send Notification' checkbox.\n");
-			break;
-
-		case CMD_START_EXECUTING_SVC_CHECKS:
-			printf("This command is used to resume execution of active service checks on a program-wide basis.  Individual services which are disabled will still not be checked.\n");
-			break;
-
-		case CMD_STOP_EXECUTING_SVC_CHECKS:
-			printf("This command is used to temporarily stop Nagios from actively executing any service checks.  This will have the side effect of preventing any notifications from being sent out (for any and all services and hosts).\n");
-			printf("Service checks will not be executed again until you issue a command to resume service check execution.\n");
-			break;
-
-		case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
-			printf("This command is used to make Nagios start accepting passive service check results that it finds in the external command file\n");
-			break;
-
-		case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
-			printf("This command is use to make Nagios stop accepting passive service check results that it finds in the external command file.  All passive check results that are found will be ignored.\n");
-			break;
-
-		case CMD_ENABLE_PASSIVE_SVC_CHECKS:
-			printf("This command is used to allow Nagios to accept passive service check results that it finds in the external command file for this particular service.\n");
-			break;
-
-		case CMD_DISABLE_PASSIVE_SVC_CHECKS:
-			printf("This command is used to stop Nagios accepting passive service check results that it finds in the external command file for this particular service.  All passive check results that are found for this service will be ignored.\n");
-			break;
-
-		case CMD_ENABLE_EVENT_HANDLERS:
-			printf("This command is used to allow Nagios to run host and service event handlers.\n");
-			break;
-
-		case CMD_DISABLE_EVENT_HANDLERS:
-			printf("This command is used to temporarily prevent Nagios from running any host or service event handlers.\n");
-			break;
-
-		case CMD_ENABLE_SVC_EVENT_HANDLER:
-			printf("This command is used to allow Nagios to run the service event handler for a particular service when necessary (if one is defined).\n");
-			break;
-
-		case CMD_DISABLE_SVC_EVENT_HANDLER:
-			printf("This command is used to temporarily prevent Nagios from running the service event handler for a particular service.\n");
-			break;
-
-		case CMD_ENABLE_HOST_EVENT_HANDLER:
-			printf("This command is used to allow Nagios to run the host event handler for a particular service when necessary (if one is defined).\n");
-			break;
-
-		case CMD_DISABLE_HOST_EVENT_HANDLER:
-			printf("This command is used to temporarily prevent Nagios from running the host event handler for a particular host.\n");
-			break;
-
-		case CMD_ENABLE_HOST_CHECK:
-			printf("This command is used to enable active checks of this host.\n");
-			break;
-
-		case CMD_DISABLE_HOST_CHECK:
-			printf("This command is used to temporarily prevent Nagios from actively checking the status of a particular host.  If Nagios needs to check the status of this host, it will assume that it is in the same state that it was in before checks were disabled.\n");
-			break;
-
-		case CMD_START_OBSESSING_OVER_SVC_CHECKS:
-			printf("This command is used to have Nagios start obsessing over service checks.  Read the documentation on distributed monitoring for more information on this.\n");
-			break;
-
-		case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
-			printf("This command is used stop Nagios from obsessing over service checks.\n");
-			break;
-
-		case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
-			printf("This command is used to remove an acknowledgement for a particular host problem.  Once the acknowledgement is removed, notifications may start being\n");
-			printf("sent out about the host problem. \n");
-			break;
-
-		case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
-			printf("This command is used to remove an acknowledgement for a particular service problem.  Once the acknowledgement is removed, notifications may start being\n");
-			printf("sent out about the service problem.\n");
-			break;
-
-		case CMD_PROCESS_SERVICE_CHECK_RESULT:
-			printf("This command is used to submit a passive check result for a particular service.  It is particularly useful for resetting security-related services to OK states once they have been dealt with.\n");
-			break;
-
-		case CMD_PROCESS_HOST_CHECK_RESULT:
-			printf("This command is used to submit a passive check result for a particular host.\n");
-			break;
-
-		case CMD_SCHEDULE_HOST_DOWNTIME:
-			printf("This command is used to schedule downtime for a particular host.  During the specified downtime, Nagios will not send notifications out about the host.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for this host as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when the host goes down or becomes unreachable (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed downtime.\n");
-			break;
-
-		case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
-			printf("This command is used to schedule downtime for all services on a particular host.  During the specified downtime, Nagios will not send notifications out about the host.\n");
-			printf("Normally, a host in downtime will not send alerts about any services in a failed state. This option will explicitly set downtime for all services for this host.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for this host as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when the host goes down or becomes unreachable (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed downtime.\n");
-			break;
-
-		case CMD_SCHEDULE_SVC_DOWNTIME:
-			printf("This command is used to schedule downtime for a particular service.  During the specified downtime, Nagios will not send notifications out about the service.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for this service as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when the service enters a non-OK state (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed downtime.\n");
-			break;
-
-		case CMD_ENABLE_HOST_FLAP_DETECTION:
-			printf("This command is used to enable flap detection for a specific host.  If flap detection is disabled on a program-wide basis, this will have no effect,\n");
-			break;
-
-		case CMD_DISABLE_HOST_FLAP_DETECTION:
-			printf("This command is used to disable flap detection for a specific host.\n");
-			break;
-
-		case CMD_ENABLE_SVC_FLAP_DETECTION:
-			printf("This command is used to enable flap detection for a specific service.  If flap detection is disabled on a program-wide basis, this will have no effect,\n");
-			break;
-
-		case CMD_DISABLE_SVC_FLAP_DETECTION:
-			printf("This command is used to disable flap detection for a specific service.\n");
-			break;
-
-		case CMD_ENABLE_FLAP_DETECTION:
-			printf("This command is used to enable flap detection for hosts and services on a program-wide basis.  Individual hosts and services may have flap detection disabled.\n");
-			break;
-
-		case CMD_DISABLE_FLAP_DETECTION:
-			printf("This command is used to disable flap detection for hosts and services on a program-wide basis.\n");
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-			printf("This command is used to enable notifications for all services in the specified hostgroup.  Notifications will only be sent out for the\n");
-			printf("service state types you defined in your service definitions.  This <i>does not</i> enable notifications for the hosts in this hostgroup unless you check the 'Enable for hosts too' option.\n");
-			break;
-
-		case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for all services in the specified hostgroup.  You will have to re-enable notifications for\n");
-			printf("all services in this hostgroup before any alerts can be sent out in the future.  This <i>does not</i> prevent notifications from being sent out about the hosts in this hostgroup unless you check the 'Disable for hosts too' option.\n");
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-			printf("This command is used to enable notifications for all hosts in the specified hostgroup.  Notifications will only be sent out for the\n");
-			printf("host state types you defined in your host definitions.\n");
-			break;
-
-		case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for all hosts in the specified hostgroup.  You will have to re-enable notifications for\n");
-			printf("all hosts in this hostgroup before any alerts can be sent out in the future.\n");
-			break;
-
-		case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
-			printf("This command is used to enable active checks of all services in the specified hostgroup.  This <i>does not</i> enable active checks of the hosts in the hostgroup unless you check the 'Enable for hosts too' option.\n");
-			break;
-
-		case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
-			printf("This command is used to disable active checks of all services in the specified hostgroup.  This <i>does not</i> disable checks of the hosts in the hostgroup unless you check the 'Disable for hosts too' option.\n");
-			break;
-
-		case CMD_DEL_HOST_DOWNTIME:
-			printf("This command is used to cancel active or pending scheduled downtime for the specified host.\n");
-			break;
-
-		case CMD_DEL_SVC_DOWNTIME:
-			printf("This command is used to cancel active or pending scheduled downtime for the specified service.\n");
-			break;
-
-		case CMD_ENABLE_PERFORMANCE_DATA:
-			printf("This command is used to enable the processing of performance data for hosts and services on a program-wide basis.  Individual hosts and services may have performance data processing disabled.\n");
-			break;
-
-		case CMD_DISABLE_PERFORMANCE_DATA:
-			printf("This command is used to disable the processing of performance data for hosts and services on a program-wide basis.\n");
-			break;
-
-		case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
-			printf("This command is used to schedule downtime for all hosts in a particular hostgroup.  During the specified downtime, Nagios will not send notifications out about the hosts.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for the hosts as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a host goes down or becomes unreachable (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
-			break;
-
-		case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
-			printf("This command is used to schedule downtime for all services in a particular hostgroup.  During the specified downtime, Nagios will not send notifications out about the services.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for the services as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a service enters a non-OK state (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
-			printf("Note that scheduling downtime for services does not automatically schedule downtime for the hosts those services are associated with.  If you want to also schedule downtime for all hosts in the hostgroup, check the 'Schedule downtime for hosts too' option.\n");
-			break;
-
-		case CMD_START_EXECUTING_HOST_CHECKS:
-			printf("This command is used to enable active host checks on a program-wide basis.\n");
-			break;
-
-		case CMD_STOP_EXECUTING_HOST_CHECKS:
-			printf("This command is used to disable active host checks on a program-wide basis.\n");
-			break;
-
-		case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
-			printf("This command is used to have Nagios start obsessing over host checks.  Read the documentation on distributed monitoring for more information on this.\n");
-			break;
-
-		case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
-			printf("This command is used to stop Nagios from obsessing over host checks.\n");
-			break;
-
-		case CMD_ENABLE_PASSIVE_HOST_CHECKS:
-			printf("This command is used to allow Nagios to accept passive host check results that it finds in the external command file for a particular host.\n");
-			break;
-
-		case CMD_DISABLE_PASSIVE_HOST_CHECKS:
-			printf("This command is used to stop Nagios from accepting passive host check results that it finds in the external command file for a particular host.  All passive check results that are found for this host will be ignored.\n");
-			break;
-
-		case CMD_START_OBSESSING_OVER_HOST_CHECKS:
-			printf("This command is used to have Nagios start obsessing over host checks.  Read the documentation on distributed monitoring for more information on this.\n");
-			break;
-
-		case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
-			printf("This command is used to stop Nagios from obsessing over host checks.\n");
-			break;
-
-		case CMD_SCHEDULE_HOST_CHECK:
-			printf("This command is used to schedule the next check of a particular host.  Nagios will re-queue the host to be checked at the time you specify.\n");
-			printf("If you select the <i>force check</i> option, Nagios will force a check of the host regardless of both what time the scheduled check occurs and whether or not checks are enabled for the host.\n");
-			break;
-
-		case CMD_START_OBSESSING_OVER_SVC:
-			printf("This command is used to have Nagios start obsessing over a particular service.\n");
-			break;
-
-		case CMD_STOP_OBSESSING_OVER_SVC:
-			printf("This command is used to stop Nagios from obsessing over a particular service.\n");
-			break;
-
-		case CMD_START_OBSESSING_OVER_HOST:
-			printf("This command is used to have Nagios start obsessing over a particular host.\n");
-			break;
-
-		case CMD_STOP_OBSESSING_OVER_HOST:
-			printf("This command is used to stop Nagios from obsessing over a particular host.\n");
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-			printf("This command is used to enable notifications for all services in the specified servicegroup.  Notifications will only be sent out for the\n");
-			printf("service state types you defined in your service definitions.  This <i>does not</i> enable notifications for the hosts in this servicegroup unless you check the 'Enable for hosts too' option.\n");
-			break;
-
-		case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for all services in the specified servicegroup.  You will have to re-enable notifications for\n");
-			printf("all services in this servicegroup before any alerts can be sent out in the future.  This <i>does not</i> prevent notifications from being sent out about the hosts in this servicegroup unless you check the 'Disable for hosts too' option.\n");
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-			printf("This command is used to enable notifications for all hosts in the specified servicegroup.  Notifications will only be sent out for the\n");
-			printf("host state types you defined in your host definitions.\n");
-			break;
-
-		case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
-			printf("This command is used to prevent notifications from being sent out for all hosts in the specified servicegroup.  You will have to re-enable notifications for\n");
-			printf("all hosts in this servicegroup before any alerts can be sent out in the future.\n");
-			break;
-
-		case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
-			printf("This command is used to enable active checks of all services in the specified servicegroup.  This <i>does not</i> enable active checks of the hosts in the servicegroup unless you check the 'Enable for hosts too' option.\n");
-			break;
-
-		case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
-			printf("This command is used to disable active checks of all services in the specified servicegroup.  This <i>does not</i> disable checks of the hosts in the servicegroup unless you check the 'Disable for hosts too' option.\n");
-			break;
-
-		case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
-			printf("This command is used to schedule downtime for all hosts in a particular servicegroup.  During the specified downtime, Nagios will not send notifications out about the hosts.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for the hosts as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a host goes down or becomes unreachable (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
-			break;
-
-		case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
-			printf("This command is used to schedule downtime for all services in a particular servicegroup.  During the specified downtime, Nagios will not send notifications out about the services.\n");
-			printf("When the scheduled downtime expires, Nagios will send out notifications for the services as it normally would.  Scheduled downtimes are preserved\n");
-			printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
-			printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
-			printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a service enters a non-OK state (sometime between the\n");
-			printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
-			printf("Note that scheduling downtime for services does not automatically schedule downtime for the hosts those services are associated with.  If you want to also schedule downtime for all hosts in the servicegroup, check the 'Schedule downtime for hosts too' option.\n");
-			break;
-
-		case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
-		case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
-			printf("This command is used to send a custom notification about the specified %s.  Useful in emergencies when you need to notify admins of an issue regarding a monitored system or service.\n", (cmd == CMD_SEND_CUSTOM_HOST_NOTIFICATION) ? "host" : "service");
-			printf("Custom notifications normally follow the regular notification logic in Nagios.  Selecting the <i>Forced</i> option will force the notification to be sent out, regardless of the time restrictions, whether or not notifications are enabled, etc.  Selecting the <i>Broadcast</i> option causes the notification to be sent out to all normal (non-escalated) and escalated contacts.  These options allow you to override the normal notification logic if you need to get an important message out.\n");
-			break;
-
-		default:
-			printf("Sorry, but no information is available for this command.");
-		}
+	case CMD_ADD_HOST_COMMENT:
+		printf("This command is used to add a comment for the specified host.  If you work with other administrators, you may find it useful to share information about a host\n");
+		printf("that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will be automatically be deleted\n");
+		printf("the next time Nagios is restarted.\n");
+		break;
+
+	case CMD_ADD_SVC_COMMENT:
+		printf("This command is used to add a comment for the specified service.  If you work with other administrators, you may find it useful to share information about a host\n");
+		printf("or service that is having problems if more than one of you may be working on it.  If you do not check the 'persistent' option, the comment will automatically be\n");
+		printf("deleted the next time Nagios is restarted.\n");
+		break;
+
+	case CMD_DEL_HOST_COMMENT:
+		printf("This command is used to delete a specific host comment.\n");
+		break;
+
+	case CMD_DEL_SVC_COMMENT:
+		printf("This command is used to delete a specific service comment.\n");
+		break;
+
+	case CMD_DELAY_HOST_NOTIFICATION:
+		printf("This command is used to delay the next problem notification that is sent out for the specified host.  The notification delay will be disregarded if\n");
+		printf("the host changes state before the next notification is scheduled to be sent out.  This command has no effect if the host is currently UP.\n");
+		break;
+
+	case CMD_DELAY_SVC_NOTIFICATION:
+		printf("This command is used to delay the next problem notification that is sent out for the specified service.  The notification delay will be disregarded if\n");
+		printf("the service changes state before the next notification is scheduled to be sent out.  This command has no effect if the service is currently in an OK state.\n");
+		break;
+
+	case CMD_SCHEDULE_SVC_CHECK:
+		printf("This command is used to schedule the next check of a particular service.  Nagios will re-queue the service to be checked at the time you specify.\n");
+		printf("If you select the <i>force check</i> option, Nagios will force a check of the service regardless of both what time the scheduled check occurs and whether or not checks are enabled for the service.\n");
+		break;
+
+	case CMD_ENABLE_SVC_CHECK:
+		printf("This command is used to enable active checks of a service.\n");
+		break;
+
+	case CMD_DISABLE_SVC_CHECK:
+		printf("This command is used to disable active checks of a service.\n");
+		break;
+
+	case CMD_DISABLE_NOTIFICATIONS:
+		printf("This command is used to disable host and service notifications on a program-wide basis.\n");
+		break;
+
+	case CMD_ENABLE_NOTIFICATIONS:
+		printf("This command is used to enable host and service notifications on a program-wide basis.\n");
+		break;
+
+	case CMD_SHUTDOWN_PROCESS:
+		printf("This command is used to shutdown the Nagios process. Note: Once the Nagios has been shutdown, it cannot be restarted via the web interface!\n");
+		break;
+
+	case CMD_RESTART_PROCESS:
+		printf("This command is used to restart the Nagios process.   Executing a restart command is equivalent to sending the process a HUP signal.\n");
+		printf("All information will be flushed from memory, the configuration files will be re-read, and Nagios will start monitoring with the new configuration information.\n");
+		break;
+
+	case CMD_ENABLE_HOST_SVC_CHECKS:
+		printf("This command is used to enable active checks of all services associated with the specified host.  This <i>does not</i> enable checks of the host unless you check the 'Enable for host too' option.\n");
+		break;
+
+	case CMD_DISABLE_HOST_SVC_CHECKS:
+		printf("This command is used to disable active checks of all services associated with the specified host.  When a service is disabled Nagios will not monitor the service.  Doing this will prevent any notifications being sent out for\n");
+		printf("the specified service while it is disabled.  In order to have Nagios check the service in the future you will have to re-enable the service.\n");
+		printf("Note that disabling service checks may not necessarily prevent notifications from being sent out about the host which those services are associated with.  This <i>does not</i> disable checks of the host unless you check the 'Disable for host too' option.\n");
+		break;
+
+	case CMD_SCHEDULE_HOST_SVC_CHECKS:
+		printf("This command is used to scheduled the next check of all services on the specified host.  If you select the <i>force check</i> option, Nagios will force a check of all services on the host regardless of both what time the scheduled checks occur and whether or not checks are enabled for those services.\n");
+		break;
+
+	case CMD_DEL_ALL_HOST_COMMENTS:
+		printf("This command is used to delete all comments associated with the specified host.\n");
+		break;
+
+	case CMD_DEL_ALL_SVC_COMMENTS:
+		printf("This command is used to delete all comments associated with the specified service.\n");
+		break;
+
+	case CMD_ENABLE_SVC_NOTIFICATIONS:
+		printf("This command is used to enable notifications for the specified service.  Notifications will only be sent out for the\n");
+		printf("service state types you defined in your service definition.\n");
+		break;
+
+	case CMD_DISABLE_SVC_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for the specified service.  You will have to re-enable notifications\n");
+		printf("for this service before any alerts can be sent out in the future.\n");
+		break;
+
+	case CMD_ENABLE_HOST_NOTIFICATIONS:
+		printf("This command is used to enable notifications for the specified host.  Notifications will only be sent out for the\n");
+		printf("host state types you defined in your host definition.  Note that this command <i>does not</i> enable notifications\n");
+		printf("for services associated with this host.\n");
+		break;
+
+	case CMD_DISABLE_HOST_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for the specified host.  You will have to re-enable notifications for this host\n");
+		printf("before any alerts can be sent out in the future.  Note that this command <i>does not</i> disable notifications for services associated with this host.\n");
+		break;
+
+	case CMD_ENABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+		printf("This command is used to enable notifications for all hosts and services that lie \"beyond\" the specified host\n");
+		printf("(from the view of Nagios).\n");
+		break;
+
+	case CMD_DISABLE_ALL_NOTIFICATIONS_BEYOND_HOST:
+		printf("This command is used to temporarily prevent notifications from being sent out for all hosts and services that lie\n");
+		printf("\"beyond\" the specified host (from the view of Nagios).\n");
+		break;
+
+	case CMD_ENABLE_HOST_SVC_NOTIFICATIONS:
+		printf("This command is used to enable notifications for all services on the specified host.  Notifications will only be sent out for the\n");
+		printf("service state types you defined in your service definition.  This <i>does not</i> enable notifications for the host unless you check the 'Enable for host too' option.\n");
+		break;
+
+	case CMD_DISABLE_HOST_SVC_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for all services on the specified host.  You will have to re-enable notifications for\n");
+		printf("all services associated with this host before any alerts can be sent out in the future.  This <i>does not</i> prevent notifications from being sent out about the host unless you check the 'Disable for host too' option.\n");
+		break;
+
+	case CMD_ACKNOWLEDGE_HOST_PROBLEM:
+		printf("This command is used to acknowledge a host problem.  When a host problem is acknowledged, future notifications about problems are temporarily disabled until the host changes from its current state.\n");
+		printf("If you want acknowledgement to disable notifications until the host recovers, check the 'Sticky Acknowledgement' checkbox.\n");
+		printf("Contacts for this host will receive a notification about the acknowledgement, so they are aware that someone is working on the problem.  Additionally, a comment will also be added to the host.\n");
+		printf("Make sure to enter your name and fill in a brief description of what you are doing in the comment field.  If you would like the host comment to remain once the acknowledgement is removed, check\n");
+		printf("the 'Persistent Comment' checkbox.  If you do not want an acknowledgement notification sent out to the appropriate contacts, uncheck the 'Send Notification' checkbox.\n");
+		break;
+
+	case CMD_ACKNOWLEDGE_SVC_PROBLEM:
+		printf("This command is used to acknowledge a service problem.  When a service problem is acknowledged, future notifications about problems are temporarily disabled until the service changes from its current state.\n");
+		printf("If you want acknowledgement to disable notifications until the service recovers, check the 'Sticky Acknowledgement' checkbox.\n");
+		printf("Contacts for this service will receive a notification about the acknowledgement, so they are aware that someone is working on the problem.  Additionally, a comment will also be added to the service.\n");
+		printf("Make sure to enter your name and fill in a brief description of what you are doing in the comment field.  If you would like the service comment to remain once the acknowledgement is removed, check\n");
+		printf("the 'Persistent Comment' checkbox.  If you do not want an acknowledgement notification sent out to the appropriate contacts, uncheck the 'Send Notification' checkbox.\n");
+		break;
+
+	case CMD_START_EXECUTING_SVC_CHECKS:
+		printf("This command is used to resume execution of active service checks on a program-wide basis.  Individual services which are disabled will still not be checked.\n");
+		break;
+
+	case CMD_STOP_EXECUTING_SVC_CHECKS:
+		printf("This command is used to temporarily stop Nagios from actively executing any service checks.  This will have the side effect of preventing any notifications from being sent out (for any and all services and hosts).\n");
+		printf("Service checks will not be executed again until you issue a command to resume service check execution.\n");
+		break;
+
+	case CMD_START_ACCEPTING_PASSIVE_SVC_CHECKS:
+		printf("This command is used to make Nagios start accepting passive service check results that it finds in the external command file\n");
+		break;
+
+	case CMD_STOP_ACCEPTING_PASSIVE_SVC_CHECKS:
+		printf("This command is use to make Nagios stop accepting passive service check results that it finds in the external command file.  All passive check results that are found will be ignored.\n");
+		break;
+
+	case CMD_ENABLE_PASSIVE_SVC_CHECKS:
+		printf("This command is used to allow Nagios to accept passive service check results that it finds in the external command file for this particular service.\n");
+		break;
+
+	case CMD_DISABLE_PASSIVE_SVC_CHECKS:
+		printf("This command is used to stop Nagios accepting passive service check results that it finds in the external command file for this particular service.  All passive check results that are found for this service will be ignored.\n");
+		break;
+
+	case CMD_ENABLE_EVENT_HANDLERS:
+		printf("This command is used to allow Nagios to run host and service event handlers.\n");
+		break;
+
+	case CMD_DISABLE_EVENT_HANDLERS:
+		printf("This command is used to temporarily prevent Nagios from running any host or service event handlers.\n");
+		break;
+
+	case CMD_ENABLE_SVC_EVENT_HANDLER:
+		printf("This command is used to allow Nagios to run the service event handler for a particular service when necessary (if one is defined).\n");
+		break;
+
+	case CMD_DISABLE_SVC_EVENT_HANDLER:
+		printf("This command is used to temporarily prevent Nagios from running the service event handler for a particular service.\n");
+		break;
+
+	case CMD_ENABLE_HOST_EVENT_HANDLER:
+		printf("This command is used to allow Nagios to run the host event handler for a particular service when necessary (if one is defined).\n");
+		break;
+
+	case CMD_DISABLE_HOST_EVENT_HANDLER:
+		printf("This command is used to temporarily prevent Nagios from running the host event handler for a particular host.\n");
+		break;
+
+	case CMD_ENABLE_HOST_CHECK:
+		printf("This command is used to enable active checks of this host.\n");
+		break;
+
+	case CMD_DISABLE_HOST_CHECK:
+		printf("This command is used to temporarily prevent Nagios from actively checking the status of a particular host.  If Nagios needs to check the status of this host, it will assume that it is in the same state that it was in before checks were disabled.\n");
+		break;
+
+	case CMD_START_OBSESSING_OVER_SVC_CHECKS:
+		printf("This command is used to have Nagios start obsessing over service checks.  Read the documentation on distributed monitoring for more information on this.\n");
+		break;
+
+	case CMD_STOP_OBSESSING_OVER_SVC_CHECKS:
+		printf("This command is used stop Nagios from obsessing over service checks.\n");
+		break;
+
+	case CMD_REMOVE_HOST_ACKNOWLEDGEMENT:
+		printf("This command is used to remove an acknowledgement for a particular host problem.  Once the acknowledgement is removed, notifications may start being\n");
+		printf("sent out about the host problem. \n");
+		break;
+
+	case CMD_REMOVE_SVC_ACKNOWLEDGEMENT:
+		printf("This command is used to remove an acknowledgement for a particular service problem.  Once the acknowledgement is removed, notifications may start being\n");
+		printf("sent out about the service problem.\n");
+		break;
+
+	case CMD_PROCESS_SERVICE_CHECK_RESULT:
+		printf("This command is used to submit a passive check result for a particular service.  It is particularly useful for resetting security-related services to OK states once they have been dealt with.\n");
+		break;
+
+	case CMD_PROCESS_HOST_CHECK_RESULT:
+		printf("This command is used to submit a passive check result for a particular host.\n");
+		break;
+
+	case CMD_SCHEDULE_HOST_DOWNTIME:
+		printf("This command is used to schedule downtime for a particular host.  During the specified downtime, Nagios will not send notifications out about the host.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for this host as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when the host goes down or becomes unreachable (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed downtime.\n");
+		break;
+
+	case CMD_SCHEDULE_HOST_SVC_DOWNTIME:
+		printf("This command is used to schedule downtime for all services on a particular host.  During the specified downtime, Nagios will not send notifications out about the host.\n");
+		printf("Normally, a host in downtime will not send alerts about any services in a failed state. This option will explicitly set downtime for all services for this host.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for this host as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when the host goes down or becomes unreachable (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed downtime.\n");
+		break;
+
+	case CMD_SCHEDULE_SVC_DOWNTIME:
+		printf("This command is used to schedule downtime for a particular service.  During the specified downtime, Nagios will not send notifications out about the service.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for this service as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when the service enters a non-OK state (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed downtime.\n");
+		break;
+
+	case CMD_ENABLE_HOST_FLAP_DETECTION:
+		printf("This command is used to enable flap detection for a specific host.  If flap detection is disabled on a program-wide basis, this will have no effect,\n");
+		break;
+
+	case CMD_DISABLE_HOST_FLAP_DETECTION:
+		printf("This command is used to disable flap detection for a specific host.\n");
+		break;
+
+	case CMD_ENABLE_SVC_FLAP_DETECTION:
+		printf("This command is used to enable flap detection for a specific service.  If flap detection is disabled on a program-wide basis, this will have no effect,\n");
+		break;
+
+	case CMD_DISABLE_SVC_FLAP_DETECTION:
+		printf("This command is used to disable flap detection for a specific service.\n");
+		break;
+
+	case CMD_ENABLE_FLAP_DETECTION:
+		printf("This command is used to enable flap detection for hosts and services on a program-wide basis.  Individual hosts and services may have flap detection disabled.\n");
+		break;
+
+	case CMD_DISABLE_FLAP_DETECTION:
+		printf("This command is used to disable flap detection for hosts and services on a program-wide basis.\n");
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+		printf("This command is used to enable notifications for all services in the specified hostgroup.  Notifications will only be sent out for the\n");
+		printf("service state types you defined in your service definitions.  This <i>does not</i> enable notifications for the hosts in this hostgroup unless you check the 'Enable for hosts too' option.\n");
+		break;
+
+	case CMD_DISABLE_HOSTGROUP_SVC_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for all services in the specified hostgroup.  You will have to re-enable notifications for\n");
+		printf("all services in this hostgroup before any alerts can be sent out in the future.  This <i>does not</i> prevent notifications from being sent out about the hosts in this hostgroup unless you check the 'Disable for hosts too' option.\n");
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+		printf("This command is used to enable notifications for all hosts in the specified hostgroup.  Notifications will only be sent out for the\n");
+		printf("host state types you defined in your host definitions.\n");
+		break;
+
+	case CMD_DISABLE_HOSTGROUP_HOST_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for all hosts in the specified hostgroup.  You will have to re-enable notifications for\n");
+		printf("all hosts in this hostgroup before any alerts can be sent out in the future.\n");
+		break;
+
+	case CMD_ENABLE_HOSTGROUP_SVC_CHECKS:
+		printf("This command is used to enable active checks of all services in the specified hostgroup.  This <i>does not</i> enable active checks of the hosts in the hostgroup unless you check the 'Enable for hosts too' option.\n");
+		break;
+
+	case CMD_DISABLE_HOSTGROUP_SVC_CHECKS:
+		printf("This command is used to disable active checks of all services in the specified hostgroup.  This <i>does not</i> disable checks of the hosts in the hostgroup unless you check the 'Disable for hosts too' option.\n");
+		break;
+
+	case CMD_DEL_HOST_DOWNTIME:
+		printf("This command is used to cancel active or pending scheduled downtime for the specified host.\n");
+		break;
+
+	case CMD_DEL_SVC_DOWNTIME:
+		printf("This command is used to cancel active or pending scheduled downtime for the specified service.\n");
+		break;
+
+	case CMD_ENABLE_PERFORMANCE_DATA:
+		printf("This command is used to enable the processing of performance data for hosts and services on a program-wide basis.  Individual hosts and services may have performance data processing disabled.\n");
+		break;
+
+	case CMD_DISABLE_PERFORMANCE_DATA:
+		printf("This command is used to disable the processing of performance data for hosts and services on a program-wide basis.\n");
+		break;
+
+	case CMD_SCHEDULE_HOSTGROUP_HOST_DOWNTIME:
+		printf("This command is used to schedule downtime for all hosts in a particular hostgroup.  During the specified downtime, Nagios will not send notifications out about the hosts.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for the hosts as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a host goes down or becomes unreachable (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
+		break;
+
+	case CMD_SCHEDULE_HOSTGROUP_SVC_DOWNTIME:
+		printf("This command is used to schedule downtime for all services in a particular hostgroup.  During the specified downtime, Nagios will not send notifications out about the services.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for the services as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a service enters a non-OK state (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
+		printf("Note that scheduling downtime for services does not automatically schedule downtime for the hosts those services are associated with.  If you want to also schedule downtime for all hosts in the hostgroup, check the 'Schedule downtime for hosts too' option.\n");
+		break;
+
+	case CMD_START_EXECUTING_HOST_CHECKS:
+		printf("This command is used to enable active host checks on a program-wide basis.\n");
+		break;
+
+	case CMD_STOP_EXECUTING_HOST_CHECKS:
+		printf("This command is used to disable active host checks on a program-wide basis.\n");
+		break;
+
+	case CMD_START_ACCEPTING_PASSIVE_HOST_CHECKS:
+		printf("This command is used to have Nagios start obsessing over host checks.  Read the documentation on distributed monitoring for more information on this.\n");
+		break;
+
+	case CMD_STOP_ACCEPTING_PASSIVE_HOST_CHECKS:
+		printf("This command is used to stop Nagios from obsessing over host checks.\n");
+		break;
+
+	case CMD_ENABLE_PASSIVE_HOST_CHECKS:
+		printf("This command is used to allow Nagios to accept passive host check results that it finds in the external command file for a particular host.\n");
+		break;
+
+	case CMD_DISABLE_PASSIVE_HOST_CHECKS:
+		printf("This command is used to stop Nagios from accepting passive host check results that it finds in the external command file for a particular host.  All passive check results that are found for this host will be ignored.\n");
+		break;
+
+	case CMD_START_OBSESSING_OVER_HOST_CHECKS:
+		printf("This command is used to have Nagios start obsessing over host checks.  Read the documentation on distributed monitoring for more information on this.\n");
+		break;
+
+	case CMD_STOP_OBSESSING_OVER_HOST_CHECKS:
+		printf("This command is used to stop Nagios from obsessing over host checks.\n");
+		break;
+
+	case CMD_SCHEDULE_HOST_CHECK:
+		printf("This command is used to schedule the next check of a particular host.  Nagios will re-queue the host to be checked at the time you specify.\n");
+		printf("If you select the <i>force check</i> option, Nagios will force a check of the host regardless of both what time the scheduled check occurs and whether or not checks are enabled for the host.\n");
+		break;
+
+	case CMD_START_OBSESSING_OVER_SVC:
+		printf("This command is used to have Nagios start obsessing over a particular service.\n");
+		break;
+
+	case CMD_STOP_OBSESSING_OVER_SVC:
+		printf("This command is used to stop Nagios from obsessing over a particular service.\n");
+		break;
+
+	case CMD_START_OBSESSING_OVER_HOST:
+		printf("This command is used to have Nagios start obsessing over a particular host.\n");
+		break;
+
+	case CMD_STOP_OBSESSING_OVER_HOST:
+		printf("This command is used to stop Nagios from obsessing over a particular host.\n");
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+		printf("This command is used to enable notifications for all services in the specified servicegroup.  Notifications will only be sent out for the\n");
+		printf("service state types you defined in your service definitions.  This <i>does not</i> enable notifications for the hosts in this servicegroup unless you check the 'Enable for hosts too' option.\n");
+		break;
+
+	case CMD_DISABLE_SERVICEGROUP_SVC_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for all services in the specified servicegroup.  You will have to re-enable notifications for\n");
+		printf("all services in this servicegroup before any alerts can be sent out in the future.  This <i>does not</i> prevent notifications from being sent out about the hosts in this servicegroup unless you check the 'Disable for hosts too' option.\n");
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+		printf("This command is used to enable notifications for all hosts in the specified servicegroup.  Notifications will only be sent out for the\n");
+		printf("host state types you defined in your host definitions.\n");
+		break;
+
+	case CMD_DISABLE_SERVICEGROUP_HOST_NOTIFICATIONS:
+		printf("This command is used to prevent notifications from being sent out for all hosts in the specified servicegroup.  You will have to re-enable notifications for\n");
+		printf("all hosts in this servicegroup before any alerts can be sent out in the future.\n");
+		break;
+
+	case CMD_ENABLE_SERVICEGROUP_SVC_CHECKS:
+		printf("This command is used to enable active checks of all services in the specified servicegroup.  This <i>does not</i> enable active checks of the hosts in the servicegroup unless you check the 'Enable for hosts too' option.\n");
+		break;
+
+	case CMD_DISABLE_SERVICEGROUP_SVC_CHECKS:
+		printf("This command is used to disable active checks of all services in the specified servicegroup.  This <i>does not</i> disable checks of the hosts in the servicegroup unless you check the 'Disable for hosts too' option.\n");
+		break;
+
+	case CMD_SCHEDULE_SERVICEGROUP_HOST_DOWNTIME:
+		printf("This command is used to schedule downtime for all hosts in a particular servicegroup.  During the specified downtime, Nagios will not send notifications out about the hosts.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for the hosts as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a host goes down or becomes unreachable (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
+		break;
+
+	case CMD_SCHEDULE_SERVICEGROUP_SVC_DOWNTIME:
+		printf("This command is used to schedule downtime for all services in a particular servicegroup.  During the specified downtime, Nagios will not send notifications out about the services.\n");
+		printf("When the scheduled downtime expires, Nagios will send out notifications for the services as it normally would.  Scheduled downtimes are preserved\n");
+		printf("across program shutdowns and restarts.  Both the start and end times should be specified in the following format:  <b>mm/dd/yyyy hh:mm:ss</b>.\n");
+		printf("If you select the <i>fixed</i> option, the downtime will be in effect between the start and end times you specify.  If you do not select the <i>fixed</i>\n");
+		printf("option, Nagios will treat this as \"flexible\" downtime.  Flexible downtime starts when a service enters a non-OK state (sometime between the\n");
+		printf("start and end times you specified) and lasts as long as the duration of time you enter.  The duration fields do not apply for fixed dowtime.\n");
+		printf("Note that scheduling downtime for services does not automatically schedule downtime for the hosts those services are associated with.  If you want to also schedule downtime for all hosts in the servicegroup, check the 'Schedule downtime for hosts too' option.\n");
+		break;
+
+	case CMD_SEND_CUSTOM_HOST_NOTIFICATION:
+	case CMD_SEND_CUSTOM_SVC_NOTIFICATION:
+		printf("This command is used to send a custom notification about the specified %s.  Useful in emergencies when you need to notify admins of an issue regarding a monitored system or service.\n", (cmd == CMD_SEND_CUSTOM_HOST_NOTIFICATION) ? "host" : "service");
+		printf("Custom notifications normally follow the regular notification logic in Nagios.  Selecting the <i>Forced</i> option will force the notification to be sent out, regardless of the time restrictions, whether or not notifications are enabled, etc.  Selecting the <i>Broadcast</i> option causes the notification to be sent out to all normal (non-escalated) and escalated contacts.  These options allow you to override the normal notification logic if you need to get an important message out.\n");
+		break;
+
+	default:
+		printf("Sorry, but no information is available for this command.");
+	}
 
 	printf("</TD></TR>\n");
 	printf("</TABLE>\n");
 
 	return;
-	}
+}
 
 
 
 /* converts a time string to a UNIX timestamp, respecting the date_format option */
-int string_to_time(char *buffer, time_t *t) {
+int string_to_time(char *buffer, time_t *t)
+{
 	struct tm lt;
 	int ret = 0;
 
@@ -2789,4 +2789,4 @@ int string_to_time(char *buffer, time_t *t) {
 	*t = mktime(&lt);
 
 	return OK;
-	}
+}

--- a/cgi/config.c
+++ b/cgi/config.c
@@ -84,31 +84,29 @@ char hashed_color[8];
 
 int embedded = FALSE;
 
-static void print_expand_input(int type) {
+static void print_expand_input(int type)
+{
 	const char *seldesc = "";
 
 	if(type == DISPLAY_COMMAND_EXPANSION) return;	/* Has its own form, w/ larger <input> */
 	else if(type == DISPLAY_SERVICES) {
 		seldesc = " Services Named or on Host";
-		}
-	else if(type == DISPLAY_SERVICEDEPENDENCIES) {
+	} else if(type == DISPLAY_SERVICEDEPENDENCIES) {
 		seldesc = " Dependencies with Host";
-		}
-	else if(type == DISPLAY_SERVICEESCALATIONS) {
+	} else if(type == DISPLAY_SERVICEESCALATIONS) {
 		seldesc = " Escalations on Host";
-		}
-	else if(type == DISPLAY_HOSTDEPENDENCIES) {
+	} else if(type == DISPLAY_HOSTDEPENDENCIES) {
 		seldesc = " Dependencies on/of Host";
-		}
-	else if(type == DISPLAY_HOSTESCALATIONS) {
+	} else if(type == DISPLAY_HOSTESCALATIONS) {
 		seldesc = " Escalations for Host";
-		}
+	}
 	printf("<tr><td align=left class='reportSelectSubTitle'>Show Only%s:</td></tr>\n", seldesc);
 	printf("<tr><td align=left class='reportSelectItem'><input type='text' name='expand'\n");
 	printf("value='%s'>", html_encode(to_expand, FALSE));
-	}
+}
 
-int main(void) {
+int main(void)
+{
 	mac = get_global_macros();
 
 	/* get the arguments passed in the URL */
@@ -168,54 +166,54 @@ int main(void) {
 		printf("<tr><td class='reportSelectItem'><input type='submit' value='Update'></td></tr>\n");
 		printf("</table>\n");
 		printf("</form>\n");
-		}
+	}
 
 	/* display context-sensitive help */
 	switch(display_type) {
-		case DISPLAY_HOSTS:
-			display_context_help(CONTEXTHELP_CONFIG_HOSTS);
-			break;
-		case DISPLAY_HOSTGROUPS:
-			display_context_help(CONTEXTHELP_CONFIG_HOSTGROUPS);
-			break;
-		case DISPLAY_SERVICEGROUPS:
-			display_context_help(CONTEXTHELP_CONFIG_SERVICEGROUPS);
-			break;
-		case DISPLAY_CONTACTS:
-			display_context_help(CONTEXTHELP_CONFIG_CONTACTS);
-			break;
-		case DISPLAY_CONTACTGROUPS:
-			display_context_help(CONTEXTHELP_CONFIG_CONTACTGROUPS);
-			break;
-		case DISPLAY_SERVICES:
-			display_context_help(CONTEXTHELP_CONFIG_SERVICES);
-			break;
-		case DISPLAY_TIMEPERIODS:
-			display_context_help(CONTEXTHELP_CONFIG_TIMEPERIODS);
-			break;
-		case DISPLAY_COMMANDS:
-			display_context_help(CONTEXTHELP_CONFIG_COMMANDS);
-			break;
-		case DISPLAY_SERVICEDEPENDENCIES:
-			display_context_help(CONTEXTHELP_CONFIG_SERVICEDEPENDENCIES);
-			break;
-		case DISPLAY_SERVICEESCALATIONS:
-			display_context_help(CONTEXTHELP_CONFIG_HOSTESCALATIONS);
-			break;
-		case DISPLAY_HOSTDEPENDENCIES:
-			display_context_help(CONTEXTHELP_CONFIG_HOSTDEPENDENCIES);
-			break;
-		case DISPLAY_HOSTESCALATIONS:
-			display_context_help(CONTEXTHELP_CONFIG_HOSTESCALATIONS);
-			break;
-		case DISPLAY_COMMAND_EXPANSION:
-			/* Reusing DISPLAY_COMMANDS help until further notice */
-			display_context_help(CONTEXTHELP_CONFIG_COMMANDS);
-			break;
-		default:
-			display_context_help(CONTEXTHELP_CONFIG_MENU);
-			break;
-		}
+	case DISPLAY_HOSTS:
+		display_context_help(CONTEXTHELP_CONFIG_HOSTS);
+		break;
+	case DISPLAY_HOSTGROUPS:
+		display_context_help(CONTEXTHELP_CONFIG_HOSTGROUPS);
+		break;
+	case DISPLAY_SERVICEGROUPS:
+		display_context_help(CONTEXTHELP_CONFIG_SERVICEGROUPS);
+		break;
+	case DISPLAY_CONTACTS:
+		display_context_help(CONTEXTHELP_CONFIG_CONTACTS);
+		break;
+	case DISPLAY_CONTACTGROUPS:
+		display_context_help(CONTEXTHELP_CONFIG_CONTACTGROUPS);
+		break;
+	case DISPLAY_SERVICES:
+		display_context_help(CONTEXTHELP_CONFIG_SERVICES);
+		break;
+	case DISPLAY_TIMEPERIODS:
+		display_context_help(CONTEXTHELP_CONFIG_TIMEPERIODS);
+		break;
+	case DISPLAY_COMMANDS:
+		display_context_help(CONTEXTHELP_CONFIG_COMMANDS);
+		break;
+	case DISPLAY_SERVICEDEPENDENCIES:
+		display_context_help(CONTEXTHELP_CONFIG_SERVICEDEPENDENCIES);
+		break;
+	case DISPLAY_SERVICEESCALATIONS:
+		display_context_help(CONTEXTHELP_CONFIG_HOSTESCALATIONS);
+		break;
+	case DISPLAY_HOSTDEPENDENCIES:
+		display_context_help(CONTEXTHELP_CONFIG_HOSTDEPENDENCIES);
+		break;
+	case DISPLAY_HOSTESCALATIONS:
+		display_context_help(CONTEXTHELP_CONFIG_HOSTESCALATIONS);
+		break;
+	case DISPLAY_COMMAND_EXPANSION:
+		/* Reusing DISPLAY_COMMANDS help until further notice */
+		display_context_help(CONTEXTHELP_CONFIG_COMMANDS);
+		break;
+	default:
+		display_context_help(CONTEXTHELP_CONFIG_MENU);
+		break;
+	}
 
 	printf("</td>\n");
 
@@ -225,59 +223,60 @@ int main(void) {
 
 
 	switch(display_type) {
-		case DISPLAY_HOSTS:
-			display_hosts();
-			break;
-		case DISPLAY_HOSTGROUPS:
-			display_hostgroups();
-			break;
-		case DISPLAY_SERVICEGROUPS:
-			display_servicegroups();
-			break;
-		case DISPLAY_CONTACTS:
-			display_contacts();
-			break;
-		case DISPLAY_CONTACTGROUPS:
-			display_contactgroups();
-			break;
-		case DISPLAY_SERVICES:
-			display_services();
-			break;
-		case DISPLAY_TIMEPERIODS:
-			display_timeperiods();
-			break;
-		case DISPLAY_COMMANDS:
-			display_commands();
-			break;
-		case DISPLAY_SERVICEDEPENDENCIES:
-			display_servicedependencies();
-			break;
-		case DISPLAY_SERVICEESCALATIONS:
-			display_serviceescalations();
-			break;
-		case DISPLAY_HOSTDEPENDENCIES:
-			display_hostdependencies();
-			break;
-		case DISPLAY_HOSTESCALATIONS:
-			display_hostescalations();
-			break;
-		case DISPLAY_COMMAND_EXPANSION:
-			display_command_expansion();
-			break;
-		default:
-			display_options();
-			break;
-		}
+	case DISPLAY_HOSTS:
+		display_hosts();
+		break;
+	case DISPLAY_HOSTGROUPS:
+		display_hostgroups();
+		break;
+	case DISPLAY_SERVICEGROUPS:
+		display_servicegroups();
+		break;
+	case DISPLAY_CONTACTS:
+		display_contacts();
+		break;
+	case DISPLAY_CONTACTGROUPS:
+		display_contactgroups();
+		break;
+	case DISPLAY_SERVICES:
+		display_services();
+		break;
+	case DISPLAY_TIMEPERIODS:
+		display_timeperiods();
+		break;
+	case DISPLAY_COMMANDS:
+		display_commands();
+		break;
+	case DISPLAY_SERVICEDEPENDENCIES:
+		display_servicedependencies();
+		break;
+	case DISPLAY_SERVICEESCALATIONS:
+		display_serviceescalations();
+		break;
+	case DISPLAY_HOSTDEPENDENCIES:
+		display_hostdependencies();
+		break;
+	case DISPLAY_HOSTESCALATIONS:
+		display_hostescalations();
+		break;
+	case DISPLAY_COMMAND_EXPANSION:
+		display_command_expansion();
+		break;
+	default:
+		display_options();
+		break;
+	}
 
 	document_footer();
 
 	return OK;
-	}
+}
 
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t t;
 
@@ -304,7 +303,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, CONFIG_CSS);
-		}
+	}
 
 	printf("</head>\n");
 
@@ -314,10 +313,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(CONFIG_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -329,10 +329,11 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -345,7 +346,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the configuration type argument */
 		else if(!strcmp(variables[x], "type")) {
@@ -353,7 +354,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			/* what information should we display? */
 			if(!strcmp(variables[x], "hosts"))
@@ -386,7 +387,7 @@ int process_cgivars(void) {
 			/* we found the embed option */
 			else if(!strcmp(variables[x], "embedded"))
 				embedded = TRUE;
-			}
+		}
 
 		/* we found the string-to-expand argument */
 		else if(!strcmp(variables[x], "expand")) {
@@ -394,27 +395,28 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			strncpy(to_expand, variables[x], MAX_COMMAND_BUFFER);
 			to_expand[MAX_COMMAND_BUFFER - 1] = '\0';
-			}
+		}
 
 
 		/* we received an invalid argument */
 		else
 			error = TRUE;
 
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
-void display_hosts(void) {
+void display_hosts(void)
+{
 	host *temp_host = NULL;
 	hostsmember *temp_hostsmember = NULL;
 	contactsmember *temp_contactsmember = NULL;
@@ -430,7 +432,7 @@ void display_hosts(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Host%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : " "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -489,11 +491,10 @@ void display_hosts(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -511,7 +512,7 @@ void display_hosts(void) {
 					printf(", ");
 
 				printf("<a href='%s?type=hosts&expand=%s'>%s</a>\n", CONFIG_CGI, url_encode(temp_hostsmember->host_name), html_encode(temp_hostsmember->host_name, FALSE));
-				}
+			}
 			if(temp_host->parent_hosts == NULL)
 				printf("&nbsp;");
 			printf("</TD>\n");
@@ -563,13 +564,13 @@ void display_hosts(void) {
 					printf(", ");
 
 				printf("<A HREF='%s?type=contacts&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactsmember->contact_name), html_encode(temp_contactsmember->contact_name, FALSE));
-				}
+			}
 			for(temp_contactgroupsmember = temp_host->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
 				num_contacts++;
 				if(num_contacts > 1)
 					printf(", ");
 				printf("<A HREF='%s?type=contactgroups&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactgroupsmember->group_name), html_encode(temp_contactgroupsmember->group_name, FALSE));
-				}
+			}
 			if(num_contacts == 0)
 				printf("&nbsp;");
 			printf("</TD>\n");
@@ -585,23 +586,23 @@ void display_hosts(void) {
 			if(flag_isset(temp_host->notification_options, OPT_DOWN) == TRUE) {
 				options = 1;
 				printf("Down");
-				}
+			}
 			if(flag_isset(temp_host->notification_options, OPT_UNREACHABLE) == TRUE) {
 				printf("%sUnreachable", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_host->notification_options, OPT_RECOVERY) == TRUE) {
 				printf("%sRecovery", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_host->notification_options, OPT_FLAPPING) == TRUE) {
 				printf("%sFlapping", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_host->notification_options, OPT_DOWNTIME) == TRUE) {
 				printf("%sDowntime", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
@@ -630,15 +631,15 @@ void display_hosts(void) {
 			if(flag_isset(temp_host->stalking_options, OPT_UP) == TRUE) {
 				options = 1;
 				printf("Up");
-				}
+			}
 			if(flag_isset(temp_host->stalking_options, OPT_DOWN) == TRUE) {
 				printf("%sDown", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_host->stalking_options, OPT_UNREACHABLE) == TRUE) {
 				printf("%sUnreachable", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
@@ -666,15 +667,15 @@ void display_hosts(void) {
 			if(flag_isset(temp_host->flap_detection_options, OPT_UP) == TRUE) {
 				options = 1;
 				printf("Up");
-				}
+			}
 			if(flag_isset(temp_host->flap_detection_options, OPT_DOWN) == TRUE) {
 				printf("%sDown", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_host->flap_detection_options, OPT_UNREACHABLE) == TRUE) {
 				printf("%sUnreachable", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
@@ -715,7 +716,7 @@ void display_hosts(void) {
 				process_macros_r(mac, temp_host->icon_image, &processed_string, 0);
 				printf("<TD CLASS='%s' valign='center'><img src='%s%s' border='0' width='20' height='20'> %s</TD>", bg_class, url_logo_images_path, processed_string, html_encode(temp_host->icon_image, FALSE));
 				free(processed_string);
-				}
+			}
 
 			printf("<TD CLASS='%s'>%s</TD>", bg_class, (temp_host->icon_image_alt == NULL) ? "&nbsp;" : html_encode(temp_host->icon_image_alt, FALSE));
 
@@ -724,28 +725,29 @@ void display_hosts(void) {
 			if(temp_host->retain_status_information == TRUE) {
 				options = 1;
 				printf("Status Information");
-				}
+			}
 			if(temp_host->retain_nonstatus_information == TRUE) {
 				printf("%sNon-Status Information", (options == 1) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_hostgroups(void) {
+void display_hostgroups(void)
+{
 	hostgroup *temp_hostgroup;
 	hostsmember *temp_hostsmember;
 	int odd = 0;
@@ -755,7 +757,7 @@ void display_hostgroups(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Host Group%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : " "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -779,11 +781,10 @@ void display_hostgroups(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -799,7 +800,7 @@ void display_hostgroups(void) {
 				if(temp_hostsmember != temp_hostgroup->members)
 					printf(", ");
 				printf("<A HREF='%s?type=hosts&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_hostsmember->host_name), html_encode(temp_hostsmember->host_name, FALSE));
-				}
+			}
 			printf("</TD>\n");
 
 			printf("<TD CLASS='%s'>%s</TD>", bg_class, (temp_hostgroup->notes == NULL) ? "&nbsp;" : html_encode(temp_hostgroup->notes, FALSE));
@@ -809,18 +810,19 @@ void display_hostgroups(void) {
 			printf("<TD CLASS='%s'>%s</TD>", bg_class, (temp_hostgroup->action_url == NULL) ? "&nbsp;" : html_encode(temp_hostgroup->action_url, FALSE));
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_servicegroups(void) {
+void display_servicegroups(void)
+{
 	servicegroup *temp_servicegroup;
 	servicesmember *temp_servicesmember;
 	int odd = 0;
@@ -830,7 +832,7 @@ void display_servicegroups(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Service Group%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : " "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -854,11 +856,10 @@ void display_servicegroups(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -875,7 +876,7 @@ void display_servicegroups(void) {
 
 				printf("<A HREF='%s?type=services&expand=%s#%s;", CONFIG_CGI, url_encode(temp_servicesmember->host_name), url_encode(temp_servicesmember->host_name));
 				printf("%s'>%s</A>\n", url_encode(temp_servicesmember->service_description), html_encode(temp_servicesmember->service_description, FALSE));
-				}
+			}
 
 			printf("</TD>\n");
 
@@ -886,18 +887,19 @@ void display_servicegroups(void) {
 			printf("<TD CLASS='%s'>%s</TD>", bg_class, (temp_servicegroup->action_url == NULL) ? "&nbsp;" : html_encode(temp_servicegroup->action_url, FALSE));
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_contacts(void) {
+void display_contacts(void)
+{
 	contact *temp_contact;
 	commandsmember *temp_commandsmember;
 	int odd = 0;
@@ -909,7 +911,7 @@ void display_contacts(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Contact%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : " "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -940,11 +942,10 @@ void display_contacts(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -959,27 +960,27 @@ void display_contacts(void) {
 			if(flag_isset(temp_contact->service_notification_options, OPT_UNKNOWN)) {
 				options = 1;
 				printf("Unknown");
-				}
+			}
 			if(flag_isset(temp_contact->service_notification_options, OPT_WARNING)) {
 				printf("%sWarning", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->service_notification_options, OPT_CRITICAL)) {
 				printf("%sCritical", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->service_notification_options, OPT_RECOVERY)) {
 				printf("%sRecovery", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->service_notification_options, OPT_FLAPPING)) {
 				printf("%sFlapping", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->service_notification_options, OPT_DOWNTIME)) {
 				printf("%sDowntime", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(!options)
 				printf("None");
 			printf("</TD>\n");
@@ -989,23 +990,23 @@ void display_contacts(void) {
 			if(flag_isset(temp_contact->host_notification_options, OPT_DOWN) == TRUE) {
 				options = 1;
 				printf("Down");
-				}
+			}
 			if(flag_isset(temp_contact->host_notification_options, OPT_UNREACHABLE) == TRUE) {
 				printf("%sUnreachable", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->host_notification_options, OPT_RECOVERY) == TRUE) {
 				printf("%sRecovery", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->host_notification_options, OPT_FLAPPING) == TRUE) {
 				printf("%sFlapping", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_contact->host_notification_options, OPT_DOWNTIME) == TRUE) {
 				printf("%sDowntime", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(!options)
 				printf("None");
 			printf("</TD>\n");
@@ -1035,7 +1036,7 @@ void display_contacts(void) {
 				printf("<A HREF='%s?type=command&expand=%s'>%s</A>", CONFIG_CGI, url_encode(temp_commandsmember->command), html_encode(temp_commandsmember->command, FALSE));
 
 				found = TRUE;
-				}
+			}
 			if(found == FALSE)
 				printf("None");
 			printf("</TD>\n");
@@ -1051,7 +1052,7 @@ void display_contacts(void) {
 				printf("<A HREF='%s?type=command&expand=%s'>%s</A>", CONFIG_CGI, url_encode(temp_commandsmember->command), html_encode(temp_commandsmember->command, FALSE));
 
 				found = TRUE;
-				}
+			}
 			if(found == FALSE)
 				printf("None");
 			printf("</TD>\n");
@@ -1061,28 +1062,29 @@ void display_contacts(void) {
 			if(temp_contact->retain_status_information == TRUE) {
 				options = 1;
 				printf("Status Information");
-				}
+			}
 			if(temp_contact->retain_nonstatus_information == TRUE) {
 				printf("%sNon-Status Information", (options == 1) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_contactgroups(void) {
+void display_contactgroups(void)
+{
 	contactgroup *temp_contactgroup;
 	contactsmember *temp_contactsmember;
 	int odd = 0;
@@ -1092,7 +1094,7 @@ void display_contactgroups(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Contact Group%s%s</DIV></P>\n",
@@ -1115,11 +1117,10 @@ void display_contactgroups(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -1134,22 +1135,23 @@ void display_contactgroups(void) {
 					printf(", ");
 
 				printf("<A HREF='%s?type=contacts&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactsmember->contact_name), html_encode(temp_contactsmember->contact_name, FALSE));
-				}
+			}
 			printf("</TD>\n");
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_services(void) {
+void display_services(void)
+{
 	service *temp_service = NULL;
 	contactsmember *temp_contactsmember = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
@@ -1167,7 +1169,7 @@ void display_services(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Service%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : "s Named or on Host "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -1227,11 +1229,10 @@ void display_services(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -1289,13 +1290,13 @@ void display_services(void) {
 				if(num_contacts > 1)
 					printf(", ");
 				printf("<A HREF='%s?type=contacts&expand=%s'>%s</A>", CONFIG_CGI, url_encode(temp_contactsmember->contact_name), html_encode(temp_contactsmember->contact_name, FALSE));
-				}
+			}
 			for(temp_contactgroupsmember = temp_service->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
 				num_contacts++;
 				if(num_contacts > 1)
 					printf(", ");
 				printf("<A HREF='%s?type=contactgroups&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactgroupsmember->group_name), html_encode(temp_contactgroupsmember->group_name, FALSE));
-				}
+			}
 			if(num_contacts == 0)
 				printf("&nbsp;");
 			printf("</TD>\n");
@@ -1315,27 +1316,27 @@ void display_services(void) {
 			if(flag_isset(temp_service->notification_options, OPT_UNKNOWN) == TRUE) {
 				options = 1;
 				printf("Unknown");
-				}
+			}
 			if(flag_isset(temp_service->notification_options, OPT_WARNING) == TRUE) {
 				printf("%sWarning", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->notification_options, OPT_CRITICAL) == TRUE) {
 				printf("%sCritical", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->notification_options, OPT_RECOVERY) == TRUE) {
 				printf("%sRecovery", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->notification_options, OPT_FLAPPING) == TRUE) {
 				printf("%sFlapping", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->notification_options, OPT_DOWNTIME) == TRUE) {
 				printf("%sDowntime", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(!options)
 				printf("None");
 			printf("</TD>\n");
@@ -1362,19 +1363,19 @@ void display_services(void) {
 			if(flag_isset(temp_service->stalking_options, OPT_OK) == TRUE) {
 				options = 1;
 				printf("Ok");
-				}
+			}
 			if(flag_isset(temp_service->stalking_options, OPT_WARNING) == TRUE) {
 				printf("%sWarning", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->stalking_options, OPT_UNKNOWN) == TRUE) {
 				printf("%sUnknown", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->stalking_options, OPT_CRITICAL) == TRUE) {
 				printf("%sCritical", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
@@ -1402,19 +1403,19 @@ void display_services(void) {
 			if(flag_isset(temp_service->flap_detection_options, OPT_OK) == TRUE) {
 				options = 1;
 				printf("Ok");
-				}
+			}
 			if(flag_isset(temp_service->flap_detection_options, OPT_WARNING) == TRUE) {
 				printf("%sWarning", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->flap_detection_options, OPT_UNKNOWN) == TRUE) {
 				printf("%sUnknown", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(flag_isset(temp_service->flap_detection_options, OPT_CRITICAL) == TRUE) {
 				printf("%sCritical", (options) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
@@ -1435,7 +1436,7 @@ void display_services(void) {
 				process_macros_r(mac, temp_service->icon_image, &processed_string, 0);
 				printf("<TD CLASS='%s' valign='center'><img src='%s%s' border='0' width='20' height='20'> %s</TD>", bg_class, url_logo_images_path, processed_string, html_encode(temp_service->icon_image, FALSE));
 				free(processed_string);
-				}
+			}
 
 			printf("<TD CLASS='%s'>%s</TD>", bg_class, (temp_service->icon_image_alt == NULL) ? "&nbsp;" : html_encode(temp_service->icon_image_alt, FALSE));
 
@@ -1444,28 +1445,29 @@ void display_services(void) {
 			if(temp_service->retain_status_information == TRUE) {
 				options = 1;
 				printf("Status Information");
-				}
+			}
 			if(temp_service->retain_nonstatus_information == TRUE) {
 				printf("%sNon-Status Information", (options == 1) ? ", " : "");
 				options = 1;
-				}
+			}
 			if(options == 0)
 				printf("None");
 			printf("</TD>\n");
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_timeperiods(void) {
+void display_timeperiods(void)
+{
 	timerange *temp_timerange = NULL;
 	daterange *temp_daterange = NULL;
 	timeperiod *temp_timeperiod = NULL;
@@ -1487,7 +1489,7 @@ void display_timeperiods(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Time Period%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : " "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -1510,11 +1512,10 @@ void display_timeperiods(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataEven";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -1526,7 +1527,7 @@ void display_timeperiods(void) {
 			for(temp_timeperiodexclusion = temp_timeperiod->exclusions; temp_timeperiodexclusion != NULL; temp_timeperiodexclusion = temp_timeperiodexclusion->next) {
 				item++;
 				printf("%s<A HREF='#%s'>%s</A>", (item == 1) ? "" : ",&nbsp;", url_encode(temp_timeperiodexclusion->timeperiod_name), html_encode(temp_timeperiodexclusion->timeperiod_name, FALSE));
-				}
+			}
 			printf("</TD>");
 
 			printf("<TD CLASS='%s'>", bg_class);
@@ -1541,48 +1542,48 @@ void display_timeperiods(void) {
 						printf("<TR><TD COLSPAN='3'></TD><TD CLASS='%s'>\n", bg_class);
 
 					switch(temp_daterange->type) {
-						case DATERANGE_CALENDAR_DATE:
-							printf("%d-%02d-%02d", temp_daterange->syear, temp_daterange->smon + 1, temp_daterange->smday);
-							if((temp_daterange->smday != temp_daterange->emday) || (temp_daterange->smon != temp_daterange->emon) || (temp_daterange->syear != temp_daterange->eyear))
-								printf(" - %d-%02d-%02d", temp_daterange->eyear, temp_daterange->emon + 1, temp_daterange->emday);
+					case DATERANGE_CALENDAR_DATE:
+						printf("%d-%02d-%02d", temp_daterange->syear, temp_daterange->smon + 1, temp_daterange->smday);
+						if((temp_daterange->smday != temp_daterange->emday) || (temp_daterange->smon != temp_daterange->emon) || (temp_daterange->syear != temp_daterange->eyear))
+							printf(" - %d-%02d-%02d", temp_daterange->eyear, temp_daterange->emon + 1, temp_daterange->emday);
+						if(temp_daterange->skip_interval > 1)
+							printf(" / %d", temp_daterange->skip_interval);
+						break;
+					case DATERANGE_MONTH_DATE:
+						printf("%s %d", months[temp_daterange->smon], temp_daterange->smday);
+						if((temp_daterange->smon != temp_daterange->emon) || (temp_daterange->smday != temp_daterange->emday)) {
+							printf(" - %s %d", months[temp_daterange->emon], temp_daterange->emday);
 							if(temp_daterange->skip_interval > 1)
 								printf(" / %d", temp_daterange->skip_interval);
-							break;
-						case DATERANGE_MONTH_DATE:
-							printf("%s %d", months[temp_daterange->smon], temp_daterange->smday);
-							if((temp_daterange->smon != temp_daterange->emon) || (temp_daterange->smday != temp_daterange->emday)) {
-								printf(" - %s %d", months[temp_daterange->emon], temp_daterange->emday);
-								if(temp_daterange->skip_interval > 1)
-									printf(" / %d", temp_daterange->skip_interval);
-								}
-							break;
-						case DATERANGE_MONTH_DAY:
-							printf("day %d", temp_daterange->smday);
-							if(temp_daterange->smday != temp_daterange->emday) {
-								printf(" - %d", temp_daterange->emday);
-								if(temp_daterange->skip_interval > 1)
-									printf(" / %d", temp_daterange->skip_interval);
-								}
-							break;
-						case DATERANGE_MONTH_WEEK_DAY:
-							printf("%s %d %s", days[temp_daterange->swday], temp_daterange->swday_offset, months[temp_daterange->smon]);
-							if((temp_daterange->smon != temp_daterange->emon) || (temp_daterange->swday != temp_daterange->ewday) || (temp_daterange->swday_offset != temp_daterange->ewday_offset)) {
-								printf(" - %s %d %s", days[temp_daterange->ewday], temp_daterange->ewday_offset, months[temp_daterange->emon]);
-								if(temp_daterange->skip_interval > 1)
-									printf(" / %d", temp_daterange->skip_interval);
-								}
-							break;
-						case DATERANGE_WEEK_DAY:
-							printf("%s %d", days[temp_daterange->swday], temp_daterange->swday_offset);
-							if((temp_daterange->swday != temp_daterange->ewday) || (temp_daterange->swday_offset != temp_daterange->ewday_offset)) {
-								printf(" - %s %d", days[temp_daterange->ewday], temp_daterange->ewday_offset);
-								if(temp_daterange->skip_interval > 1)
-									printf(" / %d", temp_daterange->skip_interval);
-								}
-							break;
-						default:
-							break;
 						}
+						break;
+					case DATERANGE_MONTH_DAY:
+						printf("day %d", temp_daterange->smday);
+						if(temp_daterange->smday != temp_daterange->emday) {
+							printf(" - %d", temp_daterange->emday);
+							if(temp_daterange->skip_interval > 1)
+								printf(" / %d", temp_daterange->skip_interval);
+						}
+						break;
+					case DATERANGE_MONTH_WEEK_DAY:
+						printf("%s %d %s", days[temp_daterange->swday], temp_daterange->swday_offset, months[temp_daterange->smon]);
+						if((temp_daterange->smon != temp_daterange->emon) || (temp_daterange->swday != temp_daterange->ewday) || (temp_daterange->swday_offset != temp_daterange->ewday_offset)) {
+							printf(" - %s %d %s", days[temp_daterange->ewday], temp_daterange->ewday_offset, months[temp_daterange->emon]);
+							if(temp_daterange->skip_interval > 1)
+								printf(" / %d", temp_daterange->skip_interval);
+						}
+						break;
+					case DATERANGE_WEEK_DAY:
+						printf("%s %d", days[temp_daterange->swday], temp_daterange->swday_offset);
+						if((temp_daterange->swday != temp_daterange->ewday) || (temp_daterange->swday_offset != temp_daterange->ewday_offset)) {
+							printf(" - %s %d", days[temp_daterange->ewday], temp_daterange->ewday_offset);
+							if(temp_daterange->skip_interval > 1)
+								printf(" / %d", temp_daterange->skip_interval);
+						}
+						break;
+					default:
+						break;
+					}
 
 					printf("</TD><TD CLASS='%s'>\n", bg_class);
 
@@ -1604,12 +1605,12 @@ void display_timeperiods(void) {
 						snprintf(timestring, sizeof(timestring) - 1, "%02d:%02d:%02d", hours, minutes, seconds);
 						timestring[sizeof(timestring) - 1] = '\x0';
 						printf("%s", timestring);
-						}
+					}
 
 					printf("</TD>\n");
 					printf("</TR>\n");
-					}
 				}
+			}
 			for(day = 0; day < 7; day++) {
 
 				if(temp_timeperiod->days[day] == NULL)
@@ -1642,28 +1643,29 @@ void display_timeperiods(void) {
 					snprintf(timestring, sizeof(timestring) - 1, "%02d:%02d:%02d", hours, minutes, seconds);
 					timestring[sizeof(timestring) - 1] = '\x0';
 					printf("%s", timestring);
-					}
+				}
 
 				printf("&nbsp;</TD>\n");
 				printf("</TR>\n");
-				}
+			}
 
 			if(line == 0) {
 				printf("</TD>\n");
 				printf("</TR>\n");
-				}
 			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_commands(void) {
+void display_commands(void)
+{
 	command *temp_command;
 	int odd = 0;
 	const char *bg_class = "";
@@ -1672,7 +1674,7 @@ void display_commands(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Command%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : " "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -1687,11 +1689,10 @@ void display_commands(void) {
 			if(odd) {
 				odd = 0;
 				bg_class = "dataEven";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "dataOdd";
-				}
+			}
 
 			printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -1699,13 +1700,13 @@ void display_commands(void) {
 			printf("<TD CLASS='%s'>%s</TD>\n", bg_class, html_encode(temp_command->command_line, FALSE));
 
 			printf("</TR>\n");
-			}
+		}
 
 	printf("</TABLE>\n");
 	printf("</DIV></P>\n");
 
 	return;
-	}
+}
 
 
 static void display_servicedependency(servicedependency *temp_sd)
@@ -1749,35 +1750,36 @@ static void display_servicedependency(servicedependency *temp_sd)
 	if(flag_isset(temp_sd->failure_options, OPT_OK) == TRUE) {
 		printf("Ok");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_sd->failure_options, OPT_WARNING) == TRUE) {
 		printf("%sWarning", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_sd->failure_options, OPT_UNKNOWN) == TRUE) {
 		printf("%sUnknown", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_sd->failure_options, OPT_CRITICAL) == TRUE) {
 		printf("%sCritical", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_sd->failure_options, OPT_PENDING) == TRUE) {
 		printf("%sPending", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	printf("</TD>\n");
 	printf("</TR>\n");
-	}
+}
 
-void display_servicedependencies(void) {
+void display_servicedependencies(void)
+{
 	unsigned int i;
 
 	/* see if user is authorized to view hostgroup information... */
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Service Dependencie%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : "s Involving Host "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -1802,18 +1804,19 @@ void display_servicedependencies(void) {
 
 	for(i = 0; i < num_objects.servicedependencies; i++) {
 		display_servicedependency(servicedependency_ary[i]);
-		}
+	}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_serviceescalations(void) {
+void display_serviceescalations(void)
+{
 	serviceescalation *temp_se = NULL;
 	contactsmember *temp_contactsmember = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
@@ -1828,7 +1831,7 @@ void display_serviceescalations(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Service Escalation%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : "s on Host "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -1860,11 +1863,10 @@ void display_serviceescalations(void) {
 		if(odd) {
 			odd = 0;
 			bg_class = "dataOdd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bg_class = "dataEven";
-			}
+		}
 
 		printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -1880,13 +1882,13 @@ void display_serviceescalations(void) {
 			if(num_contacts > 1)
 				printf(", ");
 			printf("<A HREF='%s?type=contacts&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactsmember->contact_name), html_encode(temp_contactsmember->contact_name, FALSE));
-			}
+		}
 		for(temp_contactgroupsmember = temp_se->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
 			num_contacts++;
 			if(num_contacts > 1)
 				printf(", ");
 			printf("<A HREF='%s?type=contactgroups&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactgroupsmember->group_name), html_encode(temp_contactgroupsmember->group_name, FALSE));
-			}
+		}
 		if(num_contacts == 0)
 			printf("&nbsp;");
 		printf("</TD>\n");
@@ -1920,32 +1922,32 @@ void display_serviceescalations(void) {
 		if(flag_isset(temp_se->escalation_options, OPT_WARNING) == TRUE) {
 			printf("%sWarning", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(flag_isset(temp_se->escalation_options, OPT_UNKNOWN) == TRUE) {
 			printf("%sUnknown", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(flag_isset(temp_se->escalation_options, OPT_CRITICAL) == TRUE) {
 			printf("%sCritical", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(flag_isset(temp_se->escalation_options, OPT_RECOVERY) == TRUE) {
 			printf("%sRecovery", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(options == FALSE)
 			printf("None");
 		printf("</TD>\n");
 
 		printf("</TR>\n");
-		}
+	}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 static void display_hostdependency(hostdependency *temp_hd)
 {
@@ -1982,32 +1984,33 @@ static void display_hostdependency(hostdependency *temp_hd)
 	if(flag_isset(temp_hd->failure_options, OPT_UP) == TRUE) {
 		printf("Up");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_hd->failure_options, OPT_DOWN) == TRUE) {
 		printf("%sDown", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_hd->failure_options, OPT_UNREACHABLE) == TRUE) {
 		printf("%sUnreachable", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	if(flag_isset(temp_hd->failure_options, OPT_PENDING) == TRUE) {
 		printf("%sPending", (options == TRUE) ? ", " : "");
 		options = TRUE;
-		}
+	}
 	printf("</TD>\n");
 
 	printf("</TR>\n");
-	}
+}
 
-void display_hostdependencies(void) {
+void display_hostdependencies(void)
+{
 	unsigned int i;
 
 	/* see if user is authorized to view hostdependency information... */
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Host Dependencie%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : "s Involving Host "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -2033,11 +2036,12 @@ void display_hostdependencies(void) {
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_hostescalations(void) {
+void display_hostescalations(void)
+{
 	hostescalation *temp_he = NULL;
 	contactsmember *temp_contactsmember = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
@@ -2052,7 +2056,7 @@ void display_hostescalations(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Host Escalation%s%s</DIV></P>\n",
 	       (*to_expand == '\0' ? "s" : "s for Host "), (*to_expand == '\0' ? "" : html_encode(to_expand, FALSE)));
@@ -2080,11 +2084,10 @@ void display_hostescalations(void) {
 		if(odd) {
 			odd = 0;
 			bg_class = "dataOdd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bg_class = "dataEven";
-			}
+		}
 
 		printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -2097,13 +2100,13 @@ void display_hostescalations(void) {
 			if(num_contacts > 1)
 				printf(", ");
 			printf("<A HREF='%s?type=contacts&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactsmember->contact_name), html_encode(temp_contactsmember->contact_name, FALSE));
-			}
+		}
 		for(temp_contactgroupsmember = temp_he->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
 			num_contacts++;
 			if(num_contacts > 1)
 				printf(", ");
 			printf("<A HREF='%s?type=contactgroups&expand=%s'>%s</A>\n", CONFIG_CGI, url_encode(temp_contactgroupsmember->group_name), html_encode(temp_contactgroupsmember->group_name, FALSE));
-			}
+		}
 		if(num_contacts == 0)
 			printf("&nbsp;");
 		printf("</TD>\n");
@@ -2137,42 +2140,44 @@ void display_hostescalations(void) {
 		if(flag_isset(temp_he->escalation_options, OPT_DOWN) == TRUE) {
 			printf("%sDown", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(flag_isset(temp_he->escalation_options, OPT_UNREACHABLE) == TRUE) {
 			printf("%sUnreachable", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(flag_isset(temp_he->escalation_options, OPT_RECOVERY) == TRUE) {
 			printf("%sRecovery", (options == TRUE) ? ", " : "");
 			options = TRUE;
-			}
+		}
 		if(options == FALSE)
 			printf("None");
 		printf("</TD>\n");
 
 		printf("</TR>\n");
-		}
+	}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
-void unauthorized_message(void) {
+void unauthorized_message(void)
+{
 
 	printf("<P><DIV CLASS='errorMessage'>It appears as though you do not have permission to view the configuration information you requested...</DIV></P>\n");
 	printf("<P><DIV CLASS='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 	printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 	return;
-	}
+}
 
 
-static const char *hash_color(int i) {
+static const char *hash_color(int i)
+{
 	char c;
 
 	/* This is actually optimized for MAX_COMMAND_ARGUMENTS==32 ... */
@@ -2180,11 +2185,10 @@ static const char *hash_color(int i) {
 	if((i % 32) < 16) {
 		if((i % 32) < 8) c = '7';
 		else c = '4';
-		}
-	else {
+	} else {
 		if((i % 32) < 24) c = '6';
 		else c = '5';
-		}
+	}
 
 	/* Computation for standard case */
 	hashed_color[0] = '#';
@@ -2198,9 +2202,10 @@ static const char *hash_color(int i) {
 	if((i % 8) == 0) hashed_color[2] = hashed_color[3] = hashed_color[4] = hashed_color[6] = c;
 
 	return(hashed_color);
-	}
+}
 
-void display_command_expansion(void) {
+void display_command_expansion(void)
+{
 	command *temp_command;
 	int odd = 0;
 	const char *bg_class = "";
@@ -2216,7 +2221,7 @@ void display_command_expansion(void) {
 	if(is_authorized_for_configuration_information(&current_authdata) == FALSE) {
 		unauthorized_message();
 		return;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER CLASS='dataTitle'>Command Expansion</DIV></P>\n");
 
@@ -2228,9 +2233,9 @@ void display_command_expansion(void) {
 			(*cc) = '\0';
 			cc = c++;
 			command_args[++i] = (c--);
-			}
-		(*cc) = (*c);
 		}
+		(*cc) = (*c);
+	}
 	if((*c) == '\0')(*cc) = '\0';
 	/* Precompute indexes of dangling whitespace */
 	for(i = 0; i < MAX_COMMAND_ARGUMENTS; i++) {
@@ -2238,7 +2243,7 @@ void display_command_expansion(void) {
 		trail_space[i] = 0;
 		for(; cc && ((*cc) != '\0'); cc++) if(isspace(*cc)) trail_space[i]++;
 			else trail_space[i] = 0;
-		}
+	}
 
 	printf("<P><DIV ALIGN=CENTER>\n");
 	printf("<TABLE BORDER=0 CLASS='data'>\n");
@@ -2262,11 +2267,10 @@ void display_command_expansion(void) {
 				if(odd) {
 					odd = 0;
 					bg_class = "dataEven";
-					}
-				else {
+				} else {
 					odd = 1;
 					bg_class = "dataOdd";
-					}
+				}
 
 				printf("<TR CLASS='%s'>\n", bg_class);
 
@@ -2288,15 +2292,13 @@ void display_command_expansion(void) {
 						/* Escaped '$' */
 						printf("<FONT COLOR='#444444'>$</FONT>");
 						c = (++cc);
-						}
-					else if(strncmp("ARG", cc, 3)) {
+					} else if(strncmp("ARG", cc, 3)) {
 						/* Non-$ARGn$ macro */
 						c = strstr(cc, "$");
 						if(c)(*(c++)) = '\0';
 						printf("<FONT COLOR='#777777'>$%s%s</FONT>", html_encode(cc, FALSE), (c ? "$" : ""));
 						if(!c) printf("<FONT COLOR='#FF0000'> (not properly terminated)</FONT>");
-						}
-					else {
+					} else {
 						/* $ARGn$ macro */
 						for(c = (cc += 3); isdigit(*c); c++) ;
 						if(((*c) == '\0') || ((*c) == '$')) {
@@ -2309,21 +2311,18 @@ void display_command_expansion(void) {
 										                                      hash_color(i), ((lead_space[i] > 0) || (trail_space[i] > 0) ? "<U>&zwj;" : ""),
 										                                      html_encode(command_args[i], FALSE), ((lead_space[i] > 0) || (trail_space[i] > 0) ? "&zwj;</U>" : ""));
 									else printf("<FONT COLOR='#0000FF'>(empty)</FONT>");
-									}
-								else printf("<FONT COLOR='#0000FF'>(undefined)</FONT>");
-								}
-							else printf("<FONT COLOR='#FF0000'>(not a valid $ARGn$ index: %u)</FONT>", i);
+								} else printf("<FONT COLOR='#0000FF'>(undefined)</FONT>");
+							} else printf("<FONT COLOR='#FF0000'>(not a valid $ARGn$ index: %u)</FONT>", i);
 							if((*c) != '\0') c++;
 							else printf("<FONT COLOR='#FF0000'> (not properly terminated)</FONT>");
-							}
-						else {
+						} else {
 							/* Syntax err in index */
 							c = strstr(cc, "$");
 							printf("<FONT COLOR='#FF0000'>(not an $ARGn$ index: &quot;%s&quot;)</FONT>", html_encode(strtok(cc, "$"), FALSE));
 							if(c) c++;
-							}
 						}
 					}
+				}
 				if(c) printf("%s", html_encode(c, FALSE));
 
 				printf("</TD></TR>\n");
@@ -2334,13 +2333,12 @@ void display_command_expansion(void) {
 						printf("<TD CLASS='%s'>$ARG%u$=<FONT COLOR='%s'>%s%s%s</FONT></TD></TR>\n", bg_class, i, hash_color(i),
 						       ((lead_space[i] > 0) || (trail_space[i] > 0) ? "<U>&zwj;" : ""), html_encode(command_args[i], FALSE),
 						       ((lead_space[i] > 0) || (trail_space[i] > 0) ? "&zwj;</U>" : ""));
-						}
-					else if(arg_count[i] > 1) {
+					} else if(arg_count[i] > 1) {
 						printf("<TR CLASS='%s'><TD CLASS='%s' ALIGN='right'>used %u x:</TD>\n", bg_class, bg_class, i);
 						printf("<TD CLASS='%s'>$ARG%u$=<FONT COLOR='%s'>%s%s%s</FONT></TD></TR>\n", bg_class, i, hash_color(i),
 						       ((lead_space[i] > 0) || (trail_space[i] > 0) ? "<U>&zwj;" : ""), html_encode(command_args[i], FALSE),
 						       ((lead_space[i] > 0) || (trail_space[i] > 0) ? "&zwj;</U>" : ""));
-						}
+					}
 					if((lead_space[i] > 0) || (trail_space[i] > 0)) {
 						printf("<TR CLASS='%s'><TD CLASS='%s' ALIGN='right'><FONT COLOR='#0000FF'>dangling whitespace:</FONT></TD>\n", bg_class, bg_class);
 						printf("<TD CLASS='%s'>$ARG%u$=<FONT COLOR='#0000FF'>", bg_class, i);
@@ -2370,18 +2368,18 @@ void display_command_expansion(void) {
 							else if((*c) == '\v')	printf("[VT]");
 							else			printf("[0x%x]", *c);
 						printf("</FONT></TD></TR>\n");
-						}
 					}
 				}
-
 			}
+
+		}
 
 		if(!arg_count[0]) {
 			printf("<TR CLASS='dataOdd'><TD CLASS='dataOdd' ALIGN='right'><FONT\n");
 			printf("COLOR='#FF0000'>Error:</FONT></TD><TD CLASS='dataOdd'><FONT COLOR='#FF0000'>No\n");
 			printf("command &quot;%s&quot; found</FONT></TD></TR>\n", html_encode(command_args[0], FALSE));
-			}
 		}
+	}
 
 	printf("<TR CLASS='dataEven'><TD><BR/></TD><TD CLASS='dataEven'>Enter the command_check definition from a host or service definition and press Go to see the expansion of the command</TD></TR>\n");
 	printf("<TR CLASS='dataEven'><TD CLASS='dataEven'>To expand:</TD><TD CLASS='dataEven'><FORM\n");
@@ -2393,11 +2391,12 @@ void display_command_expansion(void) {
 	printf("</DIV></P>\n");
 
 	return;
-	}
+}
 
 
 
-void display_options(void) {
+void display_options(void)
+{
 
 	printf("<br><br>\n");
 
@@ -2436,4 +2435,4 @@ void display_options(void) {
 	printf("</form>\n");
 
 	return;
-	}
+}

--- a/cgi/extcmd_list.c
+++ b/cgi/extcmd_list.c
@@ -11,7 +11,7 @@ struct nagios_extcmd {
 		int (*handler)(struct nagios_extcmd *, int, char **);
 		struct nagios_extcmd *next_handler;
 	 */
-	};
+};
 
 #define CMD_DEF(name, min_args, handler) \
 	{ #name, CMD_ ## name }
@@ -173,14 +173,15 @@ struct nagios_extcmd in_core_commands[] = {
 	CMD_DEF(CHANGE_CONTACT_MODATTR, 0, NULL),
 	CMD_DEF(CHANGE_CONTACT_MODHATTR, 0, NULL),
 	CMD_DEF(CHANGE_CONTACT_MODSATTR, 0, NULL),
-	};
+};
 #undef CMD_DEF
 
 #ifndef ARRAY_SIZE
 # define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
 #endif
 
-const char *extcmd_get_name(int id) {
+const char *extcmd_get_name(int id)
+{
 	unsigned int i;
 
 	for(i = 0; i < ARRAY_SIZE(in_core_commands); i++) {
@@ -188,13 +189,14 @@ const char *extcmd_get_name(int id) {
 		ecmd = &in_core_commands[i];
 		if(ecmd->id == id)
 			return ecmd->name;
-		}
-
-	return NULL;
 	}
 
+	return NULL;
+}
+
 #ifdef ECMD_LIST_TESTING
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int i, no_handler = 0;
 
 	for(i = 0; i < ARRAY_SIZE(in_core_commands); i++) {
@@ -202,11 +204,11 @@ int main(int argc, char **argv) {
 		if(!cmd->handler) {
 			no_handler++;
 			printf("%s has no handler\n", extcmd_get_name(i));
-			}
 		}
+	}
 	printf("%d of %d commands have no handler\n",
 	       no_handler, ARRAY_SIZE(in_core_commands));
 
 	return 0;
-	}
+}
 #endif

--- a/cgi/extinfo.c
+++ b/cgi/extinfo.c
@@ -68,7 +68,7 @@ typedef struct sortdata_struct {
 	servicestatus *svcstatus;
 	hoststatus *hststatus;
 	struct sortdata_struct *next;
-	} sortdata;
+} sortdata;
 
 void document_header(int);
 void document_footer(void);
@@ -108,7 +108,8 @@ int display_header = TRUE;
 
 
 
-int main(void) {
+int main(void)
+{
 	int found = FALSE;
 	char temp_buffer[MAX_INPUT_BUFFER] = "";
 	char *processed_string = NULL;
@@ -176,7 +177,7 @@ int main(void) {
 			if(display_type == DISPLAY_SERVICE_INFO) {
 				temp_service = find_service(host_name, service_desc);
 				grab_service_macros_r(mac, temp_service);
-				}
+			}
 
 			/* write some Javascript helper functions */
 			if(temp_host != NULL) {
@@ -191,22 +192,22 @@ int main(void) {
 					printf("function nagios_get_service_description()\n{\n");
 					printf("return \"%s\";\n", temp_service->description);
 					printf("}\n");
-					}
-				printf("//-->\n</SCRIPT>\n");
 				}
+				printf("//-->\n</SCRIPT>\n");
 			}
+		}
 
 		/* find the hostgroup */
 		else if(display_type == DISPLAY_HOSTGROUP_INFO) {
 			temp_hostgroup = find_hostgroup(hostgroup_name);
 			grab_hostgroup_macros_r(mac, temp_hostgroup);
-			}
+		}
 
 		/* find the servicegroup */
 		else if(display_type == DISPLAY_SERVICEGROUP_INFO) {
 			temp_servicegroup = find_servicegroup(servicegroup_name);
 			grab_servicegroup_macros_r(mac, temp_servicegroup);
-			}
+		}
 
 		if((display_type == DISPLAY_HOST_INFO && temp_host != NULL) || (display_type == DISPLAY_SERVICE_INFO && temp_host != NULL && temp_service != NULL) || (display_type == DISPLAY_HOSTGROUP_INFO && temp_hostgroup != NULL) || (display_type == DISPLAY_SERVICEGROUP_INFO && temp_servicegroup != NULL)) {
 			printf("<TABLE BORDER=1 CELLPADDING=0 CELLSPACING=0 CLASS='linkBox'>\n");
@@ -225,8 +226,7 @@ int main(void) {
 #endif
 				printf("<A HREF='%s?host=%s&show_log_entries'>View Availability Report For This Host</A><BR>\n", AVAIL_CGI, url_encode(host_name));
 				printf("<A HREF='%s?host=%s'>View Notifications For This Host</A>\n", NOTIFICATIONS_CGI, url_encode(host_name));
-				}
-			else if(display_type == DISPLAY_SERVICE_INFO) {
+			} else if(display_type == DISPLAY_SERVICE_INFO) {
 				printf("<A HREF='%s?host=%s&", HISTORY_CGI, url_encode(host_name));
 				printf("service=%s'>View Alert History For This Service</A><BR>\n", url_encode(service_desc));
 #ifdef USE_TRENDS
@@ -241,22 +241,20 @@ int main(void) {
 				printf("service=%s&show_log_entries'>View Availability Report For This Service</A><BR>\n", url_encode(service_desc));
 				printf("<A HREF='%s?host=%s&", NOTIFICATIONS_CGI, url_encode(host_name));
 				printf("service=%s'>View Notifications For This Service</A>\n", url_encode(service_desc));
-				}
-			else if(display_type == DISPLAY_HOSTGROUP_INFO) {
+			} else if(display_type == DISPLAY_HOSTGROUP_INFO) {
 				printf("<A HREF='%s?hostgroup=%s&style=detail'>View Status Detail For This Hostgroup</A><BR>\n", STATUS_CGI, url_encode(hostgroup_name));
 				printf("<A HREF='%s?hostgroup=%s&style=overview'>View Status Overview For This Hostgroup</A><BR>\n", STATUS_CGI, url_encode(hostgroup_name));
 				printf("<A HREF='%s?hostgroup=%s&style=grid'>View Status Grid For This Hostgroup</A><BR>\n", STATUS_CGI, url_encode(hostgroup_name));
 				printf("<A HREF='%s?hostgroup=%s'>View Availability For This Hostgroup</A><BR>\n", AVAIL_CGI, url_encode(hostgroup_name));
-				}
-			else if(display_type == DISPLAY_SERVICEGROUP_INFO) {
+			} else if(display_type == DISPLAY_SERVICEGROUP_INFO) {
 				printf("<A HREF='%s?servicegroup=%s&style=detail'>View Status Detail For This Servicegroup</A><BR>\n", STATUS_CGI, url_encode(servicegroup_name));
 				printf("<A HREF='%s?servicegroup=%s&style=overview'>View Status Overview For This Servicegroup</A><BR>\n", STATUS_CGI, url_encode(servicegroup_name));
 				printf("<A HREF='%s?servicegroup=%s&style=grid'>View Status Grid For This Servicegroup</A><BR>\n", STATUS_CGI, url_encode(servicegroup_name));
 				printf("<A HREF='%s?servicegroup=%s'>View Availability For This Servicegroup</A><BR>\n", AVAIL_CGI, url_encode(servicegroup_name));
-				}
+			}
 			printf("</TD></TR>\n");
 			printf("</TABLE>\n");
-			}
+		}
 
 		printf("</td>\n");
 
@@ -276,7 +274,7 @@ int main(void) {
 					for(temp_parenthost = temp_host->parent_hosts; temp_parenthost != NULL; temp_parenthost = temp_parenthost->next)
 						printf("<DIV CLASS='dataTitle'><A HREF='%s?host=%s'>%s</A></DIV>\n", STATUS_CGI, url_encode(temp_parenthost->host_name), temp_parenthost->host_name);
 					printf("<BR>");
-					}
+				}
 
 				printf("<DIV CLASS='data'>Member of</DIV><DIV CLASS='dataTitle'>");
 				for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
@@ -285,14 +283,14 @@ int main(void) {
 							printf(", ");
 						printf("<A HREF='%s?hostgroup=%s&style=overview'>%s</A>", STATUS_CGI, url_encode(temp_hostgroup->group_name), temp_hostgroup->group_name);
 						found = TRUE;
-						}
 					}
+				}
 
 				if(found == FALSE)
 					printf("No hostgroups");
 				printf("</DIV><BR>\n");
 				printf("<DIV CLASS='data'>%s</DIV>\n", temp_host->address);
-				}
+			}
 			if(display_type == DISPLAY_SERVICE_INFO) {
 				printf("<DIV CLASS='data'>Service</DIV><DIV CLASS='dataTitle'>%s</DIV><DIV CLASS='data'>On Host</DIV>\n", service_desc);
 				printf("<DIV CLASS='dataTitle'>%s</DIV>\n", temp_host->alias);
@@ -304,15 +302,15 @@ int main(void) {
 							printf(", ");
 						printf("<A HREF='%s?servicegroup=%s&style=overview'>%s</A>", STATUS_CGI, url_encode(temp_servicegroup->group_name), temp_servicegroup->group_name);
 						found = TRUE;
-						}
 					}
+				}
 
 				if(found == FALSE)
 					printf("No servicegroups.");
 				printf("</DIV><BR>\n");
 
 				printf("<DIV CLASS='data'>%s</DIV>\n", temp_host->address);
-				}
+			}
 			if(display_type == DISPLAY_HOSTGROUP_INFO) {
 				printf("<DIV CLASS='data'>Hostgroup</DIV>\n");
 				printf("<DIV CLASS='dataTitle'>%s</DIV>\n", temp_hostgroup->alias);
@@ -321,8 +319,8 @@ int main(void) {
 					process_macros_r(mac, temp_hostgroup->notes, &processed_string, 0);
 					printf("<p>%s</p>", processed_string);
 					free(processed_string);
-					}
 				}
+			}
 			if(display_type == DISPLAY_SERVICEGROUP_INFO) {
 				printf("<DIV CLASS='data'>Servicegroup</DIV>\n");
 				printf("<DIV CLASS='dataTitle'>%s</DIV>\n", temp_servicegroup->alias);
@@ -331,8 +329,8 @@ int main(void) {
 					process_macros_r(mac, temp_servicegroup->notes, &processed_string, 0);
 					printf("<p>%s</p>", processed_string);
 					free(processed_string);
-					}
 				}
+			}
 
 			if(display_type == DISPLAY_SERVICE_INFO) {
 				if(temp_service->icon_image != NULL) {
@@ -341,15 +339,15 @@ int main(void) {
 					printf("%s", processed_string);
 					free(processed_string);
 					printf("' border=0 alt='%s' title='%s'><BR CLEAR=ALL>", (temp_service->icon_image_alt == NULL) ? "" : temp_service->icon_image_alt, (temp_service->icon_image_alt == NULL) ? "" : temp_service->icon_image_alt);
-					}
+				}
 				if(temp_service->icon_image_alt != NULL)
 					printf("<font size=-1><i>( %s )</i></font>\n", temp_service->icon_image_alt);
 				if(temp_service->notes != NULL) {
 					process_macros_r(mac, temp_service->notes, &processed_string, 0);
 					printf("<p>%s</p>\n", processed_string);
 					free(processed_string);
-					}
 				}
+			}
 
 			if(display_type == DISPLAY_HOST_INFO) {
 				if(temp_host->icon_image != NULL) {
@@ -358,16 +356,16 @@ int main(void) {
 					printf("%s", processed_string);
 					free(processed_string);
 					printf("' border=0 alt='%s' title='%s'><BR CLEAR=ALL>", (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt);
-					}
+				}
 				if(temp_host->icon_image_alt != NULL)
 					printf("<font size=-1><i>( %s )</i><font>\n", temp_host->icon_image_alt);
 				if(temp_host->notes != NULL) {
 					process_macros_r(mac, temp_host->notes, &processed_string, 0);
 					printf("<p>%s</p>\n", processed_string);
 					free(processed_string);
-					}
 				}
 			}
+		}
 
 		printf("</td>\n");
 
@@ -385,7 +383,7 @@ int main(void) {
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='Perform Additional Actions On This Host' title='Perform Additional Actions On This Host'></A>\n", (action_url_target == NULL) ? "_blank" : action_url_target, url_images_path, ACTION_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Actions</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
 				printf("</TD></TR>\n");
-				}
+			}
 			if(temp_host->notes_url != NULL && strcmp(temp_host->notes_url, "")) {
 				printf("<TR><TD ALIGN='right'>\n");
 				printf("<A HREF='");
@@ -396,9 +394,9 @@ int main(void) {
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='View Additional Notes For This Host' title='View Additional Notes For This Host'></A>\n", (notes_url_target == NULL) ? "_blank" : notes_url_target, url_images_path, NOTES_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Notes</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
 				printf("</TD></TR>\n");
-				}
-			printf("</TABLE>\n");
 			}
+			printf("</TABLE>\n");
+		}
 
 		else if(display_type == DISPLAY_SERVICE_INFO && temp_service != NULL) {
 			printf("<TABLE BORDER='0'><TR><TD ALIGN='right'>\n");
@@ -409,7 +407,7 @@ int main(void) {
 				free(processed_string);
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='Perform Additional Actions On This Service' title='Perform Additional Actions On This Service'></A>\n", (action_url_target == NULL) ? "_blank" : action_url_target, url_images_path, ACTION_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Actions</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
-				}
+			}
 			if(temp_service->notes_url != NULL && strcmp(temp_service->notes_url, "")) {
 				printf("<A HREF='");
 				process_macros_r(mac, temp_service->notes_url, &processed_string, 0);
@@ -417,9 +415,9 @@ int main(void) {
 				free(processed_string);
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='View Additional Notes For This Service' title='View Additional Notes For This Service'></A>\n", (notes_url_target == NULL) ? "_blank" : notes_url_target, url_images_path, NOTES_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Notes</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
-				}
-			printf("</TD></TR></TABLE>\n");
 			}
+			printf("</TD></TR></TABLE>\n");
+		}
 
 		if(display_type == DISPLAY_HOSTGROUP_INFO && temp_hostgroup != NULL) {
 			printf("<TABLE BORDER='0'>\n");
@@ -430,7 +428,7 @@ int main(void) {
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='Perform Additional Actions On This Hostgroup' title='Perform Additional Actions On This Hostgroup'></A>\n", (action_url_target == NULL) ? "_blank" : action_url_target, url_images_path, ACTION_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Actions</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
 				printf("</TD></TR>\n");
-				}
+			}
 			if(temp_hostgroup->notes_url != NULL && strcmp(temp_hostgroup->notes_url, "")) {
 				printf("<TR><TD ALIGN='right'>\n");
 				printf("<A HREF='");
@@ -438,9 +436,9 @@ int main(void) {
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='View Additional Notes For This Hostgroup' title='View Additional Notes For This Hostgroup'></A>\n", (notes_url_target == NULL) ? "_blank" : notes_url_target, url_images_path, NOTES_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Notes</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
 				printf("</TD></TR>\n");
-				}
-			printf("</TABLE>\n");
 			}
+			printf("</TABLE>\n");
+		}
 
 		else if(display_type == DISPLAY_SERVICEGROUP_INFO && temp_servicegroup != NULL) {
 			printf("<TABLE BORDER='0'>\n");
@@ -449,15 +447,15 @@ int main(void) {
 				print_extra_servicegroup_url(temp_servicegroup->group_name, temp_servicegroup->action_url);
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='Perform Additional Actions On This Servicegroup' title='Perform Additional Actions On This Servicegroup'></A>\n", (action_url_target == NULL) ? "_blank" : action_url_target, url_images_path, ACTION_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Actions</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
-				}
+			}
 			if(temp_servicegroup->notes_url != NULL && strcmp(temp_servicegroup->notes_url, "")) {
 				printf("<A HREF='");
 				print_extra_servicegroup_url(temp_servicegroup->group_name, temp_servicegroup->notes_url);
 				printf("' TARGET='%s'><img src='%s%s' border=0 alt='View Additional Notes For This Servicegroup' title='View Additional Notes For This Servicegroup'></A>\n", (notes_url_target == NULL) ? "_blank" : notes_url_target, url_images_path, NOTES_ICON);
 				printf("<BR CLEAR=ALL><FONT SIZE=-1><I>Extra Notes</I></FONT><BR CLEAR=ALL><BR CLEAR=ALL>\n");
-				}
-			printf("</TABLE>\n");
 			}
+			printf("</TABLE>\n");
+		}
 
 		/* display context-sensitive help */
 		if(display_type == DISPLAY_HOST_INFO)
@@ -485,7 +483,7 @@ int main(void) {
 		printf("</tr>\n");
 		printf("</table>\n");
 
-		}
+	}
 
 	printf("<BR>\n");
 
@@ -516,11 +514,12 @@ int main(void) {
 	free_downtime_data();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -552,7 +551,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>", url_stylesheets_path, EXTINFO_CSS);
-		}
+	}
 	printf("</head>\n");
 
 	printf("<body CLASS='extinfo'>\n");
@@ -561,10 +560,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(EXTINFO_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -576,10 +576,11 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int temp_type;
@@ -592,7 +593,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the display type */
 		else if(!strcmp(variables[x], "type")) {
@@ -600,7 +601,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			temp_type = atoi(variables[x]);
 			if(temp_type == DISPLAY_HOST_INFO)
 				display_type = DISPLAY_HOST_INFO;
@@ -620,7 +621,7 @@ int process_cgivars(void) {
 				display_type = DISPLAY_SCHEDULING_QUEUE;
 			else
 				display_type = DISPLAY_PROCESS_INFO;
-			}
+		}
 
 		/* we found the host name */
 		else if(!strcmp(variables[x], "host")) {
@@ -628,13 +629,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			host_name = strdup(variables[x]);
 			if(host_name == NULL)
 				host_name = "";
 			strip_html_brackets(host_name);
-			}
+		}
 
 		/* we found the hostgroup name */
 		else if(!strcmp(variables[x], "hostgroup")) {
@@ -642,13 +643,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			hostgroup_name = strdup(variables[x]);
 			if(hostgroup_name == NULL)
 				hostgroup_name = "";
 			strip_html_brackets(hostgroup_name);
-			}
+		}
 
 		/* we found the service name */
 		else if(!strcmp(variables[x], "service")) {
@@ -656,13 +657,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			service_desc = strdup(variables[x]);
 			if(service_desc == NULL)
 				service_desc = "";
 			strip_html_brackets(service_desc);
-			}
+		}
 
 		/* we found the servicegroup name */
 		else if(!strcmp(variables[x], "servicegroup")) {
@@ -670,13 +671,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			servicegroup_name = strdup(variables[x]);
 			if(servicegroup_name == NULL)
 				servicegroup_name = "";
 			strip_html_brackets(servicegroup_name);
-			}
+		}
 
 		/* we found the sort type argument */
 		else if(!strcmp(variables[x], "sorttype")) {
@@ -684,10 +685,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			sort_type = atoi(variables[x]);
-			}
+		}
 
 		/* we found the sort option argument */
 		else if(!strcmp(variables[x], "sortoption")) {
@@ -695,10 +696,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			sort_option = atoi(variables[x]);
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -707,17 +708,18 @@ int process_cgivars(void) {
 		/* we found the noheader option */
 		else if(!strcmp(variables[x], "noheader"))
 			display_header = FALSE;
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
-void show_process_info(void) {
+void show_process_info(void)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	unsigned long run_time;
@@ -735,7 +737,7 @@ void show_process_info(void) {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	printf("<BR />\n");
 	printf("<DIV ALIGN=CENTER>\n");
@@ -871,26 +873,26 @@ void show_process_info(void) {
 			printf("<TR CLASS='command'><TD><img src='%s%s' border=0 ALT='Enable Performance Data' TITLE='Enable Performance Data'></td><td CLASS='command'><a href='%s?cmd_typ=%d'>Enable performance data</a></td></tr>\n", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_PERFORMANCE_DATA);
 
 		printf("</TABLE>\n");
-		}
-	else {
+	} else {
 		printf("<DIV ALIGN=CENTER CLASS='infoMessage'>It appears as though Nagios is not running, so commands are temporarily unavailable...\n");
 		if(!strcmp(nagios_check_command, "")) {
 			printf("<BR><BR>\n");
 			printf("Hint: It looks as though you have not defined a command for checking the process state by supplying a value for the <b>nagios_check_command</b> option in the CGI configuration file.<BR>\n");
 			printf("Read the documentation for more information on checking the status of the Nagios process in the CGIs.\n");
-			}
-		printf("</DIV>\n");
 		}
+		printf("</DIV>\n");
+	}
 
 	printf("</TD></TR>\n");
 	printf("</TABLE>\n");
 
 	printf("</TD></TR></TABLE>\n");
 	printf("</DIV>\n");
-	}
+}
 
 
-void show_host_info(void) {
+void show_host_info(void)
+{
 	hoststatus *temp_hoststatus;
 	host *temp_host;
 	char date_time[MAX_DATETIME_LENGTH];
@@ -919,7 +921,7 @@ void show_host_info(void) {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	/* get host status info */
 	temp_hoststatus = find_hoststatus(host_name);
@@ -928,11 +930,11 @@ void show_host_info(void) {
 	if(temp_host == NULL) {
 		printf("<P><DIV CLASS='errorMessage'>Error: Host Not Found!</DIV></P>>");
 		return;
-		}
+	}
 	if(temp_hoststatus == NULL) {
 		printf("<P><DIV CLASS='errorMessage'>Error: Host Status Information Not Found!</DIV></P");
 		return;
-		}
+	}
 
 
 	printf("<DIV ALIGN=CENTER>\n");
@@ -963,13 +965,12 @@ void show_host_info(void) {
 				duration_error = TRUE;
 			else
 				t = current_time - program_start;
-			}
-		else {
+		} else {
 			if(temp_hoststatus->last_state_change > current_time)
 				duration_error = TRUE;
 			else
 				t = current_time - temp_hoststatus->last_state_change;
-			}
+		}
 		get_time_breakdown((unsigned long)t, &days, &hours, &minutes, &seconds);
 		if(duration_error == TRUE)
 			snprintf(state_duration, sizeof(state_duration) - 1, "???");
@@ -980,15 +981,13 @@ void show_host_info(void) {
 		if(temp_hoststatus->status == SD_HOST_UP) {
 			strcpy(state_string, "UP");
 			bg_class = "hostUP";
-			}
-		else if(temp_hoststatus->status == SD_HOST_DOWN) {
+		} else if(temp_hoststatus->status == SD_HOST_DOWN) {
 			strcpy(state_string, "DOWN");
 			bg_class = "hostDOWN";
-			}
-		else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
+		} else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 			strcpy(state_string, "UNREACHABLE");
 			bg_class = "hostUNREACHABLE";
-			}
+		}
 
 		printf("<TR><TD CLASS='dataVar'>Host Status:</td><td CLASS='dataVal'><DIV CLASS='%s'>&nbsp;&nbsp;%s&nbsp;&nbsp;</DIV>&nbsp;(for %s)%s</td></tr>\n", bg_class, state_string, state_duration, (temp_hoststatus->problem_has_been_acknowledged == TRUE) ? "&nbsp;&nbsp;(Has been acknowledged)" : "");
 
@@ -998,7 +997,7 @@ void show_host_info(void) {
 			asprintf(&buf, "%s %s", temp_host->name, temp_hoststatus->plugin_output);
 			display_splunk_generic_url(buf, 1);
 			free(buf);
-			}
+		}
 		if(temp_hoststatus->long_plugin_output != NULL)
 			printf("<BR>%s", html_encode(temp_hoststatus->long_plugin_output, TRUE));
 		printf("</TD></TR>\n");
@@ -1087,7 +1086,7 @@ void show_host_info(void) {
 
 		printf("</TD></TR>\n");
 		printf("</TABLE>\n");
-		}
+	}
 
 	printf("</TD>\n");
 
@@ -1108,16 +1107,14 @@ void show_host_info(void) {
 #endif
 		if(temp_hoststatus->checks_enabled == TRUE) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Disable Active Checks Of This Host' TITLE='Disable Active Checks Of This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Disable active checks of this host</a></td></tr>\n", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_HOST_CHECK, url_encode(host_name));
-			}
-		else
+		} else
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Enable Active Checks Of This Host' TITLE='Enable Active Checks Of This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Enable active checks of this host</a></td></tr>\n", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_HOST_CHECK, url_encode(host_name));
 		printf("<tr CLASS='data'><td><img src='%s%s' border=0 ALT='Re-schedule Next Host Check' TITLE='Re-schedule Next Host Check'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s%s'>Re-schedule the next check of this host</a></td></tr>\n", url_images_path, DELAY_ICON, COMMAND_CGI, CMD_SCHEDULE_HOST_CHECK, url_encode(host_name), (temp_hoststatus->checks_enabled == TRUE) ? "&force_check" : "");
 
 		if(temp_hoststatus->accept_passive_checks == TRUE) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Submit Passive Check Result For This Host' TITLE='Submit Passive Check Result For This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Submit passive check result for this host</a></td></tr>\n", url_images_path, PASSIVE_ICON, COMMAND_CGI, CMD_PROCESS_HOST_CHECK_RESULT, url_encode(host_name));
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Stop Accepting Passive Checks For This Host' TITLE='Stop Accepting Passive Checks For This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Stop accepting passive checks for this host</a></td></tr>\n", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_PASSIVE_HOST_CHECKS, url_encode(host_name));
-			}
-		else
+		} else
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Start Accepting Passive Checks For This Host' TITLE='Start Accepting Passive Checks For This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Start accepting passive checks for this host</a></td></tr>\n", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_PASSIVE_HOST_CHECKS, url_encode(host_name));
 
 		if(temp_hoststatus->obsess == TRUE)
@@ -1130,7 +1127,7 @@ void show_host_info(void) {
 				printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Acknowledge This Host Problem' TITLE='Acknowledge This Host Problem'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Acknowledge this host problem</a></td></tr>\n", url_images_path, ACKNOWLEDGEMENT_ICON, COMMAND_CGI, CMD_ACKNOWLEDGE_HOST_PROBLEM, url_encode(host_name));
 			else
 				printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Remove Problem Acknowledgement' TITLE='Remove Problem Acknowledgement'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Remove problem acknowledgement</a></td></tr>\n", url_images_path, REMOVE_ACKNOWLEDGEMENT_ICON, COMMAND_CGI, CMD_REMOVE_HOST_ACKNOWLEDGEMENT, url_encode(host_name));
-			}
+		}
 
 		if(temp_hoststatus->notifications_enabled == TRUE)
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Disable Notifications For This Host' TITLE='Disable Notifications For This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Disable notifications for this host</a></td></tr>\n", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_HOST_NOTIFICATIONS, url_encode(host_name));
@@ -1166,14 +1163,12 @@ void show_host_info(void) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Enable Flap Detection For This Host' TITLE='Enable Flap Detection For This Host'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s'>Enable flap detection for this host</a></td></tr>\n", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_HOST_FLAP_DETECTION, url_encode(host_name));
 
 		printf("</TABLE>\n");
-		}
-	else if(is_authorized_for_read_only(&current_authdata) == TRUE) {
+	} else if(is_authorized_for_read_only(&current_authdata) == TRUE) {
 		printf("<DIV ALIGN=CENTER CLASS='infoMessage'>Your account does not have permissions to execute commands.<br>\n");
-		}
-	else {
+	} else {
 		printf("<DIV ALIGN=CENTER CLASS='infoMessage'>It appears as though Nagios is not running, so commands are temporarily unavailable...<br>\n");
 		printf("Click <a href='%s?type=%d'>here</a> to view Nagios process information</DIV>\n", EXTINFO_CGI, DISPLAY_PROCESS_INFO);
-		}
+	}
 	printf("</TD></TR></TABLE>\n");
 
 	printf("</TD>\n");
@@ -1188,7 +1183,7 @@ void show_host_info(void) {
 	if(is_authorized_for_read_only(&current_authdata) == FALSE) {
 		/* display comments */
 		display_comments(HOST_COMMENT);
-		}
+	}
 	printf("</TD>\n");
 
 	printf("</TR>\n");
@@ -1196,10 +1191,11 @@ void show_host_info(void) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
-void show_service_info(void) {
+void show_service_info(void)
+{
 	service *temp_service;
 	char date_time[MAX_DATETIME_LENGTH];
 	char status_age[48];
@@ -1227,7 +1223,7 @@ void show_service_info(void) {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	/* get service status info */
 	temp_svcstatus = find_servicestatus(host_name, service_desc);
@@ -1236,11 +1232,11 @@ void show_service_info(void) {
 	if(temp_service == NULL) {
 		printf("<P><DIV CLASS='errorMessage'>Error: Service Not Found!</DIV></P>");
 		return;
-		}
+	}
 	if(temp_svcstatus == NULL) {
 		printf("<P><DIV CLASS='errorMessage'>Error: Service Status Not Found!</DIV></P>");
 		return;
-		}
+	}
 
 
 	printf("<DIV ALIGN=CENTER>\n");
@@ -1273,13 +1269,12 @@ void show_service_info(void) {
 				duration_error = TRUE;
 			else
 				t = current_time - program_start;
-			}
-		else {
+		} else {
 			if(temp_svcstatus->last_state_change > current_time)
 				duration_error = TRUE;
 			else
 				t = current_time - temp_svcstatus->last_state_change;
-			}
+		}
 		get_time_breakdown((unsigned long)t, &days, &hours, &minutes, &seconds);
 		if(duration_error == TRUE)
 			snprintf(state_duration, sizeof(state_duration) - 1, "???");
@@ -1290,19 +1285,16 @@ void show_service_info(void) {
 		if(temp_svcstatus->status == SERVICE_OK) {
 			strcpy(state_string, "OK");
 			bg_class = "serviceOK";
-			}
-		else if(temp_svcstatus->status == SERVICE_WARNING) {
+		} else if(temp_svcstatus->status == SERVICE_WARNING) {
 			strcpy(state_string, "WARNING");
 			bg_class = "serviceWARNING";
-			}
-		else if(temp_svcstatus->status == SERVICE_CRITICAL) {
+		} else if(temp_svcstatus->status == SERVICE_CRITICAL) {
 			strcpy(state_string, "CRITICAL");
 			bg_class = "serviceCRITICAL";
-			}
-		else {
+		} else {
 			strcpy(state_string, "UNKNOWN");
 			bg_class = "serviceUNKNOWN";
-			}
+		}
 		printf("<TR><TD CLASS='dataVar'>Current Status:</TD><TD CLASS='dataVal'><DIV CLASS='%s'>&nbsp;&nbsp;%s&nbsp;&nbsp;</DIV>&nbsp;(for %s)%s</TD></TR>\n", bg_class, state_string, state_duration, (temp_svcstatus->problem_has_been_acknowledged == TRUE) ? "&nbsp;&nbsp;(Has been acknowledged)" : "");
 
 		printf("<TR><TD CLASS='dataVar' VALIGN='top'>Status Information:</TD><TD CLASS='dataVal'>%s", (temp_svcstatus->plugin_output == NULL) ? "" : html_encode(temp_svcstatus->plugin_output, TRUE));
@@ -1311,7 +1303,7 @@ void show_service_info(void) {
 			asprintf(&buf, "%s %s %s", temp_service->host_name, temp_service->description, temp_svcstatus->plugin_output);
 			display_splunk_generic_url(buf, 1);
 			free(buf);
-			}
+		}
 		if(temp_svcstatus->long_plugin_output != NULL)
 			printf("<BR>%s", html_encode(temp_svcstatus->long_plugin_output, TRUE));
 		printf("</TD></TR>\n");
@@ -1404,7 +1396,7 @@ void show_service_info(void) {
 		printf("</TD></TR>\n");
 
 		printf("</TABLE>\n");
-		}
+	}
 
 
 	printf("</TD>\n");
@@ -1426,11 +1418,10 @@ void show_service_info(void) {
 
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Disable Active Checks Of This Service' TITLE='Disable Active Checks Of This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_SVC_CHECK, url_encode(host_name));
 			printf("&service=%s'>Disable active checks of this service</a></td></tr>\n", url_encode(service_desc));
-			}
-		else {
+		} else {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Enable Active Checks Of This Service' TITLE='Enable Active Checks Of This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_SVC_CHECK, url_encode(host_name));
 			printf("&service=%s'>Enable active checks of this service</a></td></tr>\n", url_encode(service_desc));
-			}
+		}
 		printf("<tr CLASS='data'><td><img src='%s%s' border=0 ALT='Re-schedule Next Service Check' TITLE='Re-schedule Next Service Check'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DELAY_ICON, COMMAND_CGI, CMD_SCHEDULE_SVC_CHECK, url_encode(host_name));
 		printf("&service=%s%s'>Re-schedule the next check of this service</a></td></tr>\n", url_encode(service_desc), (temp_svcstatus->checks_enabled == TRUE) ? "&force_check" : "");
 
@@ -1440,43 +1431,39 @@ void show_service_info(void) {
 
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Stop Accepting Passive Checks For This Service' TITLE='Stop Accepting Passive Checks For This Service'></td><td CLASS='command' NOWRAP><a href='%s?cmd_typ=%d&host=%s", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_PASSIVE_SVC_CHECKS, url_encode(host_name));
 			printf("&service=%s'>Stop accepting passive checks for this service</a></td></tr>\n", url_encode(service_desc));
-			}
-		else {
+		} else {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Start Accepting Passive Checks For This Service' TITLE='Start Accepting Passive Checks For This Service'></td><td CLASS='command' NOWRAP><a href='%s?cmd_typ=%d&host=%s", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_PASSIVE_SVC_CHECKS, url_encode(host_name));
 			printf("&service=%s'>Start accepting passive checks for this service</a></td></tr>\n", url_encode(service_desc));
-			}
+		}
 
 		if(temp_svcstatus->obsess == TRUE) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Stop Obsessing Over This Service' TITLE='Stop Obsessing Over This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_STOP_OBSESSING_OVER_SVC, url_encode(host_name));
 			printf("&service=%s'>Stop obsessing over this service</a></td></tr>\n", url_encode(service_desc));
-			}
-		else {
+		} else {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Start Obsessing Over This Service' TITLE='Start Obsessing Over This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_START_OBSESSING_OVER_SVC, url_encode(host_name));
 			printf("&service=%s'>Start obsessing over this service</a></td></tr>\n", url_encode(service_desc));
-			}
+		}
 
 		if((temp_svcstatus->status == SERVICE_WARNING || temp_svcstatus->status == SERVICE_UNKNOWN || temp_svcstatus->status == SERVICE_CRITICAL) && temp_svcstatus->state_type == HARD_STATE) {
 			if(temp_svcstatus->problem_has_been_acknowledged == FALSE) {
 				printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Acknowledge This Service Problem' TITLE='Acknowledge This Service Problem'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, ACKNOWLEDGEMENT_ICON, COMMAND_CGI, CMD_ACKNOWLEDGE_SVC_PROBLEM, url_encode(host_name));
 				printf("&service=%s'>Acknowledge this service problem</a></td></tr>\n", url_encode(service_desc));
-				}
-			else {
+			} else {
 				printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Remove Problem Acknowledgement' TITLE='Remove Problem Acknowledgement'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, REMOVE_ACKNOWLEDGEMENT_ICON, COMMAND_CGI, CMD_REMOVE_SVC_ACKNOWLEDGEMENT, url_encode(host_name));
 				printf("&service=%s'>Remove problem acknowledgement</a></td></tr>\n", url_encode(service_desc));
-				}
 			}
+		}
 		if(temp_svcstatus->notifications_enabled == TRUE) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Disable Notifications For This Service' TITLE='Disable Notifications For This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_SVC_NOTIFICATIONS, url_encode(host_name));
 			printf("&service=%s'>Disable notifications for this service</a></td></tr>\n", url_encode(service_desc));
 			if(temp_svcstatus->status != SERVICE_OK) {
 				printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Delay Next Service Notification' TITLE='Delay Next Service Notification'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DELAY_ICON, COMMAND_CGI, CMD_DELAY_SVC_NOTIFICATION, url_encode(host_name));
 				printf("&service=%s'>Delay next service notification</a></td></tr>\n", url_encode(service_desc));
-				}
 			}
-		else {
+		} else {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Enable Notifications For This Service' TITLE='Enable Notifications For This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_SVC_NOTIFICATIONS, url_encode(host_name));
 			printf("&service=%s'>Enable notifications for this service</a></td></tr>\n", url_encode(service_desc));
-			}
+		}
 
 		printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Send Custom Notification' TITLE='Send Custom Notification'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, NOTIFICATION_ICON, COMMAND_CGI, CMD_SEND_CUSTOM_SVC_NOTIFICATION, url_encode(host_name));
 		printf("&service=%s'>Send custom service notification</a></td></tr>\n", url_encode(service_desc));
@@ -1492,30 +1479,26 @@ void show_service_info(void) {
 		if(temp_svcstatus->event_handler_enabled == TRUE) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Disable Event Handler For This Service' TITLE='Disable Event Handler For This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_SVC_EVENT_HANDLER, url_encode(host_name));
 			printf("&service=%s'>Disable event handler for this service</a></td></tr>\n", url_encode(service_desc));
-			}
-		else {
+		} else {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Enable Event Handler For This Service' TITLE='Enable Event Handler For This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_SVC_EVENT_HANDLER, url_encode(host_name));
 			printf("&service=%s'>Enable event handler for this service</a></td></tr>\n", url_encode(service_desc));
-			}
+		}
 
 		if(temp_svcstatus->flap_detection_enabled == TRUE) {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Disable Flap Detection For This Service' TITLE='Disable Flap Detection For This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, DISABLED_ICON, COMMAND_CGI, CMD_DISABLE_SVC_FLAP_DETECTION, url_encode(host_name));
 			printf("&service=%s'>Disable flap detection for this service</a></td></tr>\n", url_encode(service_desc));
-			}
-		else {
+		} else {
 			printf("<tr CLASS='command'><td><img src='%s%s' border=0 ALT='Enable Flap Detection For This Service' TITLE='Enable Flap Detection For This Service'></td><td CLASS='command'><a href='%s?cmd_typ=%d&host=%s", url_images_path, ENABLED_ICON, COMMAND_CGI, CMD_ENABLE_SVC_FLAP_DETECTION, url_encode(host_name));
 			printf("&service=%s'>Enable flap detection for this service</a></td></tr>\n", url_encode(service_desc));
-			}
+		}
 
 		printf("</table>\n");
-		}
-	else if(is_authorized_for_read_only(&current_authdata) == TRUE) {
+	} else if(is_authorized_for_read_only(&current_authdata) == TRUE) {
 		printf("<DIV ALIGN=CENTER CLASS='infoMessage'>Your account does not have permissions to execute commands.<br>\n");
-		}
-	else {
+	} else {
 		printf("<DIV CLASS='infoMessage'>It appears as though Nagios is not running, so commands are temporarily unavailable...<br>\n");
 		printf("Click <a href='%s?type=%d'>here</a> to view Nagios process information</DIV>\n", EXTINFO_CGI, DISPLAY_PROCESS_INFO);
-		}
+	}
 
 	printf("</td></tr>\n");
 	printf("</table>\n");
@@ -1533,7 +1516,7 @@ void show_service_info(void) {
 	if(is_authorized_for_read_only(&current_authdata) == FALSE) {
 		/* display comments */
 		display_comments(SERVICE_COMMENT);
-		}
+	}
 	printf("</TD>\n");
 	printf("</TR>\n");
 
@@ -1541,12 +1524,13 @@ void show_service_info(void) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 
 
-void show_hostgroup_info(void) {
+void show_hostgroup_info(void)
+{
 	hostgroup *temp_hostgroup;
 
 
@@ -1561,13 +1545,13 @@ void show_hostgroup_info(void) {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	/* make sure hostgroup information exists */
 	if(temp_hostgroup == NULL) {
 		printf("<P><DIV CLASS='errorMessage'>Error: Hostgroup Not Found!</DIV></P>");
 		return;
-		}
+	}
 
 
 	printf("<DIV ALIGN=CENTER>\n");
@@ -1610,14 +1594,12 @@ void show_hostgroup_info(void) {
 
 		printf("</TD></TR>\n");
 		printf("</TABLE>\n");
-		}
-	else if(is_authorized_for_read_only(&current_authdata) == TRUE) {
+	} else if(is_authorized_for_read_only(&current_authdata) == TRUE) {
 		printf("<DIV ALIGN=CENTER CLASS='infoMessage'>Your account does not have permissions to execute commands.<br>\n");
-		}
-	else {
+	} else {
 		printf("<DIV CLASS='infoMessage'>It appears as though Nagios is not running, so commands are temporarily unavailable...<br>\n");
 		printf("Click <a href='%s?type=%d'>here</a> to view Nagios process information</DIV>\n", EXTINFO_CGI, DISPLAY_PROCESS_INFO);
-		}
+	}
 
 	printf("</TD></TR>\n");
 	printf("<TR>\n");
@@ -1637,12 +1619,13 @@ void show_hostgroup_info(void) {
 
 
 	return;
-	}
+}
 
 
 
 
-void show_servicegroup_info() {
+void show_servicegroup_info()
+{
 	servicegroup *temp_servicegroup;
 
 
@@ -1657,13 +1640,13 @@ void show_servicegroup_info() {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	/* make sure servicegroup information exists */
 	if(temp_servicegroup == NULL) {
 		printf("<P><DIV CLASS='errorMessage'>Error: Servicegroup Not Found!</DIV></P>");
 		return;
-		}
+	}
 
 
 	printf("<DIV ALIGN=CENTER>\n");
@@ -1706,11 +1689,10 @@ void show_servicegroup_info() {
 
 		printf("</TD></TR>\n");
 		printf("</TABLE>\n");
-		}
-	else {
+	} else {
 		printf("<DIV CLASS='infoMessage'>It appears as though Nagios is not running, so commands are temporarily unavailable...<br>\n");
 		printf("Click <a href='%s?type=%d'>here</a> to view Nagios process information</DIV>\n", EXTINFO_CGI, DISPLAY_PROCESS_INFO);
-		}
+	}
 
 	printf("</TD></TR>\n");
 	printf("<TR>\n");
@@ -1729,12 +1711,13 @@ void show_servicegroup_info() {
 
 
 	return;
-	}
+}
 
 
 
 /* shows all service and host comments */
-void show_all_comments(void) {
+void show_all_comments(void)
+{
 	int total_comments = 0;
 	const char *bg_class = "";
 	int odd = 0;
@@ -1749,7 +1732,7 @@ void show_all_comments(void) {
 	if(is_authorized_for_read_only(&current_authdata) == TRUE) {
 		printf("<DIV ALIGN=CENTER CLASS='infoMessage'>Your account does not have permissions to view comments.<br>\n");
 		return;
-		}
+	}
 
 
 	printf("<BR />\n");
@@ -1785,28 +1768,27 @@ void show_all_comments(void) {
 		if(odd) {
 			odd = 0;
 			bg_class = "commentOdd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bg_class = "commentEven";
-			}
+		}
 
 		switch(temp_comment->entry_type) {
-			case USER_COMMENT:
-				comment_type = "User";
-				break;
-			case DOWNTIME_COMMENT:
-				comment_type = "Scheduled Downtime";
-				break;
-			case FLAPPING_COMMENT:
-				comment_type = "Flap Detection";
-				break;
-			case ACKNOWLEDGEMENT_COMMENT:
-				comment_type = "Acknowledgement";
-				break;
-			default:
-				comment_type = "?";
-			}
+		case USER_COMMENT:
+			comment_type = "User";
+			break;
+		case DOWNTIME_COMMENT:
+			comment_type = "Scheduled Downtime";
+			break;
+		case FLAPPING_COMMENT:
+			comment_type = "Flap Detection";
+			break;
+		case ACKNOWLEDGEMENT_COMMENT:
+			comment_type = "Acknowledgement";
+			break;
+		default:
+			comment_type = "?";
+		}
 
 		get_time_string(&temp_comment->entry_time, date_time, (int)sizeof(date_time), SHORT_DATE_TIME);
 		get_time_string(&temp_comment->expire_time, expire_time, (int)sizeof(date_time), SHORT_DATE_TIME);
@@ -1815,7 +1797,7 @@ void show_all_comments(void) {
 		printf("<td CLASS='%s'>%s</td><td CLASS='%s'>%s</td><td CLASS='%s'>%s</td><td CLASS='%s'>%ld</td><td CLASS='%s'>%s</td><td CLASS='%s'>%s</td><td CLASS='%s'>%s</td>", bg_class, date_time, bg_class, temp_comment->author, bg_class, temp_comment->comment_data, bg_class, temp_comment->comment_id, bg_class, (temp_comment->persistent) ? "Yes" : "No", bg_class, comment_type, bg_class, (temp_comment->expires == TRUE) ? expire_time : "N/A");
 		printf("<td><a href='%s?cmd_typ=%d&com_id=%lu'><img src='%s%s' border=0 ALT='Delete This Comment' TITLE='Delete This Comment'></td>", COMMAND_CGI, CMD_DEL_HOST_COMMENT, temp_comment->comment_id, url_images_path, DELETE_ICON);
 		printf("</tr>\n");
-		}
+	}
 
 	if(total_comments == 0)
 		printf("<TR CLASS='commentOdd'><TD CLASS='commentOdd' COLSPAN=9>There are no host comments</TD></TR>");
@@ -1855,28 +1837,27 @@ void show_all_comments(void) {
 		if(odd) {
 			odd = 0;
 			bg_class = "commentOdd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bg_class = "commentEven";
-			}
+		}
 
 		switch(temp_comment->entry_type) {
-			case USER_COMMENT:
-				comment_type = "User";
-				break;
-			case DOWNTIME_COMMENT:
-				comment_type = "Scheduled Downtime";
-				break;
-			case FLAPPING_COMMENT:
-				comment_type = "Flap Detection";
-				break;
-			case ACKNOWLEDGEMENT_COMMENT:
-				comment_type = "Acknowledgement";
-				break;
-			default:
-				comment_type = "?";
-			}
+		case USER_COMMENT:
+			comment_type = "User";
+			break;
+		case DOWNTIME_COMMENT:
+			comment_type = "Scheduled Downtime";
+			break;
+		case FLAPPING_COMMENT:
+			comment_type = "Flap Detection";
+			break;
+		case ACKNOWLEDGEMENT_COMMENT:
+			comment_type = "Acknowledgement";
+			break;
+		default:
+			comment_type = "?";
+		}
 
 		get_time_string(&temp_comment->entry_time, date_time, (int)sizeof(date_time), SHORT_DATE_TIME);
 		get_time_string(&temp_comment->expire_time, expire_time, (int)sizeof(date_time), SHORT_DATE_TIME);
@@ -1887,7 +1868,7 @@ void show_all_comments(void) {
 		printf("<td CLASS='%s'>%s</td><td CLASS='%s'>%s</td><td CLASS='%s'>%s</td><td CLASS='%s'>%ld</td><td CLASS='%s'>%s</td><td CLASS='%s'>%s</td><td CLASS='%s'>%s</td>", bg_class, date_time, bg_class, temp_comment->author, bg_class, temp_comment->comment_data, bg_class, temp_comment->comment_id, bg_class, (temp_comment->persistent) ? "Yes" : "No", bg_class, comment_type, bg_class, (temp_comment->expires == TRUE) ? expire_time : "N/A");
 		printf("<td><a href='%s?cmd_typ=%d&com_id=%ld'><img src='%s%s' border=0 ALT='Delete This Comment' TITLE='Delete This Comment'></td>", COMMAND_CGI, CMD_DEL_SVC_COMMENT, temp_comment->comment_id, url_images_path, DELETE_ICON);
 		printf("</tr>\n");
-		}
+	}
 
 	if(total_comments == 0)
 		printf("<TR CLASS='commentOdd'><TD CLASS='commentOdd' COLSPAN=10>There are no service comments</TD></TR>");
@@ -1896,11 +1877,12 @@ void show_all_comments(void) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 
-void show_performance_data(void) {
+void show_performance_data(void)
+{
 	service *temp_service = NULL;
 	servicestatus *temp_servicestatus = NULL;
 	host *temp_host = NULL;
@@ -1997,31 +1979,31 @@ void show_performance_data(void) {
 			if(have_min_service_execution_time == FALSE || temp_servicestatus->execution_time < min_service_execution_time) {
 				have_min_service_execution_time = TRUE;
 				min_service_execution_time = temp_servicestatus->execution_time;
-				}
+			}
 			if(have_max_service_execution_time == FALSE || temp_servicestatus->execution_time > max_service_execution_time) {
 				have_max_service_execution_time = TRUE;
 				max_service_execution_time = temp_servicestatus->execution_time;
-				}
+			}
 
 			total_service_percent_change_a += temp_servicestatus->percent_state_change;
 			if(have_min_service_percent_change_a == FALSE || temp_servicestatus->percent_state_change < min_service_percent_change_a) {
 				have_min_service_percent_change_a = TRUE;
 				min_service_percent_change_a = temp_servicestatus->percent_state_change;
-				}
+			}
 			if(have_max_service_percent_change_a == FALSE || temp_servicestatus->percent_state_change > max_service_percent_change_a) {
 				have_max_service_percent_change_a = TRUE;
 				max_service_percent_change_a = temp_servicestatus->percent_state_change;
-				}
+			}
 
 			total_service_latency += temp_servicestatus->latency;
 			if(have_min_service_latency == FALSE || temp_servicestatus->latency < min_service_latency) {
 				have_min_service_latency = TRUE;
 				min_service_latency = temp_servicestatus->latency;
-				}
+			}
 			if(have_max_service_latency == FALSE || temp_servicestatus->latency > max_service_latency) {
 				have_max_service_latency = TRUE;
 				max_service_latency = temp_servicestatus->latency;
-				}
+			}
 
 			if(temp_servicestatus->last_check >= (current_time - 60))
 				active_service_checks_1min++;
@@ -2035,7 +2017,7 @@ void show_performance_data(void) {
 				active_service_checks_start++;
 			if(temp_servicestatus->last_check != (time_t)0)
 				active_service_checks_ever++;
-			}
+		}
 
 		else {
 			total_passive_service_checks++;
@@ -2044,11 +2026,11 @@ void show_performance_data(void) {
 			if(have_min_service_percent_change_b == FALSE || temp_servicestatus->percent_state_change < min_service_percent_change_b) {
 				have_min_service_percent_change_b = TRUE;
 				min_service_percent_change_b = temp_servicestatus->percent_state_change;
-				}
+			}
 			if(have_max_service_percent_change_b == FALSE || temp_servicestatus->percent_state_change > max_service_percent_change_b) {
 				have_max_service_percent_change_b = TRUE;
 				max_service_percent_change_b = temp_servicestatus->percent_state_change;
-				}
+			}
 
 			if(temp_servicestatus->last_check >= (current_time - 60))
 				passive_service_checks_1min++;
@@ -2062,8 +2044,8 @@ void show_performance_data(void) {
 				passive_service_checks_start++;
 			if(temp_servicestatus->last_check != (time_t)0)
 				passive_service_checks_ever++;
-			}
 		}
+	}
 
 	/* check all hosts */
 	for(temp_hoststatus = hoststatus_list; temp_hoststatus != NULL; temp_hoststatus = temp_hoststatus->next) {
@@ -2084,31 +2066,31 @@ void show_performance_data(void) {
 			if(have_min_host_execution_time == FALSE || temp_hoststatus->execution_time < min_host_execution_time) {
 				have_min_host_execution_time = TRUE;
 				min_host_execution_time = temp_hoststatus->execution_time;
-				}
+			}
 			if(have_max_host_execution_time == FALSE || temp_hoststatus->execution_time > max_host_execution_time) {
 				have_max_host_execution_time = TRUE;
 				max_host_execution_time = temp_hoststatus->execution_time;
-				}
+			}
 
 			total_host_percent_change_a += temp_hoststatus->percent_state_change;
 			if(have_min_host_percent_change_a == FALSE || temp_hoststatus->percent_state_change < min_host_percent_change_a) {
 				have_min_host_percent_change_a = TRUE;
 				min_host_percent_change_a = temp_hoststatus->percent_state_change;
-				}
+			}
 			if(have_max_host_percent_change_a == FALSE || temp_hoststatus->percent_state_change > max_host_percent_change_a) {
 				have_max_host_percent_change_a = TRUE;
 				max_host_percent_change_a = temp_hoststatus->percent_state_change;
-				}
+			}
 
 			total_host_latency += temp_hoststatus->latency;
 			if(have_min_host_latency == FALSE || temp_hoststatus->latency < min_host_latency) {
 				have_min_host_latency = TRUE;
 				min_host_latency = temp_hoststatus->latency;
-				}
+			}
 			if(have_max_host_latency == FALSE || temp_hoststatus->latency > max_host_latency) {
 				have_max_host_latency = TRUE;
 				max_host_latency = temp_hoststatus->latency;
-				}
+			}
 
 			if(temp_hoststatus->last_check >= (current_time - 60))
 				active_host_checks_1min++;
@@ -2122,7 +2104,7 @@ void show_performance_data(void) {
 				active_host_checks_start++;
 			if(temp_hoststatus->last_check != (time_t)0)
 				active_host_checks_ever++;
-			}
+		}
 
 		else {
 			total_passive_host_checks++;
@@ -2131,11 +2113,11 @@ void show_performance_data(void) {
 			if(have_min_host_percent_change_b == FALSE || temp_hoststatus->percent_state_change < min_host_percent_change_b) {
 				have_min_host_percent_change_b = TRUE;
 				min_host_percent_change_b = temp_hoststatus->percent_state_change;
-				}
+			}
 			if(have_max_host_percent_change_b == FALSE || temp_hoststatus->percent_state_change > max_host_percent_change_b) {
 				have_max_host_percent_change_b = TRUE;
 				max_host_percent_change_b = temp_hoststatus->percent_state_change;
-				}
+			}
 
 			if(temp_hoststatus->last_check >= (current_time - 60))
 				passive_host_checks_1min++;
@@ -2149,8 +2131,8 @@ void show_performance_data(void) {
 				passive_host_checks_start++;
 			if(temp_hoststatus->last_check != (time_t)0)
 				passive_host_checks_ever++;
-			}
 		}
+	}
 
 
 	printf("<div align=center>\n");
@@ -2408,11 +2390,12 @@ void show_performance_data(void) {
 	printf("</div>\n");
 
 	return;
-	}
+}
 
 
 
-void display_comments(int type) {
+void display_comments(int type)
+{
 	host *temp_host = NULL;
 	service *temp_service = NULL;
 	int total_comments = 0;
@@ -2430,12 +2413,11 @@ void display_comments(int type) {
 		temp_host = find_host(host_name);
 		if(temp_host == NULL)
 			return;
-		}
-	else {
+	} else {
 		temp_service = find_service(host_name, service_desc);
 		if(temp_service == NULL)
 			return;
-		}
+	}
 
 
 	printf("<A NAME=comments></A>\n");
@@ -2449,7 +2431,7 @@ void display_comments(int type) {
 	else {
 		printf("<a href='%s?cmd_typ=%d&host=%s&", COMMAND_CGI, CMD_ADD_SVC_COMMENT, url_encode(host_name));
 		printf("service=%s' CLASS='comment'>", url_encode(service_desc));
-		}
+	}
 	printf("Add a new comment</a></td>\n");
 
 	printf("<td valign=middle><img src='%s%s' border=0 align=center></td><td CLASS='comment'>", url_images_path, DELETE_ICON);
@@ -2458,7 +2440,7 @@ void display_comments(int type) {
 	else {
 		printf("<a href='%s?cmd_typ=%d&host=%s&", COMMAND_CGI, CMD_DEL_ALL_SVC_COMMENTS, url_encode(host_name));
 		printf("service=%s' CLASS='comment'>", url_encode(service_desc));
-		}
+	}
 	printf("Delete all comments</a></td>\n");
 	printf("</tr>\n");
 
@@ -2487,28 +2469,27 @@ void display_comments(int type) {
 			if(odd) {
 				odd = 0;
 				bg_class = "commentOdd";
-				}
-			else {
+			} else {
 				odd = 1;
 				bg_class = "commentEven";
-				}
+			}
 
 			switch(temp_comment->entry_type) {
-				case USER_COMMENT:
-					comment_type = "User";
-					break;
-				case DOWNTIME_COMMENT:
-					comment_type = "Scheduled Downtime";
-					break;
-				case FLAPPING_COMMENT:
-					comment_type = "Flap Detection";
-					break;
-				case ACKNOWLEDGEMENT_COMMENT:
-					comment_type = "Acknowledgement";
-					break;
-				default:
-					comment_type = "?";
-				}
+			case USER_COMMENT:
+				comment_type = "User";
+				break;
+			case DOWNTIME_COMMENT:
+				comment_type = "Scheduled Downtime";
+				break;
+			case FLAPPING_COMMENT:
+				comment_type = "Flap Detection";
+				break;
+			case ACKNOWLEDGEMENT_COMMENT:
+				comment_type = "Acknowledgement";
+				break;
+			default:
+				comment_type = "?";
+			}
 
 			get_time_string(&temp_comment->entry_time, date_time, (int)sizeof(date_time), SHORT_DATE_TIME);
 			get_time_string(&temp_comment->expire_time, expire_time, (int)sizeof(date_time), SHORT_DATE_TIME);
@@ -2518,8 +2499,8 @@ void display_comments(int type) {
 			printf("</tr>\n");
 
 			total_comments++;
-			}
 		}
+	}
 
 	/* see if this host or service has any comments associated with it */
 	if(total_comments == 0)
@@ -2528,13 +2509,14 @@ void display_comments(int type) {
 	printf("</TABLE></DIV>\n");
 
 	return;
-	}
+}
 
 
 
 
 /* shows all service and host scheduled downtime */
-void show_all_downtime(void) {
+void show_all_downtime(void)
+{
 	int total_downtime = 0;
 	const char *bg_class = "";
 	int odd = 0;
@@ -2581,11 +2563,10 @@ void show_all_downtime(void) {
 		if(odd) {
 			odd = 0;
 			bg_class = "downtimeOdd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bg_class = "downtimeEven";
-			}
+		}
 
 		printf("<tr CLASS='%s'>", bg_class);
 		printf("<td CLASS='%s'><A HREF='%s?type=%d&host=%s'>%s</A></td>", bg_class, EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_downtime->host_name), temp_downtime->host_name);
@@ -2609,7 +2590,7 @@ void show_all_downtime(void) {
 		printf("</td>\n");
 		printf("<td><a href='%s?cmd_typ=%d&down_id=%lu'><img src='%s%s' border=0 ALT='Delete/Cancel This Scheduled Downtime Entry' TITLE='Delete/Cancel This Scheduled Downtime Entry'></td>", COMMAND_CGI, CMD_DEL_HOST_DOWNTIME, temp_downtime->downtime_id, url_images_path, DELETE_ICON);
 		printf("</tr>\n");
-		}
+	}
 
 	if(total_downtime == 0)
 		printf("<TR CLASS='downtimeOdd'><TD CLASS='downtimeOdd' COLSPAN=11>There are no hosts with scheduled downtime</TD></TR>");
@@ -2649,11 +2630,10 @@ void show_all_downtime(void) {
 		if(odd) {
 			odd = 0;
 			bg_class = "downtimeOdd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bg_class = "downtimeEven";
-			}
+		}
 
 		printf("<tr CLASS='%s'>", bg_class);
 		printf("<td CLASS='%s'><A HREF='%s?type=%d&host=%s'>%s</A></td>", bg_class, EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_downtime->host_name), temp_downtime->host_name);
@@ -2679,7 +2659,7 @@ void show_all_downtime(void) {
 		printf("</td>\n");
 		printf("<td><a href='%s?cmd_typ=%d&down_id=%lu'><img src='%s%s' border=0 ALT='Delete/Cancel This Scheduled Downtime Entry' TITLE='Delete/Cancel This Scheduled Downtime Entry'></td>", COMMAND_CGI, CMD_DEL_SVC_DOWNTIME, temp_downtime->downtime_id, url_images_path, DELETE_ICON);
 		printf("</tr>\n");
-		}
+	}
 
 	if(total_downtime == 0)
 		printf("<TR CLASS='downtimeOdd'><TD CLASS='downtimeOdd' COLSPAN=12>There are no services with scheduled downtime</TD></TR>");
@@ -2688,12 +2668,13 @@ void show_all_downtime(void) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 
 /* shows check scheduling queue */
-void show_scheduling_queue(void) {
+void show_scheduling_queue(void)
+{
 	sortdata *temp_sortdata;
 	servicestatus *temp_svcstatus = NULL;
 	hoststatus *temp_hststatus = NULL;
@@ -2711,7 +2692,7 @@ void show_scheduling_queue(void) {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	/* sort hosts and services */
 	sort_data(sort_type, sort_option);
@@ -2760,25 +2741,23 @@ void show_scheduling_queue(void) {
 				/* passive-only checks should appear if they're being forced */
 				if(!(temp_svcstatus->checks_enabled == FALSE && temp_svcstatus->next_check != (time_t)0L && (temp_svcstatus->check_options & CHECK_OPTION_FORCE_EXECUTION)))
 					continue;
-				}
 			}
-		else {
+		} else {
 			temp_hststatus = temp_sortdata->hststatus;
 			if(temp_hststatus->should_be_scheduled == FALSE) {
 				/* passive-only checks should appear if they're being forced */
 				if(!(temp_hststatus->checks_enabled == FALSE && temp_hststatus->next_check != (time_t)0L && (temp_hststatus->check_options & CHECK_OPTION_FORCE_EXECUTION)))
 					continue;
-				}
 			}
+		}
 
 		if(odd) {
 			odd = 0;
 			bgclass = "Even";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Odd";
-			}
+		}
 
 		printf("<TR CLASS='queue%s'>", bgclass);
 
@@ -2806,7 +2785,7 @@ void show_scheduling_queue(void) {
 					printf("Freshness ");
 				if(temp_svcstatus->check_options & CHECK_OPTION_ORPHAN_CHECK)
 					printf("Orphan ");
-				}
+			}
 			printf("</TD>");
 
 			printf("<TD CLASS='queue%s'>%s</TD>", (temp_svcstatus->checks_enabled == TRUE) ? "ENABLED" : "DISABLED", (temp_svcstatus->checks_enabled == TRUE) ? "ENABLED" : "DISABLED");
@@ -2815,15 +2794,14 @@ void show_scheduling_queue(void) {
 			if(temp_svcstatus->checks_enabled == TRUE) {
 				printf("<a href='%s?cmd_typ=%d&host=%s", COMMAND_CGI, CMD_DISABLE_SVC_CHECK, url_encode(temp_svcstatus->host_name));
 				printf("&service=%s'><img src='%s%s' border=0 ALT='Disable Active Checks Of This Service' TITLE='Disable Active Checks Of This Service'></a>\n", url_encode(temp_svcstatus->description), url_images_path, DISABLED_ICON);
-				}
-			else {
+			} else {
 				printf("<a href='%s?cmd_typ=%d&host=%s", COMMAND_CGI, CMD_ENABLE_SVC_CHECK, url_encode(temp_svcstatus->host_name));
 				printf("&service=%s'><img src='%s%s' border=0 ALT='Enable Active Checks Of This Service' TITLE='Enable Active Checks Of This Service'></a>\n", url_encode(temp_svcstatus->description), url_images_path, ENABLED_ICON);
-				}
+			}
 			printf("<a href='%s?cmd_typ=%d&host=%s", COMMAND_CGI, CMD_SCHEDULE_SVC_CHECK, url_encode(temp_svcstatus->host_name));
 			printf("&service=%s%s'><img src='%s%s' border=0 ALT='Re-schedule This Service Check' TITLE='Re-schedule This Service Check'></a>\n", url_encode(temp_svcstatus->description), (temp_svcstatus->checks_enabled == TRUE) ? "&force_check" : "", url_images_path, DELAY_ICON);
 			printf("</TD>\n");
-			}
+		}
 
 		/* get the host status */
 		else {
@@ -2848,7 +2826,7 @@ void show_scheduling_queue(void) {
 					printf("Freshness ");
 				if(temp_hststatus->check_options & CHECK_OPTION_ORPHAN_CHECK)
 					printf("Orphan ");
-				}
+			}
 			printf("</TD>");
 
 			printf("<TD CLASS='queue%s'>%s</TD>", (temp_hststatus->checks_enabled == TRUE) ? "ENABLED" : "DISABLED", (temp_hststatus->checks_enabled == TRUE) ? "ENABLED" : "DISABLED");
@@ -2857,19 +2835,18 @@ void show_scheduling_queue(void) {
 			if(temp_hststatus->checks_enabled == TRUE) {
 				printf("<a href='%s?cmd_typ=%d&host=%s", COMMAND_CGI, CMD_DISABLE_HOST_CHECK, url_encode(temp_hststatus->host_name));
 				printf("'><img src='%s%s' border=0 ALT='Disable Active Checks Of This Host' TITLE='Disable Active Checks Of This Host'></a>\n", url_images_path, DISABLED_ICON);
-				}
-			else {
+			} else {
 				printf("<a href='%s?cmd_typ=%d&host=%s", COMMAND_CGI, CMD_ENABLE_HOST_CHECK, url_encode(temp_hststatus->host_name));
 				printf("'><img src='%s%s' border=0 ALT='Enable Active Checks Of This Host' TITLE='Enable Active Checks Of This Host'></a>\n", url_images_path, ENABLED_ICON);
-				}
+			}
 			printf("<a href='%s?cmd_typ=%d&host=%s%s", COMMAND_CGI, CMD_SCHEDULE_HOST_CHECK, url_encode(temp_hststatus->host_name), (temp_hststatus->checks_enabled == TRUE) ? "&force_check" : "");
 			printf("'><img src='%s%s' border=0 ALT='Re-schedule This Host Check' TITLE='Re-schedule This Host Check'></a>\n", url_images_path, DELAY_ICON);
 			printf("</TD>\n");
-			}
+		}
 
 		printf("</TR>\n");
 
-		}
+	}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
@@ -2880,12 +2857,13 @@ void show_scheduling_queue(void) {
 	free_sortdata_list();
 
 	return;
-	}
+}
 
 
 
 /* sorts host and service data */
-int sort_data(int s_type, int s_option) {
+int sort_data(int s_type, int s_option)
+{
 	sortdata *new_sortdata;
 	sortdata *last_sortdata;
 	sortdata *temp_sortdata;
@@ -2917,20 +2895,18 @@ int sort_data(int s_type, int s_option) {
 				else
 					last_sortdata->next = new_sortdata;
 				break;
-				}
-			else
+			} else
 				last_sortdata = temp_sortdata;
-			}
+		}
 
 		if(sortdata_list == NULL) {
 			new_sortdata->next = NULL;
 			sortdata_list = new_sortdata;
-			}
-		else if(temp_sortdata == NULL) {
+		} else if(temp_sortdata == NULL) {
 			new_sortdata->next = NULL;
 			last_sortdata->next = new_sortdata;
-			}
 		}
+	}
 
 	/* sort all host status entries */
 	for(temp_hststatus = hoststatus_list; temp_hststatus != NULL; temp_hststatus = temp_hststatus->next) {
@@ -2954,26 +2930,25 @@ int sort_data(int s_type, int s_option) {
 				else
 					last_sortdata->next = new_sortdata;
 				break;
-				}
-			else
+			} else
 				last_sortdata = temp_sortdata;
-			}
+		}
 
 		if(sortdata_list == NULL) {
 			new_sortdata->next = NULL;
 			sortdata_list = new_sortdata;
-			}
-		else if(temp_sortdata == NULL) {
+		} else if(temp_sortdata == NULL) {
 			new_sortdata->next = NULL;
 			last_sortdata->next = new_sortdata;
-			}
 		}
-
-	return OK;
 	}
 
+	return OK;
+}
 
-int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, sortdata *temp_sortdata) {
+
+int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, sortdata *temp_sortdata)
+{
 	hoststatus *temp_hststatus = NULL;
 	servicestatus *temp_svcstatus = NULL;
 	time_t last_check[2];
@@ -2991,8 +2966,7 @@ int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, s
 		hname[0] = temp_svcstatus->host_name;
 		service_description[0] = temp_svcstatus->description;
 		current_attempt[0] = temp_svcstatus->current_attempt;
-		}
-	else {
+	} else {
 		temp_hststatus = new_sortdata->hststatus;
 		last_check[0] = temp_hststatus->last_check;
 		next_check[0] = temp_hststatus->next_check;
@@ -3000,7 +2974,7 @@ int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, s
 		hname[0] = temp_hststatus->host_name;
 		service_description[0] = "";
 		current_attempt[0] = temp_hststatus->current_attempt;
-		}
+	}
 	if(temp_sortdata->is_service == TRUE) {
 		temp_svcstatus = temp_sortdata->svcstatus;
 		last_check[1] = temp_svcstatus->last_check;
@@ -3009,8 +2983,7 @@ int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, s
 		hname[1] = temp_svcstatus->host_name;
 		service_description[1] = temp_svcstatus->description;
 		current_attempt[1] = temp_svcstatus->current_attempt;
-		}
-	else {
+	} else {
 		temp_hststatus = temp_sortdata->hststatus;
 		last_check[1] = temp_hststatus->last_check;
 		next_check[1] = temp_hststatus->next_check;
@@ -3018,7 +2991,7 @@ int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, s
 		hname[1] = temp_hststatus->host_name;
 		service_description[1] = "";
 		current_attempt[1] = temp_hststatus->current_attempt;
-		}
+	}
 
 	if(s_type == SORT_ASCENDING) {
 
@@ -3027,84 +3000,76 @@ int compare_sortdata_entries(int s_type, int s_option, sortdata *new_sortdata, s
 				return TRUE;
 			else
 				return FALSE;
-			}
+		}
 		if(s_option == SORT_NEXTCHECKTIME) {
 			if(next_check[0] <= next_check[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_CURRENTATTEMPT) {
+		} else if(s_option == SORT_CURRENTATTEMPT) {
 			if(current_attempt[0] <= current_attempt[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICESTATUS) {
+		} else if(s_option == SORT_SERVICESTATUS) {
 			if(status[0] <= status[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTNAME) {
+		} else if(s_option == SORT_HOSTNAME) {
 			if(strcasecmp(hname[0], hname[1]) < 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICENAME) {
+		} else if(s_option == SORT_SERVICENAME) {
 			if(strcasecmp(service_description[0], service_description[1]) < 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
 		}
-	else {
+	} else {
 		if(s_option == SORT_LASTCHECKTIME) {
 			if(last_check[0] > last_check[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
+		}
 		if(s_option == SORT_NEXTCHECKTIME) {
 			if(next_check[0] > next_check[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_CURRENTATTEMPT) {
+		} else if(s_option == SORT_CURRENTATTEMPT) {
 			if(current_attempt[0] > current_attempt[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICESTATUS) {
+		} else if(s_option == SORT_SERVICESTATUS) {
 			if(status[0] > status[1])
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTNAME) {
+		} else if(s_option == SORT_HOSTNAME) {
 			if(strcasecmp(hname[0], hname[1]) > 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICENAME) {
+		} else if(s_option == SORT_SERVICENAME) {
 			if(strcasecmp(service_description[0], service_description[1]) > 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
 		}
+	}
 
 	return TRUE;
-	}
+}
 
 
 
 /* free all memory allocated to the sortdata structures */
-void free_sortdata_list(void) {
+void free_sortdata_list(void)
+{
 	sortdata *this_sortdata;
 	sortdata *next_sortdata;
 
@@ -3112,7 +3077,7 @@ void free_sortdata_list(void) {
 	for(this_sortdata = sortdata_list; this_sortdata != NULL; this_sortdata = next_sortdata) {
 		next_sortdata = this_sortdata->next;
 		free(this_sortdata);
-		}
+	}
 
 	return;
-	}
+}

--- a/cgi/getcgi.c
+++ b/cgi/getcgi.c
@@ -15,7 +15,8 @@
 
 
 /* Remove potentially harmful characters from CGI input that we don't need or want */
-void sanitize_cgi_input(char **cgivars) {
+void sanitize_cgi_input(char **cgivars)
+{
 	char *strptr;
 	int x, y, i;
 	int keep;
@@ -38,17 +39,18 @@ void sanitize_cgi_input(char **cgivars) {
 #endif
 			if(keep == 1)
 				strptr[y++] = strptr[x];
-			}
-
-		strptr[y] = '\x0';
 		}
 
-	return;
+		strptr[y] = '\x0';
 	}
+
+	return;
+}
 
 
 /* convert encoded hex string (2 characters representing an 8-bit number) to its ASCII char equivalent */
-unsigned char hex_to_char(char *input) {
+unsigned char hex_to_char(char *input)
+{
 	unsigned char outchar = '\x0';
 	unsigned int outint;
 	char tempbuf[3];
@@ -76,12 +78,13 @@ unsigned char hex_to_char(char *input) {
 	outchar = (unsigned char)outint;
 
 	return outchar;
-	}
+}
 
 
 
 /* unescape hex characters in CGI input */
-void unescape_cgi_input(char *input) {
+void unescape_cgi_input(char *input)
+{
 	int x, y;
 	int len;
 
@@ -96,20 +99,20 @@ void unescape_cgi_input(char *input) {
 		else if(input[x] == '%') {
 			input[y] = hex_to_char(&input[x + 1]);
 			x += 2;
-			}
-		else
+		} else
 			input[y] = input[x];
-		}
+	}
 	input[y] = '\x0';
 
 	return;
-	}
+}
 
 
 
 /* read the CGI input and place all name/val pairs into list. returns list containing name1, value1, name2, value2, ... , NULL */
 /* this is a hacked version of a routine I found a long time ago somewhere - can't remember where anymore */
-char **getcgivars(void) {
+char **getcgivars(void)
+{
 	register int i;
 	char *accept_lang;
 	char *request_method;
@@ -143,14 +146,13 @@ char **getcgivars(void) {
 			cgiinput = (char *)malloc(1);
 			if(cgiinput != NULL)
 				cgiinput[0] = '\x0';
-			}
-		else
+		} else
 			cgiinput = strdup(getenv("QUERY_STRING"));
 		if(cgiinput == NULL) {
 			printf("getcgivars(): Could not allocate memory for CGI input.\n");
 			exit(1);
-			}
 		}
+	}
 
 	else if(!strcmp(request_method, "POST") || !strcmp(request_method, "PUT")) {
 
@@ -164,7 +166,7 @@ char **getcgivars(void) {
 		if(strlen(content_type) && strncasecmp(content_type, "application/x-www-form-urlencoded", 33)) {
 			printf("getcgivars(): Unsupported Content-Type.\n");
 			exit(1);
-			}
+		}
 
 		content_length_string = getenv("CONTENT_LENGTH");
 		if(content_length_string == NULL)
@@ -173,24 +175,23 @@ char **getcgivars(void) {
 		if(!(content_length = atoi(content_length_string))) {
 			printf("getcgivars(): No Content-Length was sent with the POST request.\n") ;
 			exit(1);
-			}
+		}
 		/* suspicious content length */
 		if((content_length < 0) || (content_length >= INT_MAX - 1)) {
 			printf("getcgivars(): Suspicious Content-Length was sent with the POST request.\n");
 			exit(1);
-			}
+		}
 
 		if(!(cgiinput = (char *)malloc(content_length + 1))) {
 			printf("getcgivars(): Could not allocate memory for CGI input.\n");
 			exit(1);
-			}
+		}
 		if(!fread(cgiinput, content_length, 1, stdin)) {
 			printf("getcgivars(): Could not read input from STDIN.\n");
 			exit(1);
-			}
-		cgiinput[content_length] = '\0';
 		}
-	else {
+		cgiinput[content_length] = '\0';
+	} else {
 
 		printf("getcgivars(): Unsupported REQUEST_METHOD -> '%s'\n", request_method);
 		printf("\n");
@@ -206,13 +207,13 @@ char **getcgivars(void) {
 		printf("\n");
 
 		exit(1);
-		}
+	}
 
 	/* change all plus signs back to spaces */
 	for(i = 0; cgiinput[i]; i++) {
 		if(cgiinput[i] == '+')
 			cgiinput[i] = ' ';
-		}
+	}
 
 	/* first, split on ampersands (&) to extract the name-value pairs into pairlist */
 	/* allocate memory for 256 name-value pairs at a time, increasing by same
@@ -221,7 +222,7 @@ char **getcgivars(void) {
 	if(pairlist == NULL) {
 		printf("getcgivars(): Could not allocate memory for name-value pairlist.\n");
 		exit(1);
-		}
+	}
 	paircount = 0;
 	nvpair = strtok(cgiinput, "&");
 	while(nvpair) {
@@ -229,17 +230,17 @@ char **getcgivars(void) {
 		if( NULL == pairlist[paircount]) {
 			printf("getcgivars(): Could not allocate memory for name-value pair #%d.\n", paircount);
 			exit(1);
-			}
+		}
 		paircount++;
 		if(!(paircount % 256)) {
 			pairlist = (char **)realloc(pairlist, (paircount + 256) * sizeof(char **));
 			if(pairlist == NULL) {
 				printf("getcgivars(): Could not re-allocate memory for name-value pairlist.\n");
 				exit(1);
-				}
 			}
-		nvpair = strtok(NULL, "&");
 		}
+		nvpair = strtok(NULL, "&");
+	}
 
 	/* terminate the list */
 	pairlist[paircount] = '\x0';
@@ -249,7 +250,7 @@ char **getcgivars(void) {
 	if(cgivars == NULL) {
 		printf("getcgivars(): Could not allocate memory for name-value list.\n");
 		exit(1);
-		}
+	}
 	for(i = 0; i < paircount; i++) {
 
 		/* get the variable name preceding the equal (=) sign */
@@ -259,26 +260,25 @@ char **getcgivars(void) {
 			if( NULL == cgivars[ i * 2 + 1]) {
 				printf("getcgivars(): Could not allocate memory for cgi value #%d.\n", i);
 				exit(1);
-				}
-			unescape_cgi_input(cgivars[i * 2 + 1]);
 			}
-		else {
+			unescape_cgi_input(cgivars[i * 2 + 1]);
+		} else {
 			cgivars[i * 2 + 1] = strdup("");
 			if( NULL == cgivars[ i * 2 + 1]) {
 				printf("getcgivars(): Could not allocate memory for empty stringfor variable value #%d.\n", i);
 				exit(1);
-				}
-			unescape_cgi_input(cgivars[i * 2 + 1]);
 			}
+			unescape_cgi_input(cgivars[i * 2 + 1]);
+		}
 
 		/* get the variable value (or name/value of there was no real "pair" in the first place) */
 		cgivars[i * 2] = strdup(pairlist[i]);
 		if( NULL == cgivars[ i * 2]) {
 			printf("getcgivars(): Could not allocate memory for cgi name #%d.\n", i);
 			exit(1);
-			}
-		unescape_cgi_input(cgivars[i * 2]);
 		}
+		unescape_cgi_input(cgivars[i * 2]);
+	}
 
 	/* terminate the name-value list */
 	cgivars[paircount * 2] = '\x0';
@@ -294,11 +294,12 @@ char **getcgivars(void) {
 
 	/* return the list of name-value strings */
 	return cgivars;
-	}
+}
 
 /* Set the locale based on the HTTP_ACCEPT_LANGUAGE variable value sent by
 	the browser */
-void process_language( char * accept_lang) {
+void process_language( char * accept_lang)
+{
 	accept_languages *accept_langs = NULL;
 	int x;
 	char	locale_string[ 64];
@@ -312,7 +313,7 @@ void process_language( char * accept_lang) {
 	if( NULL != accept_langs) {
 		/* Sort the results */
 		qsort( accept_langs->languages, accept_langs->count,
-				sizeof( accept_langs->languages[ 0]), compare_accept_languages);
+		       sizeof( accept_langs->languages[ 0]), compare_accept_languages);
 
 		/* Try each language in order of priority */
 		for( x = 0; (( x < accept_langs->count) && ( NULL == locale)); x++) {
@@ -321,7 +322,7 @@ void process_language( char * accept_lang) {
 			if (!l || !l->locality || !l->language)
 				continue;
 			snprintf( locale_string, sizeof( locale_string), "%s_%s.%s",
-					l->language, l->locality, "utf8");
+			          l->language, l->locality, "utf8");
 			locale = setlocale( LC_ALL, locale_string);
 		}
 
@@ -330,13 +331,14 @@ void process_language( char * accept_lang) {
 	if( NULL == locale) { /* Still isn't set */
 		/* Try the fail safe locales */
 		for( x = 0; (( x < (int)( sizeof( locale_failsafe) / sizeof( char *))) &&
-				( NULL == locale)); x++) {
+		             ( NULL == locale)); x++) {
 			locale = setlocale( LC_ALL, locale_failsafe[ x]);
 		}
 	}
 }
 
-accept_languages * parse_accept_languages( char * acceptlang) {
+accept_languages * parse_accept_languages( char * acceptlang)
+{
 	char *	langdup;	/* Duplicate of accept language for parsing */
 	accept_languages	*langs = NULL;
 	char *	langtok;	/* Language token (language + locality + q value) */
@@ -376,18 +378,17 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 		if( NULL == langs->languages) {
 			/* Adding first language */
 			if( NULL == ( langs->languages =
-					malloc( langs->count * sizeof( accept_language *)))) {
+			                  malloc( langs->count * sizeof( accept_language *)))) {
 				printf( "Unable to allocate memory for first language\n");
 				langs->count--;
 				free_accept_languages( langs);
 				free( langdup);
 				return NULL;
 			}
-		}
-		else {
+		} else {
 			/* Adding additional language */
 			if( NULL == ( langs->languages = realloc( langs->languages,
-					langs->count * sizeof( accept_language *)))) {
+			                                 langs->count * sizeof( accept_language *)))) {
 				printf( "Unable to allocate memory for additional language\n");
 				langs->count--;
 				free_accept_languages( langs);
@@ -396,7 +397,7 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 			}
 		}
 		if( NULL == ( langs->languages[ langs->count - 1] =
-				malloc( sizeof( accept_language)))) {
+		                  malloc( sizeof( accept_language)))) {
 			printf( "Unable to allocate memory for language\n");
 			langs->count--;
 			free_accept_languages( langs);
@@ -412,7 +413,7 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 
 		if( NULL != qdelim) {	/* found a q value */
 			langs->languages[ langs->count - 1]->q =
-					strtod( qdelim + strlen( ACCEPT_LANGUAGE_Q_DELIMITER), NULL);
+			    strtod( qdelim + strlen( ACCEPT_LANGUAGE_Q_DELIMITER), NULL);
 			langtok[ qdelim - langtok] = '\0';
 		}
 
@@ -424,9 +425,9 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 		if( NULL != localitydelim) {
 			/* We have a locality delimiter, so copy it */
 			if( NULL == ( langs->languages[ langs->count - 1]->locality =
-					strdup( localitydelim + 1))) {
+			                  strdup( localitydelim + 1))) {
 				printf( "Unable to allocate memory for locality '%s'\n",
-						langtok);
+				        langtok);
 				free_accept_languages( langs);
 				free( langdup);
 				return NULL;
@@ -434,8 +435,8 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 
 			/* Ensure it is upper case */
 			for( x = 0, stp = langs->languages[ langs->count - 1]->locality;
-					x < (int)strlen( langs->languages[ langs->count - 1]->locality);
-					x++, stp++) {
+			     x < (int)strlen( langs->languages[ langs->count - 1]->locality);
+			     x++, stp++) {
 				*stp = toupper( *stp);
 			}
 
@@ -443,9 +444,9 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 			*localitydelim = '\0';
 		}
 		if( NULL == ( langs->languages[ langs->count - 1]->language =
-				strdup( langtok))) {
+		                  strdup( langtok))) {
 			printf( "Unable to allocate memory for language '%s'\n",
-					langtok);
+			        langtok);
 			free_accept_languages( langs);
 			free( langdup);
 			return NULL;
@@ -459,29 +460,28 @@ accept_languages * parse_accept_languages( char * acceptlang) {
 	return langs;
 }
 
-int compare_accept_languages( const void *p1, const void *p2) {
+int compare_accept_languages( const void *p1, const void *p2)
+{
 	accept_language *	lang1 = *( accept_language **)p1;
 	accept_language *	lang2 = *( accept_language **)p2;
 
 	if( lang1->q == lang2->q) {
 		if((( NULL == lang1->locality) && ( NULL == lang2->locality)) ||
-				(( NULL != lang1->locality) && ( NULL != lang2->locality))) {
+		   (( NULL != lang1->locality) && ( NULL != lang2->locality))) {
 			return 0;
-		}
-		else if( NULL != lang1->locality) {
+		} else if( NULL != lang1->locality) {
 			return -1;
-		}
-		else { /* NULL != lang2->locality */
+		} else { /* NULL != lang2->locality */
 			return 1;
 		}
-	}
-	else {
+	} else {
 		return( lang2->q > lang1->q);
 	}
 }
 
 
-void free_accept_languages( accept_languages * langs) {
+void free_accept_languages( accept_languages * langs)
+{
 	int	x;
 
 	if( NULL == langs) {
@@ -508,11 +508,12 @@ void free_accept_languages( accept_languages * langs) {
 }
 
 /* free() memory allocated to storing the CGI variables */
-void free_cgivars(char **cgivars) {
+void free_cgivars(char **cgivars)
+{
 	register int x;
 
 	for(x = 0; cgivars[x] != '\x0'; x++)
 		free(cgivars[x]);
 
 	return;
-	}
+}

--- a/cgi/histogram.c
+++ b/cgi/histogram.c
@@ -139,7 +139,7 @@ typedef struct timeslice_data_struct {
 	unsigned long    service_unknown;
 	unsigned long    host_unreachable;
 	unsigned long    service_warning;
-	} timeslice_data;
+} timeslice_data;
 
 
 timeslice_data *tsdata;
@@ -221,7 +221,8 @@ int total_buckets = 96;
 
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result = OK;
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char image_template[MAX_INPUT_BUFFER];
@@ -255,9 +256,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			cgi_config_file_error(get_cgi_config_location());
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
@@ -266,9 +267,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			main_config_file_error(main_config_file);
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 	/* read all object configuration data */
 	result = read_all_object_configuration_data(main_config_file, READ_ALL_OBJECT_DATA);
@@ -277,9 +278,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			object_data_error();
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 	/* read all status data */
 	result = read_all_status_data(main_config_file, READ_ALL_STATUS_DATA);
@@ -288,10 +289,10 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			status_data_error();
 			document_footer();
-			}
+		}
 		free_memory();
 		return ERROR;
-		}
+	}
 
 	document_header(TRUE);
 
@@ -306,7 +307,7 @@ int main(int argc, char **argv) {
 		t3 = t2;
 		t2 = t1;
 		t1 = t3;
-		}
+	}
 
 
 	if(mode == CREATE_HTML && display_header == TRUE) {
@@ -340,8 +341,7 @@ int main(int argc, char **argv) {
 				printf("<a href='%s?host=%s'>View Status Detail For This Host</a><BR>\n", STATUS_CGI, url_encode(host_name));
 				printf("<a href='%s?host=%s'>View History For This Host</a><BR>\n", HISTORY_CGI, url_encode(host_name));
 				printf("<a href='%s?host=%s'>View Notifications For This Host</a><BR>\n", NOTIFICATIONS_CGI, url_encode(host_name));
-				}
-			else {
+			} else {
 #ifdef USE_TRENDS
 				printf("<a href='%s?host=%s", TRENDS_CGI, url_encode(host_name));
 #endif
@@ -352,11 +352,11 @@ int main(int argc, char **argv) {
 				printf("service=%s'>View History For This Service</A><BR>\n", url_encode(svc_description));
 				printf("<A HREF='%s?host=%s&", NOTIFICATIONS_CGI, url_encode(host_name));
 				printf("service=%s'>View Notifications For This Service</A><BR>\n", url_encode(svc_description));
-				}
+			}
 
 			printf("</TD></TR>\n");
 			printf("</TABLE>\n");
-			}
+		}
 
 		printf("</td>\n");
 
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
 
 			get_time_breakdown((time_t)(t2 - t1), &days, &hours, &minutes, &seconds);
 			printf("<div align=center class='reportDuration'>Duration: %dd %dh %dm %ds</div>\n", days, hours, minutes, seconds);
-			}
+		}
 
 		printf("</td>\n");
 
@@ -450,15 +450,14 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Host up events\n", GRAPH_HOST_UP, (graph_events == GRAPH_HOST_UP) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host down events\n", GRAPH_HOST_DOWN, (graph_events == GRAPH_HOST_DOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host unreachable events\n", GRAPH_HOST_UNREACHABLE, (graph_events == GRAPH_HOST_UNREACHABLE) ? "SELECTED" : "");
-				}
-			else {
+			} else {
 				printf("<option value=%d %s>All service events\n", GRAPH_SERVICE_ALL, (graph_events == GRAPH_SERVICE_ALL) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service problem events\n", GRAPH_SERVICE_PROBLEMS, (graph_events == GRAPH_SERVICE_PROBLEMS) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service ok events\n", GRAPH_SERVICE_OK, (graph_events == GRAPH_SERVICE_OK) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service warning events\n", GRAPH_SERVICE_WARNING, (graph_events == GRAPH_SERVICE_WARNING) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service unknown events\n", GRAPH_SERVICE_UNKNOWN, (graph_events == GRAPH_SERVICE_UNKNOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service critical events\n", GRAPH_SERVICE_CRITICAL, (graph_events == GRAPH_SERVICE_CRITICAL) ? "SELECTED" : "");
-				}
+			}
 			printf("</select>\n");
 			printf("</td><td CLASS='optBoxItem' valign=top align=left>\n");
 			printf("<select name='newstatesonly'>\n");
@@ -477,7 +476,7 @@ int main(int argc, char **argv) {
 			printf("</td><td CLASS='optBoxItem' valign=top align=left>\n");
 			printf("<input type='submit' value='Update'>\n");
 			printf("</td></tr>\n");
-			}
+		}
 
 		/* display context-sensitive help */
 		printf("<tr><td></td><td align=right valign=bottom>\n");
@@ -486,8 +485,7 @@ int main(int argc, char **argv) {
 				display_context_help(CONTEXTHELP_HISTOGRAM_HOST);
 			else
 				display_context_help(CONTEXTHELP_HISTOGRAM_SERVICE);
-			}
-		else if(display_type == DISPLAY_NO_HISTOGRAM || input_type != GET_INPUT_NONE) {
+		} else if(display_type == DISPLAY_NO_HISTOGRAM || input_type != GET_INPUT_NONE) {
 			if(input_type == GET_INPUT_NONE)
 				display_context_help(CONTEXTHELP_HISTOGRAM_MENU1);
 			else if(input_type == GET_INPUT_TARGET_TYPE)
@@ -498,7 +496,7 @@ int main(int argc, char **argv) {
 				display_context_help(CONTEXTHELP_HISTOGRAM_MENU3);
 			else if(input_type == GET_INPUT_OPTIONS)
 				display_context_help(CONTEXTHELP_HISTOGRAM_MENU4);
-			}
+		}
 		printf("</td></tr>\n");
 
 		printf("</table>\n");
@@ -509,19 +507,18 @@ int main(int argc, char **argv) {
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 	/* check authorization... */
 	if(display_type == DISPLAY_HOST_HISTOGRAM) {
 		temp_host = find_host(host_name);
 		if(temp_host == NULL || is_authorized_for_host(temp_host, &current_authdata) == FALSE)
 			is_authorized = FALSE;
-		}
-	else if(display_type == DISPLAY_SERVICE_HISTOGRAM) {
+	} else if(display_type == DISPLAY_SERVICE_HISTOGRAM) {
 		temp_service = find_service(host_name, svc_description);
 		if(temp_service == NULL || is_authorized_for_service(temp_service, &current_authdata) == FALSE)
 			is_authorized = FALSE;
-		}
+	}
 	if(is_authorized == FALSE) {
 
 		if(mode == CREATE_HTML)
@@ -530,7 +527,7 @@ int main(int argc, char **argv) {
 		document_footer();
 		free_memory();
 		return ERROR;
-		}
+	}
 
 	if(display_type != DISPLAY_NO_HISTOGRAM && input_type == GET_INPUT_NONE) {
 
@@ -559,7 +556,7 @@ int main(int argc, char **argv) {
 			printf("&graphstatetypes=%d", graph_statetypes);
 			printf("' BORDER=0 name='histogramimage'>\n");
 			printf("</DIV>\n");
-			}
+		}
 
 		/* read and process state data */
 		else {
@@ -587,7 +584,7 @@ int main(int argc, char **argv) {
 				tsdata[x].host_up = 0L;
 				tsdata[x].host_down = 0L;
 				tsdata[x].host_unreachable = 0L;
-				}
+			}
 
 			/* read in all necessary archived state data */
 			read_archived_state_data();
@@ -605,7 +602,7 @@ int main(int argc, char **argv) {
 			if(image_file != NULL) {
 				histogram_image = gdImageCreateFromPng(image_file);
 				fclose(image_file);
-				}
+			}
 			if(histogram_image == NULL)
 				histogram_image = gdImageCreate(image_width, image_height);
 			if(histogram_image == NULL) {
@@ -613,7 +610,7 @@ int main(int argc, char **argv) {
 				printf("Error: Could not allocate memory for image\n");
 #endif
 				return ERROR;
-				}
+			}
 
 			/* allocate colors used for drawing */
 			color_white = gdImageColorAllocate(histogram_image, 255, 255, 255);
@@ -661,8 +658,8 @@ int main(int argc, char **argv) {
 
 			/* free memory allocated for data */
 			free(tsdata);
-			}
 		}
+	}
 
 
 	/* show user a selection of hosts and services to choose from... */
@@ -688,7 +685,7 @@ int main(int argc, char **argv) {
 			for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 				if(is_authorized_for_host(temp_host, &current_authdata) == TRUE)
 					printf("<option value='%s'>%s\n", escape_string(temp_host->name), temp_host->name);
-				}
+			}
 
 			printf("</select>\n");
 			printf("</td></tr>\n");
@@ -701,7 +698,7 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
+		}
 
 		/* ask the user for what service they want a report for */
 		else if(input_type == GET_INPUT_SERVICE_TARGET) {
@@ -718,8 +715,8 @@ int main(int argc, char **argv) {
 						first_service = temp_service->host_name;
 					printf(" \"%s\"", temp_service->host_name);
 					found = TRUE;
-					}
 				}
+			}
 
 			printf(" ]\n");
 			printf("return hostnames[hostindex];\n");
@@ -745,7 +742,7 @@ int main(int argc, char **argv) {
 			for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 				if(is_authorized_for_service(temp_service, &current_authdata) == TRUE)
 					printf("<option value='%s'>%s;%s\n", escape_string(temp_service->description), temp_service->host_name, temp_service->description);
-				}
+			}
 
 			printf("</select>\n");
 			printf("</td></tr>\n");
@@ -758,7 +755,7 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
+		}
 
 		/* ask the user for report range and options */
 		else if(input_type == GET_INPUT_OPTIONS) {
@@ -874,15 +871,14 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Host up events\n", GRAPH_HOST_UP, (graph_events == GRAPH_HOST_UP) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host down events\n", GRAPH_HOST_DOWN, (graph_events == GRAPH_HOST_DOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host unreachable events\n", GRAPH_HOST_UNREACHABLE, (graph_events == GRAPH_HOST_UNREACHABLE) ? "SELECTED" : "");
-				}
-			else {
+			} else {
 				printf("<option value=%d %s>All service events\n", GRAPH_SERVICE_ALL, (graph_events == GRAPH_SERVICE_ALL) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service problem events\n", GRAPH_SERVICE_PROBLEMS, (graph_events == GRAPH_SERVICE_PROBLEMS) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service ok events\n", GRAPH_SERVICE_OK, (graph_events == GRAPH_SERVICE_OK) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service warning events\n", GRAPH_SERVICE_WARNING, (graph_events == GRAPH_SERVICE_WARNING) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service unknown events\n", GRAPH_SERVICE_UNKNOWN, (graph_events == GRAPH_SERVICE_UNKNOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service critical events\n", GRAPH_SERVICE_CRITICAL, (graph_events == GRAPH_SERVICE_CRITICAL) ? "SELECTED" : "");
-				}
+			}
 			printf("</select>\n");
 			printf("</td></tr>\n");
 
@@ -925,7 +921,7 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
+		}
 
 		/* as the user whether they want a graph for a host or service */
 		else {
@@ -953,9 +949,9 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
-
 		}
+
+	}
 
 	document_footer();
 
@@ -963,10 +959,11 @@ int main(int argc, char **argv) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -998,7 +995,7 @@ void document_header(int use_stylesheet) {
 		if(use_stylesheet == TRUE) {
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, HISTOGRAM_CSS);
-			}
+		}
 
 		printf("</head>\n");
 
@@ -1008,7 +1005,7 @@ void document_header(int use_stylesheet) {
 		include_ssi_files(HISTOGRAM_CGI, SSI_HEADER);
 
 		printf("<div id=\"popup\" style=\"position:absolute; z-index:1; visibility: hidden\"></div>\n");
-		}
+	}
 
 	else {
 		printf("Cache-Control: no-store\r\n");
@@ -1023,14 +1020,15 @@ void document_header(int use_stylesheet) {
 		printf("Expires: %s\r\n", date_time);
 
 		printf("Content-Type: image/png\r\n\r\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
 
-void document_footer(void) {
+
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -1042,14 +1040,15 @@ void document_footer(void) {
 
 		printf("</body>\n");
 		printf("</html>\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
 
-int process_cgivars(void) {
+
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -1061,7 +1060,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -1069,14 +1068,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "";
 			strip_html_brackets(host_name);
 
 			display_type = DISPLAY_HOST_HISTOGRAM;
-			}
+		}
 
 		/* we found the node width argument */
 		else if(!strcmp(variables[x], "service")) {
@@ -1084,14 +1083,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((svc_description = (char *)strdup(variables[x])) == NULL)
 				svc_description = "";
 			strip_html_brackets(svc_description);
 
 			display_type = DISPLAY_SERVICE_HISTOGRAM;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t1")) {
@@ -1099,11 +1098,11 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t1 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t2")) {
@@ -1111,16 +1110,16 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t2 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
-			}
+		}
 
 		/* we found the image creation option */
 		else if(!strcmp(variables[x], "createimage")) {
 			mode = CREATE_IMAGE;
-			}
+		}
 
 		/* we found the backtrack archives argument */
 		else if(!strcmp(variables[x], "backtrack")) {
@@ -1128,14 +1127,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			backtrack_archives = atoi(variables[x]);
 			if(backtrack_archives < 0)
 				backtrack_archives = 0;
 			if(backtrack_archives > MAX_ARCHIVE_BACKTRACKS)
 				backtrack_archives = MAX_ARCHIVE_BACKTRACKS;
-			}
+		}
 
 		/* we found the standard timeperiod argument */
 		else if(!strcmp(variables[x], "timeperiod")) {
@@ -1143,7 +1142,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "today"))
 				timeperiod_type = TIMEPERIOD_TODAY;
@@ -1179,7 +1178,7 @@ int process_cgivars(void) {
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				convert_timeperiod_to_times(timeperiod_type);
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smon")) {
@@ -1187,7 +1186,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1195,7 +1194,7 @@ int process_cgivars(void) {
 			start_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "sday")) {
@@ -1203,7 +1202,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1211,7 +1210,7 @@ int process_cgivars(void) {
 			start_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "syear")) {
@@ -1219,7 +1218,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1227,7 +1226,7 @@ int process_cgivars(void) {
 			start_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smin")) {
@@ -1235,7 +1234,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1243,7 +1242,7 @@ int process_cgivars(void) {
 			start_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ssec")) {
@@ -1251,7 +1250,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1259,7 +1258,7 @@ int process_cgivars(void) {
 			start_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "shour")) {
@@ -1267,7 +1266,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1275,7 +1274,7 @@ int process_cgivars(void) {
 			start_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 
 		/* we found time argument */
@@ -1284,7 +1283,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1292,7 +1291,7 @@ int process_cgivars(void) {
 			end_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eday")) {
@@ -1300,7 +1299,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1308,7 +1307,7 @@ int process_cgivars(void) {
 			end_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eyear")) {
@@ -1316,7 +1315,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1324,7 +1323,7 @@ int process_cgivars(void) {
 			end_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "emin")) {
@@ -1332,7 +1331,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1340,7 +1339,7 @@ int process_cgivars(void) {
 			end_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "esec")) {
@@ -1348,7 +1347,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1356,7 +1355,7 @@ int process_cgivars(void) {
 			end_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ehour")) {
@@ -1364,7 +1363,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1372,7 +1371,7 @@ int process_cgivars(void) {
 			end_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -1388,7 +1387,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "gethost"))
 				input_type = GET_INPUT_HOST_TARGET;
@@ -1398,7 +1397,7 @@ int process_cgivars(void) {
 				input_type = GET_INPUT_OPTIONS;
 			else
 				input_type = GET_INPUT_TARGET_TYPE;
-			}
+		}
 
 		/* we found the graph states option */
 		else if(!strcmp(variables[x], "graphevents")) {
@@ -1406,10 +1405,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			graph_events = atoi(variables[x]);
-			}
+		}
 
 		/* we found the graph state types option */
 		else if(!strcmp(variables[x], "graphstatetypes")) {
@@ -1417,10 +1416,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			graph_statetypes = atoi(variables[x]);
-			}
+		}
 
 		/* we found the breakdown option */
 		else if(!strcmp(variables[x], "breakdown")) {
@@ -1428,7 +1427,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "monthly"))
 				breakdown_type = BREAKDOWN_MONTHLY;
@@ -1438,7 +1437,7 @@ int process_cgivars(void) {
 				breakdown_type = BREAKDOWN_DAY_OF_WEEK;
 			else
 				breakdown_type = BREAKDOWN_HOURLY;
-			}
+		}
 
 		/* we found the assume state retention option */
 		else if(!strcmp(variables[x], "assumestateretention")) {
@@ -1446,13 +1445,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_state_retention = TRUE;
 			else
 				assume_state_retention = FALSE;
-			}
+		}
 
 		/* we found the initial states logged option */
 		else if(!strcmp(variables[x], "initialstateslogged")) {
@@ -1460,14 +1459,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				initial_states_logged = TRUE;
 			else
 				initial_states_logged = FALSE;
 
-			}
+		}
 
 		/* we found the new states only option */
 		else if(!strcmp(variables[x], "newstatesonly")) {
@@ -1475,26 +1474,27 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				new_states_only = TRUE;
 			else
 				new_states_only = FALSE;
 
-			}
 		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* graphs histogram data */
-void graph_all_histogram_data(void) {
+void graph_all_histogram_data(void)
+{
 	int pixel_x;
 	int pixel_y;
 	int last_pixel_y;
@@ -1558,7 +1558,7 @@ void graph_all_histogram_data(void) {
 			max_value = tsdata[current_bucket].host_down;
 		if(tsdata[current_bucket].host_unreachable > max_value)
 			max_value = tsdata[current_bucket].host_unreachable;
-		}
+	}
 
 #ifdef DEBUG
 	printf("Done determining max bucket values\n");
@@ -1617,8 +1617,8 @@ void graph_all_histogram_data(void) {
 #ifdef DEBUG
 			printf("  Drawing Y unit #%d @ %d\n", current_unit, (int)(current_unit * y_units * y_scaling_factor));
 #endif
-			}
 		}
+	}
 
 #ifdef DEBUG
 	printf("Starting to draw X grid lines...\n");
@@ -1639,8 +1639,8 @@ void graph_all_histogram_data(void) {
 			temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 			string_width = gdFontSmall->w * strlen(temp_buffer);
 			gdImageString(histogram_image, gdFontSmall, DRAWING_X_OFFSET - string_width - 5, DRAWING_Y_OFFSET - (current_unit * y_units * y_scaling_factor) - (string_height / 2), (unsigned char *)temp_buffer, color_black);
-			}
 		}
+	}
 
 	/* draw x units */
 	for(current_unit = 0, actual_unit = 0; (int)(current_unit * x_units) <= DRAWING_WIDTH; current_unit++, actual_unit++) {
@@ -1661,7 +1661,7 @@ void graph_all_histogram_data(void) {
 		string_width = gdFontSmall->w * strlen(temp_buffer);
 
 		gdImageStringUp(histogram_image, gdFontSmall, DRAWING_X_OFFSET + (current_unit * x_units) - (string_height / 2), DRAWING_Y_OFFSET + 5 + string_width, (unsigned char *)temp_buffer, color_black);
-		}
+	}
 
 	/* draw y unit measure */
 	snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Number of Events");
@@ -1734,13 +1734,13 @@ void graph_all_histogram_data(void) {
 					if(have_state1_min == FALSE || tsdata[actual_bucket].host_up < state1_min) {
 						state1_min = tsdata[actual_bucket].host_up;
 						have_state1_min = TRUE;
-						}
+					}
 					if(state1_max == 0 || tsdata[actual_bucket].host_up > state1_max)
 						state1_max = tsdata[actual_bucket].host_up;
 					state1_sum += tsdata[actual_bucket].host_up;
-					}
 				}
 			}
+		}
 
 #ifdef DEBUG
 		printf("Done graphing HOST UP states...\n");
@@ -1768,13 +1768,13 @@ void graph_all_histogram_data(void) {
 					if(have_state2_min == FALSE || tsdata[actual_bucket].host_down < state2_min) {
 						state2_min = tsdata[actual_bucket].host_down;
 						have_state2_min = TRUE;
-						}
+					}
 					if(state2_max == 0 || tsdata[actual_bucket].host_down > state2_max)
 						state2_max = tsdata[actual_bucket].host_down;
 					state2_sum += tsdata[actual_bucket].host_down;
-					}
 				}
 			}
+		}
 
 #ifdef DEBUG
 		printf("Done graphing HOST DOWN states...\n");
@@ -1802,19 +1802,19 @@ void graph_all_histogram_data(void) {
 					if(have_state3_min == FALSE || tsdata[actual_bucket].host_unreachable < state3_min) {
 						state3_min = tsdata[actual_bucket].host_unreachable;
 						have_state3_min = TRUE;
-						}
+					}
 					if(state3_max == 0 || tsdata[actual_bucket].host_unreachable > state3_max)
 						state3_max = tsdata[actual_bucket].host_unreachable;
 					state3_sum += tsdata[actual_bucket].host_unreachable;
-					}
 				}
 			}
+		}
 
 #ifdef DEBUG
 		printf("Done graphing HOST UNREACHABLE states...\n");
 #endif
 
-		}
+	}
 
 	/* graph service states */
 	else {
@@ -1841,13 +1841,13 @@ void graph_all_histogram_data(void) {
 					if(have_state1_min == FALSE || tsdata[actual_bucket].service_ok < state1_min) {
 						state1_min = tsdata[actual_bucket].service_ok;
 						have_state1_min = TRUE;
-						}
+					}
 					if(state1_max == 0 || tsdata[actual_bucket].service_ok > state1_max)
 						state1_max = tsdata[actual_bucket].service_ok;
 					state1_sum += tsdata[actual_bucket].service_ok;
-					}
 				}
 			}
+		}
 
 		/* graph service warning states */
 		if(graph_events & GRAPH_SERVICE_WARNING) {
@@ -1871,13 +1871,13 @@ void graph_all_histogram_data(void) {
 					if(have_state2_min == FALSE || tsdata[actual_bucket].service_warning < state2_min) {
 						state2_min = tsdata[actual_bucket].service_warning;
 						have_state2_min = TRUE;
-						}
+					}
 					if(state2_max == 0 || tsdata[actual_bucket].service_warning > state2_max)
 						state2_max = tsdata[actual_bucket].service_warning;
 					state2_sum += tsdata[actual_bucket].service_warning;
-					}
 				}
 			}
+		}
 
 		/* graph service unknown states */
 		if(graph_events & GRAPH_SERVICE_UNKNOWN) {
@@ -1901,13 +1901,13 @@ void graph_all_histogram_data(void) {
 					if(have_state3_min == FALSE || tsdata[actual_bucket].service_unknown < state3_min) {
 						state3_min = tsdata[actual_bucket].service_unknown;
 						have_state3_min = TRUE;
-						}
+					}
 					if(state3_max == 0 || tsdata[actual_bucket].service_unknown > state3_max)
 						state3_max = tsdata[actual_bucket].service_unknown;
 					state3_sum += tsdata[actual_bucket].service_unknown;
-					}
 				}
 			}
+		}
 
 		/* graph service critical states */
 		if(graph_events & GRAPH_SERVICE_CRITICAL) {
@@ -1931,14 +1931,14 @@ void graph_all_histogram_data(void) {
 					if(have_state4_min == FALSE || tsdata[actual_bucket].service_critical < state4_min) {
 						state4_min = tsdata[actual_bucket].service_critical;
 						have_state4_min = TRUE;
-						}
+					}
 					if(state4_max == 0 || tsdata[actual_bucket].service_critical > state4_max)
 						state4_max = tsdata[actual_bucket].service_critical;
 					state4_sum += tsdata[actual_bucket].service_critical;
-					}
 				}
 			}
 		}
+	}
 
 #ifdef DEBUG
 	printf("Done graphing states...\n");
@@ -2008,14 +2008,15 @@ void graph_all_histogram_data(void) {
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		string_width = gdFontSmall->w * strlen(temp_buffer);
 		gdImageString(histogram_image, gdFontSmall, DRAWING_X_OFFSET + DRAWING_WIDTH + 115, DRAWING_Y_OFFSET - DRAWING_HEIGHT + ((string_height + 5) * 4), (unsigned char *)temp_buffer, color_black);
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* adds an archived state entry */
-void add_archived_state(int state_type, time_t time_stamp) {
+void add_archived_state(int state_type, time_t time_stamp)
+{
 	struct tm *our_time;
 	int bucket;
 	int skip_state = FALSE;
@@ -2031,7 +2032,7 @@ void add_archived_state(int state_type, time_t time_stamp) {
 #endif
 		program_restart_has_occurred = TRUE;
 		return;
-		}
+	}
 
 	/* see if we should even take into account this event */
 	if(program_restart_has_occurred == TRUE) {
@@ -2045,7 +2046,7 @@ void add_archived_state(int state_type, time_t time_stamp) {
 				skip_state = TRUE;
 			if(state_type == AS_HOST_UP && last_state == AS_HOST_UP)
 				skip_state = TRUE;
-			}
+		}
 
 		if(assume_state_retention == TRUE && initial_states_logged == TRUE) {
 			if(state_type == AS_SVC_WARNING && last_state == AS_SVC_WARNING)
@@ -2058,7 +2059,7 @@ void add_archived_state(int state_type, time_t time_stamp) {
 				skip_state = TRUE;
 			if(state_type == AS_HOST_UNREACHABLE && last_state == AS_HOST_UNREACHABLE)
 				skip_state = TRUE;
-			}
+		}
 
 		if(skip_state == TRUE) {
 			program_restart_has_occurred = FALSE;
@@ -2066,8 +2067,8 @@ void add_archived_state(int state_type, time_t time_stamp) {
 			printf("Skipping state...\n");
 #endif
 			return;
-			}
 		}
+	}
 
 	/* reset program restart variable */
 	program_restart_has_occurred = FALSE;
@@ -2078,7 +2079,7 @@ void add_archived_state(int state_type, time_t time_stamp) {
 		printf("Skipping state (not a new state)...\n");
 #endif
 		return;
-		}
+	}
 
 #ifdef DEBUG2
 	printf("GOODSTATE: %d @ %lu\n", state_type, (unsigned long)time_stamp);
@@ -2125,12 +2126,13 @@ void add_archived_state(int state_type, time_t time_stamp) {
 	last_state = state_type;
 
 	return;
-	}
+}
 
 
 
 /* reads log files for archived state data */
-void read_archived_state_data(void) {
+void read_archived_state_data(void)
+{
 	char filename[MAX_FILENAME_LENGTH];
 	int newest_archive = 0;
 	int oldest_archive = 0;
@@ -2168,15 +2170,16 @@ void read_archived_state_data(void) {
 
 		/* scan the log file for archived state data */
 		scan_log_file_for_archived_state_data(filename);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* grabs archives state data from a log file */
-void scan_log_file_for_archived_state_data(char *filename) {
+void scan_log_file_for_archived_state_data(char *filename)
+{
 	char *input = NULL;
 	char *input2 = NULL;
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -2189,14 +2192,14 @@ void scan_log_file_for_archived_state_data(char *filename) {
 	if(mode == CREATE_HTML) {
 		printf(" ");
 		fflush(NULL);
-		}
+	}
 
 	if((thefile = mmap_fopen(filename)) == NULL) {
 #ifdef DEBUG2
 		printf("Could not open file '%s' for reading.\n", filename);
 #endif
 		return;
-		}
+	}
 
 #ifdef DEBUG2
 	printf("Scanning log file '%s' for archived state data...\n", filename);
@@ -2260,8 +2263,8 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					add_archived_state(AS_HOST_UNREACHABLE, time_stamp);
 				else if(strstr(input, ";RECOVERY") || strstr(input, ";UP;"))
 					add_archived_state(AS_HOST_UP, time_stamp);
-				}
 			}
+		}
 		if(display_type == DISPLAY_SERVICE_HISTOGRAM) {
 			if(strstr(input, "SERVICE ALERT:")) {
 
@@ -2298,10 +2301,10 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					add_archived_state(AS_SVC_UNKNOWN, time_stamp);
 				else if(strstr(input, ";RECOVERY;") || strstr(input, ";OK;"))
 					add_archived_state(AS_SVC_OK, time_stamp);
-				}
 			}
-
 		}
+
+	}
 
 	/* free memory and close the file */
 	free(input);
@@ -2309,12 +2312,13 @@ void scan_log_file_for_archived_state_data(char *filename) {
 	mmap_fclose(thefile);
 
 	return;
-	}
+}
 
 
 
 
-void convert_timeperiod_to_times(int type) {
+void convert_timeperiod_to_times(int type)
+{
 	time_t current_time;
 	struct tm *t;
 
@@ -2329,77 +2333,77 @@ void convert_timeperiod_to_times(int type) {
 	t->tm_isdst = -1;
 
 	switch(type) {
-		case TIMEPERIOD_LAST24HOURS:
-			t1 = current_time - (60 * 60 * 24);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_TODAY:
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_YESTERDAY:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24));
-			t2 = (time_t)mktime(t);
-			break;
-		case TIMEPERIOD_THISWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
-			t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			break;
-		case TIMEPERIOD_THISMONTH:
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTMONTH:
-			t->tm_mday = 1;
-			t2 = mktime(t);
-			if(t->tm_mon == 0) {
-				t->tm_mon = 11;
-				t->tm_year--;
-				}
-			else
-				t->tm_mon--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_THISQUARTER:
-			break;
-		case TIMEPERIOD_LASTQUARTER:
-			break;
-		case TIMEPERIOD_THISYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t2 = mktime(t);
+	case TIMEPERIOD_LAST24HOURS:
+		t1 = current_time - (60 * 60 * 24);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_TODAY:
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_YESTERDAY:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24));
+		t2 = (time_t)mktime(t);
+		break;
+	case TIMEPERIOD_THISWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
+		t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		break;
+	case TIMEPERIOD_THISMONTH:
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTMONTH:
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		if(t->tm_mon == 0) {
+			t->tm_mon = 11;
 			t->tm_year--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_LAST7DAYS:
-			t2 = current_time;
-			t1 = current_time - (7 * 24 * 60 * 60);
-			break;
-		case TIMEPERIOD_LAST31DAYS:
-			t2 = current_time;
-			t1 = current_time - (31 * 24 * 60 * 60);
-			break;
-		default:
-			break;
-		}
-
-	return;
+		} else
+			t->tm_mon--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_THISQUARTER:
+		break;
+	case TIMEPERIOD_LASTQUARTER:
+		break;
+	case TIMEPERIOD_THISYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		t->tm_year--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_LAST7DAYS:
+		t2 = current_time;
+		t1 = current_time - (7 * 24 * 60 * 60);
+		break;
+	case TIMEPERIOD_LAST31DAYS:
+		t2 = current_time;
+		t1 = current_time - (31 * 24 * 60 * 60);
+		break;
+	default:
+		break;
 	}
 
+	return;
+}
 
 
-void compute_report_times(void) {
+
+void compute_report_times(void)
+{
 	time_t current_time;
 	struct tm *st;
 	struct tm *et;
@@ -2430,12 +2434,13 @@ void compute_report_times(void) {
 	et->tm_isdst = -1;
 
 	t2 = mktime(et);
-	}
+}
 
 
 
 /* draws a solid line */
-void draw_line(int x1, int y1, int x2, int y2, int color) {
+void draw_line(int x1, int y1, int x2, int y2, int color)
+{
 	int styleSolid[1];
 
 	styleSolid[0] = color;
@@ -2447,11 +2452,12 @@ void draw_line(int x1, int y1, int x2, int y2, int color) {
 	gdImageLine(histogram_image, x1, y1, x2, y2, gdStyled);
 
 	return;
-	}
+}
 
 
 /* draws a dashed line */
-void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
+void draw_dashed_line(int x1, int y1, int x2, int y2, int color)
+{
 	int styleDashed[6];
 
 	styleDashed[0] = color;
@@ -2468,4 +2474,4 @@ void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
 	gdImageLine(histogram_image, x1, y1, x2, y2, gdStyled);
 
 	return;
-	}
+}

--- a/cgi/history.c
+++ b/cgi/history.c
@@ -80,7 +80,8 @@ int display_flapping_alerts = TRUE;
 int display_downtime_alerts = TRUE;
 
 
-int main(void) {
+int main(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char temp_buffer2[MAX_INPUT_BUFFER];
 
@@ -127,8 +128,7 @@ int main(void) {
 			if(show_all_hosts == FALSE)
 				printf("<A HREF='%s?host=%s'>View Trends For This Host</A>\n", TRENDS_CGI, url_encode(host_name));
 #endif
-			}
-		else {
+		} else {
 			printf("<A HREF='%s?host=%s&", NOTIFICATIONS_CGI, url_encode(host_name));
 			printf("service=%s'>View Notifications For This Service</A><BR />\n", url_encode(svc_description));
 #ifdef USE_TRENDS
@@ -136,7 +136,7 @@ int main(void) {
 			printf("service=%s'>View Trends For This Service</A><BR />\n", url_encode(svc_description));
 #endif
 			printf("<A HREF='%s?host=%s'>View History For This Host</A>\n", HISTORY_CGI, url_encode(host_name));
-			}
+		}
 		printf("</TD></TR>\n");
 		printf("</TABLE>\n");
 
@@ -163,7 +163,7 @@ int main(void) {
 			temp_buffer2[sizeof(temp_buffer2) - 1] = '\x0';
 			strncat(temp_buffer, temp_buffer2, sizeof(temp_buffer) - strlen(temp_buffer) - 1);
 			temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
-			}
+		}
 		display_nav_table(temp_buffer, log_archive);
 
 		printf("</td>\n");
@@ -215,7 +215,7 @@ int main(void) {
 			printf("<option value=%d %s>Host down</option>\n", HISTORY_HOST_DOWN, (history_options == HISTORY_HOST_DOWN) ? "selected" : "");
 			printf("<option value=%d %s>Host unreachable</option>\n", HISTORY_HOST_UNREACHABLE, (history_options == HISTORY_HOST_UNREACHABLE) ? "selected" : "");
 			printf("<option value=%d %s>Host recovery</option>\n", HISTORY_HOST_RECOVERY, (history_options == HISTORY_HOST_RECOVERY) ? "selected" : "");
-			}
+		}
 		printf("</select></td>\n");
 		printf("</tr>\n");
 
@@ -253,7 +253,7 @@ int main(void) {
 		printf("</tr>\n");
 		printf("</table>\n");
 
-		}
+	}
 
 
 	/* display history */
@@ -265,11 +265,12 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -300,7 +301,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, HISTORY_CSS);
-		}
+	}
 
 	printf("</head>\n");
 	printf("<BODY CLASS='history'>\n");
@@ -309,10 +310,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(HISTORY_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -324,10 +326,11 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -346,7 +349,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "";
@@ -358,7 +361,7 @@ int process_cgivars(void) {
 				show_all_hosts = TRUE;
 			else
 				show_all_hosts = FALSE;
-			}
+		}
 
 		/* we found the service argument */
 		else if(!strcmp(variables[x], "service")) {
@@ -366,14 +369,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((svc_description = (char *)strdup(variables[x])) == NULL)
 				svc_description = "";
 			strip_html_brackets(svc_description);
 
 			display_type = DISPLAY_SERVICES;
-			}
+		}
 
 
 		/* we found the history type argument */
@@ -382,10 +385,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			history_options = atoi(variables[x]);
-			}
+		}
 
 		/* we found the history state type argument */
 		else if(!strcmp(variables[x], "statetype")) {
@@ -393,10 +396,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			state_options = atoi(variables[x]);
-			}
+		}
 
 
 		/* we found the log archive argument */
@@ -405,17 +408,17 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_archive = atoi(variables[x]);
 			if(log_archive < 0)
 				log_archive = 0;
-			}
+		}
 
 		/* we found the order argument */
 		else if(!strcmp(variables[x], "oldestfirst")) {
 			use_lifo = FALSE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -444,17 +447,18 @@ int process_cgivars(void) {
 		/* we found the no downtime alerts option */
 		else if(!strcmp(variables[x], "nodowntime"))
 			display_downtime_alerts = FALSE;
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
-void get_history(void) {
+void get_history(void)
+{
 	mmapfile *thefile = NULL;
 	char image[MAX_INPUT_BUFFER];
 	char image_alt[MAX_INPUT_BUFFER];
@@ -486,22 +490,21 @@ void get_history(void) {
 		if(result != LIFO_OK) {
 			if(result == LIFO_ERROR_MEMORY) {
 				printf("<P><DIV CLASS='warningMessage'>Not enough memory to reverse log file - displaying history in natural order...</DIV></P>\n");
-				}
-			else if(result == LIFO_ERROR_FILE) {
+			} else if(result == LIFO_ERROR_FILE) {
 				printf("<HR><P><DIV CLASS='errorMessage'>Error: Cannot open log file '%s' for reading!</DIV></P><HR>", log_file_to_use);
 				return;
-				}
-			use_lifo = FALSE;
 			}
+			use_lifo = FALSE;
 		}
+	}
 
 	if(use_lifo == FALSE) {
 
 		if((thefile = mmap_fopen(log_file_to_use)) == NULL) {
 			printf("<HR><P><DIV CLASS='errorMessage'>Error: Cannot open log file '%s' for reading!</DIV></P><HR>", log_file_to_use);
 			return;
-			}
 		}
+	}
 
 	printf("<P><DIV CLASS='logEntries'>\n");
 
@@ -513,11 +516,10 @@ void get_history(void) {
 		if(use_lifo == TRUE) {
 			if((input = pop_lifo()) == NULL)
 				break;
-			}
-		else {
+		} else {
 			if((input = mmap_fgets(thefile)) == NULL)
 				break;
-			}
+		}
 
 		strip(input);
 
@@ -551,23 +553,20 @@ void get_history(void) {
 				strncpy(image, CRITICAL_ICON, sizeof(image));
 				strncpy(image_alt, CRITICAL_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_SERVICE_CRITICAL;
-				}
-			else if(strstr(input, ";WARNING;")) {
+			} else if(strstr(input, ";WARNING;")) {
 				strncpy(image, WARNING_ICON, sizeof(image));
 				strncpy(image_alt, WARNING_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_SERVICE_WARNING;
-				}
-			else if(strstr(input, ";UNKNOWN;")) {
+			} else if(strstr(input, ";UNKNOWN;")) {
 				strncpy(image, UNKNOWN_ICON, sizeof(image));
 				strncpy(image_alt, UNKNOWN_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_SERVICE_UNKNOWN;
-				}
-			else if(strstr(input, ";RECOVERY;") || strstr(input, ";OK;")) {
+			} else if(strstr(input, ";RECOVERY;") || strstr(input, ";OK;")) {
 				strncpy(image, OK_ICON, sizeof(image));
 				strncpy(image_alt, OK_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_SERVICE_RECOVERY;
-				}
 			}
+		}
 
 		/* service flapping alerts */
 		else if(strstr(input, "SERVICE FLAPPING ALERT:")) {
@@ -599,7 +598,7 @@ void get_history(void) {
 				strncpy(image_alt, "Service stopped flapping", sizeof(image_alt));
 			else if(strstr(input, ";DISABLED;"))
 				strncpy(image_alt, "Service flap detection disabled", sizeof(image_alt));
-			}
+		}
 
 		/* service downtime alerts */
 		else if(strstr(input, "SERVICE DOWNTIME ALERT:")) {
@@ -631,7 +630,7 @@ void get_history(void) {
 				strncpy(image_alt, "Service exited from a period of scheduled downtime", sizeof(image_alt));
 			else if(strstr(input, ";CANCELLED;"))
 				strncpy(image_alt, "Service scheduled downtime has been cancelled", sizeof(image_alt));
-			}
+		}
 
 		/* host state alerts */
 		else if(strstr(input, "HOST ALERT:")) {
@@ -651,18 +650,16 @@ void get_history(void) {
 				strncpy(image, HOST_DOWN_ICON, sizeof(image));
 				strncpy(image_alt, HOST_DOWN_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_HOST_DOWN;
-				}
-			else if(strstr(input, ";UNREACHABLE;")) {
+			} else if(strstr(input, ";UNREACHABLE;")) {
 				strncpy(image, HOST_UNREACHABLE_ICON, sizeof(image));
 				strncpy(image_alt, HOST_UNREACHABLE_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_HOST_UNREACHABLE;
-				}
-			else if(strstr(input, ";RECOVERY") || strstr(input, ";UP;")) {
+			} else if(strstr(input, ";RECOVERY") || strstr(input, ";UP;")) {
 				strncpy(image, HOST_UP_ICON, sizeof(image));
 				strncpy(image_alt, HOST_UP_ICON_ALT, sizeof(image_alt));
 				history_detail_type = HISTORY_HOST_RECOVERY;
-				}
 			}
+		}
 
 		/* host flapping alerts */
 		else if(strstr(input, "HOST FLAPPING ALERT:")) {
@@ -689,7 +686,7 @@ void get_history(void) {
 				strncpy(image_alt, "Host stopped flapping", sizeof(image_alt));
 			else if(strstr(input, ";DISABLED;"))
 				strncpy(image_alt, "Host flap detection disabled", sizeof(image_alt));
-			}
+		}
 
 		/* host downtime alerts */
 		else if(strstr(input, "HOST DOWNTIME ALERT:")) {
@@ -716,7 +713,7 @@ void get_history(void) {
 				strncpy(image_alt, "Host exited from a period of scheduled downtime", sizeof(image_alt));
 			else if(strstr(input, ";CANCELLED;"))
 				strncpy(image_alt, "Host scheduled downtime has been cancelled", sizeof(image_alt));
-			}
+		}
 
 		else if(display_system_messages == FALSE)
 			continue;
@@ -726,28 +723,28 @@ void get_history(void) {
 			strncpy(image, START_ICON, sizeof(image));
 			strncpy(image_alt, START_ICON_ALT, sizeof(image_alt));
 			system_message = TRUE;
-			}
+		}
 
 		/* normal program termination */
 		else if(strstr(input, " shutting down...")) {
 			strncpy(image, STOP_ICON, sizeof(image));
 			strncpy(image_alt, STOP_ICON_ALT, sizeof(image_alt));
 			system_message = TRUE;
-			}
+		}
 
 		/* abnormal program termination */
 		else if(strstr(input, "Bailing out")) {
 			strncpy(image, STOP_ICON, sizeof(image));
 			strncpy(image_alt, STOP_ICON_ALT, sizeof(image_alt));
 			system_message = TRUE;
-			}
+		}
 
 		/* program restart */
 		else if(strstr(input, " restarting...")) {
 			strncpy(image, RESTART_ICON, sizeof(image));
 			strncpy(image_alt, RESTART_ICON_ALT, sizeof(image_alt));
 			system_message = TRUE;
-			}
+		}
 
 		image[sizeof(image) - 1] = '\x0';
 		image_alt[sizeof(image_alt) - 1] = '\x0';
@@ -776,22 +773,20 @@ void get_history(void) {
 
 				if(history_type == HOST_HISTORY || history_type == SERVICE_HISTORY) {
 					snprintf(match1, sizeof( match1),
-							" HOST ALERT: %s;", host_name);
+					         " HOST ALERT: %s;", host_name);
 					snprintf(match2, sizeof( match2),
-							" SERVICE ALERT: %s;", host_name);
-					}
-				else if(history_type == HOST_FLAPPING_HISTORY || history_type == SERVICE_FLAPPING_HISTORY) {
+					         " SERVICE ALERT: %s;", host_name);
+				} else if(history_type == HOST_FLAPPING_HISTORY || history_type == SERVICE_FLAPPING_HISTORY) {
 					snprintf(match1, sizeof( match1),
-							" HOST FLAPPING ALERT: %s;", host_name);
+					         " HOST FLAPPING ALERT: %s;", host_name);
 					snprintf(match2, sizeof( match2),
-							" SERVICE FLAPPING ALERT: %s;", host_name);
-					}
-				else if(history_type == HOST_DOWNTIME_HISTORY || history_type == SERVICE_DOWNTIME_HISTORY) {
+					         " SERVICE FLAPPING ALERT: %s;", host_name);
+				} else if(history_type == HOST_DOWNTIME_HISTORY || history_type == SERVICE_DOWNTIME_HISTORY) {
 					snprintf(match1, sizeof( match1),
-							" HOST DOWNTIME ALERT: %s;", host_name);
+					         " HOST DOWNTIME ALERT: %s;", host_name);
 					snprintf(match2, sizeof( match2),
-							" SERVICE DOWNTIME ALERT: %s;", host_name);
-					}
+					         " SERVICE DOWNTIME ALERT: %s;", host_name);
+				}
 
 				if(show_all_hosts == TRUE)
 					display_line = TRUE;
@@ -811,7 +806,7 @@ void get_history(void) {
 						display_line = TRUE;
 					else
 						display_line = FALSE;
-					}
+				}
 
 				/* check alert state types */
 				if(display_line == TRUE && (history_type == HOST_HISTORY || history_type == SERVICE_HISTORY)) {
@@ -823,8 +818,8 @@ void get_history(void) {
 						display_line = TRUE;
 					else
 						display_line = FALSE;
-					}
 				}
+			}
 
 			else if(display_type == DISPLAY_SERVICES) {
 
@@ -845,7 +840,7 @@ void get_history(void) {
 						display_line = TRUE;
 					else
 						display_line = FALSE;
-					}
+				}
 
 				/* check alert state type */
 				if(display_line == TRUE && history_type == SERVICE_HISTORY) {
@@ -858,8 +853,8 @@ void get_history(void) {
 						display_line = TRUE;
 					else
 						display_line = FALSE;
-					}
 				}
+			}
 
 
 			/* make sure user is authorized to view this host or service information */
@@ -870,13 +865,12 @@ void get_history(void) {
 					if(is_authorized_for_host(temp_host, &current_authdata) == FALSE)
 						display_line = FALSE;
 
-					}
-				else {
+				} else {
 					temp_service = find_service(entry_host_name, entry_service_desc);
 					if(is_authorized_for_service(temp_service, &current_authdata) == FALSE)
 						display_line = FALSE;
-					}
 				}
+			}
 
 			/* display the entry if we should... */
 			if(display_line == TRUE) {
@@ -893,7 +887,7 @@ void get_history(void) {
 					printf("<BR CLEAR='all' /><DIV CLASS='logEntries'>\n");
 					strncpy(last_message_date, current_message_date, sizeof(last_message_date));
 					last_message_date[sizeof(last_message_date) - 1] = '\x0';
-					}
+				}
 
 				if(display_frills == TRUE)
 					printf("<img align='left' src='%s%s' alt='%s' title='%s' />", url_images_path, image, image_alt, image_alt);
@@ -901,19 +895,19 @@ void get_history(void) {
 				if(enable_splunk_integration == TRUE) {
 					printf("&nbsp;&nbsp;&nbsp;");
 					display_splunk_generic_url(temp_buffer, 2);
-					}
+				}
 				printf("<br clear='all' />\n");
 
 				found_line = TRUE;
-				}
 			}
+		}
 
 		/* free memory */
 		free(entry_host_name);
 		entry_host_name = NULL;
 		free(entry_service_desc);
 		entry_service_desc = NULL;
-		}
+	}
 
 	printf("</DIV></P>\n");
 
@@ -925,7 +919,7 @@ void get_history(void) {
 		else
 			printf("for this service ");
 		printf("in %s log file</DIV></P>", (log_archive == 0) ? "the current" : "this archived");
-		}
+	}
 
 	printf("<HR>\n");
 
@@ -938,4 +932,4 @@ void get_history(void) {
 		mmap_fclose(thefile);
 
 	return;
-	}
+}

--- a/cgi/jsonutils.c
+++ b/cgi/jsonutils.c
@@ -1,6 +1,6 @@
 /**************************************************************************
  *
- * JSONUTILS.C -  Utilities for Nagios CGIs for returning JSON-formatted 
+ * JSONUTILS.C -  Utilities for Nagios CGIs for returning JSON-formatted
  *                object data
  *
  * Copyright (c) 2013 Nagios Enterprises, LLC
@@ -42,34 +42,48 @@ const char *result_types[] = {
 	"Option Value Missing",
 	"Option Value Invalid",
 	"Option Ignored"
-	};
+};
 
 const string_value_mapping svm_format_options[] = {
-	{ "whitespace", JSON_FORMAT_WHITESPACE, 
-		"Pad with whitespace to increase readability" },
-	{ "enumerate", JSON_FORMAT_ENUMERATE, 
+	{
+		"whitespace", JSON_FORMAT_WHITESPACE,
+		"Pad with whitespace to increase readability"
+	},
+	{
+		"enumerate", JSON_FORMAT_ENUMERATE,
 		"Use textual representations of enumerated values rather than "
-		"raw numeric values" },
-	{ "bitmask", JSON_FORMAT_BITMASK, 
+		"raw numeric values"
+	},
+	{
+		"bitmask", JSON_FORMAT_BITMASK,
 		"Use textual representations of bitmask values rather than "
-		"raw numeric values" },
-	{ "duration", JSON_FORMAT_DURATION, 
+		"raw numeric values"
+	},
+	{
+		"duration", JSON_FORMAT_DURATION,
 		"Use textual representations (xd xh xm xs) of duration values rather "
-		"than raw number of seconds" },
+		"than raw number of seconds"
+	},
 #if 0
-	{ "datetime", JSON_FORMAT_DATETIME, 
+	{
+		"datetime", JSON_FORMAT_DATETIME,
 		"Format date/time values according to the supplied strftime format "
-		"or '%%Y-%%m-%%d %%H:%%M:%%S' if no format specified" },
-	{ "date", JSON_FORMAT_DATE, 
+		"or '%%Y-%%m-%%d %%H:%%M:%%S' if no format specified"
+	},
+	{
+		"date", JSON_FORMAT_DATE,
 		"Format dates according to the supplied strftime format or "
 		"default Javascript format (number of ms since the beginning of the "
-		"Unix epoch) if no format specified" },
-	{ "time", JSON_FORMAT_TIME, 
+		"Unix epoch) if no format specified"
+	},
+	{
+		"time", JSON_FORMAT_TIME,
 		"Format times according the supplied strftime format or "
-		"'%%H:%%M:%%S' in for format specified" },
+		"'%%H:%%M:%%S' in for format specified"
+	},
 #endif
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping query_statuses[] = {
 	{ "alpha", QUERY_STATUS_ALPHA, "Alpha" },
@@ -77,7 +91,7 @@ const string_value_mapping query_statuses[] = {
 	{ "released", QUERY_STATUS_RELEASED, "Released" },
 	{ "deprecated", QUERY_STATUS_DEPRECATED, "Deprecated" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_host_statuses[] = {
 #ifdef JSON_NAGIOS_4X
@@ -91,7 +105,7 @@ const string_value_mapping svm_host_statuses[] = {
 #endif
 	{ "pending", HOST_PENDING, "HOST_PENDING" },
 	{ NULL, -1, NULL },
-	};
+};
 
 /* Hard-coded values used because the HOST_UP/DOWN/UNREACHABLE
 	macros are host status (and include PENDING), not host state */
@@ -100,7 +114,7 @@ const string_value_mapping svm_host_states[] = {
 	{ "down", 1, "HOST_DOWN" },
 	{ "unreachable", 2, "HOST_UNREACHABLE" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_service_statuses[] = {
 	{ "ok", SERVICE_OK, "SERVICE_OK" },
@@ -109,7 +123,7 @@ const string_value_mapping svm_service_statuses[] = {
 	{ "unknown", SERVICE_UNKNOWN, "SERVICE_UNKNOWN" },
 	{ "pending", SERVICE_PENDING, "SERVICE_PENDING" },
 	{ NULL, -1, NULL },
-	};
+};
 
 /* Hard-coded values used because the SERVICE_OK/WARNING/CRITICAL/UNKNOWN
 	macros are service status (and include PENDING), not service state */
@@ -119,45 +133,45 @@ const string_value_mapping svm_service_states[] = {
 	{ "critical", 2, "SERVICE_CRITICAL" },
 	{ "unknown", 3, "SERVICE_UNKNOWN" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_check_options[] = {
 	{ "force_execution", CHECK_OPTION_FORCE_EXECUTION, "FORCE_EXECUTION" },
 	{ "freshness_check", CHECK_OPTION_FRESHNESS_CHECK, "FRESHNESS_CHECK" },
 	{ "ophan_check", CHECK_OPTION_ORPHAN_CHECK, "ORPHAN_CHECK" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_host_check_types[] = {
 	{ "active", HOST_CHECK_ACTIVE, "ACTIVE" },
 	{ "passive", HOST_CHECK_PASSIVE, "PASSIVE" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_service_check_types[] = {
 	{ "active", SERVICE_CHECK_ACTIVE, "ACTIVE" },
 	{ "passive", SERVICE_CHECK_PASSIVE, "PASSIVE" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_state_types[] = {
 	{ "soft", SOFT_STATE, "SOFT" },
 	{ "hard", HARD_STATE, "HARD" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_acknowledgement_types[] = {
 	{ "none", ACKNOWLEDGEMENT_NONE, "NONE" },
 	{ "normal", ACKNOWLEDGEMENT_NORMAL, "NORMAL" },
 	{ "sticky", ACKNOWLEDGEMENT_STICKY, "STICKY" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_comment_types[] = {
 	{ "host", HOST_COMMENT, "Host Comment" },
 	{ "service", SERVICE_COMMENT, "Service Comment" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_comment_entry_types[] = {
 	{ "user", USER_COMMENT, "User Comment" },
@@ -165,14 +179,14 @@ const string_value_mapping svm_comment_entry_types[] = {
 	{ "flapping", FLAPPING_COMMENT, "Flapping Comment" },
 	{ "acknowledgement", ACKNOWLEDGEMENT_COMMENT, "Acknowledgement Comment" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_downtime_types[] = {
 	{ "service", SERVICE_DOWNTIME, "Service Downtime" },
 	{ "host", HOST_DOWNTIME, "Host Downtime" },
 	{ "any", ANY_DOWNTIME, "Any Downtime" },
 	{ NULL, -1, NULL },
-	};
+};
 
 #ifdef JSON_NAGIOS_4X
 const string_value_mapping svm_option_types[] = {
@@ -188,46 +202,50 @@ const string_value_mapping svm_option_types[] = {
 	{ "flapping", OPT_FLAPPING, "Flapping" },
 	{ "downtime", OPT_DOWNTIME, "Downtime" },
 	{ NULL, -1, NULL },
-	};
+};
 #endif
 
 const string_value_mapping parent_host_extras[] = {
 	{ "none", 0, "Hosts that are directly reachable by the Nagios Core host" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping child_host_extras[] = {
 	{ "none", 0, "Hosts that have no child hosts" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping parent_service_extras[] = {
 	{ "none", 0, "Services that have no parent services" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping child_service_extras[] = {
 	{ "none", 0, "Services that have no child services" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const char *dayofweek[7] = { "Sunday", "Monday", "Tuesday", "Wednesday",
-		"Thursday", "Friday", "Saturday" };
+                             "Thursday", "Friday", "Saturday"
+                           };
 const char *month[12] = { "January", "February", "March", "April", "May",
-		"June", "July", "August", "September", "October", "November",
-		"December" };
+                          "June", "July", "August", "September", "October", "November",
+                          "December"
+                        };
 
 extern char main_config_file[MAX_FILENAME_LENGTH];
 extern time_t program_start;
 
 
-json_object *json_new_object(void) {
+json_object *json_new_object(void)
+{
 	json_object *new;
 	new = calloc(1, sizeof(json_object));
 	return new;
-	}
+}
 
-void json_free_object(json_object *obj, int free_children) {
+void json_free_object(json_object *obj, int free_children)
+{
 
 	int x;
 	json_object_member **mpp;
@@ -235,17 +253,19 @@ void json_free_object(json_object *obj, int free_children) {
 	if(1 == free_children) {
 		for(x = 0, mpp = obj->members; x < obj->member_count; x++, mpp++) {
 			json_free_member(*mpp, free_children);
-			}
 		}
+	}
 	free(obj->members);
 	free(obj);
-	}
+}
 
-json_array *json_new_array(void) {
+json_array *json_new_array(void)
+{
 	return (json_array *)json_new_object();
-	}
+}
 
-void json_free_member(json_object_member *mp, int free_children) {
+void json_free_member(json_object_member *mp, int free_children)
+{
 
 	if(NULL != mp->key) free(mp->key);
 
@@ -254,12 +274,12 @@ void json_free_member(json_object_member *mp, int free_children) {
 	case JSON_TYPE_ARRAY:
 		if(NULL != mp->value.object) {
 			json_free_object(mp->value.object, free_children);
-			}
+		}
 		break;
 	case JSON_TYPE_STRING:
 		if(NULL != mp->value.string) {
 			free(mp->value.string);
-			}
+		}
 		break;
 	case JSON_TYPE_INTEGER:
 	case JSON_TYPE_REAL:
@@ -268,36 +288,36 @@ void json_free_member(json_object_member *mp, int free_children) {
 		break;
 	default:
 		break;
-		}
-
-	free(mp);
 	}
 
-void json_object_append_object(json_object *obj, char *key, json_object *value) {
+	free(mp);
+}
+
+void json_object_append_object(json_object *obj, char *key, json_object *value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 	if(NULL == value) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_OBJECT;
@@ -306,40 +326,41 @@ void json_object_append_object(json_object *obj, char *key, json_object *value) 
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	mp->value.object = value;
-	}
+}
 
-void json_array_append_object(json_object *obj, json_object *value) {
+void json_array_append_object(json_object *obj, json_object *value)
+{
 	json_object_append_object(obj, NULL, value);
-	}
+}
 
-void json_object_append_array(json_object *obj, char *key, json_array *value) {
+void json_object_append_array(json_object *obj, char *key, json_array *value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 	if(NULL == value) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_ARRAY;
@@ -348,39 +369,40 @@ void json_object_append_array(json_object *obj, char *key, json_array *value) {
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	mp->value.object = value;
-	}
+}
 
-void json_array_append_array(json_array *obj, json_array *value) {
+void json_array_append_array(json_array *obj, json_array *value)
+{
 	json_object_append_array((json_object *)obj, NULL, value);
-	}
+}
 
-void json_object_append_integer(json_object *obj, char *key, int value) {
+void json_object_append_integer(json_object *obj, char *key, int value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_INTEGER;
@@ -389,39 +411,40 @@ void json_object_append_integer(json_object *obj, char *key, int value) {
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	mp->value.integer = value;
-	}
+}
 
-void json_array_append_integer(json_object *obj, int value) {
+void json_array_append_integer(json_object *obj, int value)
+{
 	json_object_append_integer(obj, NULL, value);
-	}
+}
 
-void json_object_append_real(json_object *obj, char *key, double value) {
+void json_object_append_real(json_object *obj, char *key, double value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_REAL;
@@ -430,16 +453,18 @@ void json_object_append_real(json_object *obj, char *key, double value) {
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	mp->value.real = value;
-	}
+}
 
-void json_array_append_real(json_array *obj, double value) {
+void json_array_append_real(json_array *obj, double value)
+{
 	json_object_append_real(obj, NULL, value);
-	}
+}
 
-void json_object_append_time(json_object *obj, char *key, unsigned long value) {
+void json_object_append_time(json_object *obj, char *key, unsigned long value)
+{
 
 	unsigned hours;
 	unsigned minutes;
@@ -451,38 +476,39 @@ void json_object_append_time(json_object *obj, char *key, unsigned long value) {
 	value -= minutes * 60;
 	seconds = value;
 
-	json_object_append_string(obj, key, "%02u:%02u:%02u", hours, minutes, 
-			seconds);
-	}
+	json_object_append_string(obj, key, "%02u:%02u:%02u", hours, minutes,
+	                          seconds);
+}
 
-void json_array_append_time(json_array *obj, unsigned long value) {
+void json_array_append_time(json_array *obj, unsigned long value)
+{
 	json_object_append_time(obj, NULL, value);
-	}
+}
 
-void json_object_append_time_t(json_object *obj, char *key, time_t value) {
+void json_object_append_time_t(json_object *obj, char *key, time_t value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_TIME_T;
@@ -491,17 +517,19 @@ void json_object_append_time_t(json_object *obj, char *key, time_t value) {
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
-	mp->value.time = value;
 	}
+	mp->value.time = value;
+}
 
-void json_set_time_t(json_object_member *mp, time_t value) {
+void json_set_time_t(json_object_member *mp, time_t value)
+{
 	if(NULL == mp) return;
 	mp->value.time = value;
-	}
+}
 
-void json_object_append_string(json_object *obj, char *key, char *format, ...) {
+void json_object_append_string(json_object *obj, char *key, char *format, ...)
+{
 	json_object_member *mp;
 	va_list a_list;
 	int		result;
@@ -510,24 +538,23 @@ void json_object_append_string(json_object *obj, char *key, char *format, ...) {
 	if(NULL == obj) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_STRING;
@@ -536,17 +563,18 @@ void json_object_append_string(json_object *obj, char *key, char *format, ...) {
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	va_start( a_list, format);
 	result = vasprintf(&buf, format, a_list);
 	va_end( a_list);
 	if(result >= 0) {
 		mp->value.string = buf;
-		}
 	}
+}
 
-void json_array_append_string(json_object *obj, char *format, ...) {
+void json_array_append_string(json_object *obj, char *format, ...)
+{
 
 	va_list a_list;
 	int		result;
@@ -557,33 +585,33 @@ void json_array_append_string(json_object *obj, char *format, ...) {
 	va_end( a_list);
 	if(result >= 0) {
 		json_object_append_string(obj, NULL, buf);
-		}
 	}
+}
 
-void json_object_append_boolean(json_object *obj, char *key, int value) {
+void json_object_append_boolean(json_object *obj, char *key, int value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_BOOLEAN;
@@ -592,40 +620,41 @@ void json_object_append_boolean(json_object *obj, char *key, int value) {
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	mp->value.boolean = value;
-	}
+}
 
-void json_array_append_boolean(json_object *obj, int value) {
+void json_array_append_boolean(json_object *obj, int value)
+{
 	json_object_append_boolean(obj, NULL, value);
-	}
+}
 
-void json_object_append_duration(json_object *obj, char *key, 
-		unsigned long value) {
+void json_object_append_duration(json_object *obj, char *key,
+                                 unsigned long value)
+{
 	json_object_member *mp;
 
 	if(NULL == obj) return;
 
 	if(0 == obj->member_count) {
-		obj->members = calloc(1, sizeof(json_object_member *)); 
+		obj->members = calloc(1, sizeof(json_object_member *));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
-	else {
-		obj->members = realloc(obj->members, 
-				((obj->member_count + 1) * sizeof(json_object_member *)));
+	} else {
+		obj->members = realloc(obj->members,
+		                       ((obj->member_count + 1) * sizeof(json_object_member *)));
 		if(NULL == obj->members) {
 			obj->member_count = 0;
 			return;
-			}
 		}
+	}
 	obj->members[ obj->member_count] = calloc(1, sizeof(json_object_member));
 	if(NULL == obj->members[ obj->member_count]) {
 		return;
-		}
+	}
 	mp = obj->members[ obj->member_count];
 	obj->member_count++;
 	mp->type = JSON_TYPE_DURATION;
@@ -634,14 +663,15 @@ void json_object_append_duration(json_object *obj, char *key,
 		if(NULL == mp->key) {
 			obj->member_count--;
 			return;
-			}
 		}
+	}
 	mp->value.unsigned_integer = value;
-	}
+}
 
-void json_array_append_duration(json_object *obj, unsigned long value) {
+void json_array_append_duration(json_object *obj, unsigned long value)
+{
 	json_object_append_duration(obj, NULL, value);
-	}
+}
 
 /*
 	Fetch an object member based on the path. The path is a dot-separated
@@ -653,7 +683,8 @@ void json_array_append_duration(json_object *obj, unsigned long value) {
 	"data.hostlist.1"
 */
 
-json_object_member *json_get_object_member(json_object *root, char *path) {
+json_object_member *json_get_object_member(json_object *root, char *path)
+{
 
 	char *dot;
 	char node[1024];
@@ -664,19 +695,17 @@ json_object_member *json_get_object_member(json_object *root, char *path) {
 	dot = strchr(path, '.');
 	if(NULL == dot) {	/* single node path */
 		strcpy(node, path);
-		}
-	else {
+	} else {
 		strncpy(node, path, (dot - path));
 		node[dot - path] = '\0';
-		}
+	}
 
 	/* Loop over the members of the passed root looking for the node name */
 	for(x = 0, mpp = root->members; x < root->member_count; x++, mpp++) {
 		if(!strcmp((*mpp)->key, node)) {
 			if(NULL == dot) { /* return this node */
 				return *mpp;
-				}
-			else {
+			} else {
 				switch((*mpp)->type) {
 				case JSON_TYPE_OBJECT:
 					return json_get_object_member((*mpp)->value.object, dot + 1);
@@ -689,15 +718,16 @@ json_object_member *json_get_object_member(json_object *root, char *path) {
 						childless node */
 					return NULL;
 					break;
-					}
 				}
 			}
 		}
-
-	return NULL;
 	}
 
-json_object_member *json_get_array_member(json_object *root, char *path) {
+	return NULL;
+}
+
+json_object_member *json_get_array_member(json_object *root, char *path)
+{
 
 	char *dot;
 	char node[1024];
@@ -708,24 +738,22 @@ json_object_member *json_get_array_member(json_object *root, char *path) {
 	dot = strchr(path, '.');
 	if(NULL == dot) {	/* single node path */
 		strcpy(node, path);
-		}
-	else {
+	} else {
 		strncpy(node, path, (dot - path));
 		node[dot - path] = '\0';
-		}
+	}
 	index = (int)strtol(node, NULL, 10);
 
 	/* Verify that we have a reasonable index */
 	if(index < 0 || index >= root->member_count) {
 		return NULL;
-		}
+	}
 
 	/* Find the requested member and deal with it appropriately */
 	mp = root->members[ index];
 	if(NULL == dot) { /* return this node */
 		return mp;
-		}
-	else {
+	} else {
 		switch(mp->type) {
 		case JSON_TYPE_OBJECT:
 			return json_get_object_member(mp->value.object, dot + 1);
@@ -738,14 +766,15 @@ json_object_member *json_get_array_member(json_object *root, char *path) {
 				childless node */
 			return NULL;
 			break;
-			}
 		}
-
-	return NULL;
 	}
 
+	return NULL;
+}
+
 void json_object_print(json_object *obj, int padding, int whitespace,
-		char *strftime_format, unsigned format_options) {
+                       char *strftime_format, unsigned format_options)
+{
 	int x;
 	json_object_member **mpp;
 
@@ -753,55 +782,55 @@ void json_object_print(json_object *obj, int padding, int whitespace,
 	printf( "{%s", (whitespace ? "\n" : ""));
 	padding++;
 	for(x = 0, mpp = obj->members; x < obj->member_count; x++, mpp++) {
-		json_member_print(*mpp, padding, whitespace, strftime_format, 
-				format_options);
+		json_member_print(*mpp, padding, whitespace, strftime_format,
+		                  format_options);
 		if(x != obj->member_count - 1) printf(",");
 		if(whitespace) printf("\n");
-		}
+	}
 	padding--;
 	indentf(padding, whitespace, "}");
 }
 
 void json_array_print(json_array *obj, int padding, int whitespace,
-		char *strftime_format, unsigned format_options) {
+                      char *strftime_format, unsigned format_options)
+{
 	int x;
 	json_object_member **mpp;
 
 	printf( "[%s", (whitespace ? "\n" : ""));
 	padding++;
 	for(x = 0, mpp = obj->members; x < obj->member_count; x++, mpp++) {
-		json_member_print(*mpp, padding, whitespace, strftime_format, 
-				format_options);
+		json_member_print(*mpp, padding, whitespace, strftime_format,
+		                  format_options);
 		if(x != obj->member_count - 1) printf(",");
 		if(whitespace) printf("\n");
-		}
+	}
 	padding--;
 	indentf(padding, whitespace, "]");
-	}
+}
 
-void json_member_print(json_object_member *mp, int padding, int whitespace, 
-		char *strftime_format, unsigned format_options) {
+void json_member_print(json_object_member *mp, int padding, int whitespace,
+                       char *strftime_format, unsigned format_options)
+{
 
 	switch(mp->type) {
 	case JSON_TYPE_OBJECT:
 		if(NULL != mp->key) {
 			indentf(padding, whitespace, "\"%s\": ", mp->key);
-			}
-		else {
+		} else {
 			indentf(padding, whitespace, "");
-			}
-		json_object_print(mp->value.object, padding, whitespace, 
-				strftime_format, format_options);
+		}
+		json_object_print(mp->value.object, padding, whitespace,
+		                  strftime_format, format_options);
 		break;
 	case JSON_TYPE_ARRAY:
 		if(NULL != mp->key) {
 			indentf(padding, whitespace, "\"%s\": ", mp->key);
-			}
-		else {
+		} else {
 			indentf(padding, whitespace, "");
-			}
+		}
 		json_array_print(mp->value.object, padding, whitespace, strftime_format,
-				format_options);
+		                 format_options);
 		break;
 	case JSON_TYPE_INTEGER:
 		json_int(padding, whitespace, mp->key, mp->value.integer);
@@ -810,8 +839,8 @@ void json_member_print(json_object_member *mp, int padding, int whitespace,
 		json_float(padding, whitespace, mp->key, mp->value.real);
 		break;
 	case JSON_TYPE_TIME_T:
-		json_time_t(padding, whitespace, mp->key, mp->value.time, 
-				strftime_format);
+		json_time_t(padding, whitespace, mp->key, mp->value.time,
+		            strftime_format);
 		break;
 	case JSON_TYPE_STRING:
 		json_string(padding, whitespace, mp->key, mp->value.string);
@@ -821,28 +850,30 @@ void json_member_print(json_object_member *mp, int padding, int whitespace,
 		break;
 	case JSON_TYPE_DURATION:
 		json_duration(padding, whitespace, mp->key, mp->value.unsigned_integer,
-				format_options & JSON_FORMAT_DURATION);
+		              format_options & JSON_FORMAT_DURATION);
 		break;
 	default:
 		break;
-		}
 	}
+}
 
-void indentf(int padding, int whitespace, char *format, ...) {
+void indentf(int padding, int whitespace, char *format, ...)
+{
 	va_list a_list;
 	int padvar;
 
 	if( whitespace > 0) {
 		for(padvar = 0; padvar < padding; padvar++) printf( "  ");
-		}
+	}
 	va_start( a_list, format);
 	vprintf(format, a_list);
 	va_end( a_list);
-	}
+}
 
 json_object * json_result(time_t query_time, char *cgi, char *query,
-		int query_status, time_t last_data_update, authdata *authinfo, int type,
-		char *message, ...) {
+                          int query_status, time_t last_data_update, authdata *authinfo, int type,
+                          char *message, ...)
+{
 
 	json_object *json_result;
 	va_list a_list;
@@ -854,20 +885,20 @@ json_object * json_result(time_t query_time, char *cgi, char *query,
 	json_object_append_string(json_result, "cgi", cgi);
 	if(NULL != authinfo) {
 		json_object_append_string(json_result, "user", authinfo->username);
-		}
+	}
 	if(NULL != query) {
 		json_object_append_string(json_result, "query", query);
 		json_object_append_string(json_result, "query_status",
-				svm_get_string_from_value(query_status, query_statuses));
-		}
+		                          svm_get_string_from_value(query_status, query_statuses));
+	}
 	json_object_append_time_t(json_result, "program_start", program_start);
 	if(last_data_update != (time_t)-1) {
 		json_object_append_time_t(json_result, "last_data_update",
-				last_data_update);
-		}
+		                          last_data_update);
+	}
 	json_object_append_integer(json_result, "type_code", type);
-	json_object_append_string(json_result, "type_text", 
-			(char *)result_types[ type]);
+	json_object_append_string(json_result, "type_text",
+	                          (char *)result_types[ type]);
 	va_start( a_list, message);
 	vsnprintf(buf, sizeof(buf)-1, message, a_list);
 	va_end( a_list);
@@ -876,7 +907,8 @@ json_object * json_result(time_t query_time, char *cgi, char *query,
 	return json_result;
 }
 
-json_object *json_help(option_help *help) {
+json_object *json_help(option_help *help)
+{
 
 	json_object *json_data = json_new_object();
 	json_object *json_options = json_new_object();
@@ -895,57 +927,57 @@ json_object *json_help(option_help *help) {
 		json_object_append_string(json_option, "type", (char *)help->type);
 
 		json_required = json_new_array();
-		for(x = 0, stpp = (char **)help->required; 
-				(( x < sizeof( help->required) / 
-				sizeof( help->required[ 0])) && ( NULL != *stpp)); 
-				x++, stpp++) {
+		for(x = 0, stpp = (char **)help->required;
+		    (( x < sizeof( help->required) /
+		       sizeof( help->required[ 0])) && ( NULL != *stpp));
+		    x++, stpp++) {
 			json_array_append_string(json_required, *stpp);
-			}
+		}
 		json_object_append_array(json_option, "required",
-				json_required);
+		                         json_required);
 
 		json_optional = json_new_array();
-		for(x = 0, stpp = (char **)help->optional; 
-				(( x < sizeof( help->optional) / 
-				sizeof( help->optional[ 0])) && ( NULL != *stpp)); 
-				x++, stpp++) {
+		for(x = 0, stpp = (char **)help->optional;
+		    (( x < sizeof( help->optional) /
+		       sizeof( help->optional[ 0])) && ( NULL != *stpp));
+		    x++, stpp++) {
 			json_array_append_string(json_optional, *stpp);
-			}
+		}
 		json_object_append_array(json_option, "optional",
-				json_optional);
+		                         json_optional);
 
-		json_object_append_string(json_option, "depends_on", 
-				(char *)help->depends_on);
-		json_object_append_string(json_option, "description", 
-				(char *)help->description);
+		json_object_append_string(json_option, "depends_on",
+		                          (char *)help->depends_on);
+		json_object_append_string(json_option, "description",
+		                          (char *)help->description);
 		if( NULL != help->valid_values) {
 			json_validvalues = json_new_object();
-			for(svmp = (string_value_mapping *)help->valid_values; 
-					NULL != svmp->string; svmp++) {
+			for(svmp = (string_value_mapping *)help->valid_values;
+			    NULL != svmp->string; svmp++) {
 				if( NULL != svmp->description) {
 					json_validvalue = json_new_object();
-					json_object_append_string(json_validvalue, "description", 
-							svmp->description);
-					json_object_append_object(json_validvalues, svmp->string, 
-							json_validvalue);
-					}
-				else {
+					json_object_append_string(json_validvalue, "description",
+					                          svmp->description);
+					json_object_append_object(json_validvalues, svmp->string,
+					                          json_validvalue);
+				} else {
 					json_array_append_string(json_validvalues, svmp->string);
-					}
 				}
-			json_object_append_object(json_option, "valid_values", 
-					json_validvalues);
 			}
+			json_object_append_object(json_option, "valid_values",
+			                          json_validvalues);
+		}
 		json_object_append_object(json_options, (char *)help->name, json_option);
 		help++;
-		}
+	}
 
 	json_object_append_object(json_data, "options", json_options);
 
 	return json_data;
-	}
+}
 
-int passes_start_and_count_limits(int start, int max, int current, int counted) {
+int passes_start_and_count_limits(int start, int max, int current, int counted)
+{
 
 	int result = FALSE;
 
@@ -956,33 +988,31 @@ int passes_start_and_count_limits(int start, int max, int current, int counted) 
 				/* The user requested a limit on the number of items returned */
 				if(counted < max) {
 					result = TRUE;
-					}
 				}
-			else {
-				/* The user did not request a limit on the number of items 
+			} else {
+				/* The user did not request a limit on the number of items
 					returned */
 				result = TRUE;
-				}
 			}
 		}
-	else {
+	} else {
 		/* The user did not request we start at a specific index */
 		if(max > 0) {
 			/* The user requested a limit on the number of items returned */
 			if(counted < max) {
 				result = TRUE;
-				}
 			}
-		else {
-			/* The user did not request a limit on the number of items 
+		} else {
+			/* The user did not request a limit on the number of items
 					returned */
 			result = TRUE;
-			}
 		}
-	return result;
 	}
+	return result;
+}
 
-void json_string(int padding, int whitespace, char *key, char *format, ...) {
+void json_string(int padding, int whitespace, char *key, char *format, ...)
+{
 
 	va_list a_list;
 	char buf[8192];
@@ -993,7 +1023,7 @@ void json_string(int padding, int whitespace, char *key, char *format, ...) {
 		va_start( a_list, format);
 		vsnprintf(buf, sizeof(buf)-1, format, a_list);
 		va_end( a_list);
-		}
+	}
 
 	/* Escape any double quotes and strip any newlines */
 	for(stp = buf; *stp != '\0'; stp++) {
@@ -1002,7 +1032,7 @@ void json_string(int padding, int whitespace, char *key, char *format, ...) {
 			bytes = strlen(buf) - (stp - buf) + 1;
 			if(strlen(buf) > sizeof(buf) - 2) {
 				bytes--;
-				}
+			}
 			memmove(stp+1, stp, bytes);
 			*stp = '\\';
 			stp++;
@@ -1011,62 +1041,62 @@ void json_string(int padding, int whitespace, char *key, char *format, ...) {
 			bytes = strlen(buf) - (stp - buf) + 1;
 			memmove(stp, stp+1, bytes);
 			break;
-			}
 		}
+	}
 
 	if( NULL == key) {
 		indentf(padding, whitespace, "\"%s\"", (( NULL == format) ? "" : buf));
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s\"%s\"", key, 
-				(( whitespace> 0) ? " " : ""), (( NULL == format) ? "" : buf));
-		}
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s\"%s\"", key,
+		        (( whitespace> 0) ? " " : ""), (( NULL == format) ? "" : buf));
 	}
+}
 
-void json_boolean(int padding, int whitespace, char *key, int value) {
+void json_boolean(int padding, int whitespace, char *key, int value)
+{
 	if( NULL == key) {
-		indentf(padding, whitespace, "%s", 
-				(( 0 == value) ? "false" : "true"));
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s%s", key, 
-				(( whitespace > 0) ? " " : ""),
-				(( 0 == value) ? "false" : "true"));
-		}
+		indentf(padding, whitespace, "%s",
+		        (( 0 == value) ? "false" : "true"));
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s%s", key,
+		        (( whitespace > 0) ? " " : ""),
+		        (( 0 == value) ? "false" : "true"));
 	}
+}
 
-void json_int(int padding, int whitespace, char *key, int value) {
+void json_int(int padding, int whitespace, char *key, int value)
+{
 	if( NULL == key) {
-		indentf(padding, whitespace, "%d", value); 
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s%d", key, 
-				(( whitespace > 0) ? " " : ""), value); 
-		}
+		indentf(padding, whitespace, "%d", value);
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s%d", key,
+		        (( whitespace > 0) ? " " : ""), value);
 	}
+}
 
-void json_unsigned(int padding, int whitespace, char *key, 
-		unsigned long long value) {
+void json_unsigned(int padding, int whitespace, char *key,
+                   unsigned long long value)
+{
 	if( NULL == key) {
 		indentf(padding, whitespace, "%llu", value);
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s%llu", key, 
-				(( whitespace > 0) ? " " : ""), value);
-		}
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s%llu", key,
+		        (( whitespace > 0) ? " " : ""), value);
 	}
+}
 
-void json_float(int padding, int whitespace, char *key, double value) {
+void json_float(int padding, int whitespace, char *key, double value)
+{
 	if( NULL == key) {
 		indentf(padding, whitespace, "%.2f", value);
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s%.2f", key, 
-				(( whitespace > 0) ? " " : ""), value);
-		}
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s%.2f", key,
+		        (( whitespace > 0) ? " " : ""), value);
 	}
+}
 
-void json_time(int padding, int whitespace, char *key, unsigned long value) {
+void json_time(int padding, int whitespace, char *key, unsigned long value)
+{
 	unsigned hours;
 	unsigned minutes;
 	unsigned seconds;
@@ -1079,43 +1109,42 @@ void json_time(int padding, int whitespace, char *key, unsigned long value) {
 
 	if( NULL == key) {
 		indentf(padding, whitespace, "\"%02u:%02u:%02u\"", hours, minutes,
-				seconds);
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s\"%02u:%02u:%02u\"", key, 
-				(( whitespace > 0) ? " " : ""), hours, minutes,
-				seconds);
-		}
+		        seconds);
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s\"%02u:%02u:%02u\"", key,
+		        (( whitespace > 0) ? " " : ""), hours, minutes,
+		        seconds);
 	}
+}
 
-void json_time_t(int padding, int whitespace, char *key, time_t value, 
-		char *format) {
+void json_time_t(int padding, int whitespace, char *key, time_t value,
+                 char *format)
+{
 
 	char		buf[1024];
 	struct tm	*tmp_tm;
 
 	if(NULL == format) {
-		snprintf(buf, sizeof(buf)-1, "%llu%s", (unsigned long long)value, 
-				((unsigned long long)value > 0 ? "000" : ""));
-		}
-	else {
+		snprintf(buf, sizeof(buf)-1, "%llu%s", (unsigned long long)value,
+		         ((unsigned long long)value > 0 ? "000" : ""));
+	} else {
 		tmp_tm = localtime(&value);
 		buf[ 0] = '"';
 		strftime(buf+1, sizeof(buf)-3, format, tmp_tm);
 		strcat(buf, "\"");
-		}
+	}
 
 	if(NULL == key) {
 		indentf(padding, whitespace, "%s", buf);
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s%s", key, 
-				(( whitespace > 0) ? " " : ""), buf);
-		}
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s%s", key,
+		        (( whitespace > 0) ? " " : ""), buf);
 	}
+}
 
 void json_duration(int padding, int whitespace, char *key, unsigned long value,
-		int format_duration) {
+                   int format_duration)
+{
 
 	char		buf[1024];
 	int			days = 0;
@@ -1125,8 +1154,7 @@ void json_duration(int padding, int whitespace, char *key, unsigned long value,
 
 	if(0 == format_duration) {
 		snprintf(buf, sizeof(buf)-1, "%lu", (unsigned long)value);
-		}
-	else {
+	} else {
 		days = (unsigned)(value / 86400);
 		value -= days * 86400;
 		hours = (unsigned)(value / 3600);
@@ -1134,21 +1162,21 @@ void json_duration(int padding, int whitespace, char *key, unsigned long value,
 		minutes = (unsigned)(value / 60);
 		value -= minutes * 60;
 		seconds = value;
-		snprintf(buf, sizeof(buf)-1, "%ud %uh %um %us", days, hours, minutes, 
-				seconds);
-		}
+		snprintf(buf, sizeof(buf)-1, "%ud %uh %um %us", days, hours, minutes,
+		         seconds);
+	}
 
 	if( NULL == key) {
 		indentf(padding, whitespace, "%s", buf);
-		}
-	else {
-		indentf(padding, whitespace, "\"%s\":%s\"%s\"", key, 
-				(( whitespace > 0) ? " " : ""), buf);
-		}
+	} else {
+		indentf(padding, whitespace, "\"%s\":%s\"%s\"", key,
+		        (( whitespace > 0) ? " " : ""), buf);
 	}
+}
 
-void json_enumeration(json_object *json_parent, unsigned format_options, 
-		char *key, int value, const string_value_mapping *map) {
+void json_enumeration(json_object *json_parent, unsigned format_options,
+                      char *key, int value, const string_value_mapping *map)
+{
 
 	string_value_mapping *svmp;
 
@@ -1157,20 +1185,20 @@ void json_enumeration(json_object *json_parent, unsigned format_options,
 			if( value == svmp->value) {
 				json_object_append_string(json_parent, key, svmp->string);
 				break;
-				}
 			}
-			if( NULL == svmp->string) {
-				json_object_append_string(json_parent, key, "Unknown value %d", 
-						svmp->value);
-				}
 		}
-	else {
+		if( NULL == svmp->string) {
+			json_object_append_string(json_parent, key, "Unknown value %d",
+			                          svmp->value);
+		}
+	} else {
 		json_object_append_integer(json_parent, key, value);
-		}
 	}
+}
 
-void json_bitmask(json_object *json_parent, unsigned format_options, char *key, 
-		int value, const string_value_mapping *map) {
+void json_bitmask(json_object *json_parent, unsigned format_options, char *key,
+                  int value, const string_value_mapping *map)
+{
 
 	json_array *json_bitmask_array;
 	string_value_mapping *svmp;
@@ -1180,19 +1208,19 @@ void json_bitmask(json_object *json_parent, unsigned format_options, char *key,
 		for(svmp = (string_value_mapping *)map; NULL != svmp->string; svmp++) {
 			if( value & svmp->value) {
 				json_array_append_string(json_bitmask_array, svmp->string);
-				}
 			}
+		}
 		json_object_append_array(json_parent, key, json_bitmask_array);
-		}
-	else {
+	} else {
 		json_object_append_integer(json_parent, key, value);
-		}
 	}
+}
 
 int parse_bitmask_cgivar(char *cgi, char *query, int query_status,
-		json_object *json_parent, time_t query_time, authdata *authinfo,
-		char *key, char *value, const string_value_mapping *svm,
-		unsigned *var) {
+                         json_object *json_parent, time_t query_time, authdata *authinfo,
+                         char *key, char *value, const string_value_mapping *svm,
+                         unsigned *var)
+{
 
 	int result = RESULT_SUCCESS;
 	char *option;
@@ -1200,199 +1228,204 @@ int parse_bitmask_cgivar(char *cgi, char *query, int query_status,
 	string_value_mapping *svmp;
 
 	if(value == NULL) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
-				"No value specified for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
+		                                      "No value specified for %s option.", key));
 		return RESULT_OPTION_VALUE_MISSING;
-		}
-
-	option = strtok_r(value, " ", &saveptr);
-	while(NULL != option) {	
-		for(svmp = (string_value_mapping *)svm; NULL != svmp->string; svmp++) {
-			if( !strcmp( svmp->string, option)) {
-					*var |= svmp->value;
-					break;
-				}
-			}
-		if( NULL == svmp->string) {
-			json_object_append_object(json_parent, "result", 
-					json_result(query_time, cgi, query, query_status,
-					(time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
-					"The %s option value '%s' is invalid.", key, option));
-			result = RESULT_OPTION_VALUE_INVALID;
-			break;
-			}
-		option = strtok_r(NULL, " ", &saveptr);
-		}
-	return result;
 	}
 
+	option = strtok_r(value, " ", &saveptr);
+	while(NULL != option) {
+		for(svmp = (string_value_mapping *)svm; NULL != svmp->string; svmp++) {
+			if( !strcmp( svmp->string, option)) {
+				*var |= svmp->value;
+				break;
+			}
+		}
+		if( NULL == svmp->string) {
+			json_object_append_object(json_parent, "result",
+			                          json_result(query_time, cgi, query, query_status,
+			                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
+			                                      "The %s option value '%s' is invalid.", key, option));
+			result = RESULT_OPTION_VALUE_INVALID;
+			break;
+		}
+		option = strtok_r(NULL, " ", &saveptr);
+	}
+	return result;
+}
+
 int parse_enumeration_cgivar(char *cgi, char *query, int query_status,
-		json_object *json_parent, time_t query_time, authdata *authinfo,
-		char *key, char *value, const string_value_mapping *svm, int *var) {
+                             json_object *json_parent, time_t query_time, authdata *authinfo,
+                             char *key, char *value, const string_value_mapping *svm, int *var)
+{
 
 	string_value_mapping *svmp;
 
 	if(value == NULL) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
-				"No value specified for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
+		                                      "No value specified for %s option.", key));
 		return RESULT_OPTION_VALUE_MISSING;
-		}
+	}
 
 	for(svmp = (string_value_mapping *)svm; NULL != svmp->string; svmp++) {
 		if( !strcmp( svmp->string, value)) {
-				*var = svmp->value;
-				break;
-			}
+			*var = svmp->value;
+			break;
 		}
+	}
 	if( NULL == svmp->string) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
-				"The %s option value '%s' is invalid.", key, value));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
+		                                      "The %s option value '%s' is invalid.", key, value));
 		return RESULT_OPTION_VALUE_INVALID;
-		} 
+	}
 
 	return RESULT_SUCCESS;
-	}
+}
 
 
 int parse_string_cgivar(char *cgi, char *query, int query_status,
-		json_object *json_parent, time_t query_time, authdata *authinfo,
-		char *key, char *value, char **var) {
+                        json_object *json_parent, time_t query_time, authdata *authinfo,
+                        char *key, char *value, char **var)
+{
 
 	if(value == NULL) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
-				"No value specified for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
+		                                      "No value specified for %s option.", key));
 		return RESULT_OPTION_VALUE_MISSING;
-		}
+	}
 
 	if(NULL == (*var = strdup( value))) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_MEMORY_ALLOCATION_ERROR,
-				"Unable to allocate memory for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_MEMORY_ALLOCATION_ERROR,
+		                                      "Unable to allocate memory for %s option.", key));
 		return RESULT_MEMORY_ALLOCATION_ERROR;
-		}
+	}
 
 	return RESULT_SUCCESS;
-	}
+}
 
 
 int parse_time_cgivar(char *cgi, char *query, int query_status,
-		json_object *json_parent, time_t query_time, authdata *authinfo,
-		char *key, char *value, time_t *var) {
+                      json_object *json_parent, time_t query_time, authdata *authinfo,
+                      char *key, char *value, time_t *var)
+{
 
 	long long templl;
 
 	if(value == NULL) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
-				"No value specified for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
+		                                      "No value specified for %s option.", key));
 		return RESULT_OPTION_VALUE_MISSING;
-		}
+	}
 
 	if('+' == value[0]) {
 		templl = strtoll(&(value[1]), NULL, 10);
 		*var = (time_t)((long long)query_time + templl);
-		}
-	else if('-' == value[0]) {
+	} else if('-' == value[0]) {
 		templl = strtoll(&(value[1]), NULL, 10);
 		*var = (time_t)((long long)query_time - templl);
-		}
-	else {
+	} else {
 		templl = strtoll(value, NULL, 10);
 		*var = (time_t)templl;
-		}
+	}
 
 	return RESULT_SUCCESS;
-	}
+}
 
 
 int parse_boolean_cgivar(char *cgi, char *query, int query_status,
-		json_object *json_parent, time_t query_time, authdata *authinfo,
-		char *key, char *value, int *var) {
+                         json_object *json_parent, time_t query_time, authdata *authinfo,
+                         char *key, char *value, int *var)
+{
 
 	if(value == NULL) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
-				"No value specified for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
+		                                      "No value specified for %s option.", key));
 		return ERROR;
-		}
+	}
 
 	if(!strcmp(value, "true")) {
 		*var = 1;
-		}
-	else if(!strcmp(value, "false")) {
+	} else if(!strcmp(value, "false")) {
 		*var = 0;
-		}
-	else {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
-				"Value for %s option must be 'true' or 'false'.", key));
+	} else {
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
+		                                      "Value for %s option must be 'true' or 'false'.", key));
 		return RESULT_OPTION_VALUE_INVALID;
-		}
+	}
 
 	return RESULT_SUCCESS;
-	}
+}
 
 
 int parse_int_cgivar(char *cgi, char *query, int query_status,
-		json_object *json_parent, time_t query_time, authdata *authinfo,
-		char *key, char *value, int *var) {
+                     json_object *json_parent, time_t query_time, authdata *authinfo,
+                     char *key, char *value, int *var)
+{
 
 	if(value == NULL) {
-		json_object_append_object(json_parent, "result", 
-				json_result(query_time, cgi, query, query_status,
-				(time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
-				"No value specified for %s option.", key));
+		json_object_append_object(json_parent, "result",
+		                          json_result(query_time, cgi, query, query_status,
+		                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_MISSING,
+		                                      "No value specified for %s option.", key));
 		return RESULT_OPTION_VALUE_MISSING;
-		}
+	}
 
 	*var = atoi(value);
 	return RESULT_SUCCESS;
-	}
+}
 
-int get_query_status(const int statuses[][2], int query) {
+int get_query_status(const int statuses[][2], int query)
+{
 	int x;
 
 	for(x = 0; -1 != statuses[x][0]; x++) {
 		if(statuses[x][0] == query) return statuses[x][1];
-		}
-	return -1;
 	}
+	return -1;
+}
 
-char *svm_get_string_from_value(int value, const string_value_mapping *svm) {
+char *svm_get_string_from_value(int value, const string_value_mapping *svm)
+{
 
 	string_value_mapping *svmp;
 
 	for(svmp = (string_value_mapping *)svm; NULL != svmp->string; svmp++) {
 		if(svmp->value == value) return svmp->string;
-		}
-	return NULL;
 	}
+	return NULL;
+}
 
-char *svm_get_description_from_value(int value, const string_value_mapping *svm) {
+char *svm_get_description_from_value(int value, const string_value_mapping *svm)
+{
 
 	string_value_mapping *svmp;
 
 	for(svmp = (string_value_mapping *)svm; NULL != svmp->string; svmp++) {
 		if(svmp->value == value) return svmp->description;
-		}
-	return NULL;
 	}
+	return NULL;
+}
 
 /* Thanks to Jerry Coffin for posting the basis of this function on Stack
 	Overflow */
-time_t compile_time(const char *date, const char *time) {
+time_t compile_time(const char *date, const char *time)
+{
 
 	char buf[5];
 	int year;
@@ -1402,21 +1435,21 @@ time_t compile_time(const char *date, const char *time) {
 	int minute;
 	int second;
 
-    struct tm t;
-    const char *months = "JanFebMarAprMayJunJulAugSepOctNovDec";
+	struct tm t;
+	const char *months = "JanFebMarAprMayJunJulAugSepOctNovDec";
 
-    sscanf(date, "%s %d %d", buf, &day, &year);
-    sscanf(time, "%d:%d:%d", &hour, &minute, &second);
+	sscanf(date, "%s %d %d", buf, &day, &year);
+	sscanf(time, "%d:%d:%d", &hour, &minute, &second);
 
-    month = (strstr(months, buf) - months) / 3;
+	month = (strstr(months, buf) - months) / 3;
 
-    t.tm_year = year - 1900;
-    t.tm_mon = month;
-    t.tm_mday = day;
-    t.tm_hour = hour;
-    t.tm_min = minute;
-    t.tm_sec = second;
-    t.tm_isdst = -1;
+	t.tm_year = year - 1900;
+	t.tm_mon = month;
+	t.tm_mday = day;
+	t.tm_hour = hour;
+	t.tm_min = minute;
+	t.tm_sec = second;
+	t.tm_isdst = -1;
 
-    return mktime(&t);
+	return mktime(&t);
 }

--- a/cgi/notifications.c
+++ b/cgi/notifications.c
@@ -72,7 +72,8 @@ int embedded = FALSE;
 int display_header = TRUE;
 
 
-int main(void) {
+int main(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char temp_buffer2[MAX_INPUT_BUFFER];
 
@@ -110,8 +111,7 @@ int main(void) {
 				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Notifications");
 			else
 				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Host Notifications");
-			}
-		else
+		} else
 			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "Contact Notifications");
 		display_info_table(temp_buffer, FALSE, &current_authdata);
 
@@ -125,18 +125,17 @@ int main(void) {
 				if(find_all == FALSE)
 					printf("<A HREF='%s?host=%s'>View Trends For This Host</A><BR>\n", TRENDS_CGI, url_encode(query_host_name));
 #endif
-				}
-			else if(query_type == FIND_SERVICE) {
+			} else if(query_type == FIND_SERVICE) {
 				printf("<A HREF='%s?host=%s&", HISTORY_CGI, (find_all == TRUE) ? "all" : url_encode(query_host_name));
 				printf("service=%s'>View History For This Service</A><BR>\n", url_encode(query_svc_description));
 #ifdef USE_TRENDS
 				printf("<A HREF='%s?host=%s&", TRENDS_CGI, (find_all == TRUE) ? "all" : url_encode(query_host_name));
 				printf("service=%s'>View Trends For This Service</A><BR>\n", url_encode(query_svc_description));
 #endif
-				}
+			}
 			printf("</TD></TR>\n");
 			printf("</TABLE>\n");
-			}
+		}
 
 		printf("</td>\n");
 
@@ -152,13 +151,12 @@ int main(void) {
 				printf("All Hosts and Services");
 			else
 				printf("Host '%s'", query_host_name);
-			}
-		else {
+		} else {
 			if(find_all == TRUE)
 				printf("All Contacts");
 			else
 				printf("Contact '%s'", query_contact_name);
-			}
+		}
 		printf("</DIV>\n");
 		printf("<BR>\n");
 
@@ -166,8 +164,7 @@ int main(void) {
 			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "%s?%shost=%s&", NOTIFICATIONS_CGI, (use_lifo == FALSE) ? "oldestfirst&" : "", url_encode(query_host_name));
 			snprintf(temp_buffer2, sizeof(temp_buffer2) - 1, "service=%s&type=%d&", url_encode(query_svc_description), notification_options);
 			strncat(temp_buffer, temp_buffer2, sizeof(temp_buffer) - strlen(temp_buffer) - 1);
-			}
-		else
+		} else
 			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "%s?%s%s=%s&type=%d&", NOTIFICATIONS_CGI, (use_lifo == FALSE) ? "oldestfirst&" : "", (query_type == FIND_HOST) ? "host" : "contact", (query_type == FIND_HOST) ? url_encode(query_host_name) : url_encode(query_contact_name), notification_options);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		display_nav_table(temp_buffer, log_archive);
@@ -182,8 +179,7 @@ int main(void) {
 		if(query_type == FIND_SERVICE) {
 			printf("<input type='hidden' name='host' value='%s'>\n", escape_string(query_host_name));
 			printf("<input type='hidden' name='service' value='%s'>\n", escape_string(query_svc_description));
-			}
-		else
+		} else
 			printf("<input type='hidden' name='%s' value='%s'>\n", (query_type == FIND_HOST) ? "host" : "contact", (query_type == FIND_HOST) ? escape_string(query_host_name) : escape_string(query_contact_name));
 		printf("<input type='hidden' name='archive' value='%d'>\n", log_archive);
 		printf("<table border=0 CLASS='optBox'>\n");
@@ -199,7 +195,7 @@ int main(void) {
 		if(query_type != FIND_SERVICE) {
 			printf("<option value=%d %s>All service notifications\n", NOTIFICATION_SERVICE_ALL, (notification_options == NOTIFICATION_SERVICE_ALL) ? "selected" : "");
 			printf("<option value=%d %s>All host notifications\n", NOTIFICATION_HOST_ALL, (notification_options == NOTIFICATION_HOST_ALL) ? "selected" : "");
-			}
+		}
 		printf("<option value=%d %s>Service custom\n", NOTIFICATION_SERVICE_CUSTOM, (notification_options == NOTIFICATION_SERVICE_CUSTOM) ? "selected" : "");
 		printf("<option value=%d %s>Service acknowledgements\n", NOTIFICATION_SERVICE_ACK, (notification_options == NOTIFICATION_SERVICE_ACK) ? "selected" : "");
 		printf("<option value=%d %s>Service warning\n", NOTIFICATION_SERVICE_WARNING, (notification_options == NOTIFICATION_SERVICE_WARNING) ? "selected" : "");
@@ -214,7 +210,7 @@ int main(void) {
 			printf("<option value=%d %s>Host unreachable\n", NOTIFICATION_HOST_UNREACHABLE, (notification_options == NOTIFICATION_HOST_UNREACHABLE) ? "selected" : "");
 			printf("<option value=%d %s>Host recovery\n", NOTIFICATION_HOST_RECOVERY, (notification_options == NOTIFICATION_HOST_RECOVERY) ? "selected" : "");
 			printf("<option value=%d %s>Host flapping\n", NOTIFICATION_HOST_FLAP, (notification_options == NOTIFICATION_HOST_FLAP) ? "selected" : "");
-			}
+		}
 		printf("</select></td>\n");
 		printf("</tr>\n");
 		printf("<tr>\n");
@@ -240,7 +236,7 @@ int main(void) {
 		printf("</tr>\n");
 		printf("</table>\n");
 
-		}
+	}
 
 
 	/* display notifications */
@@ -252,11 +248,12 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -287,7 +284,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, NOTIFICATIONS_CSS);
-		}
+	}
 
 	printf("</head>\n");
 
@@ -297,11 +294,12 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(NOTIFICATIONS_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -313,10 +311,11 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -328,7 +327,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -337,7 +336,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((query_host_name = strdup(variables[x])) == NULL)
 				query_host_name = "";
@@ -347,7 +346,7 @@ int process_cgivars(void) {
 				find_all = TRUE;
 			else
 				find_all = FALSE;
-			}
+		}
 
 		/* we found the contact argument */
 		else if(!strcmp(variables[x], "contact")) {
@@ -356,7 +355,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((query_contact_name = strdup(variables[x])) == NULL)
 				query_contact_name = "";
@@ -366,7 +365,7 @@ int process_cgivars(void) {
 				find_all = TRUE;
 			else
 				find_all = FALSE;
-			}
+		}
 
 		/* we found the service argument */
 		else if(!strcmp(variables[x], "service")) {
@@ -375,11 +374,11 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			if((query_svc_description = strdup(variables[x])) == NULL)
 				query_svc_description = "";
 			strip_html_brackets(query_svc_description);
-			}
+		}
 
 		/* we found the notification type argument */
 		else if(!strcmp(variables[x], "type")) {
@@ -387,10 +386,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			notification_options = atoi(variables[x]);
-			}
+		}
 
 		/* we found the log archive argument */
 		else if(!strcmp(variables[x], "archive")) {
@@ -398,17 +397,17 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_archive = atoi(variables[x]);
 			if(log_archive < 0)
 				log_archive = 0;
-			}
+		}
 
 		/* we found the order argument */
 		else if(!strcmp(variables[x], "oldestfirst")) {
 			use_lifo = FALSE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -417,7 +416,7 @@ int process_cgivars(void) {
 		/* we found the noheader option */
 		else if(!strcmp(variables[x], "noheader"))
 			display_header = FALSE;
-		}
+	}
 
 	/*
 	 * Set some default values if not already set.
@@ -429,21 +428,22 @@ int process_cgivars(void) {
 	if(query_type == FIND_HOST && strlen(query_host_name) == 0) {
 		query_host_name = "all";
 		find_all = TRUE;
-		}
+	}
 	if(query_type == FIND_CONTACT && strlen(query_contact_name) == 0) {
 		query_contact_name = "all";
 		find_all = TRUE;
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
-void display_notifications(void) {
+void display_notifications(void)
+{
 	mmapfile *thefile = NULL;
 	char *input = NULL;
 	char *temp_buffer;
@@ -469,22 +469,21 @@ void display_notifications(void) {
 		if(result != LIFO_OK) {
 			if(result == LIFO_ERROR_MEMORY) {
 				printf("<P><DIV CLASS='warningMessage'>Not enough memory to reverse log file - displaying notifications in natural order...</DIV></P>");
-				}
-			else if(result == LIFO_ERROR_FILE) {
+			} else if(result == LIFO_ERROR_FILE) {
 				printf("<P><DIV CLASS='errorMessage'>Error: Cannot open log file '%s' for reading!</DIV></P>", log_file_to_use);
 				return;
-				}
-			use_lifo = FALSE;
 			}
+			use_lifo = FALSE;
 		}
+	}
 
 	if(use_lifo == FALSE) {
 
 		if((thefile = mmap_fopen(log_file_to_use)) == NULL) {
 			printf("<P><DIV CLASS='errorMessage'>Error: Cannot open log file '%s' for reading!</DIV></P>", log_file_to_use);
 			return;
-			}
 		}
+	}
 
 	printf("<p>\n");
 	printf("<div align='center'>\n");
@@ -509,11 +508,10 @@ void display_notifications(void) {
 		if(use_lifo == TRUE) {
 			if((input = pop_lifo()) == NULL)
 				break;
-			}
-		else {
+		} else {
 			if((input = mmap_fgets(thefile)) == NULL)
 				break;
-			}
+		}
 
 		strip(input);
 
@@ -547,7 +545,7 @@ void display_notifications(void) {
 				temp_buffer = (char *)strtok(NULL, ";");
 				snprintf(service_name, sizeof(service_name), "%s", (temp_buffer == NULL) ? "" : temp_buffer);
 				service_name[sizeof(service_name) - 1] = '\x0';
-				}
+			}
 
 			/* get the alert level */
 			temp_buffer = (char *)strtok(NULL, ";");
@@ -559,40 +557,33 @@ void display_notifications(void) {
 				if(!strcmp(alert_level, "CRITICAL")) {
 					notification_detail_type = NOTIFICATION_SERVICE_CRITICAL;
 					strcpy(alert_level_class, "CRITICAL");
-					}
-				else if(!strcmp(alert_level, "WARNING")) {
+				} else if(!strcmp(alert_level, "WARNING")) {
 					notification_detail_type = NOTIFICATION_SERVICE_WARNING;
 					strcpy(alert_level_class, "WARNING");
-					}
-				else if(!strcmp(alert_level, "RECOVERY") || !strcmp(alert_level, "OK")) {
+				} else if(!strcmp(alert_level, "RECOVERY") || !strcmp(alert_level, "OK")) {
 					strcpy(alert_level, "OK");
 					notification_detail_type = NOTIFICATION_SERVICE_RECOVERY;
 					strcpy(alert_level_class, "OK");
-					}
-				else if(strstr(alert_level, "CUSTOM (")) {
+				} else if(strstr(alert_level, "CUSTOM (")) {
 					notification_detail_type = NOTIFICATION_SERVICE_CUSTOM;
 					strcpy(alert_level_class, "CUSTOM");
-					}
-				else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
+				} else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
 					notification_detail_type = NOTIFICATION_SERVICE_ACK;
 					strcpy(alert_level_class, "ACKNOWLEDGEMENT");
-					}
-				else if(strstr(alert_level, "FLAPPINGSTART (")) {
+				} else if(strstr(alert_level, "FLAPPINGSTART (")) {
 					strcpy(alert_level, "FLAPPING START");
 					notification_detail_type = NOTIFICATION_SERVICE_FLAP;
 					strcpy(alert_level_class, "UNKNOWN");
-					}
-				else if(strstr(alert_level, "FLAPPINGSTOP (")) {
+				} else if(strstr(alert_level, "FLAPPINGSTOP (")) {
 					strcpy(alert_level, "FLAPPING STOP");
 					notification_detail_type = NOTIFICATION_SERVICE_FLAP;
 					strcpy(alert_level_class, "UNKNOWN");
-					}
-				else {
+				} else {
 					strcpy(alert_level, "UNKNOWN");
 					notification_detail_type = NOTIFICATION_SERVICE_UNKNOWN;
 					strcpy(alert_level_class, "UNKNOWN");
-					}
 				}
+			}
 
 			else {
 
@@ -600,36 +591,30 @@ void display_notifications(void) {
 					strncpy(alert_level, "HOST DOWN", sizeof(alert_level));
 					strcpy(alert_level_class, "HOSTDOWN");
 					notification_detail_type = NOTIFICATION_HOST_DOWN;
-					}
-				else if(!strcmp(alert_level, "UNREACHABLE")) {
+				} else if(!strcmp(alert_level, "UNREACHABLE")) {
 					strncpy(alert_level, "HOST UNREACHABLE", sizeof(alert_level));
 					strcpy(alert_level_class, "HOSTUNREACHABLE");
 					notification_detail_type = NOTIFICATION_HOST_UNREACHABLE;
-					}
-				else if(!strcmp(alert_level, "RECOVERY") || !strcmp(alert_level, "UP")) {
+				} else if(!strcmp(alert_level, "RECOVERY") || !strcmp(alert_level, "UP")) {
 					strncpy(alert_level, "HOST UP", sizeof(alert_level));
 					strcpy(alert_level_class, "HOSTUP");
 					notification_detail_type = NOTIFICATION_HOST_RECOVERY;
-					}
-				else if(strstr(alert_level, "CUSTOM (")) {
+				} else if(strstr(alert_level, "CUSTOM (")) {
 					strcpy(alert_level_class, "HOSTCUSTOM");
 					notification_detail_type = NOTIFICATION_HOST_CUSTOM;
-					}
-				else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
+				} else if(strstr(alert_level, "ACKNOWLEDGEMENT (")) {
 					strcpy(alert_level_class, "HOSTACKNOWLEDGEMENT");
 					notification_detail_type = NOTIFICATION_HOST_ACK;
-					}
-				else if(strstr(alert_level, "FLAPPINGSTART (")) {
+				} else if(strstr(alert_level, "FLAPPINGSTART (")) {
 					strcpy(alert_level, "FLAPPING START");
 					strcpy(alert_level_class, "UNKNOWN");
 					notification_detail_type = NOTIFICATION_HOST_FLAP;
-					}
-				else if(strstr(alert_level, "FLAPPINGSTOP (")) {
+				} else if(strstr(alert_level, "FLAPPINGSTOP (")) {
 					strcpy(alert_level, "FLAPPING STOP");
 					strcpy(alert_level_class, "UNKNOWN");
 					notification_detail_type = NOTIFICATION_HOST_FLAP;
-					}
 				}
+			}
 
 			/* get the method name */
 			temp_buffer = (char *)strtok(NULL, ";");
@@ -647,19 +632,19 @@ void display_notifications(void) {
 					show_entry = TRUE;
 				else if(!strcmp(query_contact_name, contact_name))
 					show_entry = TRUE;
-				}
+			}
 
 			else if(query_type == FIND_HOST) {
 				if(find_all == TRUE)
 					show_entry = TRUE;
 				else if(!strcmp(query_host_name, host_name))
 					show_entry = TRUE;
-				}
+			}
 
 			else if(query_type == FIND_SERVICE) {
 				if(!strcmp(query_host_name, host_name) && !strcmp(query_svc_description, service_name))
 					show_entry = TRUE;
-				}
+			}
 
 			if(show_entry == TRUE) {
 				if(notification_options == NOTIFICATION_ALL)
@@ -672,19 +657,18 @@ void display_notifications(void) {
 					show_entry = TRUE;
 				else
 					show_entry = FALSE;
-				}
+			}
 
 			/* make sure user has authorization to view this notification */
 			if(notification_type == HOST_NOTIFICATION) {
 				temp_host = find_host(host_name);
 				if(is_authorized_for_host(temp_host, &current_authdata) == FALSE)
 					show_entry = FALSE;
-				}
-			else {
+			} else {
 				temp_service = find_service(host_name, service_name);
 				if(is_authorized_for_service(temp_service, &current_authdata) == FALSE)
 					show_entry = FALSE;
-				}
+			}
 
 			if(show_entry == TRUE) {
 
@@ -693,17 +677,15 @@ void display_notifications(void) {
 				if(odd) {
 					odd = 0;
 					printf("<tr CLASS='notificationsOdd'>\n");
-					}
-				else {
+				} else {
 					odd = 1;
 					printf("<tr CLASS='notificationsEven'>\n");
-					}
+				}
 				printf("<td CLASS='notifications%s'><a href='%s?type=%d&host=%s'>%s</a></td>\n", (odd) ? "Even" : "Odd", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(host_name), host_name);
 				if(notification_type == SERVICE_NOTIFICATION) {
 					printf("<td CLASS='notifications%s'><a href='%s?type=%d&host=%s", (odd) ? "Even" : "Odd", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(host_name));
 					printf("&service=%s'>%s</a></td>\n", url_encode(service_name), service_name);
-					}
-				else
+				} else
 					printf("<td CLASS='notifications%s'>N/A</td>\n", (odd) ? "Even" : "Odd");
 				printf("<td CLASS='notifications%s'>%s</td>\n", alert_level_class, alert_level);
 				printf("<td CLASS='notifications%s'>%s</td>\n", (odd) ? "Even" : "Odd", date_time);
@@ -711,9 +693,9 @@ void display_notifications(void) {
 				printf("<td CLASS='notifications%s'><a href='%s?type=commands#%s'>%s</a></td>\n", (odd) ? "Even" : "Odd", CONFIG_CGI, url_encode(method_name), method_name);
 				printf("<td CLASS='notifications%s'>%s</td>\n", (odd) ? "Even" : "Odd", html_encode(temp_buffer, FALSE));
 				printf("</tr>\n");
-				}
 			}
 		}
+	}
 
 
 	printf("</table>\n");
@@ -730,9 +712,9 @@ void display_notifications(void) {
 				printf(" for this contact");
 			else
 				printf(" for this host");
-			}
-		printf(" in %s log file</DIV></P>", (log_archive == 0) ? "the current" : "this archived");
 		}
+		printf(" in %s log file</DIV></P>", (log_archive == 0) ? "the current" : "this archived");
+	}
 
 	free(input);
 
@@ -742,4 +724,4 @@ void display_notifications(void) {
 		mmap_fclose(thefile);
 
 	return;
-	}
+}

--- a/cgi/objectjson.c
+++ b/cgi/objectjson.c
@@ -70,74 +70,140 @@ int validate_arguments(json_object *, object_json_cgi_data *, time_t);
 authdata current_authdata;
 
 const string_value_mapping valid_queries[] = {
-	{ "hostcount", OBJECT_QUERY_HOSTCOUNT, 
-		"Return the number of hosts" },
-	{ "hostlist", OBJECT_QUERY_HOSTLIST, 
-		"Return a list of hosts" },
-	{ "host", OBJECT_QUERY_HOST, 
-		"Return the configuration for a single host" },
-	{ "hostgroupcount", OBJECT_QUERY_HOSTGROUPCOUNT, 
-		"Return the number of host groups" },
-	{ "hostgrouplist", OBJECT_QUERY_HOSTGROUPLIST, 
-		"Return a list of host groups" },
-	{ "hostgroup", OBJECT_QUERY_HOSTGROUP, 
-		"Return the configuration for a single hostgroup" },
-	{ "servicecount", OBJECT_QUERY_SERVICECOUNT, 
-		"Return a list of services" },
-	{ "servicelist", OBJECT_QUERY_SERVICELIST, 
-		"Return a list of services" },
-	{ "service", OBJECT_QUERY_SERVICE, 
-		"Return the configuration for a single service" },
-	{ "servicegroupcount", OBJECT_QUERY_SERVICEGROUPCOUNT, 
-		"Return the number of service groups" },
-	{ "servicegrouplist", OBJECT_QUERY_SERVICEGROUPLIST, 
-		"Return a list of service groups" },
-	{ "servicegroup", OBJECT_QUERY_SERVICEGROUP,
-		"Return the configuration for a single servicegroup" },
-	{ "contactcount", OBJECT_QUERY_CONTACTCOUNT, 
-		"Return the number of contacts" },
-	{ "contactlist", OBJECT_QUERY_CONTACTLIST, 
-		"Return a list of contacts" },
-	{ "contact", OBJECT_QUERY_CONTACT, 
-		"Return the configuration for a single contact" },
-	{ "contactgroupcount", OBJECT_QUERY_CONTACTGROUPCOUNT,
-		"Return the number of contact groups" },
-	{ "contactgrouplist", OBJECT_QUERY_CONTACTGROUPLIST,
-		"Return a list of contact groups" },
-	{ "contactgroup", OBJECT_QUERY_CONTACTGROUP,
-		"Return the configuration for a single contactgroup" },
-	{ "timeperiodcount", OBJECT_QUERY_TIMEPERIODCOUNT,
-		"Return the number of time periods" },
-	{ "timeperiodlist", OBJECT_QUERY_TIMEPERIODLIST,
-		"Return a list of time periods" },
-	{ "timeperiod", OBJECT_QUERY_TIMEPERIOD,
-		"Return the configuration for a single timeperiod" },
-	{ "commandcount", OBJECT_QUERY_COMMANDCOUNT,
-		"Return the number of commands" },
-	{ "commandlist", OBJECT_QUERY_COMMANDLIST,
-		"Return a list of commands" },
-	{ "command", OBJECT_QUERY_COMMAND,
-		"Return the configuration for a single command" },
-	{ "servicedependencycount", OBJECT_QUERY_SERVICEDEPENDENCYCOUNT,
-		"Return the number of service dependencies" },
-	{ "servicedependencylist", OBJECT_QUERY_SERVICEDEPENDENCYLIST,
-		"Return a list of service dependencies" },
-	{ "serviceescalationcount", OBJECT_QUERY_SERVICEESCALATIONCOUNT,
-		"Return the number of service escalations" },
-	{ "serviceescalationlist", OBJECT_QUERY_SERVICEESCALATIONLIST,
-		"Return a list of service escalations" },
-	{ "hostdependencycount", OBJECT_QUERY_HOSTDEPENDENCYCOUNT,
-		"Return the number of host dependencies" },
-	{ "hostdependencylist", OBJECT_QUERY_HOSTDEPENDENCYLIST,
-		"Return a list of host dependencies" },
-	{ "hostescalationcount", OBJECT_QUERY_HOSTESCALATIONCOUNT,
-		"Return the number of host escalations" },
-	{ "hostescalationlist", OBJECT_QUERY_HOSTESCALATIONLIST,
-		"Return a list of host escalations" },
-	{ "help", OBJECT_QUERY_HELP, 
-		"Display help for this CGI" },
+	{
+		"hostcount", OBJECT_QUERY_HOSTCOUNT,
+		"Return the number of hosts"
+	},
+	{
+		"hostlist", OBJECT_QUERY_HOSTLIST,
+		"Return a list of hosts"
+	},
+	{
+		"host", OBJECT_QUERY_HOST,
+		"Return the configuration for a single host"
+	},
+	{
+		"hostgroupcount", OBJECT_QUERY_HOSTGROUPCOUNT,
+		"Return the number of host groups"
+	},
+	{
+		"hostgrouplist", OBJECT_QUERY_HOSTGROUPLIST,
+		"Return a list of host groups"
+	},
+	{
+		"hostgroup", OBJECT_QUERY_HOSTGROUP,
+		"Return the configuration for a single hostgroup"
+	},
+	{
+		"servicecount", OBJECT_QUERY_SERVICECOUNT,
+		"Return a list of services"
+	},
+	{
+		"servicelist", OBJECT_QUERY_SERVICELIST,
+		"Return a list of services"
+	},
+	{
+		"service", OBJECT_QUERY_SERVICE,
+		"Return the configuration for a single service"
+	},
+	{
+		"servicegroupcount", OBJECT_QUERY_SERVICEGROUPCOUNT,
+		"Return the number of service groups"
+	},
+	{
+		"servicegrouplist", OBJECT_QUERY_SERVICEGROUPLIST,
+		"Return a list of service groups"
+	},
+	{
+		"servicegroup", OBJECT_QUERY_SERVICEGROUP,
+		"Return the configuration for a single servicegroup"
+	},
+	{
+		"contactcount", OBJECT_QUERY_CONTACTCOUNT,
+		"Return the number of contacts"
+	},
+	{
+		"contactlist", OBJECT_QUERY_CONTACTLIST,
+		"Return a list of contacts"
+	},
+	{
+		"contact", OBJECT_QUERY_CONTACT,
+		"Return the configuration for a single contact"
+	},
+	{
+		"contactgroupcount", OBJECT_QUERY_CONTACTGROUPCOUNT,
+		"Return the number of contact groups"
+	},
+	{
+		"contactgrouplist", OBJECT_QUERY_CONTACTGROUPLIST,
+		"Return a list of contact groups"
+	},
+	{
+		"contactgroup", OBJECT_QUERY_CONTACTGROUP,
+		"Return the configuration for a single contactgroup"
+	},
+	{
+		"timeperiodcount", OBJECT_QUERY_TIMEPERIODCOUNT,
+		"Return the number of time periods"
+	},
+	{
+		"timeperiodlist", OBJECT_QUERY_TIMEPERIODLIST,
+		"Return a list of time periods"
+	},
+	{
+		"timeperiod", OBJECT_QUERY_TIMEPERIOD,
+		"Return the configuration for a single timeperiod"
+	},
+	{
+		"commandcount", OBJECT_QUERY_COMMANDCOUNT,
+		"Return the number of commands"
+	},
+	{
+		"commandlist", OBJECT_QUERY_COMMANDLIST,
+		"Return a list of commands"
+	},
+	{
+		"command", OBJECT_QUERY_COMMAND,
+		"Return the configuration for a single command"
+	},
+	{
+		"servicedependencycount", OBJECT_QUERY_SERVICEDEPENDENCYCOUNT,
+		"Return the number of service dependencies"
+	},
+	{
+		"servicedependencylist", OBJECT_QUERY_SERVICEDEPENDENCYLIST,
+		"Return a list of service dependencies"
+	},
+	{
+		"serviceescalationcount", OBJECT_QUERY_SERVICEESCALATIONCOUNT,
+		"Return the number of service escalations"
+	},
+	{
+		"serviceescalationlist", OBJECT_QUERY_SERVICEESCALATIONLIST,
+		"Return a list of service escalations"
+	},
+	{
+		"hostdependencycount", OBJECT_QUERY_HOSTDEPENDENCYCOUNT,
+		"Return the number of host dependencies"
+	},
+	{
+		"hostdependencylist", OBJECT_QUERY_HOSTDEPENDENCYLIST,
+		"Return a list of host dependencies"
+	},
+	{
+		"hostescalationcount", OBJECT_QUERY_HOSTESCALATIONCOUNT,
+		"Return the number of host escalations"
+	},
+	{
+		"hostescalationlist", OBJECT_QUERY_HOSTESCALATIONLIST,
+		"Return a list of host escalations"
+	},
+	{
+		"help", OBJECT_QUERY_HELP,
+		"Display help for this CGI"
+	},
 	{ NULL, -1, NULL },
-	};
+};
 
 static const int query_status[][2] = {
 	{ OBJECT_QUERY_HOSTCOUNT, QUERY_STATUS_BETA },
@@ -177,7 +243,7 @@ static const int query_status[][2] = {
 };
 
 option_help object_json_help[] = {
-	{ 
+	{
 		"query",
 		"Query",
 		"enumeration",
@@ -186,8 +252,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Specifies the type of query to be exeuted.",
 		valid_queries
-		},
-	{ 
+	},
+	{
 		"formatoptions",
 		"Format Options",
 		"list",
@@ -196,8 +262,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Specifies the formatting options to be used when displaying the results. Multiple options are allowed and are separated by a plus (+) sign..",
 		svm_format_options
-		},
-	{ 
+	},
+	{
 		"start",
 		"Start",
 		"integer",
@@ -206,8 +272,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Specifies the index (zero-based) of the first object in the list to be returned.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"count",
 		"Count",
 		"integer",
@@ -216,8 +282,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Specifies the number of objects in the list to be returned.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"dateformat",
 		"Date Format",
 		"string",
@@ -226,8 +292,8 @@ option_help object_json_help[] = {
 		NULL,
 		"strftime format string for values of type time_t. In the absence of a format, the Javascript default format of the number of milliseconds since the beginning of the Unix epoch is used. Because of URL encoding, percent signs must be encoded as %25 and a space must be encoded as a plus (+) sign.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"parenthost",
 		"Parent Host",
 		"nagios:objectjson/hostlist",
@@ -236,8 +302,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the hosts or serivces returned to those whose host parent is specified. A value of 'none' returns all hosts or services reachable directly by the Nagios core host.",
 		parent_host_extras
-		},
-	{ 
+	},
+	{
 		"childhost",
 		"Child Host",
 		"nagios:objectjson/hostlist",
@@ -246,8 +312,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the hosts or serivces returned to those whose having the host specified as a child host. A value of 'none' returns all hosts or services with no child hosts.",
 		child_host_extras
-		},
-	{ 
+	},
+	{
 		"details",
 		"Show Details",
 		"boolean",
@@ -256,8 +322,8 @@ option_help object_json_help[] = {
 		NULL,
 		"If true, return the details for all entities in the list.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hostname",
 		"Host Name",
 		"nagios:objectjson/hostlist",
@@ -266,8 +332,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for the host requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hostgroupmember",
 		"Host Group Member",
 		"nagios:objectjson/hostlist",
@@ -276,8 +342,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the hostgroups returned to those containing the hostgroupmember.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hostgroup",
 		"Host Group",
 		"nagios:objectjson/hostgrouplist",
@@ -286,8 +352,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Returns information applicable to the hostgroup or the hosts in the hostgroup depending on the query.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicegroup",
 		"Service Group",
 		"nagios:objectjson/servicegrouplist",
@@ -296,7 +362,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Returns information applicable to the servicegroup or the services in the servicegroup depending on the query.",
 		NULL
-		},
+	},
 	{
 		"parentservice",
 		"Parent Service",
@@ -306,7 +372,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the serivces returned to those whose service parent has the name specified. A value of 'none' returns all services with no service parent.",
 		parent_service_extras
-		},
+	},
 	{
 		"childservice",
 		"Child Service",
@@ -316,8 +382,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the serivces returned to those whose having the named service as a child service. A value of 'none' returns all services with no child services.",
 		child_service_extras
-		},
-	{ 
+	},
+	{
 		"contactgroup",
 		"Contact Group",
 		"nagios:objectjson/contactgrouplist",
@@ -326,8 +392,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Returns information applicable to the contactgroup or the contacts in the contactgroup depending on the query.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicedescription",
 		"Service Description",
 		"nagios:objectjson/servicelist",
@@ -336,8 +402,8 @@ option_help object_json_help[] = {
 		"hostname",
 		"Description for the service requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicegroupmemberhost",
 		"Service Group Member Host",
 		"nagios:objectjson/hostlist",
@@ -346,8 +412,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the servicegroups returned to those containing the servicegroupmemberhost (and servicegroupmemberservice).",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicegroupmemberservice",
 		"Service Group Member Service",
 		"nagios:objectjson/servicelist",
@@ -356,8 +422,8 @@ option_help object_json_help[] = {
 		"servicegroupmemberhost",
 		"Limits the servicegroups returned to those containing the servicegroupmemberservice (and servicegroupmemberhost).",
 		NULL
-		},
-	{ 
+	},
+	{
 		"contactname",
 		"Contact Name",
 		"nagios:objectjson/contactlist",
@@ -366,8 +432,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for the contact requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"contactgroupmember",
 		"Contact Group Member",
 		"nagios:objectjson/contactlist",
@@ -376,8 +442,8 @@ option_help object_json_help[] = {
 		NULL,
 		"Limits the contactgroups returned to those containing the contactgroupmember.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"timeperiod",
 		"Timeperiod Name",
 		"nagios:objectjson/timeperiodlist",
@@ -386,7 +452,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for the timeperiod requested.",
 		NULL
-		},
+	},
 	{
 		"checktimeperiod",
 		"Check Timeperiod Name",
@@ -396,7 +462,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name of a check timeperiod to be used as selection criteria.",
 		NULL
-		},
+	},
 	{
 		"hostnotificationtimeperiod",
 		"Host Notification Timeperiod Name",
@@ -406,7 +472,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name of a host notification timeperiod to be used as selection criteria.",
 		NULL
-		},
+	},
 	{
 		"servicenotificationtimeperiod",
 		"Service Notification Timeperiod Name",
@@ -416,7 +482,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name of a service notification timeperiod to be used as selection criteria.",
 		NULL
-		},
+	},
 	{
 		"command",
 		"Command Name",
@@ -426,7 +492,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for the command requested.",
 		NULL
-		},
+	},
 	{
 		"checkcommand",
 		"Check Command Name",
@@ -436,7 +502,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name of a check command to be be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"eventhandler",
 		"Event Handler Name",
@@ -446,7 +512,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name of an event handler to be be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"masterhostname",
 		"Master Host Name",
@@ -456,7 +522,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for a master host to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"masterhostgroupname",
 		"Master Hostgroup Name",
@@ -466,7 +532,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for a master hostgroup to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"masterservicedescription",
 		"Master Service Description",
@@ -476,7 +542,7 @@ option_help object_json_help[] = {
 		"masterhostname",
 		"Description for a master service to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"masterservicegroupname",
 		"Master Servicegroup Name",
@@ -486,7 +552,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for a master servicegroup to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"dependenthostname",
 		"Dependent Host Name",
@@ -496,7 +562,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for a dependent host to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"dependenthostgroupname",
 		"Dependent Hostgroup Name",
@@ -506,7 +572,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for a dependent hostgroup to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"dependentservicedescription",
 		"Dependent Service Description",
@@ -516,7 +582,7 @@ option_help object_json_help[] = {
 		"dependenthostname",
 		"Description for a dependent service to be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"dependentservicegroupname",
 		"Dependent Servicegroup Name",
@@ -526,7 +592,7 @@ option_help object_json_help[] = {
 		NULL,
 		"Name for a dependent servicegroup to be used as a selector.",
 		NULL
-		},
+	},
 	{ /* The last entry must contain all NULL entries */
 		NULL,
 		NULL,
@@ -536,35 +602,35 @@ option_help object_json_help[] = {
 		NULL,
 		NULL,
 		NULL
-		},
-	};
+	},
+};
 
-int json_object_host_passes_selection(host *, int, host *, int, host *, 
-		hostgroup *, contact *, contactgroup *, timeperiod *, timeperiod *,
-		command *, command *);
-json_object *json_object_host_selectors(int, int, int, host *, int, host *, 
-		hostgroup *, contact *, contactgroup *, timeperiod *, timeperiod *,
-		command *, command *);
+int json_object_host_passes_selection(host *, int, host *, int, host *,
+                                      hostgroup *, contact *, contactgroup *, timeperiod *, timeperiod *,
+                                      command *, command *);
+json_object *json_object_host_selectors(int, int, int, host *, int, host *,
+                                        hostgroup *, contact *, contactgroup *, timeperiod *, timeperiod *,
+                                        command *, command *);
 
 int json_object_hostgroup_passes_selection(hostgroup *, host *);
 json_object *json_object_hostgroup_selectors(int, int, host *);
 
-int json_object_service_passes_host_selection(host *, int, host *, int, host *, 
-		hostgroup *, host *);
-int json_object_service_passes_service_selection(service *, servicegroup *, 
-		contact *, char *, char *, char *, contactgroup *, timeperiod *,
-		timeperiod *, command *, command *);
-json_object *json_object_service_selectors(int, int, int, host *, int, host *, 
-		hostgroup *, host *, servicegroup *, contact *, char *, char *, char *,
-		contactgroup *, timeperiod *, timeperiod *, command *, command *);
+int json_object_service_passes_host_selection(host *, int, host *, int, host *,
+        hostgroup *, host *);
+int json_object_service_passes_service_selection(service *, servicegroup *,
+        contact *, char *, char *, char *, contactgroup *, timeperiod *,
+        timeperiod *, command *, command *);
+json_object *json_object_service_selectors(int, int, int, host *, int, host *,
+        hostgroup *, host *, servicegroup *, contact *, char *, char *, char *,
+        contactgroup *, timeperiod *, timeperiod *, command *, command *);
 
 int json_object_servicegroup_passes_selection(servicegroup *, service *);
 json_object *json_object_servicegroup_display_selectors(int, int, service *);
 
 int json_object_contact_passes_selection(contact *, contactgroup *,
-		timeperiod *, timeperiod *);
+        timeperiod *, timeperiod *);
 json_object *json_object_contact_selectors(int, int, contactgroup *,
-		timeperiod *, timeperiod *);
+        timeperiod *, timeperiod *);
 
 int json_object_contactgroup_passes_selection(contactgroup *, contact *);
 json_object *json_object_contactgroup_display_selectors(int, int, contact *);
@@ -574,28 +640,29 @@ json_object *json_object_timeperiod_selectors(int, int);
 json_object *json_object_command_selectors(int, int);
 
 int json_object_servicedependency_passes_selection(servicedependency *, host *,
-		hostgroup *, char *, servicegroup *, host *, hostgroup *, char *,
-		servicegroup *);
+        hostgroup *, char *, servicegroup *, host *, hostgroup *, char *,
+        servicegroup *);
 json_object *json_object_servicedependency_selectors(int, int, host *,
-		hostgroup *, char *, servicegroup *, host *, hostgroup *, char *,
-		servicegroup *);
+        hostgroup *, char *, servicegroup *, host *, hostgroup *, char *,
+        servicegroup *);
 
 int json_object_serviceescalation_passes_selection(serviceescalation *, host *,
-		char *, hostgroup *, servicegroup *, contact *, contactgroup *);
+        char *, hostgroup *, servicegroup *, contact *, contactgroup *);
 json_object *json_object_serviceescalation_selectors(int, int, host *, char *,
-		hostgroup *, servicegroup *, contact *, contactgroup *);
+        hostgroup *, servicegroup *, contact *, contactgroup *);
 
 int json_object_hostdependency_passes_selection(hostdependency *, host *,
-		hostgroup *, host *, hostgroup *);
+        hostgroup *, host *, hostgroup *);
 json_object *json_object_hostdependency_selectors(int, int, host *,
-		hostgroup *, host *, hostgroup *);
+        hostgroup *, host *, hostgroup *);
 
 int json_object_hostescalation_passes_selection(hostescalation *, host *,
-		hostgroup *, contact *, contactgroup *);
+        hostgroup *, contact *, contactgroup *);
 json_object *json_object_hostescalation_selectors(int, int, host *,
-		hostgroup *, contact *, contactgroup *);
+        hostgroup *, contact *, contactgroup *);
 
-int main(void) {
+int main(void)
+{
 	int result = OK;
 	time_t query_time;
 	object_json_cgi_data	cgi_data;
@@ -611,9 +678,9 @@ int main(void) {
 	if(NULL == json_root) {
 		printf( "Failed to create new json object\n");
 		exit( 1);
-		}
-	json_object_append_integer(json_root, "format_version", 
-			OUTPUT_FORMAT_VERSION);
+	}
+	json_object_append_integer(json_root, "format_version",
+	                           OUTPUT_FORMAT_VERSION);
 
 	init_cgi_data(&cgi_data);
 
@@ -622,13 +689,13 @@ int main(void) {
 	/* get the arguments passed in the URL */
 	result = process_cgivars(json_root, &cgi_data, query_time);
 	if(result != RESULT_SUCCESS) {
-		json_object_append_object(json_root, "data", 
-				json_help(object_json_help));
+		json_object_append_object(json_root, "data",
+		                          json_help(object_json_help));
 		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
-				cgi_data.format_options);
+		                  cgi_data.format_options);
 		document_footer();
 		return result;
-		}
+	}
 	whitespace = cgi_data.format_options & JSON_FORMAT_WHITESPACE;
 
 	/* reset internal variables */
@@ -637,89 +704,89 @@ int main(void) {
 	/* read the CGI configuration file */
 	result = read_cgi_config_file(get_cgi_config_location());
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not open CGI configuration file '%s' for reading!", 
-				get_cgi_config_location()));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not open CGI configuration file '%s' for reading!",
+		                                      get_cgi_config_location()));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
-				cgi_data.format_options);
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not open main configuration file '%s' for reading!",
-				main_config_file));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not open main configuration file '%s' for reading!",
+		                                      main_config_file));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all object configuration data */
-	result = read_all_object_configuration_data(main_config_file, 
-			READ_ALL_OBJECT_DATA);
+	result = read_all_object_configuration_data(main_config_file,
+	         READ_ALL_OBJECT_DATA);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not read some or all object configuration data!"));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not read some or all object configuration data!"));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* Get the update time on the object cache file */
 	if(stat(object_cache_file, &ocstat) < 0) {
 		json_object_append_object(json_root, "result",
-				json_result(query_time, THISCGI,
-				svm_get_string_from_value(cgi_data.query, valid_queries),
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not obtain object cache file status: %s!",
-				strerror(errno)));
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not obtain object cache file status: %s!",
+		                                      strerror(errno)));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		document_footer();
 		return ERROR;
-		}
+	}
 	last_object_cache_update = ocstat.st_mtime;
 
 	/* read all status data */
 	result = read_all_status_data(get_cgi_config_location(), READ_ALL_STATUS_DATA);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not read host and service status information!"));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not read host and service status information!"));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* validate arguments in URL */
 	result = validate_arguments(json_root, &cgi_data, query_time);
 	if(result != RESULT_SUCCESS) {
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
-				cgi_data.format_options);
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* get authentication information */
 	get_authentication_information(&current_authdata);
@@ -727,418 +794,418 @@ int main(void) {
 	/* Return something to the user */
 	switch( cgi_data.query) {
 	case OBJECT_QUERY_HOSTCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostcount(cgi_data.use_parent_host, 
-				cgi_data.parent_host, cgi_data.use_child_host, 
-				cgi_data.child_host, cgi_data.hostgroup, cgi_data.contact,
-				cgi_data.contactgroup, cgi_data.check_timeperiod,
-				cgi_data.host_notification_timeperiod, cgi_data.check_command,
-				cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostcount(cgi_data.use_parent_host,
+		                                  cgi_data.parent_host, cgi_data.use_child_host,
+		                                  cgi_data.child_host, cgi_data.hostgroup, cgi_data.contact,
+		                                  cgi_data.contactgroup, cgi_data.check_timeperiod,
+		                                  cgi_data.host_notification_timeperiod, cgi_data.check_command,
+		                                  cgi_data.event_handler));
 		break;
 	case OBJECT_QUERY_HOSTLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostlist(cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details, cgi_data.use_parent_host, 
-				cgi_data.parent_host, cgi_data.use_child_host, 
-				cgi_data.child_host, cgi_data.hostgroup, cgi_data.contact,
-				cgi_data.contactgroup, cgi_data.check_timeperiod,
-				cgi_data.host_notification_timeperiod, cgi_data.check_command,
-				cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostlist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details, cgi_data.use_parent_host,
+		                                  cgi_data.parent_host, cgi_data.use_child_host,
+		                                  cgi_data.child_host, cgi_data.hostgroup, cgi_data.contact,
+		                                  cgi_data.contactgroup, cgi_data.check_timeperiod,
+		                                  cgi_data.host_notification_timeperiod, cgi_data.check_command,
+		                                  cgi_data.event_handler));
 		break;
 	case OBJECT_QUERY_HOST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_host(cgi_data.format_options, cgi_data.host));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_host(cgi_data.format_options, cgi_data.host));
 		break;
 	case OBJECT_QUERY_HOSTGROUPCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostgroupcount(cgi_data.format_options, 
-				cgi_data.hostgroup_member));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostgroupcount(cgi_data.format_options,
+		                                  cgi_data.hostgroup_member));
 		break;
 	case OBJECT_QUERY_HOSTGROUPLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data",
-				json_object_hostgrouplist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.details, 
-				cgi_data.hostgroup_member));
+		                          json_object_hostgrouplist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.details,
+		                                  cgi_data.hostgroup_member));
 		break;
 	case OBJECT_QUERY_HOSTGROUP:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostgroup(cgi_data.format_options, 
-				cgi_data.hostgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostgroup(cgi_data.format_options,
+		                                  cgi_data.hostgroup));
 		break;
 	case OBJECT_QUERY_SERVICECOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_servicecount(cgi_data.host, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.servicegroup, cgi_data.contact, 
-				cgi_data.service_description, cgi_data.parent_service_name,
-				cgi_data.child_service_name, cgi_data.contactgroup,
-				cgi_data.check_timeperiod,
-				cgi_data.service_notification_timeperiod,
-				cgi_data.check_command, cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_servicecount(cgi_data.host,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.servicegroup, cgi_data.contact,
+		                                  cgi_data.service_description, cgi_data.parent_service_name,
+		                                  cgi_data.child_service_name, cgi_data.contactgroup,
+		                                  cgi_data.check_timeperiod,
+		                                  cgi_data.service_notification_timeperiod,
+		                                  cgi_data.check_command, cgi_data.event_handler));
 		break;
 	case OBJECT_QUERY_SERVICELIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_servicelist(cgi_data.format_options, cgi_data.start,
-				cgi_data.count, cgi_data.details, cgi_data.host, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.servicegroup, cgi_data.contact, 
-				cgi_data.service_description, cgi_data.parent_service_name,
-				cgi_data.child_service_name, cgi_data.contactgroup,
-				cgi_data.check_timeperiod,
-				cgi_data.service_notification_timeperiod,
-				cgi_data.check_command, cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_servicelist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details, cgi_data.host,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.servicegroup, cgi_data.contact,
+		                                  cgi_data.service_description, cgi_data.parent_service_name,
+		                                  cgi_data.child_service_name, cgi_data.contactgroup,
+		                                  cgi_data.check_timeperiod,
+		                                  cgi_data.service_notification_timeperiod,
+		                                  cgi_data.check_command, cgi_data.event_handler));
 		break;
 	case OBJECT_QUERY_SERVICE:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_service(cgi_data.format_options, cgi_data.service));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_service(cgi_data.format_options, cgi_data.service));
 		break;
 	case OBJECT_QUERY_SERVICEGROUPCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_servicegroupcount(cgi_data.servicegroup_member));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_servicegroupcount(cgi_data.servicegroup_member));
 		break;
 	case OBJECT_QUERY_SERVICEGROUPLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data",
-				json_object_servicegrouplist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.details, 
-				cgi_data.servicegroup_member));
+		                          json_object_servicegrouplist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.details,
+		                                  cgi_data.servicegroup_member));
 		break;
 	case OBJECT_QUERY_SERVICEGROUP:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_servicegroup(cgi_data.format_options, 
-				cgi_data.servicegroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_servicegroup(cgi_data.format_options,
+		                                  cgi_data.servicegroup));
 		break;
 	case OBJECT_QUERY_CONTACTCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_contactcount(cgi_data.contactgroup,
-				cgi_data.host_notification_timeperiod,
-				cgi_data.service_notification_timeperiod));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_contactcount(cgi_data.contactgroup,
+		                                  cgi_data.host_notification_timeperiod,
+		                                  cgi_data.service_notification_timeperiod));
 		break;
 	case OBJECT_QUERY_CONTACTLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_contactlist(cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details, cgi_data.contactgroup,
-				cgi_data.host_notification_timeperiod,
-				cgi_data.service_notification_timeperiod));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_contactlist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details, cgi_data.contactgroup,
+		                                  cgi_data.host_notification_timeperiod,
+		                                  cgi_data.service_notification_timeperiod));
 		break;
 	case OBJECT_QUERY_CONTACT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_contact(cgi_data.format_options, cgi_data.contact));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_contact(cgi_data.format_options, cgi_data.contact));
 		break;
 	case OBJECT_QUERY_CONTACTGROUPCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_contactgroupcount(cgi_data.contactgroup_member));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_contactgroupcount(cgi_data.contactgroup_member));
 		break;
 	case OBJECT_QUERY_CONTACTGROUPLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data",
-				json_object_contactgrouplist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.details, 
-				cgi_data.contactgroup_member));
+		                          json_object_contactgrouplist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.details,
+		                                  cgi_data.contactgroup_member));
 		break;
 	case OBJECT_QUERY_CONTACTGROUP:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_contactgroup(cgi_data.format_options, 
-				cgi_data.contactgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_contactgroup(cgi_data.format_options,
+		                                  cgi_data.contactgroup));
 		break;
 	case OBJECT_QUERY_TIMEPERIODCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_timeperiodcount());
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_timeperiodcount());
 		break;
 	case OBJECT_QUERY_TIMEPERIODLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_timeperiodlist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.details));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_timeperiodlist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.details));
 		break;
 	case OBJECT_QUERY_TIMEPERIOD:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_timeperiod(cgi_data.format_options, 
-				cgi_data.timeperiod));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_timeperiod(cgi_data.format_options,
+		                                  cgi_data.timeperiod));
 		break;
 	case OBJECT_QUERY_COMMANDCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data", json_object_commandcount());
 		break;
 	case OBJECT_QUERY_COMMANDLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_commandlist(cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_commandlist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details));
 		break;
 	case OBJECT_QUERY_COMMAND:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_command(cgi_data.format_options, cgi_data.command));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_command(cgi_data.format_options, cgi_data.command));
 		break;
 	case OBJECT_QUERY_SERVICEDEPENDENCYCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_servicedependencycount(cgi_data.master_host, 
-				cgi_data.master_hostgroup, cgi_data.master_service_description,
-				cgi_data.master_servicegroup, cgi_data.dependent_host,
-				cgi_data.dependent_hostgroup,
-				cgi_data.dependent_service_description,
-				cgi_data.dependent_servicegroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_servicedependencycount(cgi_data.master_host,
+		                                  cgi_data.master_hostgroup, cgi_data.master_service_description,
+		                                  cgi_data.master_servicegroup, cgi_data.dependent_host,
+		                                  cgi_data.dependent_hostgroup,
+		                                  cgi_data.dependent_service_description,
+		                                  cgi_data.dependent_servicegroup));
 		break;
 	case OBJECT_QUERY_SERVICEDEPENDENCYLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_servicedependencylist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.master_host,
-				cgi_data.master_hostgroup, cgi_data.master_service_description,
-				cgi_data.master_servicegroup, cgi_data.dependent_host,
-				cgi_data.dependent_hostgroup,
-				cgi_data.dependent_service_description,
-				cgi_data.dependent_servicegroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_servicedependencylist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.master_host,
+		                                  cgi_data.master_hostgroup, cgi_data.master_service_description,
+		                                  cgi_data.master_servicegroup, cgi_data.dependent_host,
+		                                  cgi_data.dependent_hostgroup,
+		                                  cgi_data.dependent_service_description,
+		                                  cgi_data.dependent_servicegroup));
 		break;
 	case OBJECT_QUERY_SERVICEESCALATIONCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_serviceescalationcount(cgi_data.host,
-				cgi_data.service_description, cgi_data.hostgroup,
-				cgi_data.servicegroup, cgi_data.contact,
-				cgi_data.contactgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_serviceescalationcount(cgi_data.host,
+		                                  cgi_data.service_description, cgi_data.hostgroup,
+		                                  cgi_data.servicegroup, cgi_data.contact,
+		                                  cgi_data.contactgroup));
 		break;
 	case OBJECT_QUERY_SERVICEESCALATIONLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_serviceescalationlist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.host,
-				cgi_data.service_description, cgi_data.hostgroup,
-				cgi_data.servicegroup, cgi_data.contact,
-				cgi_data.contactgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_serviceescalationlist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.host,
+		                                  cgi_data.service_description, cgi_data.hostgroup,
+		                                  cgi_data.servicegroup, cgi_data.contact,
+		                                  cgi_data.contactgroup));
 		break;
 	case OBJECT_QUERY_HOSTDEPENDENCYCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostdependencycount(cgi_data.master_host,
-				cgi_data.master_hostgroup, cgi_data.dependent_host,
-				cgi_data.dependent_hostgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostdependencycount(cgi_data.master_host,
+		                                  cgi_data.master_hostgroup, cgi_data.dependent_host,
+		                                  cgi_data.dependent_hostgroup));
 		break;
 	case OBJECT_QUERY_HOSTDEPENDENCYLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostdependencylist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.master_host,
-				cgi_data.master_hostgroup, cgi_data.dependent_host,
-				cgi_data.dependent_hostgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostdependencylist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.master_host,
+		                                  cgi_data.master_hostgroup, cgi_data.dependent_host,
+		                                  cgi_data.dependent_hostgroup));
 		break;
 	case OBJECT_QUERY_HOSTESCALATIONCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostescalationcount(cgi_data.host,
-				cgi_data.hostgroup, cgi_data.contact, cgi_data.contactgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostescalationcount(cgi_data.host,
+		                                  cgi_data.hostgroup, cgi_data.contact, cgi_data.contactgroup));
 		break;
 	case OBJECT_QUERY_HOSTESCALATIONLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_object_cache_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_object_hostescalationlist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.host,
-				cgi_data.hostgroup, cgi_data.contact, cgi_data.contactgroup));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_object_cache_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_object_hostescalationlist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.host,
+		                                  cgi_data.hostgroup, cgi_data.contact, cgi_data.contactgroup));
 		break;
 	case OBJECT_QUERY_HELP:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				compile_time(__DATE__, __TIME__), &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      compile_time(__DATE__, __TIME__), &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		break;
 	default:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, &current_authdata, RESULT_OPTION_MISSING,
-				"Error: Object Type not specified. See data for help."));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, &current_authdata, RESULT_OPTION_MISSING,
+		                                      "Error: Object Type not specified. See data for help."));
 		json_object_append_object(json_root, "data", json_help(object_json_help));
 		break;
-		}
+	}
 
 	json_object_print(json_root, 0, 1, cgi_data.strftime_format,
-			cgi_data.format_options);
+	                  cgi_data.format_options);
 	document_footer();
 
 	/* free all allocated memory */
@@ -1147,9 +1214,10 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
-void document_header(int whitespace) {
+void document_header(int whitespace)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t expire_time;
 	time_t current_time;
@@ -1169,18 +1237,20 @@ void document_header(int whitespace) {
 	printf("Content-type: application/json; charset=utf-8\r\n\r\n");
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	printf( "\n");
 
 	return;
-	}
+}
 
 
-void init_cgi_data(object_json_cgi_data *cgi_data) {
+void init_cgi_data(object_json_cgi_data *cgi_data)
+{
 	cgi_data->format_options = 0;
 	cgi_data->query = OBJECT_QUERY_INVALID;
 	cgi_data->start = 0;
@@ -1246,7 +1316,8 @@ void init_cgi_data(object_json_cgi_data *cgi_data) {
 	cgi_data->dependent_servicegroup = NULL;
 }
 
-void free_cgi_data( object_json_cgi_data *cgi_data) {
+void free_cgi_data( object_json_cgi_data *cgi_data)
+{
 	if( NULL != cgi_data->strftime_format) free( cgi_data->strftime_format);
 	if( NULL != cgi_data->parent_host_name) free( cgi_data->parent_host_name);
 	if( NULL != cgi_data->child_host_name) free( cgi_data->child_host_name);
@@ -1277,11 +1348,12 @@ void free_cgi_data( object_json_cgi_data *cgi_data) {
 	if( NULL != cgi_data->dependent_hostgroup_name) free(cgi_data->dependent_hostgroup_name);
 	if( NULL != cgi_data->dependent_service_description) free(cgi_data->dependent_service_description);
 	if( NULL != cgi_data->dependent_servicegroup_name) free(cgi_data->dependent_servicegroup_name);
-	}
+}
 
 
 int process_cgivars(json_object *json_root, object_json_cgi_data *cgi_data,
-		time_t query_time) {
+                    time_t query_time)
+{
 	char **variables;
 	int result = RESULT_SUCCESS;
 	int x;
@@ -1299,461 +1371,462 @@ int process_cgivars(json_object *json_root, object_json_cgi_data *cgi_data,
 		whitespace = cgi_data->format_options & JSON_FORMAT_WHITESPACE;
 
 		if(!strcmp(variables[x], "query")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_queries, &(cgi_data->query)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_queries, &(cgi_data->query)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "formatoptions")) {
 			cgi_data->format_options = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_format_options,
-					&(cgi_data->format_options))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_format_options,
+			                                  &(cgi_data->format_options))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "start")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->start))) != RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->start))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "count")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->count))) != RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->count))) != RESULT_SUCCESS) {
 				break;
-				}
+			}
 
 			if(cgi_data->count == 0) {
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries),
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
-						"The count option value is invalid. "
-						"It must be an integer greater than zero"));
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
+				                                      "The count option value is invalid. "
+				                                      "It must be an integer greater than zero"));
 				result = RESULT_OPTION_VALUE_INVALID;
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "parenthost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->parent_host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->parent_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "childhost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->child_host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->child_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostname")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostgroupmember")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->hostgroup_member_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->hostgroup_member_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostgroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->hostgroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->hostgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicegroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->servicegroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->servicegroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "parentservice")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->parent_service_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->parent_service_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "childservice")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->child_service_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->child_service_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactgroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contactgroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contactgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicedescription")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->service_description)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->service_description)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicegroupmemberhost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->servicegroup_member_host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->servicegroup_member_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicegroupmemberservice")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1],
-					&(cgi_data->servicegroup_member_service_description)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1],
+			                                 &(cgi_data->servicegroup_member_service_description)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactname")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contact_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contact_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactgroupmember")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contactgroup_member_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contactgroup_member_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "timeperiod")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "checktimeperiod")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->check_timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->check_timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostnotificationtimeperiod")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1],
-					&(cgi_data->host_notification_timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1],
+			                                 &(cgi_data->host_notification_timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicenotificationtimeperiod")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1],
-					&(cgi_data->service_notification_timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1],
+			                                 &(cgi_data->service_notification_timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "command")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->command_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->command_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "checkcommand")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->check_command_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->check_command_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "eventhandler")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->event_handler_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->event_handler_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "masterhostname")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->master_host_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->master_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "masterhostgroupname")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->master_hostgroup_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->master_hostgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "masterservicedescription")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->master_service_description)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->master_service_description)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "masterservicegroupname")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->master_servicegroup_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->master_servicegroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dependenthostname")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->dependent_host_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->dependent_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dependenthostgroupname")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->dependent_hostgroup_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->dependent_hostgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dependentservicedescription")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->dependent_service_description)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->dependent_service_description)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dependentservicegroupname")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->dependent_servicegroup_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->dependent_servicegroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "details")) {
-			if((result = parse_boolean_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->details))) != RESULT_SUCCESS) {
+			if((result = parse_boolean_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], &(cgi_data->details))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dateformat")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->strftime_format)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->strftime_format)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], ""));
 
 		else {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, RESULT_OPTION_INVALID,
-					"Invalid option: '%s'.", variables[x]));
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, RESULT_OPTION_INVALID,
+			                                      "Invalid option: '%s'.", variables[x]));
 			result = RESULT_OPTION_INVALID;
 			break;
-			}
 		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return result;
-	}
+}
 
 int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
-		time_t query_time) {
+                       time_t query_time)
+{
 	int result = RESULT_SUCCESS;
 	host *temp_host = NULL;
 	hostgroup *temp_hostgroup = NULL;
@@ -1777,13 +1850,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_HOST:
 		if( NULL == cgi_data->host_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Host information requested, but no host name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Host information requested, but no host name specified."));
+		}
 		break;
 	case OBJECT_QUERY_HOSTGROUPCOUNT:
 		break;
@@ -1792,13 +1865,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_HOSTGROUP:
 		if( NULL == cgi_data->hostgroup_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Hostgroup information requested, but no hostgroup name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Hostgroup information requested, but no hostgroup name specified."));
+		}
 		break;
 	case OBJECT_QUERY_SERVICECOUNT:
 		break;
@@ -1807,22 +1880,22 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_SERVICE:
 		if( NULL == cgi_data->host_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Service information requested, but no host name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Service information requested, but no host name specified."));
+		}
 		if( NULL == cgi_data->service_description) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Service information requested, but no service description specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Service information requested, but no service description specified."));
+		}
 		break;
 	case OBJECT_QUERY_SERVICEGROUPCOUNT:
 		break;
@@ -1831,13 +1904,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_SERVICEGROUP:
 		if( NULL == cgi_data->servicegroup_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Service group information requested, but no service group name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Service group information requested, but no service group name specified."));
+		}
 		break;
 	case OBJECT_QUERY_CONTACTCOUNT:
 		break;
@@ -1846,13 +1919,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_CONTACT:
 		if( NULL == cgi_data->contact_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Contact information requested, but no contact name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Contact information requested, but no contact name specified."));
+		}
 		break;
 	case OBJECT_QUERY_CONTACTGROUPCOUNT:
 		break;
@@ -1861,13 +1934,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_CONTACTGROUP:
 		if( NULL == cgi_data->contactgroup_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Contactgroup information requested, but no contactgroup name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Contactgroup information requested, but no contactgroup name specified."));
+		}
 		break;
 	case OBJECT_QUERY_TIMEPERIODCOUNT:
 		break;
@@ -1876,13 +1949,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_TIMEPERIOD:
 		if( NULL == cgi_data->timeperiod_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Timeperiod information requested, but no timeperiod name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Timeperiod information requested, but no timeperiod name specified."));
+		}
 		break;
 	case OBJECT_QUERY_COMMANDCOUNT:
 		break;
@@ -1891,13 +1964,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	case OBJECT_QUERY_COMMAND:
 		if( NULL == cgi_data->command_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Command information requested, but no command name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Command information requested, but no command name specified."));
+		}
 		break;
 	case OBJECT_QUERY_SERVICEDEPENDENCYCOUNT:
 		break;
@@ -1920,13 +1993,13 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 	default:
 		result = RESULT_OPTION_MISSING;
 		json_object_append_object(json_root, "result", json_result(query_time,
-				THISCGI,
-				svm_get_string_from_value(cgi_data->query, valid_queries),
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result,
-				"Missing validation for object type %u.", cgi_data->query));
+		                          THISCGI,
+		                          svm_get_string_from_value(cgi_data->query, valid_queries),
+		                          get_query_status(query_status, cgi_data->query),
+		                          (time_t)-1, authinfo, result,
+		                          "Missing validation for object type %u.", cgi_data->query));
 		break;
-		}
+	}
 
 	/* Validate the requested parent host */
 	if( NULL != cgi_data->parent_host_name) {
@@ -1937,20 +2010,19 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 			if( NULL == temp_host) {
 				cgi_data->use_parent_host = 0;
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries), 
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The parenthost '%s' could not be found.", 
-						cgi_data->parent_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The parenthost '%s' could not be found.",
+				                                      cgi_data->parent_host_name));
+			} else {
 				cgi_data->parent_host = temp_host;
-				}
 			}
 		}
+	}
 
 	/* Validate the requested child host */
 	if( NULL != cgi_data->child_host_name) {
@@ -1961,220 +2033,208 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 			if( NULL == temp_host) {
 				cgi_data->use_child_host = 0;
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries), 
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The childhost '%s' could not be found.", 
-						cgi_data->child_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The childhost '%s' could not be found.",
+				                                      cgi_data->child_host_name));
+			} else {
 				cgi_data->child_host = temp_host;
-				}
 			}
 		}
+	}
 
 	/* Validate the requested host */
 	if( NULL != cgi_data->host_name) {
 		temp_host = find_host(cgi_data->host_name);
 		if( NULL == temp_host) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The host '%s' could not be found.", cgi_data->host_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The host '%s' could not be found.", cgi_data->host_name));
+		} else {
 			cgi_data->host = temp_host;
-			}
 		}
+	}
 
 	/* Validate the requested hostgroup member */
 	if( NULL != cgi_data->hostgroup_member_name) {
 		temp_host = find_host(cgi_data->hostgroup_member_name);
 		if( NULL == temp_host) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The hostgroup member '%s' could not be found.", 
-					cgi_data->hostgroup_member_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The hostgroup member '%s' could not be found.",
+			                                      cgi_data->hostgroup_member_name));
+		} else {
 			cgi_data->hostgroup_member = temp_host;
-			}
 		}
+	}
 
 	/* Validate the requested hostgroup */
 	if( NULL != cgi_data->hostgroup_name) {
 		temp_hostgroup = find_hostgroup(cgi_data->hostgroup_name);
 		if( NULL == temp_hostgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The hostgroup '%s' could not be found.", 
-					cgi_data->hostgroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The hostgroup '%s' could not be found.",
+			                                      cgi_data->hostgroup_name));
+		} else {
 			cgi_data->hostgroup = temp_hostgroup;
-			}
 		}
+	}
 
 	/* Validate the requested servicegroup */
 	if( NULL != cgi_data->servicegroup_name) {
 		temp_servicegroup = find_servicegroup(cgi_data->servicegroup_name);
 		if( NULL == temp_servicegroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The servicegroup '%s' could not be found.", 
-					cgi_data->servicegroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The servicegroup '%s' could not be found.",
+			                                      cgi_data->servicegroup_name));
+		} else {
 			cgi_data->servicegroup = temp_servicegroup;
-			}
 		}
+	}
 
 	/* Validate the requested contactgroup */
 	if( NULL != cgi_data->contactgroup_name) {
 		temp_contactgroup = find_contactgroup(cgi_data->contactgroup_name);
 		if( NULL == temp_contactgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The contactgroup '%s' could not be found.", 
-					cgi_data->contactgroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The contactgroup '%s' could not be found.",
+			                                      cgi_data->contactgroup_name));
+		} else {
 			cgi_data->contactgroup = temp_contactgroup;
-			}
 		}
+	}
 
 	/* Validate the requested service. Note that the host name is not a
-		required parameter for all queries and so it may not make sense to 
+		required parameter for all queries and so it may not make sense to
 		try to obtain the service associated with a service description */
-	if((NULL != cgi_data->service_description) && 
-			(NULL != cgi_data->host_name)) {
-		temp_service = find_service(cgi_data->host_name, 
-				cgi_data->service_description);
+	if((NULL != cgi_data->service_description) &&
+	   (NULL != cgi_data->host_name)) {
+		temp_service = find_service(cgi_data->host_name,
+		                            cgi_data->service_description);
 		if( NULL == temp_service) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The service '%s' on host '%s' could not be found.", 
-					cgi_data->service_description, cgi_data->host_name));
-			}
-		else {
-				cgi_data->service = temp_service;
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The service '%s' on host '%s' could not be found.",
+			                                      cgi_data->service_description, cgi_data->host_name));
+		} else {
+			cgi_data->service = temp_service;
 		}
+	}
 
-	/* Validate the requested servicegroup member host name and service 
+	/* Validate the requested servicegroup member host name and service
 		description */
-	if( NULL != cgi_data->servicegroup_member_host_name || 
-			NULL != cgi_data->servicegroup_member_service_description) {
-		if( NULL == cgi_data->servicegroup_member_host_name || 
-				NULL == cgi_data->servicegroup_member_service_description) {
+	if( NULL != cgi_data->servicegroup_member_host_name ||
+	    NULL != cgi_data->servicegroup_member_service_description) {
+		if( NULL == cgi_data->servicegroup_member_host_name ||
+		    NULL == cgi_data->servicegroup_member_service_description) {
 			result = RESULT_OPTION_VALUE_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"If either the servicegroupmemberhost or servicegroupmemberservice is specified, both must be specified."));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "If either the servicegroupmemberhost or servicegroupmemberservice is specified, both must be specified."));
+		} else {
 			temp_service = find_service( cgi_data->servicegroup_member_host_name,
-					cgi_data->servicegroup_member_service_description);
+			                             cgi_data->servicegroup_member_service_description);
 			if( NULL == temp_service) {
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries),
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The servicegroup member service '%s' on host '%s' could not be found.", 
-						cgi_data->servicegroup_member_service_description,
-						cgi_data->servicegroup_member_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The servicegroup member service '%s' on host '%s' could not be found.",
+				                                      cgi_data->servicegroup_member_service_description,
+				                                      cgi_data->servicegroup_member_host_name));
+			} else {
 				cgi_data->servicegroup_member = temp_service;
-				}
 			}
 		}
+	}
 
 	/* Validate the requested contact */
 	if( NULL != cgi_data->contact_name) {
 		temp_contact = find_contact(cgi_data->contact_name);
 		if( NULL == temp_contact) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The contact '%s' could not be found.",
-					cgi_data->contact_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The contact '%s' could not be found.",
+			                                      cgi_data->contact_name));
+		} else {
 			cgi_data->contact = temp_contact;
-			}
 		}
+	}
 
 	/* Validate the requested contactgroup member */
 	if( NULL != cgi_data->contactgroup_member_name) {
 		temp_contact = find_contact(cgi_data->contactgroup_member_name);
 		if( NULL == temp_contact) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The contactgroup member '%s' could not be found.", 
-					cgi_data->contactgroup_member_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The contactgroup member '%s' could not be found.",
+			                                      cgi_data->contactgroup_member_name));
+		} else {
 			cgi_data->contactgroup_member = temp_contact;
-			}
 		}
+	}
 
 	/* Validate the requested timeperiod */
 	if( NULL != cgi_data->timeperiod_name) {
 		temp_timeperiod = find_timeperiod(cgi_data->timeperiod_name);
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The timeperiod '%s' could not be found.", 
-					cgi_data->timeperiod_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The timeperiod '%s' could not be found.",
+			                                      cgi_data->timeperiod_name));
+		} else {
 			cgi_data->timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested check timeperiod */
 	if( NULL != cgi_data->check_timeperiod_name) {
@@ -2182,72 +2242,68 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The check timeperiod '%s' could not be found.",
-					cgi_data->check_timeperiod_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The check timeperiod '%s' could not be found.",
+			                                      cgi_data->check_timeperiod_name));
+		} else {
 			cgi_data->check_timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested host notification timeperiod */
 	if( NULL != cgi_data->host_notification_timeperiod_name) {
 		temp_timeperiod =
-				find_timeperiod(cgi_data->host_notification_timeperiod_name);
+		    find_timeperiod(cgi_data->host_notification_timeperiod_name);
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The host notification timeperiod '%s' could not be found.",
-					cgi_data->host_notification_timeperiod_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The host notification timeperiod '%s' could not be found.",
+			                                      cgi_data->host_notification_timeperiod_name));
+		} else {
 			cgi_data->host_notification_timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested service notification timeperiod */
 	if( NULL != cgi_data->service_notification_timeperiod_name) {
 		temp_timeperiod =
-				find_timeperiod(cgi_data->service_notification_timeperiod_name);
+		    find_timeperiod(cgi_data->service_notification_timeperiod_name);
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The service notification timeperiod '%s' could not be found.",
-					cgi_data->service_notification_timeperiod_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The service notification timeperiod '%s' could not be found.",
+			                                      cgi_data->service_notification_timeperiod_name));
+		} else {
 			cgi_data->service_notification_timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested command */
 	if( NULL != cgi_data->command_name) {
 		temp_command = find_command(cgi_data->command_name);
 		if( NULL == temp_command) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result, "The command '%s' could not be found.", 
-					cgi_data->command_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result, "The command '%s' could not be found.",
+			                                      cgi_data->command_name));
+		} else {
 			cgi_data->command = temp_command;
-			}
 		}
+	}
 
 	/* Validate the requested check command */
 	if( NULL != cgi_data->check_command_name) {
@@ -2255,17 +2311,16 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_command) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The check command '%s' could not be found.",
-					cgi_data->check_command_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The check command '%s' could not be found.",
+			                                      cgi_data->check_command_name));
+		} else {
 			cgi_data->check_command = temp_command;
-			}
 		}
+	}
 
 	/* Validate the requested event handler */
 	if( NULL != cgi_data->event_handler_name) {
@@ -2273,17 +2328,16 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_command) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The event handler '%s' could not be found.",
-					cgi_data->event_handler_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The event handler '%s' could not be found.",
+			                                      cgi_data->event_handler_name));
+		} else {
 			cgi_data->event_handler = temp_command;
-			}
 		}
+	}
 
 	/* Validate the requested master host */
 	if( NULL != cgi_data->master_host_name) {
@@ -2291,17 +2345,16 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_host) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The master host '%s' could not be found.",
-					cgi_data->master_host_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The master host '%s' could not be found.",
+			                                      cgi_data->master_host_name));
+		} else {
 			cgi_data->master_host = temp_host;
-			}
 		}
+	}
 
 	/* Validate the requested master hostgroup */
 	if( NULL != cgi_data->master_hostgroup_name) {
@@ -2309,36 +2362,34 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_hostgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The master hostgroup '%s' could not be found.",
-					cgi_data->master_hostgroup_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The master hostgroup '%s' could not be found.",
+			                                      cgi_data->master_hostgroup_name));
+		} else {
 			cgi_data->master_hostgroup = temp_hostgroup;
-			}
 		}
+	}
 
 	/* Validate the requested master servicegroup */
 	if( NULL != cgi_data->master_servicegroup_name) {
 		temp_servicegroup =
-				find_servicegroup(cgi_data->master_servicegroup_name);
+		    find_servicegroup(cgi_data->master_servicegroup_name);
 		if( NULL == temp_servicegroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The master servicegroup '%s' could not be found.",
-					cgi_data->master_servicegroup_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The master servicegroup '%s' could not be found.",
+			                                      cgi_data->master_servicegroup_name));
+		} else {
 			cgi_data->master_servicegroup = temp_servicegroup;
-			}
 		}
+	}
 
 	/* Validate the requested dependent host */
 	if( NULL != cgi_data->dependent_host_name) {
@@ -2346,17 +2397,16 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_host) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The dependent host '%s' could not be found.",
-					cgi_data->dependent_host_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The dependent host '%s' could not be found.",
+			                                      cgi_data->dependent_host_name));
+		} else {
 			cgi_data->dependent_host = temp_host;
-			}
 		}
+	}
 
 	/* Validate the requested dependent hostgroup */
 	if( NULL != cgi_data->dependent_hostgroup_name) {
@@ -2364,228 +2414,230 @@ int validate_arguments(json_object *json_root, object_json_cgi_data *cgi_data,
 		if( NULL == temp_hostgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The dependent hostgroup '%s' could not be found.",
-					cgi_data->dependent_hostgroup_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The dependent hostgroup '%s' could not be found.",
+			                                      cgi_data->dependent_hostgroup_name));
+		} else {
 			cgi_data->dependent_hostgroup = temp_hostgroup;
-			}
 		}
+	}
 
 	/* Validate the requested dependent servicegroup */
 	if( NULL != cgi_data->dependent_servicegroup_name) {
 		temp_servicegroup =
-				find_servicegroup(cgi_data->dependent_servicegroup_name);
+		    find_servicegroup(cgi_data->dependent_servicegroup_name);
 		if( NULL == temp_servicegroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The dependent servicegroup '%s' could not be found.",
-					cgi_data->dependent_servicegroup_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The dependent servicegroup '%s' could not be found.",
+			                                      cgi_data->dependent_servicegroup_name));
+		} else {
 			cgi_data->dependent_servicegroup = temp_servicegroup;
-			}
 		}
-
-	return result;
 	}
 
+	return result;
+}
+
 int json_object_host_passes_selection(host *temp_host, int use_parent_host,
-		host *parent_host, int use_child_host, host *child_host,
-		hostgroup *temp_hostgroup, contact *temp_contact,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+                                      host *parent_host, int use_child_host, host *child_host,
+                                      hostgroup *temp_hostgroup, contact *temp_contact,
+                                      contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+                                      timeperiod *notification_timeperiod, command *check_command,
+                                      command *event_handler)
+{
 
 	host *temp_host2;
 
 	/* Skip if user is not authorized for this host */
 	if(FALSE == is_authorized_for_host(temp_host, &current_authdata)) {
 		return 0;
-		}
+	}
 
-	/* If the host parent was specified, skip this host if it's parent is 
+	/* If the host parent was specified, skip this host if it's parent is
 		not the parent host specified */
-	if( 1 == use_parent_host && 
-			FALSE == is_host_immediate_child_of_host(parent_host, temp_host)) {
+	if( 1 == use_parent_host &&
+	    FALSE == is_host_immediate_child_of_host(parent_host, temp_host)) {
 		return 0;
-		}
+	}
 
 	/* If the hostgroup was specified, skip this host if it is not a member
 		of the hostgroup specified */
-	if( NULL != temp_hostgroup && 
-			( FALSE == is_host_member_of_hostgroup(temp_hostgroup, 
-					temp_host))) {
+	if( NULL != temp_hostgroup &&
+	    ( FALSE == is_host_member_of_hostgroup(temp_hostgroup,
+	            temp_host))) {
 		return 0;
-		}
+	}
 
 	/* If the contact was specified, skip this host if it does not have
 		the contact specified */
-	if( NULL != temp_contact && 
-			( FALSE == is_contact_for_host(temp_host, temp_contact))) {
+	if( NULL != temp_contact &&
+	    ( FALSE == is_contact_for_host(temp_host, temp_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a contactgroup was specified, skip this host if it does not have
 		the contactgroup specified */
 	if(NULL != temp_contactgroup &&
-			(FALSE == is_contactgroup_for_host(temp_host, temp_contactgroup))) {
+	   (FALSE == is_contactgroup_for_host(temp_host, temp_contactgroup))) {
 		return 0;
-		}
+	}
 
 	/* If a check timeperiod was specified, skip this host if it does not have
 		the check timeperiod specified */
 	if(NULL != check_timeperiod &&
-			(check_timeperiod != temp_host->check_period_ptr)) {
+	   (check_timeperiod != temp_host->check_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a notification timeperiod was specified, skip this host if it
 		does not have the notification timeperiod specified */
 	if(NULL != notification_timeperiod &&
-			(notification_timeperiod != temp_host->notification_period_ptr)) {
+	   (notification_timeperiod != temp_host->notification_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a check command was specified, skip this host if it does not
 		have the check command specified */
 	if(NULL != check_command &&
-			(check_command != temp_host->check_command_ptr)) {
+	   (check_command != temp_host->check_command_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If an event handler was specified, skip this host if it does not
 		have the event handler specified */
 	if(NULL != event_handler &&
-			(event_handler != temp_host->event_handler_ptr)) {
+	   (event_handler != temp_host->event_handler_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a child host was specified... */
-	if(1 == use_child_host) { 
+	if(1 == use_child_host) {
 		/* If the child host is "none", skip this host if it has children */
 		if(NULL == child_host) {
-			for(temp_host2 = host_list; temp_host2 != NULL; 
-					temp_host2 = temp_host2->next) {
-				if(TRUE == is_host_immediate_child_of_host(temp_host, 
-						temp_host2)) {
+			for(temp_host2 = host_list; temp_host2 != NULL;
+			    temp_host2 = temp_host2->next) {
+				if(TRUE == is_host_immediate_child_of_host(temp_host,
+				        temp_host2)) {
 					return 0;
-					}
 				}
 			}
+		}
 		/* Otherwise, skip this host if it does not have the specified host
 			as a child */
 		else if(FALSE == is_host_immediate_child_of_host(temp_host, child_host)) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
-json_object * json_object_host_selectors(int start, int count, 
-		int use_parent_host, host *parent_host, int use_child_host,
-		host *child_host, hostgroup *temp_hostgroup, contact *temp_contact,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+	return 1;
+}
+
+json_object * json_object_host_selectors(int start, int count,
+        int use_parent_host, host *parent_host, int use_child_host,
+        host *child_host, hostgroup *temp_hostgroup, contact *temp_contact,
+        contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+        timeperiod *notification_timeperiod, command *check_command,
+        command *event_handler)
+{
 
 	json_object *json_selectors;
 
 	json_selectors = json_new_object();
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( 1 == use_parent_host) {
-		json_object_append_string(json_selectors, "parenthost", 
-				( NULL == parent_host ? "none" : parent_host->name));
-		}
+		json_object_append_string(json_selectors, "parenthost",
+		                          ( NULL == parent_host ? "none" : parent_host->name));
+	}
 	if( 1 == use_child_host) {
-		json_object_append_string(json_selectors, "childhost", 
-				( NULL == child_host ? "none" : child_host->name));
-		}
+		json_object_append_string(json_selectors, "childhost",
+		                          ( NULL == child_host ? "none" : child_host->name));
+	}
 	if( NULL != temp_hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				temp_hostgroup->group_name);
-		}
+		json_object_append_string(json_selectors, "hostgroup",
+		                          temp_hostgroup->group_name);
+	}
 	if( NULL != temp_contact) {
 		json_object_append_string(json_selectors, "contact",
-				temp_contact->name);
-		}
+		                          temp_contact->name);
+	}
 	if( NULL != temp_contactgroup) {
 		json_object_append_string(json_selectors, "contactgroup",
-				temp_contactgroup->group_name);
-		}
+		                          temp_contactgroup->group_name);
+	}
 	if( NULL != check_timeperiod) {
 		json_object_append_string(json_selectors, "checktimeperiod",
-				check_timeperiod->name);
-		}
+		                          check_timeperiod->name);
+	}
 	if( NULL != notification_timeperiod) {
 		json_object_append_string(json_selectors, "hostnotificationtimeperiod",
-				notification_timeperiod->name);
-		}
+		                          notification_timeperiod->name);
+	}
 	if( NULL != check_command) {
 		json_object_append_string(json_selectors, "checkcommand",
-				check_command->name);
-		}
+		                          check_command->name);
+	}
 	if( NULL != event_handler) {
 		json_object_append_string(json_selectors, "eventhandler",
-				event_handler->name);
-		}
-
-	return json_selectors;
+		                          event_handler->name);
 	}
 
-json_object * json_object_hostcount(int use_parent_host, host *parent_host, 
-		int use_child_host, host *child_host, hostgroup *temp_hostgroup, 
-		contact *temp_contact, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+	return json_selectors;
+}
+
+json_object * json_object_hostcount(int use_parent_host, host *parent_host,
+                                    int use_child_host, host *child_host, hostgroup *temp_hostgroup,
+                                    contact *temp_contact, contactgroup *temp_contactgroup,
+                                    timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+                                    command *check_command, command *event_handler)
+{
 
 	json_object *json_data;
 	host *temp_host;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_host_selectors(0, 0, use_parent_host, parent_host, 
-			use_child_host, child_host, temp_hostgroup, temp_contact,
-			temp_contactgroup, check_timeperiod, notification_timeperiod,
-			check_command, event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_host_selectors(0, 0, use_parent_host, parent_host,
+	                                  use_child_host, child_host, temp_hostgroup, temp_contact,
+	                                  temp_contactgroup, check_timeperiod, notification_timeperiod,
+	                                  check_command, event_handler));
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
 		if(json_object_host_passes_selection(temp_host, use_parent_host,
-				parent_host, use_child_host, child_host, temp_hostgroup, 
-				temp_contact, temp_contactgroup, check_timeperiod,
-				notification_timeperiod, check_command, event_handler) == 0) {
+		                                     parent_host, use_child_host, child_host, temp_hostgroup,
+		                                     temp_contact, temp_contactgroup, check_timeperiod,
+		                                     notification_timeperiod, check_command, event_handler) == 0) {
 			continue;
-			}
+		}
 
 		count++;
-		}
+	}
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
 json_object * json_object_hostlist(unsigned format_options, int start,
-		int count, int details, int use_parent_host, host *parent_host,
-		int use_child_host, host *child_host, hostgroup *temp_hostgroup,
-		contact *temp_contact, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+                                   int count, int details, int use_parent_host, host *parent_host,
+                                   int use_child_host, host *child_host, hostgroup *temp_hostgroup,
+                                   contact *temp_contact, contactgroup *temp_contactgroup,
+                                   timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+                                   command *check_command, command *event_handler)
+{
 
 	json_object *json_data;
 	json_object *json_hostlist_object = NULL;
@@ -2596,56 +2648,54 @@ json_object * json_object_hostlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_host_selectors(start, count, use_parent_host, 
-			parent_host, use_child_host, child_host, temp_hostgroup, 
-			temp_contact, temp_contactgroup, check_timeperiod,
-			notification_timeperiod, check_command, event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_host_selectors(start, count, use_parent_host,
+	                                  parent_host, use_child_host, child_host, temp_hostgroup,
+	                                  temp_contact, temp_contactgroup, check_timeperiod,
+	                                  notification_timeperiod, check_command, event_handler));
 
 	if(details > 0) {
 		json_hostlist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_hostlist_array = json_new_array();
-		}
+	}
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
 		if(json_object_host_passes_selection(temp_host, use_parent_host,
-				parent_host, use_child_host, child_host, temp_hostgroup, 
-				temp_contact, temp_contactgroup, check_timeperiod,
-				notification_timeperiod, check_command, event_handler) == 0) {
+		                                     parent_host, use_child_host, child_host, temp_hostgroup,
+		                                     temp_contact, temp_contactgroup, check_timeperiod,
+		                                     notification_timeperiod, check_command, event_handler) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_host_details = json_new_object();
-				json_object_host_details(json_host_details, format_options, 
-						temp_host);
-				json_object_append_object(json_hostlist_object, temp_host->name, 
-						json_host_details);
-				}
-			else {
+				json_object_host_details(json_host_details, format_options,
+				                         temp_host);
+				json_object_append_object(json_hostlist_object, temp_host->name,
+				                          json_host_details);
+			} else {
 				json_array_append_string(json_hostlist_array, temp_host->name);
-				}
-			counted++;
 			}
-		current++; 
+			counted++;
 		}
+		current++;
+	}
 
 	if(details > 0) {
 		json_object_append_object(json_data, "hostlist", json_hostlist_object);
-		}
-	else {
+	} else {
 		json_object_append_array(json_data, "hostlist", json_hostlist_array);
-		}
-
-	return json_data;
 	}
 
-json_object *json_object_host(unsigned format_options, host *temp_host) {
+	return json_data;
+}
+
+json_object *json_object_host(unsigned format_options, host *temp_host)
+{
 
 	json_object *json_host = json_new_object();
 	json_object *json_details = json_new_object();
@@ -2657,8 +2707,9 @@ json_object *json_object_host(unsigned format_options, host *temp_host) {
 	return json_host;
 }
 
-void json_object_host_details(json_object *json_details, unsigned format_options, 
-		host *temp_host) {
+void json_object_host_details(json_object *json_details, unsigned format_options,
+                              host *temp_host)
+{
 
 	json_array *json_parent_hosts;
 	json_array *json_child_hosts;
@@ -2677,289 +2728,286 @@ void json_object_host_details(json_object *json_details, unsigned format_options
 	customvariablesmember *temp_custom_variablesmember;
 
 	json_object_append_string(json_details, "name", temp_host->name);
-	json_object_append_string(json_details, "display_name", 
-			temp_host->display_name);
+	json_object_append_string(json_details, "display_name",
+	                          temp_host->display_name);
 	json_object_append_string(json_details, "alias", temp_host->alias);
 	json_object_append_string(json_details, "address", temp_host->address);
 
 	json_parent_hosts = json_new_array();
-	for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL; 
-			temp_hostsmember = temp_hostsmember->next) {
+	for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL;
+	    temp_hostsmember = temp_hostsmember->next) {
 		json_array_append_string(json_parent_hosts, temp_hostsmember->host_name);
-		}
+	}
 	json_object_append_array(json_details, "parent_hosts", json_parent_hosts);
 
 	json_child_hosts = json_new_array();
-	for(temp_hostsmember = temp_host->child_hosts; temp_hostsmember != NULL; 
-			temp_hostsmember = temp_hostsmember->next) {
+	for(temp_hostsmember = temp_host->child_hosts; temp_hostsmember != NULL;
+	    temp_hostsmember = temp_hostsmember->next) {
 		json_array_append_string(json_child_hosts, temp_hostsmember->host_name);
-		}
+	}
 	json_object_append_array(json_details, "child_hosts", json_child_hosts);
 
 	json_services = json_new_array();
-	for(temp_servicesmember = temp_host->services; temp_servicesmember != NULL; 
-			temp_servicesmember = temp_servicesmember->next) {
-		json_array_append_string(json_services, 
-				temp_servicesmember->service_description);
-		}
+	for(temp_servicesmember = temp_host->services; temp_servicesmember != NULL;
+	    temp_servicesmember = temp_servicesmember->next) {
+		json_array_append_string(json_services,
+		                         temp_servicesmember->service_description);
+	}
 	json_object_append_array(json_details, "services", json_services);
 
 #ifdef JSON_NAGIOS_4X
-	json_object_append_string(json_details, "check_command", 
-			temp_host->check_command);
+	json_object_append_string(json_details, "check_command",
+	                          temp_host->check_command);
 #else
-	json_object_append_string(json_details, "host_check_command", 
-			temp_host->host_check_command);
+	json_object_append_string(json_details, "host_check_command",
+	                          temp_host->host_check_command);
 #endif
 
-	json_enumeration(json_details, format_options, "initial_state", 
-			temp_host->initial_state, svm_host_states);
-	json_object_append_real(json_details, "check_interval", 
-			temp_host->check_interval);
-	json_object_append_real(json_details, "retry_interval", 
-			temp_host->retry_interval);
-	json_object_append_integer(json_details, "max_attempts", 
-			temp_host->max_attempts);
-	json_object_append_string(json_details, "event_handler", 
-			temp_host->event_handler);
+	json_enumeration(json_details, format_options, "initial_state",
+	                 temp_host->initial_state, svm_host_states);
+	json_object_append_real(json_details, "check_interval",
+	                        temp_host->check_interval);
+	json_object_append_real(json_details, "retry_interval",
+	                        temp_host->retry_interval);
+	json_object_append_integer(json_details, "max_attempts",
+	                           temp_host->max_attempts);
+	json_object_append_string(json_details, "event_handler",
+	                          temp_host->event_handler);
 
 	json_contactgroups = json_new_array();
-	for(temp_contact_groupsmember = temp_host->contact_groups; 
-			temp_contact_groupsmember != NULL; 
-			temp_contact_groupsmember = temp_contact_groupsmember->next) {
-		json_array_append_string(json_contactgroups, 
-				temp_contact_groupsmember->group_name);
-		}
+	for(temp_contact_groupsmember = temp_host->contact_groups;
+	    temp_contact_groupsmember != NULL;
+	    temp_contact_groupsmember = temp_contact_groupsmember->next) {
+		json_array_append_string(json_contactgroups,
+		                         temp_contact_groupsmember->group_name);
+	}
 	json_object_append_array(json_details, "contact_groups", json_contactgroups);
 
 	json_contacts = json_new_array();
 #ifdef NSCORE
-	for(temp_contactsmember = temp_host->contacts; 
-			temp_contactsmember != NULL; 
-			temp_contactsmember = temp_contactsmember->next) {
-		json_array_append_string(json_contacts, 
-				temp_contactsmember->contact_name);
-		}
+	for(temp_contactsmember = temp_host->contacts;
+	    temp_contactsmember != NULL;
+	    temp_contactsmember = temp_contactsmember->next) {
+		json_array_append_string(json_contacts,
+		                         temp_contactsmember->contact_name);
+	}
 #else
-	for(temp_contact = contact_list; temp_contact != NULL; 
-			temp_contact = temp_contact->next) {
+	for(temp_contact = contact_list; temp_contact != NULL;
+	    temp_contact = temp_contact->next) {
 		if(TRUE == is_contact_for_host(temp_host, temp_contact)) {
 			json_array_append_string(json_contacts, temp_contact->name);
-			}
 		}
+	}
 #endif
 	json_object_append_array(json_details, "contacts", json_contacts);
 
-	json_object_append_real(json_details, "notification_interval", 
-			temp_host->notification_interval);
-	json_object_append_real(json_details, "first_notification_delay", 
-			temp_host->first_notification_delay);
+	json_object_append_real(json_details, "notification_interval",
+	                        temp_host->notification_interval);
+	json_object_append_real(json_details, "first_notification_delay",
+	                        temp_host->first_notification_delay);
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "notify_on_down", 
-				flag_isset(temp_host->notification_options, OPT_DOWN));
-		json_object_append_boolean(json_details, "notify_on_unreachable", 
-				flag_isset(temp_host->notification_options, OPT_UNREACHABLE));
-		json_object_append_boolean(json_details, "notify_on_recovery", 
-				flag_isset(temp_host->notification_options, OPT_RECOVERY));
-		json_object_append_boolean(json_details, "notify_on_flapping", 
-				flag_isset(temp_host->notification_options, OPT_FLAPPING));
-		json_object_append_boolean(json_details, "notify_on_downtime", 
-				flag_isset(temp_host->notification_options, OPT_DOWNTIME));
-		}
-	else {
+		json_object_append_boolean(json_details, "notify_on_down",
+		                           flag_isset(temp_host->notification_options, OPT_DOWN));
+		json_object_append_boolean(json_details, "notify_on_unreachable",
+		                           flag_isset(temp_host->notification_options, OPT_UNREACHABLE));
+		json_object_append_boolean(json_details, "notify_on_recovery",
+		                           flag_isset(temp_host->notification_options, OPT_RECOVERY));
+		json_object_append_boolean(json_details, "notify_on_flapping",
+		                           flag_isset(temp_host->notification_options, OPT_FLAPPING));
+		json_object_append_boolean(json_details, "notify_on_downtime",
+		                           flag_isset(temp_host->notification_options, OPT_DOWNTIME));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "notifications_options",
-				temp_host->notification_options, svm_option_types);
+		             temp_host->notification_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "notify_on_down", 
-			temp_host->notify_on_down);
-	json_object_append_boolean(json_details, "notify_on_unreachable", 
-			temp_host->notify_on_unreachable);
-	json_object_append_boolean(json_details, "notify_on_recovery", 
-			temp_host->notify_on_recovery);
-	json_object_append_boolean(json_details, "notify_on_flapping", 
-			temp_host->notify_on_flapping);
-	json_object_append_boolean(json_details, "notify_on_downtime", 
-			temp_host->notify_on_downtime);
+	json_object_append_boolean(json_details, "notify_on_down",
+	                           temp_host->notify_on_down);
+	json_object_append_boolean(json_details, "notify_on_unreachable",
+	                           temp_host->notify_on_unreachable);
+	json_object_append_boolean(json_details, "notify_on_recovery",
+	                           temp_host->notify_on_recovery);
+	json_object_append_boolean(json_details, "notify_on_flapping",
+	                           temp_host->notify_on_flapping);
+	json_object_append_boolean(json_details, "notify_on_downtime",
+	                           temp_host->notify_on_downtime);
 #endif
-	json_object_append_string(json_details, "notification_period", 
-			temp_host->notification_period);
-	json_object_append_string(json_details, "check_period", 
-			temp_host->check_period);
-	json_object_append_boolean(json_details, "flap_detection_enabled", 
-			temp_host->flap_detection_enabled);
-	json_object_append_real(json_details, "low_flap_threshold", 
-			temp_host->low_flap_threshold);
-	json_object_append_real(json_details, "high_flap_threshold", 
-			temp_host->high_flap_threshold);
+	json_object_append_string(json_details, "notification_period",
+	                          temp_host->notification_period);
+	json_object_append_string(json_details, "check_period",
+	                          temp_host->check_period);
+	json_object_append_boolean(json_details, "flap_detection_enabled",
+	                           temp_host->flap_detection_enabled);
+	json_object_append_real(json_details, "low_flap_threshold",
+	                        temp_host->low_flap_threshold);
+	json_object_append_real(json_details, "high_flap_threshold",
+	                        temp_host->high_flap_threshold);
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details "flap_detection_on_up", 
-				flag_isset(temp_host->flap_detection_options, OPT_UP));
-		json_object_append_boolean(json_details "flap_detection_on_down", 
-				flag_isset(temp_host->flap_detection_options, OPT_DOWN));
-		json_object_append_boolean(json_details "flap_detection_on_unreachable", 
-				flag_isset(temp_host->flap_detection_options, OPT_UNREACHABLE));
-		}
-	else {
+		json_object_append_boolean(json_details "flap_detection_on_up",
+		                           flag_isset(temp_host->flap_detection_options, OPT_UP));
+		json_object_append_boolean(json_details "flap_detection_on_down",
+		                           flag_isset(temp_host->flap_detection_options, OPT_DOWN));
+		json_object_append_boolean(json_details "flap_detection_on_unreachable",
+		                           flag_isset(temp_host->flap_detection_options, OPT_UNREACHABLE));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "flap_detection_options",
-				temp_host->flap_detection_options, svm_option_types);
+		             temp_host->flap_detection_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "flap_detection_on_up", 
-			temp_host->flap_detection_on_up);
-	json_object_append_boolean(json_details, "flap_detection_on_down", 
-			temp_host->flap_detection_on_down);
-	json_object_append_boolean(json_details, "flap_detection_on_unreachable", 
-			temp_host->flap_detection_on_unreachable);
+	json_object_append_boolean(json_details, "flap_detection_on_up",
+	                           temp_host->flap_detection_on_up);
+	json_object_append_boolean(json_details, "flap_detection_on_down",
+	                           temp_host->flap_detection_on_down);
+	json_object_append_boolean(json_details, "flap_detection_on_unreachable",
+	                           temp_host->flap_detection_on_unreachable);
 #endif
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "stalk_on_up", 
-				flag_isset(temp_host->stalking_options, OPT_UP));
-		json_object_append_boolean(json_details, "stalk_on_down", 
-				flag_isset(temp_host->stalking_options, OPT_DOWN));
-		json_object_append_boolean(json_details, "stalk_on_unreachable", 
-				flag_isset(temp_host->stalking_options, OPT_UNREACHABLE));
-		}
-	else {
+		json_object_append_boolean(json_details, "stalk_on_up",
+		                           flag_isset(temp_host->stalking_options, OPT_UP));
+		json_object_append_boolean(json_details, "stalk_on_down",
+		                           flag_isset(temp_host->stalking_options, OPT_DOWN));
+		json_object_append_boolean(json_details, "stalk_on_unreachable",
+		                           flag_isset(temp_host->stalking_options, OPT_UNREACHABLE));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "stalking_options",
-				temp_host->stalking_options, svm_option_types);
+		             temp_host->stalking_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "stalk_on_up", 
-			temp_host->stalk_on_up);
-	json_object_append_boolean(json_details, "stalk_on_down", 
-			temp_host->stalk_on_down);
-	json_object_append_boolean(json_details, "stalk_on_unreachable", 
-			temp_host->stalk_on_unreachable);
+	json_object_append_boolean(json_details, "stalk_on_up",
+	                           temp_host->stalk_on_up);
+	json_object_append_boolean(json_details, "stalk_on_down",
+	                           temp_host->stalk_on_down);
+	json_object_append_boolean(json_details, "stalk_on_unreachable",
+	                           temp_host->stalk_on_unreachable);
 #endif
 
-	json_object_append_boolean(json_details, "check_freshness", 
-			temp_host->check_freshness);
-	json_object_append_integer(json_details, "freshness_threshold", 
-			temp_host->freshness_threshold);
-	json_object_append_boolean(json_details, "process_performance_data", 
-			temp_host->process_performance_data);
-	json_object_append_boolean(json_details, "checks_enabled", 
-			temp_host->checks_enabled);
+	json_object_append_boolean(json_details, "check_freshness",
+	                           temp_host->check_freshness);
+	json_object_append_integer(json_details, "freshness_threshold",
+	                           temp_host->freshness_threshold);
+	json_object_append_boolean(json_details, "process_performance_data",
+	                           temp_host->process_performance_data);
+	json_object_append_boolean(json_details, "checks_enabled",
+	                           temp_host->checks_enabled);
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "accept_passive_host_checks", 
-				temp_host->accept_passive_checks);
-		}
-	else {
+		json_object_append_boolean(json_details, "accept_passive_host_checks",
+		                           temp_host->accept_passive_checks);
+	} else {
 #endif
-		json_object_append_boolean(json_details, "accept_passive_checks", 
-				temp_host->accept_passive_checks);
+		json_object_append_boolean(json_details, "accept_passive_checks",
+		                           temp_host->accept_passive_checks);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "accept_passive_host_checks", 
-			temp_host->accept_passive_host_checks);
+	json_object_append_boolean(json_details, "accept_passive_host_checks",
+	                           temp_host->accept_passive_host_checks);
 #endif
-	json_object_append_boolean(json_details, "event_handler_enabled", 
-			temp_host->event_handler_enabled);
-	json_object_append_boolean(json_details, "retain_status_information", 
-			temp_host->retain_status_information);
-	json_object_append_boolean(json_details, "retain_nonstatus_information", 
-			temp_host->retain_nonstatus_information);
+	json_object_append_boolean(json_details, "event_handler_enabled",
+	                           temp_host->event_handler_enabled);
+	json_object_append_boolean(json_details, "retain_status_information",
+	                           temp_host->retain_status_information);
+	json_object_append_boolean(json_details, "retain_nonstatus_information",
+	                           temp_host->retain_nonstatus_information);
 #ifndef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "failure_prediction_enabled", 
-			temp_host->failure_prediction_enabled);
-	json_object_append_string(json_details, "failure_prediction_options", 
-			temp_host->failure_prediction_options);
+	json_object_append_boolean(json_details, "failure_prediction_enabled",
+	                           temp_host->failure_prediction_enabled);
+	json_object_append_string(json_details, "failure_prediction_options",
+	                          temp_host->failure_prediction_options);
 #endif
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "obsess_over_host", 
-				temp_host->obsess);
-		}
-	else {
+		json_object_append_boolean(json_details, "obsess_over_host",
+		                           temp_host->obsess);
+	} else {
 #endif
 		json_object_append_boolean(json_details, "obsess", temp_host->obsess);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "obsess_over_host", 
-			temp_host->obsess_over_host);
+	json_object_append_boolean(json_details, "obsess_over_host",
+	                           temp_host->obsess_over_host);
 #endif
 #ifdef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "hourly_value", 
-			temp_host->hourly_value);
+	json_object_append_boolean(json_details, "hourly_value",
+	                           temp_host->hourly_value);
 #endif
 	json_object_append_string(json_details, "notes", temp_host->notes);
 	json_object_append_string(json_details, "notes_url", temp_host->notes_url);
 	json_object_append_string(json_details, "action_url", temp_host->action_url);
 	json_object_append_string(json_details, "icon_image", temp_host->icon_image);
-	json_object_append_string(json_details, "icon_image_alt", 
-			temp_host->icon_image_alt);
+	json_object_append_string(json_details, "icon_image_alt",
+	                          temp_host->icon_image_alt);
 	json_object_append_string(json_details, "vrml_image", temp_host->vrml_image);
-	json_object_append_string(json_details, "statusmap_image", 
-			temp_host->statusmap_image);
-	json_object_append_boolean(json_details, "have_2d_coords", 
-			temp_host->have_2d_coords);
+	json_object_append_string(json_details, "statusmap_image",
+	                          temp_host->statusmap_image);
+	json_object_append_boolean(json_details, "have_2d_coords",
+	                           temp_host->have_2d_coords);
 	json_object_append_integer(json_details, "x_2d", temp_host->x_2d);
 	json_object_append_integer(json_details, "y_2d", temp_host->y_2d);
-	json_object_append_boolean(json_details, "have_3d_coords", 
-			temp_host->have_3d_coords);
+	json_object_append_boolean(json_details, "have_3d_coords",
+	                           temp_host->have_3d_coords);
 	json_object_append_real(json_details, "x_3d", temp_host->x_3d);
 	json_object_append_real(json_details, "y_3d", temp_host->y_3d);
 	json_object_append_real(json_details, "z_3d", temp_host->z_3d);
-	json_object_append_boolean(json_details, "should_be_drawn", 
-			temp_host->should_be_drawn);
+	json_object_append_boolean(json_details, "should_be_drawn",
+	                           temp_host->should_be_drawn);
 
 	json_custom_variables = json_new_array();
-	for(temp_custom_variablesmember = temp_host->custom_variables; 
-			temp_custom_variablesmember != NULL; 
-			temp_custom_variablesmember = temp_custom_variablesmember->next) {
+	for(temp_custom_variablesmember = temp_host->custom_variables;
+	    temp_custom_variablesmember != NULL;
+	    temp_custom_variablesmember = temp_custom_variablesmember->next) {
 		json_array_append_string(json_custom_variables,
-				temp_custom_variablesmember->variable_name);
-		}
-	json_object_append_array(json_details, "custom_variables", 
-			json_custom_variables);
+		                         temp_custom_variablesmember->variable_name);
 	}
+	json_object_append_array(json_details, "custom_variables",
+	                         json_custom_variables);
+}
 
-int json_object_hostgroup_passes_selection(hostgroup *temp_hostgroup, 
-		host *temp_hostgroup_member) {
+int json_object_hostgroup_passes_selection(hostgroup *temp_hostgroup,
+        host *temp_hostgroup_member)
+{
 
 	/* Skip if user is not authorized for this hostgroup */
-	if(FALSE == is_authorized_for_hostgroup(temp_hostgroup, 
-			&current_authdata)) {
+	if(FALSE == is_authorized_for_hostgroup(temp_hostgroup,
+	                                        &current_authdata)) {
 		return 0;
-		}
+	}
 
 	/* Skip if a hostgroup member is specified and the hostgroup member
 		host is not a member of the hostgroup */
-	if( NULL != temp_hostgroup_member && 
-			( FALSE == is_host_member_of_hostgroup(temp_hostgroup, 
-					temp_hostgroup_member))) {
+	if( NULL != temp_hostgroup_member &&
+	    ( FALSE == is_host_member_of_hostgroup(temp_hostgroup,
+	            temp_hostgroup_member))) {
 		return 0;
-		}
-
-	return 1;
 	}
 
-json_object *json_object_hostgroup_selectors(int start, int count, 
-		host *temp_hostgroup_member) {
+	return 1;
+}
+
+json_object *json_object_hostgroup_selectors(int start, int count,
+        host *temp_hostgroup_member)
+{
 
 	json_object *json_selectors;
 
@@ -2967,47 +3015,49 @@ json_object *json_object_hostgroup_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( NULL != temp_hostgroup_member) {
-		json_object_append_string(json_selectors, "hostgroupmember", 
-				temp_hostgroup_member->name);
-		}
-
-	return json_selectors;
+		json_object_append_string(json_selectors, "hostgroupmember",
+		                          temp_hostgroup_member->name);
 	}
 
-json_object *json_object_hostgroupcount(unsigned format_options, 
-		host *temp_hostgroup_member) {
+	return json_selectors;
+}
+
+json_object *json_object_hostgroupcount(unsigned format_options,
+                                        host *temp_hostgroup_member)
+{
 
 	json_object *json_data;
 	hostgroup *temp_hostgroup;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_hostgroup_selectors(0, 0, temp_hostgroup_member));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_hostgroup_selectors(0, 0, temp_hostgroup_member));
 
-	for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; 
-			temp_hostgroup = temp_hostgroup->next) {
+	for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL;
+	    temp_hostgroup = temp_hostgroup->next) {
 
-		if(json_object_hostgroup_passes_selection(temp_hostgroup, 
-				temp_hostgroup_member) == 0) {
+		if(json_object_hostgroup_passes_selection(temp_hostgroup,
+		        temp_hostgroup_member) == 0) {
 			continue;
-			}
-
-		count++; 
 		}
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_hostgrouplist(unsigned format_options, int start, 
-		int count, int details, host *temp_hostgroup_member) {
+json_object *json_object_hostgrouplist(unsigned format_options, int start,
+                                       int count, int details, host *temp_hostgroup_member)
+{
 
 	json_object *json_data;
 	json_object *json_hostgrouplist_object = NULL;
@@ -3018,96 +3068,96 @@ json_object *json_object_hostgrouplist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_hostgroup_selectors(start, count, 
-			temp_hostgroup_member));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_hostgroup_selectors(start, count,
+	                                  temp_hostgroup_member));
 
 	if(details > 0) {
 		json_hostgrouplist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_hostgrouplist_array = json_new_array();
-		}
+	}
 
-	for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; 
-			temp_hostgroup = temp_hostgroup->next) {
+	for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL;
+	    temp_hostgroup = temp_hostgroup->next) {
 
-		if(json_object_hostgroup_passes_selection(temp_hostgroup, 
-				temp_hostgroup_member) == 0) {
+		if(json_object_hostgroup_passes_selection(temp_hostgroup,
+		        temp_hostgroup_member) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_hostgroup_details = json_new_object();
-				json_object_hostgroup_details(json_hostgroup_details, 
-						format_options, temp_hostgroup);
-				json_object_append_object(json_hostgrouplist_object, 
-						temp_hostgroup->group_name, json_hostgroup_details);
-				}
-			else {
-				json_array_append_string(json_hostgrouplist_array, 
-						temp_hostgroup->group_name);
-				}
-			counted++;
+				json_object_hostgroup_details(json_hostgroup_details,
+				                              format_options, temp_hostgroup);
+				json_object_append_object(json_hostgrouplist_object,
+				                          temp_hostgroup->group_name, json_hostgroup_details);
+			} else {
+				json_array_append_string(json_hostgrouplist_array,
+				                         temp_hostgroup->group_name);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "hostgrouplist", 
-				json_hostgrouplist_object);
-		}
-	else {
-		json_object_append_array(json_data, "hostgrouplist", 
-				json_hostgrouplist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
+	if(details > 0) {
+		json_object_append_object(json_data, "hostgrouplist",
+		                          json_hostgrouplist_object);
+	} else {
+		json_object_append_array(json_data, "hostgrouplist",
+		                         json_hostgrouplist_array);
+	}
+
+	return json_data;
+}
+
 json_object *json_object_hostgroup(unsigned format_options,
-		hostgroup *temp_hostgroup) {
+                                   hostgroup *temp_hostgroup)
+{
 
 	json_object *json_hostgroup = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_string(json_details, "group_name", 
-			temp_hostgroup->group_name);
+	json_object_append_string(json_details, "group_name",
+	                          temp_hostgroup->group_name);
 	json_object_hostgroup_details(json_details, format_options, temp_hostgroup);
 	json_object_append_object(json_hostgroup, "hostgroup", json_details);
 
 	return json_hostgroup;
 }
 
-void json_object_hostgroup_details(json_object *json_details, 
-		unsigned format_options, hostgroup *temp_hostgroup) {
+void json_object_hostgroup_details(json_object *json_details,
+                                   unsigned format_options, hostgroup *temp_hostgroup)
+{
 
 	json_array *json_members;
 	hostsmember *temp_member;
 
-	json_object_append_string(json_details, "group_name", 
-			temp_hostgroup->group_name);
+	json_object_append_string(json_details, "group_name",
+	                          temp_hostgroup->group_name);
 	json_object_append_string(json_details, "alias", temp_hostgroup->alias);
 
 	json_members = json_new_array();
-	for(temp_member = temp_hostgroup->members; temp_member != NULL; 
-			temp_member = temp_member->next) {
+	for(temp_member = temp_hostgroup->members; temp_member != NULL;
+	    temp_member = temp_member->next) {
 		json_array_append_string(json_members, temp_member->host_name);
-		}
+	}
 	json_object_append_array(json_details, "members", json_members);
 
 	json_object_append_string(json_details, "notes", temp_hostgroup->notes);
-	json_object_append_string(json_details, "notes_url", 
-			temp_hostgroup->notes_url);
-	json_object_append_string(json_details, "action_url", 
-			temp_hostgroup->action_url);
-	}
+	json_object_append_string(json_details, "notes_url",
+	                          temp_hostgroup->notes_url);
+	json_object_append_string(json_details, "action_url",
+	                          temp_hostgroup->action_url);
+}
 
-int json_object_service_passes_host_selection(host *temp_host, 
-		int use_parent_host, host *parent_host, int use_child_host, 
-		host *child_host, hostgroup *temp_hostgroup, host *match_host) {
+int json_object_service_passes_host_selection(host *temp_host,
+        int use_parent_host, host *parent_host, int use_child_host,
+        host *child_host, hostgroup *temp_hostgroup, host *match_host)
+{
 
 	host *temp_host2;
 
@@ -3116,55 +3166,56 @@ int json_object_service_passes_host_selection(host *temp_host,
 		return 0;
 	}
 
-	/* If the host parent was specified, skip the services whose host is 
+	/* If the host parent was specified, skip the services whose host is
 		not a child of the parent host specified */
-	if( 1 == use_parent_host && NULL != temp_host && 
-			FALSE == is_host_immediate_child_of_host(parent_host, temp_host)) {
+	if( 1 == use_parent_host && NULL != temp_host &&
+	    FALSE == is_host_immediate_child_of_host(parent_host, temp_host)) {
 		return 0;
-		}
+	}
 
-	/* If the hostgroup was specified, skip the services on hosts that 
+	/* If the hostgroup was specified, skip the services on hosts that
 		are not members of the hostgroup specified */
 	if( NULL != temp_hostgroup && NULL != temp_host &&
-			( FALSE == is_host_member_of_hostgroup(temp_hostgroup, 
-					temp_host))) {
+	    ( FALSE == is_host_member_of_hostgroup(temp_hostgroup,
+	            temp_host))) {
 		return 0;
-		}
+	}
 
 	/* If the host was specified, skip the services not on the host
 		specified */
 	if( NULL != match_host && NULL != temp_host && temp_host != match_host) {
 		return 0;
-		}
+	}
 
 	/* If a child host was specified... */
-	if(1 == use_child_host) { 
+	if(1 == use_child_host) {
 		/* If the child host is "none", skip this host if it has children */
 		if(NULL == child_host) {
-			for(temp_host2 = host_list; temp_host2 != NULL; 
-					temp_host2 = temp_host2->next) {
-				if(TRUE == is_host_immediate_child_of_host(temp_host, 
-						temp_host2)) {
+			for(temp_host2 = host_list; temp_host2 != NULL;
+			    temp_host2 = temp_host2->next) {
+				if(TRUE == is_host_immediate_child_of_host(temp_host,
+				        temp_host2)) {
 					return 0;
-					}
 				}
 			}
+		}
 		/* Otherwise, skip this host if it does not have the specified host
 			as a child */
 		else if(FALSE == is_host_immediate_child_of_host(temp_host, child_host)) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
-int json_object_service_passes_service_selection(service *temp_service, 
-		servicegroup *temp_servicegroup, contact *temp_contact, 
-		char *service_description, char *parent_service_name,
-		char *child_service_name, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+	return 1;
+}
+
+int json_object_service_passes_service_selection(service *temp_service,
+        servicegroup *temp_servicegroup, contact *temp_contact,
+        char *service_description, char *parent_service_name,
+        char *child_service_name, contactgroup *temp_contactgroup,
+        timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+        command *check_command, command *event_handler)
+{
 
 	servicesmember *temp_servicesmember;
 
@@ -3173,63 +3224,63 @@ int json_object_service_passes_service_selection(service *temp_service,
 		return 0;
 	}
 
-	/* If the servicegroup was specified, skip the services that are not 
+	/* If the servicegroup was specified, skip the services that are not
 		members of the servicegroup specified */
-	if( NULL != temp_servicegroup && 
-			( FALSE == is_service_member_of_servicegroup(temp_servicegroup, 
-			temp_service))) {
+	if( NULL != temp_servicegroup &&
+	    ( FALSE == is_service_member_of_servicegroup(temp_servicegroup,
+	            temp_service))) {
 		return 0;
-		}
+	}
 
 	/* If the contact was specified, skip the services that do not have
 		the contact specified */
-	if( NULL != temp_contact && 
-			( FALSE == is_contact_for_service(temp_service, temp_contact))) {
+	if( NULL != temp_contact &&
+	    ( FALSE == is_contact_for_service(temp_service, temp_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a contactgroup was specified, skip the services that do not have
 		the contactgroup specified */
 	if(NULL != temp_contactgroup &&
-			(FALSE == is_contactgroup_for_service(temp_service,
-			temp_contactgroup))) {
+	   (FALSE == is_contactgroup_for_service(temp_service,
+	           temp_contactgroup))) {
 		return 0;
-		}
+	}
 
 	/* If the service description was supplied, skip the services that do not
 		have this service description */
-	if((NULL != service_description) && 
-			strcmp(temp_service->description, service_description)) {
+	if((NULL != service_description) &&
+	   strcmp(temp_service->description, service_description)) {
 		return 0;
-		}
+	}
 
 	/* If a check timeperiod was specified, skip this service if it does
 		not have the check timeperiod specified */
 	if(NULL != check_timeperiod &&
-			(check_timeperiod != temp_service->check_period_ptr)) {
+	   (check_timeperiod != temp_service->check_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a notification timeperiod was specified, skip this service if it does
 		not have the notification timeperiod specified */
 	if(NULL != notification_timeperiod && (notification_timeperiod !=
-			temp_service->notification_period_ptr)) {
+	                                       temp_service->notification_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a check command was specified, skip this service if it does not
 		have the check command specified */
 	if(NULL != check_command &&
-			(check_command != temp_service->check_command_ptr)) {
+	   (check_command != temp_service->check_command_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If an event handler was specified, skip this service if it does not
 		have the event handler specified */
 	if(NULL != event_handler &&
-			(event_handler != temp_service->event_handler_ptr)) {
+	   (event_handler != temp_service->event_handler_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a parent service was specified... */
 	if(NULL != parent_service_name) {
@@ -3238,25 +3289,25 @@ int json_object_service_passes_service_selection(service *temp_service,
 		if(!strcmp(parent_service_name,"none")) {
 			if(NULL != temp_service->parents) {
 				return 0;
-				}
 			}
+		}
 		/* Otherwise, skip this service if it does not have the specified
 			service as a parent */
 		else {
 			int found = 0;
 			for(temp_servicesmember = temp_service->parents;
-					temp_servicesmember != NULL;
-					temp_servicesmember = temp_servicesmember->next) {
+			    temp_servicesmember != NULL;
+			    temp_servicesmember = temp_servicesmember->next) {
 				if(!strcmp(temp_servicesmember->service_description,
-						parent_service_name)) {
+				           parent_service_name)) {
 					found = 1;
-					}
-				}
-			if(0 == found) {
-				return 0;
 				}
 			}
+			if(0 == found) {
+				return 0;
+			}
 		}
+	}
 
 	/* If a child service was specified... */
 	if(NULL != child_service_name) {
@@ -3265,37 +3316,38 @@ int json_object_service_passes_service_selection(service *temp_service,
 		if(!strcmp(child_service_name,"none")) {
 			if(NULL != temp_service->children) {
 				return 0;
-				}
 			}
+		}
 		/* Otherwise, skip this service if it does not have the specified
 			service as a child */
 		else {
 			int found = 0;
 			for(temp_servicesmember = temp_service->children;
-					temp_servicesmember != NULL;
-					temp_servicesmember = temp_servicesmember->next) {
+			    temp_servicesmember != NULL;
+			    temp_servicesmember = temp_servicesmember->next) {
 				if(!strcmp(temp_servicesmember->service_description,
-						child_service_name)) {
+				           child_service_name)) {
 					found = 1;
-					}
-				}
-			if(0 == found) {
-				return 0;
 				}
 			}
+			if(0 == found) {
+				return 0;
+			}
 		}
-
-	return 1;
 	}
 
-json_object *json_object_service_selectors(int start, int count, 
-		int use_parent_host, host *parent_host, int use_child_host,
-		host *child_host, hostgroup *temp_hostgroup, host *match_host, 
-		servicegroup *temp_servicegroup, contact *temp_contact, 
-		char *service_description, char *parent_service_name,
-		char *child_service_name, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+	return 1;
+}
+
+json_object *json_object_service_selectors(int start, int count,
+        int use_parent_host, host *parent_host, int use_child_host,
+        host *child_host, hostgroup *temp_hostgroup, host *match_host,
+        servicegroup *temp_servicegroup, contact *temp_contact,
+        char *service_description, char *parent_service_name,
+        char *child_service_name, contactgroup *temp_contactgroup,
+        timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+        command *check_command, command *event_handler)
+{
 
 	json_object *json_selectors;
 
@@ -3303,77 +3355,78 @@ json_object *json_object_service_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( NULL != match_host) {
 		json_object_append_string(json_selectors, "host", match_host->name);
-		}
+	}
 	if( 1 == use_parent_host) {
-		json_object_append_string(json_selectors, "parenthost", 
-				( NULL == parent_host ? "none" : parent_host->name));
-		}
+		json_object_append_string(json_selectors, "parenthost",
+		                          ( NULL == parent_host ? "none" : parent_host->name));
+	}
 	if( 1 == use_child_host) {
-		json_object_append_string(json_selectors, "childhost", 
-				( NULL == child_host ? "none" : child_host->name));
-		}
+		json_object_append_string(json_selectors, "childhost",
+		                          ( NULL == child_host ? "none" : child_host->name));
+	}
 	if( NULL != temp_hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				temp_hostgroup->group_name);
-		}
+		json_object_append_string(json_selectors, "hostgroup",
+		                          temp_hostgroup->group_name);
+	}
 	if( NULL != temp_servicegroup) {
-		json_object_append_string(json_selectors, "servicegroup", 
-				temp_servicegroup->group_name);
-		}
+		json_object_append_string(json_selectors, "servicegroup",
+		                          temp_servicegroup->group_name);
+	}
 	if(NULL != temp_contact) {
 		json_object_append_string(json_selectors, "contact",
-				temp_contact->name);
-		}
+		                          temp_contact->name);
+	}
 	if(NULL != temp_contactgroup) {
 		json_object_append_string(json_selectors, "contactgroup",
-				temp_contactgroup->group_name);
-		}
+		                          temp_contactgroup->group_name);
+	}
 	if( NULL != service_description) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				service_description);
-		}
+		json_object_append_string(json_selectors, "servicedescription",
+		                          service_description);
+	}
 	if( NULL != parent_service_name) {
 		json_object_append_string(json_selectors, "parentservice",
-				parent_service_name);
-		}
+		                          parent_service_name);
+	}
 	if( NULL != child_service_name) {
 		json_object_append_string(json_selectors, "childservice",
-				child_service_name);
-		}
+		                          child_service_name);
+	}
 	if( NULL != check_timeperiod) {
 		json_object_append_string(json_selectors, "checktimeperiod",
-				check_timeperiod->name);
-		}
+		                          check_timeperiod->name);
+	}
 	if( NULL != notification_timeperiod) {
 		json_object_append_string(json_selectors,
-				"servicenotificationtimeperiod", notification_timeperiod->name);
-		}
+		                          "servicenotificationtimeperiod", notification_timeperiod->name);
+	}
 	if( NULL != check_command) {
 		json_object_append_string(json_selectors, "checkcommand",
-				check_command->name);
-		}
+		                          check_command->name);
+	}
 	if( NULL != event_handler) {
 		json_object_append_string(json_selectors, "eventhandler",
-				event_handler->name);
-		}
-
-	return json_selectors;
+		                          event_handler->name);
 	}
 
-json_object *json_object_servicecount(host *match_host, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *temp_hostgroup, servicegroup *temp_servicegroup, 
-		contact *temp_contact, char *service_description,
-		char *parent_service_name, char *child_service_name,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+	return json_selectors;
+}
+
+json_object *json_object_servicecount(host *match_host, int use_parent_host,
+                                      host *parent_host, int use_child_host, host *child_host,
+                                      hostgroup *temp_hostgroup, servicegroup *temp_servicegroup,
+                                      contact *temp_contact, char *service_description,
+                                      char *parent_service_name, char *child_service_name,
+                                      contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+                                      timeperiod *notification_timeperiod, command *check_command,
+                                      command *event_handler)
+{
 
 	json_object *json_data;
 	host *temp_host;
@@ -3381,53 +3434,54 @@ json_object *json_object_servicecount(host *match_host, int use_parent_host,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_service_selectors(0, 0, use_parent_host, parent_host, 
-			use_child_host, child_host, temp_hostgroup, match_host, 
-			temp_servicegroup, temp_contact, service_description,
-			parent_service_name, child_service_name, temp_contactgroup,
-			check_timeperiod, notification_timeperiod, check_command,
-			event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_service_selectors(0, 0, use_parent_host, parent_host,
+	                                  use_child_host, child_host, temp_hostgroup, match_host,
+	                                  temp_servicegroup, temp_contact, service_description,
+	                                  parent_service_name, child_service_name, temp_contactgroup,
+	                                  check_timeperiod, notification_timeperiod, check_command,
+	                                  event_handler));
 
-	for(temp_service = service_list; temp_service != NULL; 
-			temp_service = temp_service->next) {
+	for(temp_service = service_list; temp_service != NULL;
+	    temp_service = temp_service->next) {
 
 		temp_host = find_host(temp_service->host_name);
 		if(NULL == temp_host) {
 			continue;
-			}
-
-		if(json_object_service_passes_host_selection(temp_host, 
-				use_parent_host, parent_host, use_child_host, child_host, 
-				temp_hostgroup, match_host) == 0) {
-			continue;
-			}
-
-		if(json_object_service_passes_service_selection(temp_service, 
-				temp_servicegroup, temp_contact, service_description,
-				parent_service_name, child_service_name,
-				temp_contactgroup, check_timeperiod,
-				notification_timeperiod, check_command, event_handler) == 0) {
-			continue;
-			}
-
-		count++; 
 		}
+
+		if(json_object_service_passes_host_selection(temp_host,
+		        use_parent_host, parent_host, use_child_host, child_host,
+		        temp_hostgroup, match_host) == 0) {
+			continue;
+		}
+
+		if(json_object_service_passes_service_selection(temp_service,
+		        temp_servicegroup, temp_contact, service_description,
+		        parent_service_name, child_service_name,
+		        temp_contactgroup, check_timeperiod,
+		        notification_timeperiod, check_command, event_handler) == 0) {
+			continue;
+		}
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_servicelist(unsigned format_options, int start, 
-		int count, int details, host *match_host, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *temp_hostgroup, servicegroup *temp_servicegroup, 
-		contact *temp_contact, char *service_description,
-		char *parent_service_name, char *child_service_name,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+json_object *json_object_servicelist(unsigned format_options, int start,
+                                     int count, int details, host *match_host, int use_parent_host,
+                                     host *parent_host, int use_child_host, host *child_host,
+                                     hostgroup *temp_hostgroup, servicegroup *temp_servicegroup,
+                                     contact *temp_contact, char *service_description,
+                                     char *parent_service_name, char *child_service_name,
+                                     contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+                                     timeperiod *notification_timeperiod, command *check_command,
+                                     command *event_handler)
+{
 
 	json_object *json_data;
 	json_object *json_hostlist;
@@ -3442,44 +3496,43 @@ json_object *json_object_servicelist(unsigned format_options, int start,
 	char *buf;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_service_selectors(start, count, use_parent_host, 
-			parent_host, use_child_host, child_host, temp_hostgroup, match_host,
-			temp_servicegroup, temp_contact, service_description,
-			parent_service_name, child_service_name, temp_contactgroup,
-			check_timeperiod, notification_timeperiod, check_command,
-			event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_service_selectors(start, count, use_parent_host,
+	                                  parent_host, use_child_host, child_host, temp_hostgroup, match_host,
+	                                  temp_servicegroup, temp_contact, service_description,
+	                                  parent_service_name, child_service_name, temp_contactgroup,
+	                                  check_timeperiod, notification_timeperiod, check_command,
+	                                  event_handler));
 
 	json_hostlist = json_new_object();
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 		if(json_object_service_passes_host_selection(temp_host, use_parent_host,
-					parent_host, use_child_host, child_host, temp_hostgroup, 
-					match_host) == 0) {
-				continue;
-				}
+		        parent_host, use_child_host, child_host, temp_hostgroup,
+		        match_host) == 0) {
+			continue;
+		}
 
 		service_count = 0;
 		if(details > 0) {
 			json_servicelist_object = json_new_object();
-			}
-		else {
+		} else {
 			json_servicelist_array = json_new_array();
+		}
+
+		for(temp_service = service_list; temp_service != NULL;
+		    temp_service = temp_service->next) {
+
+			if(json_object_service_passes_service_selection(temp_service,
+			        temp_servicegroup, temp_contact,
+			        service_description, parent_service_name,
+			        child_service_name, temp_contactgroup,
+			        check_timeperiod, notification_timeperiod,
+			        check_command, event_handler) == 0) {
+				continue;
 			}
 
-		for(temp_service = service_list; temp_service != NULL; 
-				temp_service = temp_service->next) {
-	
-			if(json_object_service_passes_service_selection(temp_service,
-					temp_servicegroup, temp_contact, 
-					service_description, parent_service_name,
-					child_service_name, temp_contactgroup,
-					check_timeperiod, notification_timeperiod,
-					check_command, event_handler) == 0) {
-				continue;
-				}
-
-			/* If this service isn't on the host we're currently working with, 
+			/* If this service isn't on the host we're currently working with,
 					skip it */
 			if( strcmp( temp_host->name, temp_service->host_name)) continue;
 
@@ -3487,56 +3540,56 @@ json_object *json_object_servicelist(unsigned format_options, int start,
 			if( passes_start_and_count_limits(start, count, current, counted)) {
 				if( details > 0) {
 					json_service_details = json_new_object();
-					json_object_service_details(json_service_details, 
-							format_options, temp_service);
-					asprintf(&buf, "%s", 
-							temp_service->description);
-					json_object_append_object(json_servicelist_object, buf, 
-							json_service_details);
-					}
-				else {
+					json_object_service_details(json_service_details,
+					                            format_options, temp_service);
+					asprintf(&buf, "%s",
+					         temp_service->description);
+					json_object_append_object(json_servicelist_object, buf,
+					                          json_service_details);
+				} else {
 					json_array_append_string(json_servicelist_array, "%s",
-							temp_service->description); 
-					}
+					                         temp_service->description);
+				}
 				counted++;
 				service_count++;
-				}
-			current++; 
 			}
+			current++;
+		}
 
 		if(service_count > 0) {
 			if(details > 0) {
-				json_object_append_object(json_hostlist, temp_host->name, 
-						json_servicelist_object);
-				}
-			else {
-				json_object_append_array(json_hostlist, temp_host->name, 
-						json_servicelist_array);
-				}
+				json_object_append_object(json_hostlist, temp_host->name,
+				                          json_servicelist_object);
+			} else {
+				json_object_append_array(json_hostlist, temp_host->name,
+				                         json_servicelist_array);
 			}
 		}
+	}
 
 	json_object_append_object(json_data, "servicelist", json_hostlist);
 	return json_data;
-	}
+}
 
-json_object *json_object_service(unsigned format_options, service *temp_service) {
+json_object *json_object_service(unsigned format_options, service *temp_service)
+{
 
 	json_object *json_service = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_string(json_details, "host_name", 
-			temp_service->host_name);
-	json_object_append_string(json_details, "description", 
-			temp_service->description);
+	json_object_append_string(json_details, "host_name",
+	                          temp_service->host_name);
+	json_object_append_string(json_details, "description",
+	                          temp_service->description);
 	json_object_service_details(json_details, format_options, temp_service);
 	json_object_append_object(json_service, "service", json_details);
 
 	return json_service;
 }
 
-void json_object_service_details(json_object *json_details, 
-		unsigned format_options, service *temp_service) {
+void json_object_service_details(json_object *json_details,
+                                 unsigned format_options, service *temp_service)
+{
 
 	json_array *json_contactgroups;
 	json_array *json_contacts;
@@ -3556,318 +3609,314 @@ void json_object_service_details(json_object *json_details,
 	json_array *json_custom_variables;
 	customvariablesmember *temp_customvariablesmember;
 
-	json_object_append_string(json_details, "host_name", 
-			temp_service->host_name);
-	json_object_append_string(json_details, "description", 
-			temp_service->description);
-	json_object_append_string(json_details, "display_name", 
-			temp_service->display_name);
+	json_object_append_string(json_details, "host_name",
+	                          temp_service->host_name);
+	json_object_append_string(json_details, "description",
+	                          temp_service->description);
+	json_object_append_string(json_details, "display_name",
+	                          temp_service->display_name);
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_string(json_details, "service_check_command", 
-				temp_service->check_command);
-		}
-	else {
+		json_object_append_string(json_details, "service_check_command",
+		                          temp_service->check_command);
+	} else {
 #endif
-		json_object_append_string(json_details, "check_command", 
-				temp_service->check_command);
+		json_object_append_string(json_details, "check_command",
+		                          temp_service->check_command);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_string(json_details, "service_check_command", 
-			temp_service->service_check_command);
+	json_object_append_string(json_details, "service_check_command",
+	                          temp_service->service_check_command);
 #endif
-	json_object_append_string(json_details, "event_handler", 
-			temp_service->event_handler);
+	json_object_append_string(json_details, "event_handler",
+	                          temp_service->event_handler);
 
-	json_enumeration(json_details, format_options, "initial_state", 
-			temp_service->initial_state, svm_service_states);
+	json_enumeration(json_details, format_options, "initial_state",
+	                 temp_service->initial_state, svm_service_states);
 
-	json_object_append_real(json_details, "check_interval", 
-			temp_service->check_interval);
-	json_object_append_real(json_details, "retry_interval", 
-			temp_service->retry_interval);
-	json_object_append_integer(json_details, "max_attempts", 
-			temp_service->max_attempts);
-	json_object_append_boolean(json_details, "parallelize",  
-			temp_service->parallelize);
+	json_object_append_real(json_details, "check_interval",
+	                        temp_service->check_interval);
+	json_object_append_real(json_details, "retry_interval",
+	                        temp_service->retry_interval);
+	json_object_append_integer(json_details, "max_attempts",
+	                           temp_service->max_attempts);
+	json_object_append_boolean(json_details, "parallelize",
+	                           temp_service->parallelize);
 
 	json_contactgroups = json_new_array();
-	for(temp_contact_groupsmember = temp_service->contact_groups; 
-			temp_contact_groupsmember != NULL; 
-			temp_contact_groupsmember = temp_contact_groupsmember->next) {
+	for(temp_contact_groupsmember = temp_service->contact_groups;
+	    temp_contact_groupsmember != NULL;
+	    temp_contact_groupsmember = temp_contact_groupsmember->next) {
 		json_array_append_string(json_contactgroups,
-				temp_contact_groupsmember->group_name);
-		}
+		                         temp_contact_groupsmember->group_name);
+	}
 	json_object_append_array(json_details, "contact_groups", json_contactgroups);
 
 	json_contacts = json_new_array();
 #ifdef NSCORE
-	for(temp_contactsmember = temp_service->contacts; 
-			temp_contactsmember != NULL; 
-			temp_contactsmember = temp_contactsmember->next) {
+	for(temp_contactsmember = temp_service->contacts;
+	    temp_contactsmember != NULL;
+	    temp_contactsmember = temp_contactsmember->next) {
 		json_array_append_string(json_contacts,
-				temp_contactsmember->contact_name);
-		}
+		                         temp_contactsmember->contact_name);
+	}
 #else
-	for(temp_contact = contact_list; temp_contact != NULL; 
-			temp_contact = temp_contact->next) {
+	for(temp_contact = contact_list; temp_contact != NULL;
+	    temp_contact = temp_contact->next) {
 		if(TRUE == is_contact_for_service(temp_service, temp_contact)) {
 			json_array_append_string(json_contacts, temp_contact->name);
-			}
 		}
+	}
 #endif
 	json_object_append_array(json_details, "contacts", json_contacts);
 
-	json_object_append_real(json_details, "notification_interval", 
-			temp_service->notification_interval);
-	json_object_append_real(json_details, "first_notification_delay", 
-			temp_service->first_notification_delay);
+	json_object_append_real(json_details, "notification_interval",
+	                        temp_service->notification_interval);
+	json_object_append_real(json_details, "first_notification_delay",
+	                        temp_service->first_notification_delay);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "notify_on_unknown", 
-				flag_isset(temp_service->notification_options, OPT_UNKNOWN));
-		json_object_append_boolean(json_details, "notify_on_warning", 
-				flag_isset(temp_service->notification_options, OPT_WARNING));
-		json_object_append_boolean(json_details, "notify_on_critical", 
-				flag_isset(temp_service->notification_options, OPT_CRITICAL));
-		json_object_append_boolean(json_details, "notify_on_recovery", 
-				flag_isset(temp_service->notification_options, OPT_RECOVERY));
-		json_object_append_boolean(json_details, "notify_on_flapping", 
-				flag_isset(temp_service->notification_options, OPT_FLAPPING));
-		json_object_append_boolean(json_details, "notify_on_downtime", 
-				flag_isset(temp_service->notification_options, OPT_DOWNTIME));
-		}
-	else {
+		json_object_append_boolean(json_details, "notify_on_unknown",
+		                           flag_isset(temp_service->notification_options, OPT_UNKNOWN));
+		json_object_append_boolean(json_details, "notify_on_warning",
+		                           flag_isset(temp_service->notification_options, OPT_WARNING));
+		json_object_append_boolean(json_details, "notify_on_critical",
+		                           flag_isset(temp_service->notification_options, OPT_CRITICAL));
+		json_object_append_boolean(json_details, "notify_on_recovery",
+		                           flag_isset(temp_service->notification_options, OPT_RECOVERY));
+		json_object_append_boolean(json_details, "notify_on_flapping",
+		                           flag_isset(temp_service->notification_options, OPT_FLAPPING));
+		json_object_append_boolean(json_details, "notify_on_downtime",
+		                           flag_isset(temp_service->notification_options, OPT_DOWNTIME));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "notifications_options",
-				temp_service->notification_options, svm_option_types);
+		             temp_service->notification_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "notify_on_unknown", 
-			temp_service->notify_on_unknown);
-	json_object_append_boolean(json_details, "notify_on_warning", 
-			temp_service->notify_on_warning);
-	json_object_append_boolean(json_details, "notify_on_critical", 
-			temp_service->notify_on_critical);
-	json_object_append_boolean(json_details, "notify_on_recovery", 
-			temp_service->notify_on_recovery);
-	json_object_append_boolean(json_details, "notify_on_flapping", 
-			temp_service->notify_on_flapping);
-	json_object_append_boolean(json_details, "notify_on_downtime", 
-			temp_service->notify_on_downtime);
+	json_object_append_boolean(json_details, "notify_on_unknown",
+	                           temp_service->notify_on_unknown);
+	json_object_append_boolean(json_details, "notify_on_warning",
+	                           temp_service->notify_on_warning);
+	json_object_append_boolean(json_details, "notify_on_critical",
+	                           temp_service->notify_on_critical);
+	json_object_append_boolean(json_details, "notify_on_recovery",
+	                           temp_service->notify_on_recovery);
+	json_object_append_boolean(json_details, "notify_on_flapping",
+	                           temp_service->notify_on_flapping);
+	json_object_append_boolean(json_details, "notify_on_downtime",
+	                           temp_service->notify_on_downtime);
 #endif
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "stalk_on_ok", 
-				flag_isset(temp_service->stalking_options, OPT_OK));
-		json_object_append_boolean(json_details, "stalk_on_warning", 
-				flag_isset(temp_service->stalking_options, OPT_WARNING));
-		json_object_append_boolean(json_details, "stalk_on_unknown", 
-				flag_isset(temp_service->stalking_options, OPT_UNKNOWN));
-		json_object_append_boolean(json_details, "stalk_on_critical", 
-				flag_isset(temp_service->stalking_options, OPT_CRITICAL));
-		}
-	else {
+		json_object_append_boolean(json_details, "stalk_on_ok",
+		                           flag_isset(temp_service->stalking_options, OPT_OK));
+		json_object_append_boolean(json_details, "stalk_on_warning",
+		                           flag_isset(temp_service->stalking_options, OPT_WARNING));
+		json_object_append_boolean(json_details, "stalk_on_unknown",
+		                           flag_isset(temp_service->stalking_options, OPT_UNKNOWN));
+		json_object_append_boolean(json_details, "stalk_on_critical",
+		                           flag_isset(temp_service->stalking_options, OPT_CRITICAL));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "stalking_options",
-				temp_service->stalking_options, svm_option_types);
+		             temp_service->stalking_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "stalk_on_ok", 
-			temp_service->stalk_on_ok);
-	json_object_append_boolean(json_details, "stalk_on_warning", 
-			temp_service->stalk_on_warning);
-	json_object_append_boolean(json_details, "stalk_on_unknown", 
-			temp_service->stalk_on_unknown);
-	json_object_append_boolean(json_details, "stalk_on_critical", 
-			temp_service->stalk_on_critical);
+	json_object_append_boolean(json_details, "stalk_on_ok",
+	                           temp_service->stalk_on_ok);
+	json_object_append_boolean(json_details, "stalk_on_warning",
+	                           temp_service->stalk_on_warning);
+	json_object_append_boolean(json_details, "stalk_on_unknown",
+	                           temp_service->stalk_on_unknown);
+	json_object_append_boolean(json_details, "stalk_on_critical",
+	                           temp_service->stalk_on_critical);
 #endif
 
-	json_object_append_boolean(json_details, "is_volatile", 
-			temp_service->is_volatile);
-	json_object_append_string(json_details, "notification_period", 
-			temp_service->notification_period);
-	json_object_append_string(json_details, "check_period", 
-			temp_service->check_period);
-	json_object_append_boolean(json_details, "flap_detection_enabled", 
-			temp_service->flap_detection_enabled);
-	json_object_append_real(json_details, "low_flap_threshold", 
-			temp_service->low_flap_threshold);
-	json_object_append_real(json_details, "high_flap_threshold", 
-			temp_service->high_flap_threshold);
+	json_object_append_boolean(json_details, "is_volatile",
+	                           temp_service->is_volatile);
+	json_object_append_string(json_details, "notification_period",
+	                          temp_service->notification_period);
+	json_object_append_string(json_details, "check_period",
+	                          temp_service->check_period);
+	json_object_append_boolean(json_details, "flap_detection_enabled",
+	                           temp_service->flap_detection_enabled);
+	json_object_append_real(json_details, "low_flap_threshold",
+	                        temp_service->low_flap_threshold);
+	json_object_append_real(json_details, "high_flap_threshold",
+	                        temp_service->high_flap_threshold);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "flap_dectetion_on_ok", 
-				flag_isset(temp_service->flap_detection_options, OPT_OK));
-		json_object_append_boolean(json_details, "flap_dectetion_on_warning", 
-				flag_isset(temp_service->flap_detection_options, OPT_WARNING));
-		json_object_append_boolean(json_details, "flap_dectetion_on_unknown", 
-				flag_isset(temp_service->flap_detection_options, OPT_UNKNOWN));
-		json_object_append_boolean(json_details, "flap_detection_on_critical", 
-				flag_isset(temp_service->flap_detection_options, OPT_CRITICAL));
-		}
-	else {
+		json_object_append_boolean(json_details, "flap_dectetion_on_ok",
+		                           flag_isset(temp_service->flap_detection_options, OPT_OK));
+		json_object_append_boolean(json_details, "flap_dectetion_on_warning",
+		                           flag_isset(temp_service->flap_detection_options, OPT_WARNING));
+		json_object_append_boolean(json_details, "flap_dectetion_on_unknown",
+		                           flag_isset(temp_service->flap_detection_options, OPT_UNKNOWN));
+		json_object_append_boolean(json_details, "flap_detection_on_critical",
+		                           flag_isset(temp_service->flap_detection_options, OPT_CRITICAL));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "flap_detection_options",
-				temp_service->flap_detection_options, svm_option_types);
+		             temp_service->flap_detection_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "flap_dectetion_on_ok", 
-			temp_service->flap_detection_on_ok);
-	json_object_append_boolean(json_details, "flap_dectetion_on_warning", 
-			temp_service->flap_detection_on_warning);
-	json_object_append_boolean(json_details, "flap_dectetion_on_unknown", 
-			temp_service->flap_detection_on_unknown);
-	json_object_append_boolean(json_details, "flap_detection_on_critical", 
-			temp_service->flap_detection_on_critical);
+	json_object_append_boolean(json_details, "flap_dectetion_on_ok",
+	                           temp_service->flap_detection_on_ok);
+	json_object_append_boolean(json_details, "flap_dectetion_on_warning",
+	                           temp_service->flap_detection_on_warning);
+	json_object_append_boolean(json_details, "flap_dectetion_on_unknown",
+	                           temp_service->flap_detection_on_unknown);
+	json_object_append_boolean(json_details, "flap_detection_on_critical",
+	                           temp_service->flap_detection_on_critical);
 #endif
 
-	json_object_append_boolean(json_details, "process_performance_data", 
-			temp_service->process_performance_data);
-	json_object_append_boolean(json_details, "check_freshness", 
-			temp_service->check_freshness);
-	json_object_append_integer(json_details, "freshness_threshold", 
-			temp_service->freshness_threshold);
+	json_object_append_boolean(json_details, "process_performance_data",
+	                           temp_service->process_performance_data);
+	json_object_append_boolean(json_details, "check_freshness",
+	                           temp_service->check_freshness);
+	json_object_append_integer(json_details, "freshness_threshold",
+	                           temp_service->freshness_threshold);
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, 
-				"accept_passive_service_checks",
-				temp_service->accept_passive_checks);
-		}
-	else {
+		json_object_append_boolean(json_details,
+		                           "accept_passive_service_checks",
+		                           temp_service->accept_passive_checks);
+	} else {
 #endif
-		json_object_append_boolean(json_details, "accept_passive_checks", 
-				temp_service->accept_passive_checks);
+		json_object_append_boolean(json_details, "accept_passive_checks",
+		                           temp_service->accept_passive_checks);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "accept_passive_service_checks", 
-			temp_service->accept_passive_service_checks);
+	json_object_append_boolean(json_details, "accept_passive_service_checks",
+	                           temp_service->accept_passive_service_checks);
 #endif
-	json_object_append_boolean(json_details, "event_handler_enabled", 
-			temp_service->event_handler_enabled);
-	json_object_append_boolean(json_details, "checks_enabled", 
-			temp_service->checks_enabled);
-	json_object_append_boolean(json_details, "retain_status_information", 
-			temp_service->retain_status_information);
-	json_object_append_boolean(json_details, "retain_nonstatus_information", 
-			temp_service->retain_nonstatus_information);
-	json_object_append_boolean(json_details, "notifications_enabled", 
-			temp_service->notifications_enabled);
+	json_object_append_boolean(json_details, "event_handler_enabled",
+	                           temp_service->event_handler_enabled);
+	json_object_append_boolean(json_details, "checks_enabled",
+	                           temp_service->checks_enabled);
+	json_object_append_boolean(json_details, "retain_status_information",
+	                           temp_service->retain_status_information);
+	json_object_append_boolean(json_details, "retain_nonstatus_information",
+	                           temp_service->retain_nonstatus_information);
+	json_object_append_boolean(json_details, "notifications_enabled",
+	                           temp_service->notifications_enabled);
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "obsess_over_service", 
-				temp_service->obsess);
-		}
-	else {
+		json_object_append_boolean(json_details, "obsess_over_service",
+		                           temp_service->obsess);
+	} else {
 #endif
 		json_object_append_boolean(json_details, "obsess", temp_service->obsess);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "obsess_over_service", 
-			temp_service->obsess_over_service);
+	json_object_append_boolean(json_details, "obsess_over_service",
+	                           temp_service->obsess_over_service);
 #endif
 #ifndef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "failure_prediction_enabled", 
-			temp_service->failure_prediction_enabled);
-	json_object_append_string(json_details, "failure_prediction_options", 
-			temp_service->failure_prediction_options);
+	json_object_append_boolean(json_details, "failure_prediction_enabled",
+	                           temp_service->failure_prediction_enabled);
+	json_object_append_string(json_details, "failure_prediction_options",
+	                          temp_service->failure_prediction_options);
 #endif
 #ifdef JSON_NAGIOS_4X
-	json_object_append_integer(json_details, "hourly_value", 
-			temp_service->hourly_value);
+	json_object_append_integer(json_details, "hourly_value",
+	                           temp_service->hourly_value);
 #endif
 
 #ifdef JSON_NAGIOS_4X
 	json_parent_services = json_new_array();
-	for(temp_servicesmember = temp_service->parents; 
-			temp_servicesmember != NULL; 
-			temp_servicesmember = temp_servicesmember->next) {
+	for(temp_servicesmember = temp_service->parents;
+	    temp_servicesmember != NULL;
+	    temp_servicesmember = temp_servicesmember->next) {
 		json_parent_service = json_new_object();
 		json_object_append_string(json_parent_service, "host_name",
-				temp_servicesmember->host_name);
+		                          temp_servicesmember->host_name);
 		json_object_append_string(json_parent_service, "service_description",
-				temp_servicesmember->service_description);
+		                          temp_servicesmember->service_description);
 		json_array_append_object(json_parent_services, json_parent_service);
-		}
+	}
 	json_object_append_array(json_details, "parents", json_parent_services);
 
 	json_child_services = json_new_array();
 	for(temp_servicesmember = temp_service->children;
-			temp_servicesmember != NULL;
-			temp_servicesmember = temp_servicesmember->next) {
+	    temp_servicesmember != NULL;
+	    temp_servicesmember = temp_servicesmember->next) {
 		json_child_service = json_new_object();
 		json_object_append_string(json_child_service, "host_name",
-				temp_servicesmember->host_name);
+		                          temp_servicesmember->host_name);
 		json_object_append_string(json_child_service, "service_description",
-				temp_servicesmember->service_description);
+		                          temp_servicesmember->service_description);
 		json_array_append_object(json_child_services, json_child_service);
-		}
+	}
 	json_object_append_array(json_details, "children", json_child_services);
 #endif
 
 	json_object_append_string(json_details, "notes", temp_service->notes);
 	json_object_append_string(json_details, "notes_url", temp_service->notes_url);
-	json_object_append_string(json_details, "action_url", 
-			temp_service->action_url);
-	json_object_append_string(json_details, "icon_image", 
-			temp_service->icon_image);
-	json_object_append_string(json_details, "icon_image_alt", 
-			temp_service->icon_image_alt);
+	json_object_append_string(json_details, "action_url",
+	                          temp_service->action_url);
+	json_object_append_string(json_details, "icon_image",
+	                          temp_service->icon_image);
+	json_object_append_string(json_details, "icon_image_alt",
+	                          temp_service->icon_image_alt);
 
 	json_custom_variables = json_new_array();
-	for(temp_customvariablesmember = temp_service->custom_variables; 
-			temp_customvariablesmember != NULL; 
-			temp_customvariablesmember = temp_customvariablesmember->next) {
-		json_array_append_string(json_custom_variables, 
-				temp_customvariablesmember->variable_name);
-		}
-	json_object_append_array(json_details, "custom_variables", 
-				json_custom_variables);
+	for(temp_customvariablesmember = temp_service->custom_variables;
+	    temp_customvariablesmember != NULL;
+	    temp_customvariablesmember = temp_customvariablesmember->next) {
+		json_array_append_string(json_custom_variables,
+		                         temp_customvariablesmember->variable_name);
 	}
+	json_object_append_array(json_details, "custom_variables",
+	                         json_custom_variables);
+}
 
 int json_object_servicegroup_passes_selection(servicegroup *temp_servicegroup,
-		service *temp_servicegroup_member) {
+        service *temp_servicegroup_member)
+{
 
 	/* Skip if user is not authorized for this hostgroup */
-	if(FALSE == is_authorized_for_servicegroup(temp_servicegroup, 
-			&current_authdata)) {
+	if(FALSE == is_authorized_for_servicegroup(temp_servicegroup,
+	        &current_authdata)) {
 		return 0;
-		}
-
-	/* Skip if a servicegroup member is specified and the servicegroup 
-		member service is not a member of the servicegroup */
-	if( NULL != temp_servicegroup_member && 
-			( FALSE == is_service_member_of_servicegroup(temp_servicegroup, 
-					temp_servicegroup_member))) {
-		return 0;
-		}
-
-	return 1;
 	}
 
-json_object * json_object_servicegroup_selectors(int start, int count, 
-		service *temp_servicegroup_member) {
+	/* Skip if a servicegroup member is specified and the servicegroup
+		member service is not a member of the servicegroup */
+	if( NULL != temp_servicegroup_member &&
+	    ( FALSE == is_service_member_of_servicegroup(temp_servicegroup,
+	            temp_servicegroup_member))) {
+		return 0;
+	}
+
+	return 1;
+}
+
+json_object * json_object_servicegroup_selectors(int start, int count,
+        service *temp_servicegroup_member)
+{
 
 	json_object *json_selectors;
 
@@ -3875,49 +3924,51 @@ json_object * json_object_servicegroup_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( NULL != temp_servicegroup_member) {
-		json_object_append_string(json_selectors, "servicegroupmemberhost", 
-				temp_servicegroup_member->host_name);
-		json_object_append_string(json_selectors, "servicegroupmemberservice", 
-				temp_servicegroup_member->description);
-		}
-
-	return json_selectors;
+		json_object_append_string(json_selectors, "servicegroupmemberhost",
+		                          temp_servicegroup_member->host_name);
+		json_object_append_string(json_selectors, "servicegroupmemberservice",
+		                          temp_servicegroup_member->description);
 	}
 
-json_object *json_object_servicegroupcount(service *temp_servicegroup_member) {
+	return json_selectors;
+}
+
+json_object *json_object_servicegroupcount(service *temp_servicegroup_member)
+{
 
 	json_object *json_data;
 	servicegroup *temp_servicegroup;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_servicegroup_selectors(0, 0, 
-			temp_servicegroup_member));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_servicegroup_selectors(0, 0,
+	                                  temp_servicegroup_member));
 
-	for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; 
-			temp_servicegroup = temp_servicegroup->next) {
+	for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL;
+	    temp_servicegroup = temp_servicegroup->next) {
 
 		if(json_object_servicegroup_passes_selection(temp_servicegroup,
-				temp_servicegroup_member) == 0) {
+		        temp_servicegroup_member) == 0) {
 			continue;
-			}
-
-		count++; 
 		}
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_servicegrouplist(unsigned format_options, int start, 
-		int count, int details, service *temp_servicegroup_member) {
+json_object *json_object_servicegrouplist(unsigned format_options, int start,
+        int count, int details, service *temp_servicegroup_member)
+{
 
 	json_object *json_data;
 	json_object *json_servicegrouplist_object = NULL;
@@ -3928,136 +3979,137 @@ json_object *json_object_servicegrouplist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_servicegroup_selectors(start, count, 
-			temp_servicegroup_member));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_servicegroup_selectors(start, count,
+	                                  temp_servicegroup_member));
 
 	if(details > 0) {
 		json_servicegrouplist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_servicegrouplist_array = json_new_array();
-		}
+	}
 
-	for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; 
-			temp_servicegroup = temp_servicegroup->next) {
+	for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL;
+	    temp_servicegroup = temp_servicegroup->next) {
 
 		if(json_object_servicegroup_passes_selection(temp_servicegroup,
-				temp_servicegroup_member) == 0) {
+		        temp_servicegroup_member) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_servicegroup_details = json_new_object();
-				json_object_servicegroup_details(json_servicegroup_details, 
-						format_options, temp_servicegroup);
-				json_object_append_object(json_servicegrouplist_object, 
-						temp_servicegroup->group_name,
-						json_servicegroup_details);
-				}
-			else {
-				json_object_append_string(json_servicegrouplist_array, NULL, 
-						temp_servicegroup->group_name);
-				}
-			counted++;
+				json_object_servicegroup_details(json_servicegroup_details,
+				                                 format_options, temp_servicegroup);
+				json_object_append_object(json_servicegrouplist_object,
+				                          temp_servicegroup->group_name,
+				                          json_servicegroup_details);
+			} else {
+				json_object_append_string(json_servicegrouplist_array, NULL,
+				                          temp_servicegroup->group_name);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "servicegrouplist", 
-				json_servicegrouplist_object);
-		}
-	else {
-		json_object_append_array(json_data, "servicegrouplist", 
-				json_servicegrouplist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object * json_object_servicegroup(unsigned format_options, 
-		servicegroup *temp_servicegroup) {
+	if(details > 0) {
+		json_object_append_object(json_data, "servicegrouplist",
+		                          json_servicegrouplist_object);
+	} else {
+		json_object_append_array(json_data, "servicegrouplist",
+		                         json_servicegrouplist_array);
+	}
+
+	return json_data;
+}
+
+json_object * json_object_servicegroup(unsigned format_options,
+                                       servicegroup *temp_servicegroup)
+{
 
 	json_object *json_servicegroup = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_string(json_details, "group_name", 
-			temp_servicegroup->group_name);
-	json_object_servicegroup_details(json_details, format_options, 
-			temp_servicegroup);
+	json_object_append_string(json_details, "group_name",
+	                          temp_servicegroup->group_name);
+	json_object_servicegroup_details(json_details, format_options,
+	                                 temp_servicegroup);
 	json_object_append_object(json_servicegroup, "servicegroup", json_details);
 
 	return json_servicegroup;
 }
 
-void json_object_servicegroup_details(json_object *json_details, 
-		unsigned format_options, servicegroup *temp_servicegroup) {
+void json_object_servicegroup_details(json_object *json_details,
+                                      unsigned format_options, servicegroup *temp_servicegroup)
+{
 
 	json_array *json_members;
 	servicesmember *temp_member;
 	json_object *json_member;
 
-	json_object_append_string(json_details, "group_name", 
-			temp_servicegroup->group_name);
+	json_object_append_string(json_details, "group_name",
+	                          temp_servicegroup->group_name);
 	json_object_append_string(json_details, "alias", temp_servicegroup->alias);
 
 	json_members = json_new_array();
-	for(temp_member = temp_servicegroup->members; temp_member != NULL; 
-			temp_member = temp_member->next) {
+	for(temp_member = temp_servicegroup->members; temp_member != NULL;
+	    temp_member = temp_member->next) {
 		json_member = json_new_object();
-		json_object_append_string(json_member, "host_name", 
-				temp_member->host_name);
-		json_object_append_string(json_member, "service_description", 
-				temp_member->service_description);
+		json_object_append_string(json_member, "host_name",
+		                          temp_member->host_name);
+		json_object_append_string(json_member, "service_description",
+		                          temp_member->service_description);
 		json_array_append_object(json_members, json_member);
-		}
+	}
 	json_object_append_array(json_details, "members", json_members);
 
 	json_object_append_string(json_details, "notes", temp_servicegroup->notes);
-	json_object_append_string(json_details, "notes_url", 
-			temp_servicegroup->notes_url);
-	json_object_append_string(json_details, "action_url", 
-			temp_servicegroup->action_url);
-	}
+	json_object_append_string(json_details, "notes_url",
+	                          temp_servicegroup->notes_url);
+	json_object_append_string(json_details, "action_url",
+	                          temp_servicegroup->action_url);
+}
 
 int json_object_contact_passes_selection(contact *temp_contact,
-		contactgroup *temp_contactgroup,
-		timeperiod *host_notification_timeperiod,
-		timeperiod *service_notification_timeperiod) {
+        contactgroup *temp_contactgroup,
+        timeperiod *host_notification_timeperiod,
+        timeperiod *service_notification_timeperiod)
+{
 
-	/* If the contactgroup was specified, skip the contacts that are not 
+	/* If the contactgroup was specified, skip the contacts that are not
 		members of the contactgroup specified */
-	if( NULL != temp_contactgroup && 
-			( FALSE == is_contact_member_of_contactgroup(temp_contactgroup, 
-					temp_contact))) {
+	if( NULL != temp_contactgroup &&
+	    ( FALSE == is_contact_member_of_contactgroup(temp_contactgroup,
+	            temp_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a host notification timeperiod was specified, skip this contact
 		if it does not have the host notification timeperiod specified */
 	if(NULL != host_notification_timeperiod && (host_notification_timeperiod !=
-			temp_contact->host_notification_period_ptr)) {
+	        temp_contact->host_notification_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a service notification timeperiod was specified, skip this contact
 		if it does not have the service notification timeperiod specified */
 	if(NULL != service_notification_timeperiod &&
-			(service_notification_timeperiod !=
-			temp_contact->service_notification_period_ptr)) {
+	   (service_notification_timeperiod !=
+	    temp_contact->service_notification_period_ptr)) {
 		return 0;
-		}
-
-	return 1;
 	}
 
-json_object *json_object_contact_display_selectors(int start, int count, 
-		contactgroup *temp_contactgroup,
-		timeperiod *host_notification_timeperiod,
-		timeperiod *service_notification_timeperiod) {
+	return 1;
+}
+
+json_object *json_object_contact_display_selectors(int start, int count,
+        contactgroup *temp_contactgroup,
+        timeperiod *host_notification_timeperiod,
+        timeperiod *service_notification_timeperiod)
+{
 
 	json_object *json_selectors;
 
@@ -4065,61 +4117,63 @@ json_object *json_object_contact_display_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( NULL != temp_contactgroup) {
-		json_object_append_string(json_selectors, "contactgroup", 
-				temp_contactgroup->group_name);
-		}
+		json_object_append_string(json_selectors, "contactgroup",
+		                          temp_contactgroup->group_name);
+	}
 	if( NULL != host_notification_timeperiod) {
 		json_object_append_string(json_selectors, "hostnotificationtimeperiod",
-				host_notification_timeperiod->name);
-		}
+		                          host_notification_timeperiod->name);
+	}
 	if( NULL != service_notification_timeperiod) {
 		json_object_append_string(json_selectors,
-				"servicenotificationtimeperiod",
-				service_notification_timeperiod->name);
-		}
-
-	return json_selectors;
+		                          "servicenotificationtimeperiod",
+		                          service_notification_timeperiod->name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_object_contactcount(contactgroup *temp_contactgroup,
-		timeperiod *host_notification_timeperiod,
-		timeperiod *service_notification_timeperiod) {
+                                      timeperiod *host_notification_timeperiod,
+                                      timeperiod *service_notification_timeperiod)
+{
 
 	json_object *json_data;
 	contact *temp_contact;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_contact_display_selectors(0, 0, temp_contactgroup,
-			host_notification_timeperiod, service_notification_timeperiod));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_contact_display_selectors(0, 0, temp_contactgroup,
+	                                  host_notification_timeperiod, service_notification_timeperiod));
 
-	for(temp_contact = contact_list; temp_contact != NULL; 
-			temp_contact = temp_contact->next) {
+	for(temp_contact = contact_list; temp_contact != NULL;
+	    temp_contact = temp_contact->next) {
 
-		if(json_object_contact_passes_selection(temp_contact, 
-				temp_contactgroup, host_notification_timeperiod,
-				service_notification_timeperiod) == 0) {
+		if(json_object_contact_passes_selection(temp_contact,
+		                                        temp_contactgroup, host_notification_timeperiod,
+		                                        service_notification_timeperiod) == 0) {
 			continue;
-			}
-
-		count++; 
 		}
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_contactlist(unsigned format_options, int start, 
-		int count, int details, contactgroup *temp_contactgroup,
-		timeperiod *host_notification_timeperiod,
-		timeperiod *service_notification_timeperiod) {
+json_object *json_object_contactlist(unsigned format_options, int start,
+                                     int count, int details, contactgroup *temp_contactgroup,
+                                     timeperiod *host_notification_timeperiod,
+                                     timeperiod *service_notification_timeperiod)
+{
 
 	json_object *json_data;
 	json_object *json_contactlist_object = NULL;
@@ -4130,58 +4184,56 @@ json_object *json_object_contactlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_contact_display_selectors(start, count,
-			temp_contactgroup, host_notification_timeperiod,
-			service_notification_timeperiod));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_contact_display_selectors(start, count,
+	                                  temp_contactgroup, host_notification_timeperiod,
+	                                  service_notification_timeperiod));
 
 	if(details > 0) {
 		json_contactlist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_contactlist_array = json_new_array();
-		}
+	}
 
-	for(temp_contact = contact_list; temp_contact != NULL; 
-			temp_contact = temp_contact->next) {
+	for(temp_contact = contact_list; temp_contact != NULL;
+	    temp_contact = temp_contact->next) {
 
-		if(json_object_contact_passes_selection(temp_contact, 
-				temp_contactgroup, host_notification_timeperiod,
-				service_notification_timeperiod) == 0) {
+		if(json_object_contact_passes_selection(temp_contact,
+		                                        temp_contactgroup, host_notification_timeperiod,
+		                                        service_notification_timeperiod) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_contact_details = json_new_object();
-				json_object_contact_details(json_contact_details, 
-						format_options, temp_contact);
-				json_object_append_object(json_contactlist_object, 
-						temp_contact->name, json_contact_details);
-				}
-			else {
-				json_array_append_string(json_contactlist_array, 
-						temp_contact->name);
-				}
-			counted++;
+				json_object_contact_details(json_contact_details,
+				                            format_options, temp_contact);
+				json_object_append_object(json_contactlist_object,
+				                          temp_contact->name, json_contact_details);
+			} else {
+				json_array_append_string(json_contactlist_array,
+				                         temp_contact->name);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "contactlist", 
-				json_contactlist_object);
-		}
-	else {
-		json_object_append_array(json_data, "contactlist", 
-				json_contactlist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object *json_object_contact(unsigned format_options, contact *temp_contact) {
+	if(details > 0) {
+		json_object_append_object(json_data, "contactlist",
+		                          json_contactlist_object);
+	} else {
+		json_object_append_array(json_data, "contactlist",
+		                         json_contactlist_array);
+	}
+
+	return json_data;
+}
+
+json_object *json_object_contact(unsigned format_options, contact *temp_contact)
+{
 
 	json_object *json_contact = json_new_object();
 	json_object *json_details = json_new_object();
@@ -4193,8 +4245,9 @@ json_object *json_object_contact(unsigned format_options, contact *temp_contact)
 	return json_contact;
 }
 
-void json_object_contact_details(json_object *json_details, 
-		unsigned format_options, contact *temp_contact) {
+void json_object_contact_details(json_object *json_details,
+                                 unsigned format_options, contact *temp_contact)
+{
 
 	json_array *json_addresses;
 	json_array *json_host_commands;
@@ -4213,159 +4266,159 @@ void json_object_contact_details(json_object *json_details,
 	for( x = 0; x < MAX_CONTACT_ADDRESSES; x++) {
 		if( NULL != temp_contact->address[ x]) {
 			json_array_append_string(json_addresses, temp_contact->address[ x]);
-			}
 		}
+	}
 	json_object_append_array(json_details, "addresses", json_addresses);
 
 	json_host_commands = json_new_array();
-	for(temp_commandsmember = temp_contact->host_notification_commands; 
-			temp_commandsmember != NULL; 
-			temp_commandsmember = temp_commandsmember->next) {
-		json_array_append_string(json_host_commands, 
-				temp_commandsmember->command);
-		}
-	json_object_append_array(json_details, "host_notification_commands", 
-			json_host_commands);
+	for(temp_commandsmember = temp_contact->host_notification_commands;
+	    temp_commandsmember != NULL;
+	    temp_commandsmember = temp_commandsmember->next) {
+		json_array_append_string(json_host_commands,
+		                         temp_commandsmember->command);
+	}
+	json_object_append_array(json_details, "host_notification_commands",
+	                         json_host_commands);
 
 	json_service_commands = json_new_array();
-	for(temp_commandsmember = temp_contact->service_notification_commands; 
-			temp_commandsmember != NULL; 
-			temp_commandsmember = temp_commandsmember->next) {
-		json_array_append_string(json_service_commands, 
-				temp_commandsmember->command);
-		}
-	json_object_append_array(json_details, "service_notification_commands", 
-			json_service_commands);
+	for(temp_commandsmember = temp_contact->service_notification_commands;
+	    temp_commandsmember != NULL;
+	    temp_commandsmember = temp_commandsmember->next) {
+		json_array_append_string(json_service_commands,
+		                         temp_commandsmember->command);
+	}
+	json_object_append_array(json_details, "service_notification_commands",
+	                         json_service_commands);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "notify_on_service_unknown", 
-				flag_isset(temp_contact->service_notification_options, 
-				OPT_UNKNOWN));
-		json_object_append_boolean(json_details, "notify_on_service_warning", 
-				flag_isset(temp_contact->service_notification_options, 
-				OPT_WARNING));
-		json_object_append_boolean(json_details, "notify_on_service_critical", 
-				flag_isset(temp_contact->service_notification_options, 
-				OPT_CRITICAL));
-		json_object_append_boolean(json_details, "notify_on_service_recovery", 
-				flag_isset(temp_contact->service_notification_options, 
-				OPT_RECOVERY));
-		json_object_append_boolean(json_details, "notify_on_service_flapping", 
-				flag_isset(temp_contact->service_notification_options, 
-				OPT_FLAPPING));
-		json_object_append_boolean(json_details, "notify_on_service_downtime", 
-				flag_isset(temp_contact->service_notification_options, 
-				OPT_DOWNTIME));
-		}
-	else {
+		json_object_append_boolean(json_details, "notify_on_service_unknown",
+		                           flag_isset(temp_contact->service_notification_options,
+		                                      OPT_UNKNOWN));
+		json_object_append_boolean(json_details, "notify_on_service_warning",
+		                           flag_isset(temp_contact->service_notification_options,
+		                                      OPT_WARNING));
+		json_object_append_boolean(json_details, "notify_on_service_critical",
+		                           flag_isset(temp_contact->service_notification_options,
+		                                      OPT_CRITICAL));
+		json_object_append_boolean(json_details, "notify_on_service_recovery",
+		                           flag_isset(temp_contact->service_notification_options,
+		                                      OPT_RECOVERY));
+		json_object_append_boolean(json_details, "notify_on_service_flapping",
+		                           flag_isset(temp_contact->service_notification_options,
+		                                      OPT_FLAPPING));
+		json_object_append_boolean(json_details, "notify_on_service_downtime",
+		                           flag_isset(temp_contact->service_notification_options,
+		                                      OPT_DOWNTIME));
+	} else {
 #endif
-		json_bitmask(json_details, format_options, 
-				"service_notification_options",
-				temp_contact->service_notification_options, svm_option_types);
+		json_bitmask(json_details, format_options,
+		             "service_notification_options",
+		             temp_contact->service_notification_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "notify_on_service_unknown", 
-			temp_contact->notify_on_service_unknown);
-	json_object_append_boolean(json_details, "notify_on_service_warning", 
-			temp_contact->notify_on_service_warning);
-	json_object_append_boolean(json_details, "notify_on_service_critical", 
-			temp_contact->notify_on_service_critical);
-	json_object_append_boolean(json_details, "notify_on_service_recovery", 
-			temp_contact->notify_on_service_recovery);
-	json_object_append_boolean(json_details, "notify_on_service_flapping", 
-			temp_contact->notify_on_service_flapping);
-	json_object_append_boolean(json_details, "notify_on_service_downtime", 
-			temp_contact->notify_on_service_downtime);
+	json_object_append_boolean(json_details, "notify_on_service_unknown",
+	                           temp_contact->notify_on_service_unknown);
+	json_object_append_boolean(json_details, "notify_on_service_warning",
+	                           temp_contact->notify_on_service_warning);
+	json_object_append_boolean(json_details, "notify_on_service_critical",
+	                           temp_contact->notify_on_service_critical);
+	json_object_append_boolean(json_details, "notify_on_service_recovery",
+	                           temp_contact->notify_on_service_recovery);
+	json_object_append_boolean(json_details, "notify_on_service_flapping",
+	                           temp_contact->notify_on_service_flapping);
+	json_object_append_boolean(json_details, "notify_on_service_downtime",
+	                           temp_contact->notify_on_service_downtime);
 #endif
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "notify_on_host_down", 
-				flag_isset(temp_contact->host_notification_options, OPT_DOWN));
-		json_object_append_boolean(json_details, "notify_on_host_unreachable", 
-				flag_isset(temp_contact->host_notification_options, 
-				OPT_UNREACHABLE));
-		json_object_append_boolean(json_details, "notify_on_host_recovery", 
-				flag_isset(temp_contact->host_notification_options, 
-				OPT_RECOVERY));
-		json_object_append_boolean(json_details, "notify_on_host_flapping", 
-				flag_isset(temp_contact->host_notification_options, 
-				OPT_FLAPPING));
-		json_object_append_boolean(json_details, "notify_on_host_downtime", 
-				flag_isset(temp_contact->host_notification_options, 
-				OPT_DOWNTIME));
-		}
-	else {
+		json_object_append_boolean(json_details, "notify_on_host_down",
+		                           flag_isset(temp_contact->host_notification_options, OPT_DOWN));
+		json_object_append_boolean(json_details, "notify_on_host_unreachable",
+		                           flag_isset(temp_contact->host_notification_options,
+		                                      OPT_UNREACHABLE));
+		json_object_append_boolean(json_details, "notify_on_host_recovery",
+		                           flag_isset(temp_contact->host_notification_options,
+		                                      OPT_RECOVERY));
+		json_object_append_boolean(json_details, "notify_on_host_flapping",
+		                           flag_isset(temp_contact->host_notification_options,
+		                                      OPT_FLAPPING));
+		json_object_append_boolean(json_details, "notify_on_host_downtime",
+		                           flag_isset(temp_contact->host_notification_options,
+		                                      OPT_DOWNTIME));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "host_notification_options",
-				temp_contact->host_notification_options, svm_option_types);
+		             temp_contact->host_notification_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "notify_on_host_down", 
-			temp_contact->notify_on_host_down);
-	json_object_append_boolean(json_details, "notify_on_host_unreachable", 
-			temp_contact->notify_on_host_unreachable);
-	json_object_append_boolean(json_details, "notify_on_host_recovery", 
-			temp_contact->notify_on_host_recovery);
-	json_object_append_boolean(json_details, "notify_on_host_flapping", 
-			temp_contact->notify_on_host_flapping);
-	json_object_append_boolean(json_details, "notify_on_host_downtime", 
-			temp_contact->notify_on_host_downtime);
+	json_object_append_boolean(json_details, "notify_on_host_down",
+	                           temp_contact->notify_on_host_down);
+	json_object_append_boolean(json_details, "notify_on_host_unreachable",
+	                           temp_contact->notify_on_host_unreachable);
+	json_object_append_boolean(json_details, "notify_on_host_recovery",
+	                           temp_contact->notify_on_host_recovery);
+	json_object_append_boolean(json_details, "notify_on_host_flapping",
+	                           temp_contact->notify_on_host_flapping);
+	json_object_append_boolean(json_details, "notify_on_host_downtime",
+	                           temp_contact->notify_on_host_downtime);
 #endif
 
-	json_object_append_string(json_details, "host_notification_period", 
-			temp_contact->host_notification_period);
-	json_object_append_string(json_details, "service_notification_period", 
-			temp_contact->service_notification_period);
-	json_object_append_boolean(json_details, "host_notifications_enabled", 
-			temp_contact->host_notifications_enabled);
-	json_object_append_boolean(json_details, "service_notifications_enabled", 
-			temp_contact->service_notifications_enabled);
-	json_object_append_boolean(json_details, "can_submit_commands", 
-			temp_contact->can_submit_commands);
-	json_object_append_boolean(json_details, "retain_status_information", 
-			temp_contact->retain_status_information);
-	json_object_append_boolean(json_details, "retain_nonstatus_information", 
-			temp_contact->retain_nonstatus_information);
+	json_object_append_string(json_details, "host_notification_period",
+	                          temp_contact->host_notification_period);
+	json_object_append_string(json_details, "service_notification_period",
+	                          temp_contact->service_notification_period);
+	json_object_append_boolean(json_details, "host_notifications_enabled",
+	                           temp_contact->host_notifications_enabled);
+	json_object_append_boolean(json_details, "service_notifications_enabled",
+	                           temp_contact->service_notifications_enabled);
+	json_object_append_boolean(json_details, "can_submit_commands",
+	                           temp_contact->can_submit_commands);
+	json_object_append_boolean(json_details, "retain_status_information",
+	                           temp_contact->retain_status_information);
+	json_object_append_boolean(json_details, "retain_nonstatus_information",
+	                           temp_contact->retain_nonstatus_information);
 #ifdef JSON_NAGIOS_4X
-	json_object_append_integer(json_details, "minimum_value", 
-			temp_contact->minimum_value);
+	json_object_append_integer(json_details, "minimum_value",
+	                           temp_contact->minimum_value);
 #endif
 
 	json_custom_variables = json_new_array();
-	for(temp_customvariablesmember = temp_contact->custom_variables; 
-			temp_customvariablesmember != NULL; 
-			temp_customvariablesmember = temp_customvariablesmember->next) {
-		json_array_append_string(json_custom_variables, 
-				temp_customvariablesmember->variable_name);
-		}
-	json_object_append_array(json_details, "custom_variables", 
-			json_custom_variables);
+	for(temp_customvariablesmember = temp_contact->custom_variables;
+	    temp_customvariablesmember != NULL;
+	    temp_customvariablesmember = temp_customvariablesmember->next) {
+		json_array_append_string(json_custom_variables,
+		                         temp_customvariablesmember->variable_name);
 	}
+	json_object_append_array(json_details, "custom_variables",
+	                         json_custom_variables);
+}
 
 int json_object_contactgroup_passes_selection(contactgroup *temp_contactgroup,
-		contact *temp_contactgroup_member) {
+        contact *temp_contactgroup_member)
+{
 
-	/* Skip if a contactgroup member is specified and the contactgroup 
+	/* Skip if a contactgroup member is specified and the contactgroup
 		member contact is not a member of the contactgroup */
-	if( NULL != temp_contactgroup_member && 
-			( FALSE == is_contact_member_of_contactgroup(temp_contactgroup, 
-					temp_contactgroup_member))) {
+	if( NULL != temp_contactgroup_member &&
+	    ( FALSE == is_contact_member_of_contactgroup(temp_contactgroup,
+	            temp_contactgroup_member))) {
 		return 0;
-		}
-
-	return 1;
 	}
 
-json_object *json_object_contactgroup_display_selectors( int start, int count, 
-		contact *temp_contactgroup_member) {
+	return 1;
+}
+
+json_object *json_object_contactgroup_display_selectors( int start, int count,
+        contact *temp_contactgroup_member)
+{
 
 	json_object *json_selectors;
 
@@ -4373,47 +4426,49 @@ json_object *json_object_contactgroup_display_selectors( int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( NULL != temp_contactgroup_member) {
-		json_object_append_string(json_selectors, "contactgroupmember", 
-				temp_contactgroup_member->name);
-		}
-
-	return json_selectors;
+		json_object_append_string(json_selectors, "contactgroupmember",
+		                          temp_contactgroup_member->name);
 	}
 
-json_object *json_object_contactgroupcount(contact * temp_contactgroup_member) {
+	return json_selectors;
+}
+
+json_object *json_object_contactgroupcount(contact * temp_contactgroup_member)
+{
 
 	json_object *json_data;
 	contactgroup *temp_contactgroup;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_contactgroup_display_selectors(0, 0, 
-			temp_contactgroup_member));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_contactgroup_display_selectors(0, 0,
+	                                  temp_contactgroup_member));
 
-	for(temp_contactgroup = contactgroup_list; temp_contactgroup != NULL; 
-			temp_contactgroup = temp_contactgroup->next) {
+	for(temp_contactgroup = contactgroup_list; temp_contactgroup != NULL;
+	    temp_contactgroup = temp_contactgroup->next) {
 
 		if(json_object_contactgroup_passes_selection(temp_contactgroup,
-				temp_contactgroup_member) == 0) {
+		        temp_contactgroup_member) == 0) {
 			continue;
-			}
-
-		count++; 
 		}
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_contactgrouplist(unsigned format_options, int start, 
-		int count, int details, contact * temp_contactgroup_member) {
+json_object *json_object_contactgrouplist(unsigned format_options, int start,
+        int count, int details, contact * temp_contactgroup_member)
+{
 
 	json_object *json_data;
 	json_object *json_contactgrouplist_object = NULL;
@@ -4424,89 +4479,89 @@ json_object *json_object_contactgrouplist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_contactgroup_display_selectors(start, count, 
-			temp_contactgroup_member));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_contactgroup_display_selectors(start, count,
+	                                  temp_contactgroup_member));
 
 	if(details > 0) {
 		json_contactgrouplist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_contactgrouplist_array = json_new_array();
-		}
+	}
 
-	for(temp_contactgroup = contactgroup_list; temp_contactgroup != NULL; 
-			temp_contactgroup = temp_contactgroup->next) {
+	for(temp_contactgroup = contactgroup_list; temp_contactgroup != NULL;
+	    temp_contactgroup = temp_contactgroup->next) {
 
 		if(json_object_contactgroup_passes_selection(temp_contactgroup,
-				temp_contactgroup_member) == 0) {
+		        temp_contactgroup_member) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_contactgroup_details = json_new_object();
-				json_object_contactgroup_details(json_contactgroup_details, 
-						format_options, temp_contactgroup);
-				json_object_append_object(json_contactgrouplist_object, 
-						temp_contactgroup->group_name, json_contactgroup_details);
-				}
-			else {
-				json_array_append_string(json_contactgrouplist_array, 
-						temp_contactgroup->group_name);
-				}
-			counted++;
+				json_object_contactgroup_details(json_contactgroup_details,
+				                                 format_options, temp_contactgroup);
+				json_object_append_object(json_contactgrouplist_object,
+				                          temp_contactgroup->group_name, json_contactgroup_details);
+			} else {
+				json_array_append_string(json_contactgrouplist_array,
+				                         temp_contactgroup->group_name);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "contactgrouplist", 
-				json_contactgrouplist_object);
-		}
-	else {
-		json_object_append_array(json_data, "contactgrouplist", 
-				json_contactgrouplist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object *json_object_contactgroup(unsigned format_options, 
-		contactgroup *temp_contactgroup) {
+	if(details > 0) {
+		json_object_append_object(json_data, "contactgrouplist",
+		                          json_contactgrouplist_object);
+	} else {
+		json_object_append_array(json_data, "contactgrouplist",
+		                         json_contactgrouplist_array);
+	}
+
+	return json_data;
+}
+
+json_object *json_object_contactgroup(unsigned format_options,
+                                      contactgroup *temp_contactgroup)
+{
 
 	json_object *json_contactgroup = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_string(json_details, "group_name", 
-			temp_contactgroup->group_name);
-	json_object_contactgroup_details(json_details, format_options, 
-			temp_contactgroup);
+	json_object_append_string(json_details, "group_name",
+	                          temp_contactgroup->group_name);
+	json_object_contactgroup_details(json_details, format_options,
+	                                 temp_contactgroup);
 	json_object_append_object(json_contactgroup, "contactgroup", json_details);
 
 	return json_contactgroup;
 }
 
-void json_object_contactgroup_details(json_object *json_details, 
-		unsigned format_options, contactgroup *temp_contactgroup) {
+void json_object_contactgroup_details(json_object *json_details,
+                                      unsigned format_options, contactgroup *temp_contactgroup)
+{
 
 	json_array *json_members;
 	contactsmember *temp_member;
 
-	json_object_append_string(json_details, "group_name", 
-			temp_contactgroup->group_name);
+	json_object_append_string(json_details, "group_name",
+	                          temp_contactgroup->group_name);
 	json_object_append_string(json_details, "alias", temp_contactgroup->alias);
 
 	json_members = json_new_array();
-	for(temp_member = temp_contactgroup->members; temp_member != NULL; 
-			temp_member = temp_member->next) {
+	for(temp_member = temp_contactgroup->members; temp_member != NULL;
+	    temp_member = temp_member->next) {
 		json_array_append_string(json_members, temp_member->contact_name);
-		}
-	json_object_append_array(json_details, "members", json_members);
 	}
+	json_object_append_array(json_details, "members", json_members);
+}
 
-json_object *json_object_timeperiod_selectors(int start, int count) {
+json_object *json_object_timeperiod_selectors(int start, int count)
+{
 
 	json_object *json_selectors;
 
@@ -4514,37 +4569,39 @@ json_object *json_object_timeperiod_selectors(int start, int count) {
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
-
-	return json_selectors;
 	}
 
-json_object *json_object_timeperiodcount(void) {
+	return json_selectors;
+}
+
+json_object *json_object_timeperiodcount(void)
+{
 
 	json_object *json_data;
 	timeperiod *temp_timeperiod;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_timeperiod_selectors(0, 0));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_timeperiod_selectors(0, 0));
 
-	for(temp_timeperiod = timeperiod_list; temp_timeperiod != NULL; 
-			temp_timeperiod = temp_timeperiod->next) {
+	for(temp_timeperiod = timeperiod_list; temp_timeperiod != NULL;
+	    temp_timeperiod = temp_timeperiod->next) {
 
-		count++; 
-		}
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_timeperiodlist(unsigned format_options, int start, 
-		int count, int details) {
+json_object *json_object_timeperiodlist(unsigned format_options, int start,
+                                        int count, int details)
+{
 
 	json_object *json_data;
 	json_object *json_timeperiodlist_object = NULL;
@@ -4555,51 +4612,49 @@ json_object *json_object_timeperiodlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_timeperiod_selectors(start, count));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_timeperiod_selectors(start, count));
 
 	if(details > 0) {
 		json_timeperiodlist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_timeperiodlist_array = json_new_array();
-		}
+	}
 
-	for(temp_timeperiod = timeperiod_list; temp_timeperiod != NULL; 
-			temp_timeperiod = temp_timeperiod->next) {
+	for(temp_timeperiod = timeperiod_list; temp_timeperiod != NULL;
+	    temp_timeperiod = temp_timeperiod->next) {
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_timeperiod_details = json_new_object();
-				json_object_timeperiod_details(json_timeperiod_details, 
-						format_options, temp_timeperiod);
-				json_object_append_object(json_timeperiodlist_object, 
-						temp_timeperiod->name, json_timeperiod_details);
-				}
-			else {
-				json_array_append_string(json_timeperiodlist_array, 
-						temp_timeperiod->name);
-				}
-			counted++;
+				json_object_timeperiod_details(json_timeperiod_details,
+				                               format_options, temp_timeperiod);
+				json_object_append_object(json_timeperiodlist_object,
+				                          temp_timeperiod->name, json_timeperiod_details);
+			} else {
+				json_array_append_string(json_timeperiodlist_array,
+				                         temp_timeperiod->name);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "timeperiodlist", 
-				json_timeperiodlist_object);
-		}
-	else {
-		json_object_append_array(json_data, "timeperiodlist", 
-				json_timeperiodlist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object *json_object_timeperiod(unsigned format_options, 
-		timeperiod *temp_timeperiod) {
+	if(details > 0) {
+		json_object_append_object(json_data, "timeperiodlist",
+		                          json_timeperiodlist_object);
+	} else {
+		json_object_append_array(json_data, "timeperiodlist",
+		                         json_timeperiodlist_array);
+	}
+
+	return json_data;
+}
+
+json_object *json_object_timeperiod(unsigned format_options,
+                                    timeperiod *temp_timeperiod)
+{
 
 	json_object *json_timeperiod = json_new_object();
 	json_object *json_details = json_new_object();
@@ -4611,8 +4666,9 @@ json_object *json_object_timeperiod(unsigned format_options,
 	return json_timeperiod;
 }
 
-void json_object_timeperiod_details(json_object *json_details, 
-		unsigned format_options, timeperiod *temp_timeperiod) {
+void json_object_timeperiod_details(json_object *json_details,
+                                    unsigned format_options, timeperiod *temp_timeperiod)
+{
 
 	json_object *json_days;
 	int x;
@@ -4629,36 +4685,37 @@ void json_object_timeperiod_details(json_object *json_details,
 	for(x = 0; x < sizeof(temp_timeperiod->days) / sizeof(temp_timeperiod->days[0]); x++) {
 		if( NULL != temp_timeperiod->days[x]) {
 			json_timeranges = json_new_array();
-			json_object_timerange(json_timeranges, format_options, 
-					temp_timeperiod->days[x]);
-			json_object_append_array(json_days, (char *)dayofweek[x], 
-					json_timeranges);
-			}
+			json_object_timerange(json_timeranges, format_options,
+			                      temp_timeperiod->days[x]);
+			json_object_append_array(json_days, (char *)dayofweek[x],
+			                         json_timeranges);
 		}
+	}
 	json_object_append_object(json_details, "days", json_days);
 
 	json_exceptions = json_new_array();
 	for(x = 0; x < DATERANGE_TYPES; x++) {
-		for(temp_daterange = temp_timeperiod->exceptions[x]; 
-				temp_daterange != NULL; temp_daterange = temp_daterange->next) {
-			json_array_append_object(json_exceptions, 
-					json_object_daterange(format_options, temp_daterange, x));
-			}
+		for(temp_daterange = temp_timeperiod->exceptions[x];
+		    temp_daterange != NULL; temp_daterange = temp_daterange->next) {
+			json_array_append_object(json_exceptions,
+			                         json_object_daterange(format_options, temp_daterange, x));
 		}
+	}
 	json_object_append_array(json_details, "exceptions", json_exceptions);
 
 	json_exclusions = json_new_array();
-	for(temp_timeperiodexclusion = temp_timeperiod->exclusions; 
-			temp_timeperiodexclusion != NULL; 
-			temp_timeperiodexclusion = temp_timeperiodexclusion->next) {
-		json_array_append_string(json_exclusions, 
-				temp_timeperiodexclusion->timeperiod_name);
-		}
-	json_object_append_array(json_details, "exclusions", json_exclusions);
+	for(temp_timeperiodexclusion = temp_timeperiod->exclusions;
+	    temp_timeperiodexclusion != NULL;
+	    temp_timeperiodexclusion = temp_timeperiodexclusion->next) {
+		json_array_append_string(json_exclusions,
+		                         temp_timeperiodexclusion->timeperiod_name);
 	}
+	json_object_append_array(json_details, "exclusions", json_exclusions);
+}
 
-json_object * json_object_daterange(unsigned format_options, 
-	daterange *temp_daterange, int daterange_type) {
+json_object * json_object_daterange(unsigned format_options,
+                                    daterange *temp_daterange, int daterange_type)
+{
 
 	json_object *json_daterange;
 	json_array *json_timeranges;
@@ -4667,170 +4724,167 @@ json_object * json_object_daterange(unsigned format_options,
 
 	switch(daterange_type) {
 	case DATERANGE_CALENDAR_DATE:
-		json_object_append_string(json_daterange, "type", 
-				"DATERANGE_CALENDAR_DATE");
+		json_object_append_string(json_daterange, "type",
+		                          "DATERANGE_CALENDAR_DATE");
 		if(temp_daterange->syear == temp_daterange->eyear &&
-				temp_daterange->smon == temp_daterange->emon &&
-				temp_daterange->smday == temp_daterange->emday) {
+		   temp_daterange->smon == temp_daterange->emon &&
+		   temp_daterange->smday == temp_daterange->emday) {
 			json_object_append_string(json_daterange, "date", "%4d-%02d-%02d",
-					temp_daterange->syear, temp_daterange->smon+1,
-					temp_daterange->smday);
-			}
-		else {
-			json_object_append_string(json_daterange, "startdate", 
-					"%4d-%02d-%02d", temp_daterange->syear, 
-					temp_daterange->smon+1, temp_daterange->smday);
-			json_object_append_string(json_daterange, "enddate", "%4d-%02d-%02d", 
-					temp_daterange->eyear, temp_daterange->emon+1, 
-					temp_daterange->emday);
-			}
+			                          temp_daterange->syear, temp_daterange->smon+1,
+			                          temp_daterange->smday);
+		} else {
+			json_object_append_string(json_daterange, "startdate",
+			                          "%4d-%02d-%02d", temp_daterange->syear,
+			                          temp_daterange->smon+1, temp_daterange->smday);
+			json_object_append_string(json_daterange, "enddate", "%4d-%02d-%02d",
+			                          temp_daterange->eyear, temp_daterange->emon+1,
+			                          temp_daterange->emday);
+		}
 		if( temp_daterange->skip_interval > 0) {
-			json_object_append_integer(json_daterange, "skip_interval", 
-					temp_daterange->skip_interval);
-			}
+			json_object_append_integer(json_daterange, "skip_interval",
+			                           temp_daterange->skip_interval);
+		}
 		json_timeranges = json_new_array();
-		json_object_timerange(json_timeranges, format_options, 
-				temp_daterange->times);
+		json_object_timerange(json_timeranges, format_options,
+		                      temp_daterange->times);
 		json_object_append_array(json_daterange, "times", json_timeranges);
 		break;
 	case DATERANGE_MONTH_DATE:
 		json_object_append_string(json_daterange, "type", "DATERANGE_MONTH_DATE");
 		if(temp_daterange->smon == temp_daterange->emon &&
-				temp_daterange->smday == temp_daterange->emday) {
-			json_object_append_string(json_daterange, "month", 
-					(char *)month[temp_daterange->smon]);
-			json_object_append_integer(json_daterange, "day", 
-					temp_daterange->smday);
-			}
-		else {
-			json_object_append_string(json_daterange, "startmonth", 
-					(char *)month[temp_daterange->smon]);
-			json_object_append_integer(json_daterange, "startday", 
-					temp_daterange->smday);
-			json_object_append_string(json_daterange, "endmonth", 
-					(char *)month[temp_daterange->emon]);
-			json_object_append_integer(json_daterange, "endday", 
-					temp_daterange->emday);
-			}
+		   temp_daterange->smday == temp_daterange->emday) {
+			json_object_append_string(json_daterange, "month",
+			                          (char *)month[temp_daterange->smon]);
+			json_object_append_integer(json_daterange, "day",
+			                           temp_daterange->smday);
+		} else {
+			json_object_append_string(json_daterange, "startmonth",
+			                          (char *)month[temp_daterange->smon]);
+			json_object_append_integer(json_daterange, "startday",
+			                           temp_daterange->smday);
+			json_object_append_string(json_daterange, "endmonth",
+			                          (char *)month[temp_daterange->emon]);
+			json_object_append_integer(json_daterange, "endday",
+			                           temp_daterange->emday);
+		}
 		if( temp_daterange->skip_interval > 0) {
-			json_object_append_integer(json_daterange, "skip_interval", 
-					temp_daterange->skip_interval);
-			}
+			json_object_append_integer(json_daterange, "skip_interval",
+			                           temp_daterange->skip_interval);
+		}
 		json_timeranges = json_new_array();
-		json_object_timerange(json_timeranges, format_options, 
-					temp_daterange->times);
+		json_object_timerange(json_timeranges, format_options,
+		                      temp_daterange->times);
 		json_object_append_array(json_daterange, "times", json_timeranges);
 		break;
 	case DATERANGE_MONTH_DAY:
 		json_object_append_string(json_daterange, "type", "DATERANGE_MONTH_DAY");
 		if(temp_daterange->smday == temp_daterange->emday) {
-			json_object_append_integer(json_daterange, "day", 
-					temp_daterange->smday);
-			}
-		else {
-			json_object_append_integer(json_daterange, "startday", 
-					temp_daterange->smday);
-			json_object_append_integer(json_daterange, "endday", 
-					temp_daterange->emday);
-			}
+			json_object_append_integer(json_daterange, "day",
+			                           temp_daterange->smday);
+		} else {
+			json_object_append_integer(json_daterange, "startday",
+			                           temp_daterange->smday);
+			json_object_append_integer(json_daterange, "endday",
+			                           temp_daterange->emday);
+		}
 		if( temp_daterange->skip_interval > 0) {
-			json_object_append_integer(json_daterange, "skip_interval", 
-					temp_daterange->skip_interval);
-			}
+			json_object_append_integer(json_daterange, "skip_interval",
+			                           temp_daterange->skip_interval);
+		}
 		json_timeranges = json_new_array();
-		json_object_timerange(json_timeranges, format_options, 
-				temp_daterange->times);
+		json_object_timerange(json_timeranges, format_options,
+		                      temp_daterange->times);
 		json_object_append_array(json_daterange, "times", json_timeranges);
 		break;
 	case DATERANGE_MONTH_WEEK_DAY:
-		json_object_append_string(json_daterange, "type", 
-				"DATERANGE_MONTH_WEEK_DAY");
+		json_object_append_string(json_daterange, "type",
+		                          "DATERANGE_MONTH_WEEK_DAY");
 		if(temp_daterange->smon == temp_daterange->emon &&
-				temp_daterange->swday == temp_daterange->ewday &&
-				temp_daterange->swday_offset == temp_daterange->ewday_offset) {
-			json_object_append_string(json_daterange, "month", 
-					(char *)month[temp_daterange->smon]);
-			json_object_append_string(json_daterange, "weekday", 
-					(char *)dayofweek[temp_daterange->swday]);
-			json_object_append_integer(json_daterange, "weekdayoffset", 
-					temp_daterange->swday_offset);
-			}
-		else {
-			json_object_append_string(json_daterange, "startmonth", 
-					(char *)month[temp_daterange->smon]);
-			json_object_append_string(json_daterange, "startweekday", 
-					(char *)dayofweek[temp_daterange->swday]);
-			json_object_append_integer(json_daterange, "startweekdayoffset", 
-					temp_daterange->swday_offset);
-			json_object_append_string(json_daterange, "endmonth", 
-					(char *)month[temp_daterange->emon]);
-			json_object_append_string(json_daterange, "endweekday", 
-					(char *)dayofweek[temp_daterange->ewday]);
-			json_object_append_integer(json_daterange, "endweekdayoffset", 
-					temp_daterange->ewday_offset);
-			}
+		   temp_daterange->swday == temp_daterange->ewday &&
+		   temp_daterange->swday_offset == temp_daterange->ewday_offset) {
+			json_object_append_string(json_daterange, "month",
+			                          (char *)month[temp_daterange->smon]);
+			json_object_append_string(json_daterange, "weekday",
+			                          (char *)dayofweek[temp_daterange->swday]);
+			json_object_append_integer(json_daterange, "weekdayoffset",
+			                           temp_daterange->swday_offset);
+		} else {
+			json_object_append_string(json_daterange, "startmonth",
+			                          (char *)month[temp_daterange->smon]);
+			json_object_append_string(json_daterange, "startweekday",
+			                          (char *)dayofweek[temp_daterange->swday]);
+			json_object_append_integer(json_daterange, "startweekdayoffset",
+			                           temp_daterange->swday_offset);
+			json_object_append_string(json_daterange, "endmonth",
+			                          (char *)month[temp_daterange->emon]);
+			json_object_append_string(json_daterange, "endweekday",
+			                          (char *)dayofweek[temp_daterange->ewday]);
+			json_object_append_integer(json_daterange, "endweekdayoffset",
+			                           temp_daterange->ewday_offset);
+		}
 		if( temp_daterange->skip_interval > 0) {
-			json_object_append_integer(json_daterange, "skip_interval", 
-					temp_daterange->skip_interval);
-			}
+			json_object_append_integer(json_daterange, "skip_interval",
+			                           temp_daterange->skip_interval);
+		}
 		json_timeranges = json_new_array();
-		json_object_timerange(json_timeranges, format_options, 
-				temp_daterange->times);
+		json_object_timerange(json_timeranges, format_options,
+		                      temp_daterange->times);
 		json_object_append_array(json_daterange, "times", json_timeranges);
 		break;
 	case DATERANGE_WEEK_DAY:
 		json_object_append_string(json_daterange, "type", "DATERANGE_WEEK_DAY");
 		if(temp_daterange->swday == temp_daterange->ewday &&
-				temp_daterange->swday_offset == temp_daterange->ewday_offset) {
-			json_object_append_string(json_daterange, "weekday", 
-					(char *)dayofweek[temp_daterange->swday]);
-			json_object_append_integer(json_daterange, "weekdayoffset", 
-					temp_daterange->swday_offset);
-			}
-		else {
-			json_object_append_string(json_daterange, "startweekday", 
-					(char *)dayofweek[temp_daterange->swday]);
-			json_object_append_integer(json_daterange, "startweekdayoffset", 
-					temp_daterange->swday_offset);
-			json_object_append_string(json_daterange, "endweekday", 
-					(char *)dayofweek[temp_daterange->ewday]);
-			json_object_append_integer(json_daterange, "endweekdayoffset", 
-					temp_daterange->ewday_offset);
-			}
+		   temp_daterange->swday_offset == temp_daterange->ewday_offset) {
+			json_object_append_string(json_daterange, "weekday",
+			                          (char *)dayofweek[temp_daterange->swday]);
+			json_object_append_integer(json_daterange, "weekdayoffset",
+			                           temp_daterange->swday_offset);
+		} else {
+			json_object_append_string(json_daterange, "startweekday",
+			                          (char *)dayofweek[temp_daterange->swday]);
+			json_object_append_integer(json_daterange, "startweekdayoffset",
+			                           temp_daterange->swday_offset);
+			json_object_append_string(json_daterange, "endweekday",
+			                          (char *)dayofweek[temp_daterange->ewday]);
+			json_object_append_integer(json_daterange, "endweekdayoffset",
+			                           temp_daterange->ewday_offset);
+		}
 		if( temp_daterange->skip_interval > 0) {
-			json_object_append_integer(json_daterange, "skip_interval", 
-					temp_daterange->skip_interval);
-			}
+			json_object_append_integer(json_daterange, "skip_interval",
+			                           temp_daterange->skip_interval);
+		}
 		json_timeranges = json_new_array();
-		json_object_timerange(json_timeranges, format_options, 
-				temp_daterange->times);
+		json_object_timerange(json_timeranges, format_options,
+		                      temp_daterange->times);
 		json_object_append_array(json_daterange, "times", json_timeranges);
 		break;
 	default:
-		json_object_append_string(json_daterange, "type", 
-				"Unknown daterange type: %u", daterange_type);
+		json_object_append_string(json_daterange, "type",
+		                          "Unknown daterange type: %u", daterange_type);
 		break;
-		}
-
-	return json_daterange;
 	}
 
-void json_object_timerange(json_array *json_parent, unsigned format_options, 
-		timerange *temp_timerange) {
+	return json_daterange;
+}
+
+void json_object_timerange(json_array *json_parent, unsigned format_options,
+                           timerange *temp_timerange)
+{
 
 	json_object *json_timerange;
 
 	for(; temp_timerange != NULL; temp_timerange = temp_timerange->next) {
 		json_timerange = json_new_object();
-		json_object_append_time(json_timerange, "range_start", 
-				temp_timerange->range_start);
-		json_object_append_time(json_timerange, "range_end", 
-				temp_timerange->range_end);
+		json_object_append_time(json_timerange, "range_start",
+		                        temp_timerange->range_start);
+		json_object_append_time(json_timerange, "range_end",
+		                        temp_timerange->range_end);
 		json_array_append_object(json_parent, json_timerange);
-		}
 	}
+}
 
-json_object *json_object_command_selectors(int start, int count) {
+json_object *json_object_command_selectors(int start, int count)
+{
 
 	json_object *json_selectors;
 
@@ -4838,37 +4892,39 @@ json_object *json_object_command_selectors(int start, int count) {
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
-
-	return json_selectors;
 	}
 
-json_object *json_object_commandcount(void) {
+	return json_selectors;
+}
+
+json_object *json_object_commandcount(void)
+{
 
 	json_object *json_data;
 	command *temp_command;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_command_selectors(0, 0));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_command_selectors(0, 0));
 
-	for(temp_command = command_list; temp_command != NULL; 
-			temp_command = temp_command->next) {
+	for(temp_command = command_list; temp_command != NULL;
+	    temp_command = temp_command->next) {
 
-		count++; 
-		}
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_commandlist(unsigned format_options, int start, 
-		int count, int details) {
+json_object *json_object_commandlist(unsigned format_options, int start,
+                                     int count, int details)
+{
 
 	json_object *json_data;
 	json_object *json_commandlist_object = NULL;
@@ -4879,50 +4935,48 @@ json_object *json_object_commandlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_command_selectors(start, count));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_command_selectors(start, count));
 
 	if(details > 0) {
 		json_commandlist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_commandlist_array = json_new_array();
-		}
+	}
 
-	for(temp_command = command_list; temp_command != NULL; 
-			temp_command = temp_command->next) {
+	for(temp_command = command_list; temp_command != NULL;
+	    temp_command = temp_command->next) {
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_command_details = json_new_object();
-				json_object_command_details(json_command_details, format_options, 
-						temp_command);
-				json_object_append_object(json_commandlist_object, 
-						temp_command->name, json_command_details);
-				}
-			else {
-				json_array_append_string(json_commandlist_array, 
-						temp_command->name);
-				}
-			counted++;
+				json_object_command_details(json_command_details, format_options,
+				                            temp_command);
+				json_object_append_object(json_commandlist_object,
+				                          temp_command->name, json_command_details);
+			} else {
+				json_array_append_string(json_commandlist_array,
+				                         temp_command->name);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "commandlist", 
-				json_commandlist_object);
-		}
-	else {
-		json_object_append_array(json_data, "commandlist", 
-				json_commandlist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object *json_object_command(unsigned format_options, command *temp_command) {
+	if(details > 0) {
+		json_object_append_object(json_data, "commandlist",
+		                          json_commandlist_object);
+	} else {
+		json_object_append_array(json_data, "commandlist",
+		                         json_commandlist_array);
+	}
+
+	return json_data;
+}
+
+json_object *json_object_command(unsigned format_options, command *temp_command)
+{
 
 	json_object *json_command = json_new_object();
 	json_object *json_details = json_new_object();
@@ -4934,106 +4988,109 @@ json_object *json_object_command(unsigned format_options, command *temp_command)
 	return json_command;
 }
 
-void json_object_command_details(json_object *json_details, 
-		unsigned format_options, command *temp_command) {
+void json_object_command_details(json_object *json_details,
+                                 unsigned format_options, command *temp_command)
+{
 	json_object_append_string(json_details, "name", temp_command->name);
-	json_object_append_string(json_details, "command_line", 
-			temp_command->command_line);
-	}
+	json_object_append_string(json_details, "command_line",
+	                          temp_command->command_line);
+}
 
 int json_object_servicedependency_passes_selection(
-		servicedependency *temp_servicedependency, host *master_host,
-		hostgroup *master_hostgroup, char *master_service_description,
-		servicegroup *master_servicegroup, host *dependent_host,
-		hostgroup *dependent_hostgroup, char * dependent_service_description,
-		servicegroup *dependent_servicegroup) {
+    servicedependency *temp_servicedependency, host *master_host,
+    hostgroup *master_hostgroup, char *master_service_description,
+    servicegroup *master_servicegroup, host *dependent_host,
+    hostgroup *dependent_hostgroup, char * dependent_service_description,
+    servicegroup *dependent_servicegroup)
+{
 
 	host *temp_host = NULL;
 	service *temp_service = NULL;
 
 	/* Skip if the servicedependency does not have the specified master host */
 	if(NULL != master_host &&
-			strcmp(temp_servicedependency->host_name, master_host->name)) {
+	   strcmp(temp_servicedependency->host_name, master_host->name)) {
 		return 0;
-		}
+	}
 
 	/* Skip if the servicedependency does not have a master host in the
 		specified hostgroup */
 	if(NULL != master_hostgroup) {
 		temp_host = find_host(temp_servicedependency->host_name);
 		if((NULL != temp_host) && (FALSE ==
-				is_host_member_of_hostgroup(master_hostgroup, temp_host))) {
+		                           is_host_member_of_hostgroup(master_hostgroup, temp_host))) {
 			return 0;
-			}
 		}
+	}
 
 	/* Skip if the servicedependency does not have the specified master
 		service */
 	if(NULL != master_service_description &&
-			strcmp(temp_servicedependency->service_description,
-			master_service_description)) {
+	   strcmp(temp_servicedependency->service_description,
+	          master_service_description)) {
 		return 0;
-		}
+	}
 
 	/* Skip if the servicedependency does not have a master service in the
 		specified servicegroup */
 	if(NULL != master_servicegroup) {
 		temp_service = find_service(temp_servicedependency->host_name,
-				temp_servicedependency->service_description);
+		                            temp_servicedependency->service_description);
 		if((NULL != temp_service) && (FALSE ==
-				is_service_member_of_servicegroup(master_servicegroup,
-				temp_service))) {
+		                              is_service_member_of_servicegroup(master_servicegroup,
+		                                      temp_service))) {
 			return 0;
-			}
 		}
+	}
 
 	/* Skip if the servicedependency does not have the specified dependent
 		host */
 	if(NULL != dependent_host &&
-			strcmp(temp_servicedependency->dependent_host_name,
-			dependent_host->name)) {
+	   strcmp(temp_servicedependency->dependent_host_name,
+	          dependent_host->name)) {
 		return 0;
-		}
+	}
 
 	/* Skip if the servicedependency does not have a dependent host in the
 		specified hostgroup */
 	if(NULL != dependent_hostgroup) {
 		temp_host = find_host(temp_servicedependency->dependent_host_name);
 		if((NULL != temp_host) && (FALSE ==
-				is_host_member_of_hostgroup(dependent_hostgroup, temp_host))) {
+		                           is_host_member_of_hostgroup(dependent_hostgroup, temp_host))) {
 			return 0;
-			}
 		}
+	}
 
 	/* Skip if the servicedependency does not have the specified dependent
 		service */
 	if(NULL != dependent_service_description &&
-			strcmp(temp_servicedependency->dependent_service_description,
-			dependent_service_description)) {
+	   strcmp(temp_servicedependency->dependent_service_description,
+	          dependent_service_description)) {
 		return 0;
-		}
+	}
 
 	/* Skip if the servicedependency does not have a dependent service in the
 		specified servicegroup */
 	if(NULL != dependent_servicegroup) {
 		temp_service = find_service(temp_servicedependency->dependent_host_name,
-				temp_servicedependency->dependent_service_description);
+		                            temp_servicedependency->dependent_service_description);
 		if((NULL != temp_service) && (FALSE ==
-				is_service_member_of_servicegroup(dependent_servicegroup,
-				temp_service))) {
+		                              is_service_member_of_servicegroup(dependent_servicegroup,
+		                                      temp_service))) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
+	return 1;
+}
+
 json_object *json_object_servicedependency_selectors(int start, int count,
-		host *master_host, hostgroup *master_hostgroup,
-		char *master_service_description, servicegroup *master_servicegroup,
-		host *dependent_host, hostgroup *dependent_hostgroup,
-		char * dependent_service_description,
-		servicegroup *dependent_servicegroup) {
+        host *master_host, hostgroup *master_hostgroup,
+        char *master_service_description, servicegroup *master_servicegroup,
+        host *dependent_host, hostgroup *dependent_hostgroup,
+        char * dependent_service_description,
+        servicegroup *dependent_servicegroup)
+{
 
 	json_object *json_selectors;
 
@@ -5041,51 +5098,52 @@ json_object *json_object_servicedependency_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if(NULL != master_host) {
 		json_object_append_string(json_selectors, "masterhostname",
-				master_host->name);
-		}
+		                          master_host->name);
+	}
 	if(NULL != master_hostgroup) {
 		json_object_append_string(json_selectors, "masterhostgroupname",
-				master_hostgroup->group_name);
-		}
+		                          master_hostgroup->group_name);
+	}
 	if(NULL != master_service_description) {
 		json_object_append_string(json_selectors, "masterservicedescription",
-				master_service_description);
-		}
+		                          master_service_description);
+	}
 	if(NULL != master_servicegroup) {
 		json_object_append_string(json_selectors, "masterservicegroupname",
-				master_servicegroup->group_name);
-		}
+		                          master_servicegroup->group_name);
+	}
 	if(NULL != dependent_host) {
 		json_object_append_string(json_selectors, "dependenthostname",
-				dependent_host->name);
-		}
+		                          dependent_host->name);
+	}
 	if(NULL != dependent_hostgroup) {
 		json_object_append_string(json_selectors, "dependenthostgroupname",
-				dependent_hostgroup->group_name);
-		}
+		                          dependent_hostgroup->group_name);
+	}
 	if(NULL != dependent_service_description) {
 		json_object_append_string(json_selectors, "dependentservicedescription",
-				dependent_service_description);
-		}
+		                          dependent_service_description);
+	}
 	if(NULL != dependent_servicegroup) {
 		json_object_append_string(json_selectors, "dependentservicegroupname",
-				dependent_servicegroup->group_name);
-		}
-
-	return json_selectors;
+		                          dependent_servicegroup->group_name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_object_servicedependencycount(host *master_host,
-		hostgroup *master_hostgroup, char *master_service_description,
-		servicegroup *master_servicegroup, host *dependent_host,
-		hostgroup *dependent_hostgroup, char * dependent_service_description,
-		servicegroup *dependent_servicegroup) {
+        hostgroup *master_hostgroup, char *master_service_description,
+        servicegroup *master_servicegroup, host *dependent_host,
+        hostgroup *dependent_hostgroup, char * dependent_service_description,
+        servicegroup *dependent_servicegroup)
+{
 
 	json_object *json_data;
 #ifdef JSON_NAGIOS_4X
@@ -5095,40 +5153,41 @@ json_object *json_object_servicedependencycount(host *master_host,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_servicedependency_selectors(0, 0, master_host,
-			master_hostgroup, master_service_description, master_servicegroup,
-			dependent_host, dependent_hostgroup, dependent_service_description,
-			dependent_servicegroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_servicedependency_selectors(0, 0, master_host,
+	                                  master_hostgroup, master_service_description, master_servicegroup,
+	                                  dependent_host, dependent_hostgroup, dependent_service_description,
+	                                  dependent_servicegroup));
 
 #ifdef JSON_NAGIOS_4X
 	for(x = 0; x < num_objects.servicedependencies; x++) {
 		temp_servicedependency = servicedependency_ary[ x];
 #else
-	for(temp_servicedependency = servicedependency_list; 
-			temp_servicedependency != NULL; 
-			temp_servicedependency = temp_servicedependency->next) {
+	for(temp_servicedependency = servicedependency_list;
+	    temp_servicedependency != NULL;
+	    temp_servicedependency = temp_servicedependency->next) {
 #endif
 
 		if(json_object_servicedependency_passes_selection(temp_servicedependency,
-				master_host, master_hostgroup, master_service_description,
-				master_servicegroup, dependent_host, dependent_hostgroup,
-				dependent_service_description, dependent_servicegroup)) {
-			count++; 
-			}
+		        master_host, master_hostgroup, master_service_description,
+		        master_servicegroup, dependent_host, dependent_hostgroup,
+		        dependent_service_description, dependent_servicegroup)) {
+			count++;
 		}
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
 json_object *json_object_servicedependencylist(unsigned format_options,
-		int start, int count, host *master_host, hostgroup *master_hostgroup,
-		char *master_service_description, servicegroup *master_servicegroup,
-		host *dependent_host, hostgroup *dependent_hostgroup,
-		char * dependent_service_description,
-		servicegroup *dependent_servicegroup) {
+        int start, int count, host *master_host, hostgroup *master_hostgroup,
+        char *master_service_description, servicegroup *master_servicegroup,
+        host *dependent_host, hostgroup *dependent_hostgroup,
+        char * dependent_service_description,
+        servicegroup *dependent_servicegroup)
+{
 
 	json_object *json_data;
 	json_array *json_servicedependencylist;
@@ -5141,11 +5200,11 @@ json_object *json_object_servicedependencylist(unsigned format_options,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_servicedependency_selectors(start, count,
-			master_host, master_hostgroup, master_service_description,
-			master_servicegroup, dependent_host, dependent_hostgroup,
-			dependent_service_description, dependent_servicegroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_servicedependency_selectors(start, count,
+	                                  master_host, master_hostgroup, master_service_description,
+	                                  master_servicegroup, dependent_host, dependent_hostgroup,
+	                                  dependent_service_description, dependent_servicegroup));
 
 	json_servicedependencylist = json_new_array();
 
@@ -5153,171 +5212,173 @@ json_object *json_object_servicedependencylist(unsigned format_options,
 	for(x = 0; x < num_objects.servicedependencies; x++) {
 		temp_servicedependency = servicedependency_ary[ x];
 #else
-	for(temp_servicedependency = servicedependency_list; 
-			temp_servicedependency != NULL; 
-			temp_servicedependency = temp_servicedependency->next) {
+	for(temp_servicedependency = servicedependency_list;
+	    temp_servicedependency != NULL;
+	    temp_servicedependency = temp_servicedependency->next) {
 #endif
 
 		if(!json_object_servicedependency_passes_selection(temp_servicedependency,
-				master_host, master_hostgroup, master_service_description,
-				master_servicegroup, dependent_host, dependent_hostgroup,
-				dependent_service_description, dependent_servicegroup)) {
+		        master_host, master_hostgroup, master_service_description,
+		        master_servicegroup, dependent_host, dependent_hostgroup,
+		        dependent_service_description, dependent_servicegroup)) {
 			continue;
-			}
-
-		/* If the current item passes the start and limit tests, display it */
-		if( passes_start_and_count_limits(start, count, 
-				current, counted)) {
-			json_servicedependency_details = json_new_object();
-			json_object_servicedependency_details(json_servicedependency_details, 
-					format_options, temp_servicedependency);
-			json_array_append_object(json_servicedependencylist, 
-					json_servicedependency_details);
-			}
-			counted++;
-		current++; 
 		}
 
-	json_object_append_array(json_data, "servicedependencylist", 
-			json_servicedependencylist);
-
-	return json_data;
+		/* If the current item passes the start and limit tests, display it */
+		if( passes_start_and_count_limits(start, count,
+		                                  current, counted)) {
+			json_servicedependency_details = json_new_object();
+			json_object_servicedependency_details(json_servicedependency_details,
+			                                      format_options, temp_servicedependency);
+			json_array_append_object(json_servicedependencylist,
+			                         json_servicedependency_details);
+		}
+		counted++;
+		current++;
 	}
 
-void json_object_servicedependency_details(json_object *json_details, 
-		unsigned format_options, servicedependency *temp_servicedependency) {
+	json_object_append_array(json_data, "servicedependencylist",
+	                         json_servicedependencylist);
 
-	json_object_append_integer(json_details, "dependency_type", 
-			temp_servicedependency->dependency_type);
-	json_object_append_string(json_details, "dependent_host_name", 
-			temp_servicedependency->dependent_host_name);
-	json_object_append_string(json_details, "dependent_service_description", 
-			temp_servicedependency->dependent_service_description);
-	json_object_append_string(json_details, "host_name", 
-			temp_servicedependency->host_name);
-	json_object_append_string(json_details, "service_description", 
-			temp_servicedependency->service_description);
-	json_object_append_string(json_details, "dependency_period", 
-			temp_servicedependency->dependency_period);
-	json_object_append_boolean(json_details, "inherits_parent", 
-			temp_servicedependency->inherits_parent);
+	return json_data;
+}
+
+void json_object_servicedependency_details(json_object *json_details,
+        unsigned format_options, servicedependency *temp_servicedependency)
+{
+
+	json_object_append_integer(json_details, "dependency_type",
+	                           temp_servicedependency->dependency_type);
+	json_object_append_string(json_details, "dependent_host_name",
+	                          temp_servicedependency->dependent_host_name);
+	json_object_append_string(json_details, "dependent_service_description",
+	                          temp_servicedependency->dependent_service_description);
+	json_object_append_string(json_details, "host_name",
+	                          temp_servicedependency->host_name);
+	json_object_append_string(json_details, "service_description",
+	                          temp_servicedependency->service_description);
+	json_object_append_string(json_details, "dependency_period",
+	                          temp_servicedependency->dependency_period);
+	json_object_append_boolean(json_details, "inherits_parent",
+	                           temp_servicedependency->inherits_parent);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
 		json_object_append_boolean(json_details, "fail_on_ok",
-				flag_isset(temp_servicedependency->failure_options, OPT_OK));
-		json_object_append_boolean(json_details, "fail_on_warning", 
-				flag_isset(temp_servicedependency->failure_options, 
-				OPT_WARNING));
-		json_object_append_boolean(json_details, "fail_on_unknown", 
-				flag_isset(temp_servicedependency->failure_options, 
-				OPT_UNKNOWN));
-		json_object_append_boolean(json_details, "fail_on_critical", 
-				flag_isset(temp_servicedependency->failure_options, 
-				OPT_CRITICAL));
-		json_object_append_boolean(json_details, "fail_on_pending", 
-				flag_isset(temp_servicedependency->failure_options, 
-				OPT_PENDING));
-		}
-	else {
+		                           flag_isset(temp_servicedependency->failure_options, OPT_OK));
+		json_object_append_boolean(json_details, "fail_on_warning",
+		                           flag_isset(temp_servicedependency->failure_options,
+		                                      OPT_WARNING));
+		json_object_append_boolean(json_details, "fail_on_unknown",
+		                           flag_isset(temp_servicedependency->failure_options,
+		                                      OPT_UNKNOWN));
+		json_object_append_boolean(json_details, "fail_on_critical",
+		                           flag_isset(temp_servicedependency->failure_options,
+		                                      OPT_CRITICAL));
+		json_object_append_boolean(json_details, "fail_on_pending",
+		                           flag_isset(temp_servicedependency->failure_options,
+		                                      OPT_PENDING));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "failure_options",
-				temp_servicedependency->failure_options, svm_option_types);
+		             temp_servicedependency->failure_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
 	json_object_append_boolean(json_details, "fail_on_ok",
-			temp_servicedependency->fail_on_ok);
-	json_object_append_boolean(json_details, "fail_on_warning", 
-			temp_servicedependency->fail_on_warning);
-	json_object_append_boolean(json_details, "fail_on_unknown", 
-			temp_servicedependency->fail_on_unknown);
-	json_object_append_boolean(json_details, "fail_on_critical", 
-			temp_servicedependency->fail_on_critical);
-	json_object_append_boolean(json_details, "fail_on_pending", 
-			temp_servicedependency->fail_on_pending);
+	                           temp_servicedependency->fail_on_ok);
+	json_object_append_boolean(json_details, "fail_on_warning",
+	                           temp_servicedependency->fail_on_warning);
+	json_object_append_boolean(json_details, "fail_on_unknown",
+	                           temp_servicedependency->fail_on_unknown);
+	json_object_append_boolean(json_details, "fail_on_critical",
+	                           temp_servicedependency->fail_on_critical);
+	json_object_append_boolean(json_details, "fail_on_pending",
+	                           temp_servicedependency->fail_on_pending);
 #endif
-	}
+}
 
-int json_object_serviceescalation_passes_selection(serviceescalation *temp_serviceescalation, 
-		host *match_host, char *service_description,
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup,
-		contact *match_contact, contactgroup *match_contactgroup) {
+int json_object_serviceescalation_passes_selection(serviceescalation *temp_serviceescalation,
+        host *match_host, char *service_description,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        contact *match_contact, contactgroup *match_contactgroup)
+{
 
 	int found;
 	hostsmember *temp_hostsmember;
 	servicesmember *temp_servicesmember;
 
 	/* Skip if the serviceescalation is not for the specified host */
-	if( NULL != match_host && 
-			strcmp( temp_serviceescalation->host_name, match_host->name)) {
+	if( NULL != match_host &&
+	    strcmp( temp_serviceescalation->host_name, match_host->name)) {
 		return 0;
-		}
+	}
 
 	if((NULL != service_description) &&
-			strcmp(temp_serviceescalation->description, service_description)) {
+	   strcmp(temp_serviceescalation->description, service_description)) {
 		return 0;
-		}
+	}
 
 	if(NULL != match_hostgroup) {
 		found = 0;
 		for(temp_hostsmember = match_hostgroup->members;
-				temp_hostsmember != NULL;
-				temp_hostsmember = temp_hostsmember->next) {
+		    temp_hostsmember != NULL;
+		    temp_hostsmember = temp_hostsmember->next) {
 			if(!strcmp(temp_hostsmember->host_name,
-					temp_serviceescalation->host_name)) {
+			           temp_serviceescalation->host_name)) {
 				found = 1;
 				break;
-				}
 			}
-			if(0 == found) {
-				return 0;
-				}
 		}
+		if(0 == found) {
+			return 0;
+		}
+	}
 
 	if(NULL != match_servicegroup) {
 		found = 0;
 		for(temp_servicesmember = match_servicegroup->members;
-				temp_servicesmember != NULL;
-				temp_servicesmember = temp_servicesmember->next) {
+		    temp_servicesmember != NULL;
+		    temp_servicesmember = temp_servicesmember->next) {
 			if(!strcmp(temp_servicesmember->host_name,
-					temp_serviceescalation->host_name) &&
-					!strcmp(temp_servicesmember->service_description,
-					temp_serviceescalation->description)) {
+			           temp_serviceescalation->host_name) &&
+			   !strcmp(temp_servicesmember->service_description,
+			           temp_serviceescalation->description)) {
 				found = 1;
 				break;
-				}
 			}
-			if(0 == found) {
-				return 0;
-				}
 		}
+		if(0 == found) {
+			return 0;
+		}
+	}
 
 	/* If a contact was specified, skip this service escalation if it does
 		not have the contact specified */
 	if( NULL != match_contact &&
-			( FALSE == is_contact_for_service_escalation(temp_serviceescalation,
-			match_contact))) {
+	    ( FALSE == is_contact_for_service_escalation(temp_serviceescalation,
+	            match_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a contactgroup was specified, skip this service escalation if
 		it does not have the contactgroup specified */
 	if(NULL != match_contactgroup && (FALSE ==
-			is_contactgroup_for_service_escalation(temp_serviceescalation,
-			 match_contactgroup))) {
+	                                  is_contactgroup_for_service_escalation(temp_serviceescalation,
+	                                          match_contactgroup))) {
 		return 0;
-		}
-
-	return 1;
 	}
 
+	return 1;
+}
+
 json_object *json_object_serviceescalation_selectors(int start, int count,
-		host *match_host, char *service_description,
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup,
-		contact *match_contact, contactgroup *match_contactgroup) {
+        host *match_host, char *service_description,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        contact *match_contact, contactgroup *match_contactgroup)
+{
 
 	json_object *json_selectors;
 
@@ -5325,41 +5386,42 @@ json_object *json_object_serviceescalation_selectors(int start, int count,
 
 	if(start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if(count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if(NULL != match_host) {
 		json_object_append_string(json_selectors, "hostname", match_host->name);
-		}
+	}
 	if(NULL != service_description) {
 		json_object_append_string(json_selectors, "servicedescription",
-				service_description);
-		}
+		                          service_description);
+	}
 	if(NULL != match_hostgroup) {
 		json_object_append_string(json_selectors, "hostgroup",
-				match_hostgroup->group_name);
-		}
+		                          match_hostgroup->group_name);
+	}
 	if(NULL != match_servicegroup) {
 		json_object_append_string(json_selectors, "servicegroup",
-				match_servicegroup->group_name);
-		}
+		                          match_servicegroup->group_name);
+	}
 	if( NULL != match_contact) {
 		json_object_append_string(json_selectors, "contact",
-				match_contact->name);
-		}
+		                          match_contact->name);
+	}
 	if( NULL != match_contactgroup) {
 		json_object_append_string(json_selectors, "contactgroup",
-				match_contactgroup->group_name);
-		}
-
-	return json_selectors;
+		                          match_contactgroup->group_name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_object_serviceescalationcount(host *match_host,
-		char *service_description, hostgroup *match_hostgroup,
-		servicegroup *match_servicegroup, contact *match_contact,
-		contactgroup *match_contactgroup) {
+        char *service_description, hostgroup *match_hostgroup,
+        servicegroup *match_servicegroup, contact *match_contact,
+        contactgroup *match_contactgroup)
+{
 
 	json_object *json_data;
 #ifdef JSON_NAGIOS_4X
@@ -5369,38 +5431,39 @@ json_object *json_object_serviceescalationcount(host *match_host,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_serviceescalation_selectors(0, 0, match_host,
-			service_description, match_hostgroup, match_servicegroup,
-			match_contact, match_contactgroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_serviceescalation_selectors(0, 0, match_host,
+	                                  service_description, match_hostgroup, match_servicegroup,
+	                                  match_contact, match_contactgroup));
 
 #ifdef JSON_NAGIOS_4X
 	for(x = 0; x < num_objects.serviceescalations; x++) {
 		temp_serviceescalation=serviceescalation_ary[ x];
 #else
-	for(temp_serviceescalation = serviceescalation_list; 
-			temp_serviceescalation != NULL; 
-			temp_serviceescalation = temp_serviceescalation->next) {
+	for(temp_serviceescalation = serviceescalation_list;
+	    temp_serviceescalation != NULL;
+	    temp_serviceescalation = temp_serviceescalation->next) {
 #endif
 		if(json_object_serviceescalation_passes_selection(temp_serviceescalation,
-				match_host, service_description, match_hostgroup,
-				match_servicegroup, match_contact, match_contactgroup) == 0) {
+		        match_host, service_description, match_hostgroup,
+		        match_servicegroup, match_contact, match_contactgroup) == 0) {
 			continue;
-			}
-
-
-		count++; 
 		}
+
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_serviceescalationlist(unsigned format_options, 
-		int start, int count, host *match_host, char *service_description,
-		hostgroup *match_hostgroup, servicegroup *match_servicegroup,
-		contact *match_contact, contactgroup *match_contactgroup) {
+json_object *json_object_serviceescalationlist(unsigned format_options,
+        int start, int count, host *match_host, char *service_description,
+        hostgroup *match_hostgroup, servicegroup *match_servicegroup,
+        contact *match_contact, contactgroup *match_contactgroup)
+{
 
 	json_object *json_data;
 	json_array *json_serviceescalationlist;
@@ -5413,10 +5476,10 @@ json_object *json_object_serviceescalationlist(unsigned format_options,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_serviceescalation_selectors(start, count, match_host,
-			service_description, match_hostgroup, match_servicegroup,
-			match_contact, match_contactgroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_serviceescalation_selectors(start, count, match_host,
+	                                  service_description, match_hostgroup, match_servicegroup,
+	                                  match_contact, match_contactgroup));
 
 	json_serviceescalationlist = json_new_array();
 
@@ -5424,155 +5487,157 @@ json_object *json_object_serviceescalationlist(unsigned format_options,
 	for(x = 0; x < num_objects.serviceescalations; x++) {
 		temp_serviceescalation=serviceescalation_ary[ x];
 #else
-	for(temp_serviceescalation = serviceescalation_list; 
-			temp_serviceescalation != NULL; 
-			temp_serviceescalation = temp_serviceescalation->next) {
+	for(temp_serviceescalation = serviceescalation_list;
+	    temp_serviceescalation != NULL;
+	    temp_serviceescalation = temp_serviceescalation->next) {
 #endif
 		if(json_object_serviceescalation_passes_selection(temp_serviceescalation,
-				match_host, service_description, match_hostgroup,
-				match_servicegroup, match_contact, match_contactgroup) == 0) {
+		        match_host, service_description, match_hostgroup,
+		        match_servicegroup, match_contact, match_contactgroup) == 0) {
 			continue;
-			}
+		}
 
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			json_serviceescalation_details = json_new_object();
-			json_object_serviceescalation_details(json_serviceescalation_details, 
-					format_options, temp_serviceescalation);
-			json_array_append_object(json_serviceescalationlist, 
-					json_serviceescalation_details);
-			}
-			counted++;
-		current++; 
+			json_object_serviceescalation_details(json_serviceescalation_details,
+			                                      format_options, temp_serviceescalation);
+			json_array_append_object(json_serviceescalationlist,
+			                         json_serviceescalation_details);
 		}
-
-	json_object_append_array(json_data, "serviceescalationlist", 
-			json_serviceescalationlist);
-
-	return json_data;
+		counted++;
+		current++;
 	}
 
-void json_object_serviceescalation_details(json_object *json_details, 
-		unsigned format_options, serviceescalation *temp_serviceescalation) {
+	json_object_append_array(json_data, "serviceescalationlist",
+	                         json_serviceescalationlist);
+
+	return json_data;
+}
+
+void json_object_serviceescalation_details(json_object *json_details,
+        unsigned format_options, serviceescalation *temp_serviceescalation)
+{
 
 	json_array *json_contactgroups;
 	json_array *json_contacts;
 	contactgroupsmember *temp_contact_groupsmember;
 	contactsmember *temp_contactsmember;
 
-	json_object_append_string(json_details, "host_name", 
-			temp_serviceescalation->host_name);
-	json_object_append_string(json_details, "description", 
-			temp_serviceescalation->description);
-	json_object_append_integer(json_details, "first_notification", 
-			temp_serviceescalation->first_notification);
-	json_object_append_integer(json_details, "last_notification", 
-			temp_serviceescalation->last_notification);
-	json_object_append_real(json_details, "notification_interval", 
-			temp_serviceescalation->notification_interval);
-	json_object_append_string(json_details, "escalation_period", 
-			temp_serviceescalation->escalation_period);
+	json_object_append_string(json_details, "host_name",
+	                          temp_serviceescalation->host_name);
+	json_object_append_string(json_details, "description",
+	                          temp_serviceescalation->description);
+	json_object_append_integer(json_details, "first_notification",
+	                           temp_serviceescalation->first_notification);
+	json_object_append_integer(json_details, "last_notification",
+	                           temp_serviceescalation->last_notification);
+	json_object_append_real(json_details, "notification_interval",
+	                        temp_serviceescalation->notification_interval);
+	json_object_append_string(json_details, "escalation_period",
+	                          temp_serviceescalation->escalation_period);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "escalate_on_recovery", 
-				flag_isset(temp_serviceescalation->escalation_options, 
-				OPT_RECOVERY));
-		json_object_append_boolean(json_details, "escalate_on_warning", 
-				flag_isset(temp_serviceescalation->escalation_options, 
-				OPT_WARNING));
-		json_object_append_boolean(json_details, "escalate_on_unknown", 
-				flag_isset(temp_serviceescalation->escalation_options, 
-				OPT_UNKNOWN)));
-		json_object_append_boolean(json_details, "escalate_on_critical", 
-				flag_isset(temp_serviceescalation->escalation_options, 
-				OPT_CRITICAL));
-		}
-	else {
+		json_object_append_boolean(json_details, "escalate_on_recovery",
+		                           flag_isset(temp_serviceescalation->escalation_options,
+		                                      OPT_RECOVERY));
+		json_object_append_boolean(json_details, "escalate_on_warning",
+		                           flag_isset(temp_serviceescalation->escalation_options,
+		                                      OPT_WARNING));
+		json_object_append_boolean(json_details, "escalate_on_unknown",
+		                           flag_isset(temp_serviceescalation->escalation_options,
+		                                      OPT_UNKNOWN)));
+		json_object_append_boolean(json_details, "escalate_on_critical",
+		                           flag_isset(temp_serviceescalation->escalation_options,
+		                                      OPT_CRITICAL));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "escalation_options",
-				temp_serviceescalation->escalation_options, svm_option_types);
+		             temp_serviceescalation->escalation_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "escalate_on_recovery", 
-			temp_serviceescalation->escalate_on_recovery);
-	json_object_append_boolean(json_details, "escalate_on_warning", 
-			temp_serviceescalation->escalate_on_warning);
-	json_object_append_boolean(json_details, "escalate_on_unknown", 
-			temp_serviceescalation->escalate_on_unknown);
-	json_object_append_boolean(json_details, "escalate_on_critical", 
-			temp_serviceescalation->escalate_on_critical);
+	json_object_append_boolean(json_details, "escalate_on_recovery",
+	                           temp_serviceescalation->escalate_on_recovery);
+	json_object_append_boolean(json_details, "escalate_on_warning",
+	                           temp_serviceescalation->escalate_on_warning);
+	json_object_append_boolean(json_details, "escalate_on_unknown",
+	                           temp_serviceescalation->escalate_on_unknown);
+	json_object_append_boolean(json_details, "escalate_on_critical",
+	                           temp_serviceescalation->escalate_on_critical);
 #endif
 
 	json_contactgroups = json_new_object();
-	for(temp_contact_groupsmember = temp_serviceescalation->contact_groups; 
-			temp_contact_groupsmember != NULL; 
-			temp_contact_groupsmember = temp_contact_groupsmember->next) {
+	for(temp_contact_groupsmember = temp_serviceescalation->contact_groups;
+	    temp_contact_groupsmember != NULL;
+	    temp_contact_groupsmember = temp_contact_groupsmember->next) {
 		json_array_append_string(json_contactgroups,
-				temp_contact_groupsmember->group_name);
-		}
+		                         temp_contact_groupsmember->group_name);
+	}
 	json_object_append_array(json_details, "contact_groups", json_contactgroups);
 
 	json_contacts = json_new_object();
-	for(temp_contactsmember = temp_serviceescalation->contacts; 
-			temp_contactsmember != NULL; 
-			temp_contactsmember = temp_contactsmember->next) {
-		json_array_append_string(json_contacts, 
-				temp_contactsmember->contact_name);
-		}
-	json_object_append_array(json_details, "contacts", json_contacts);
+	for(temp_contactsmember = temp_serviceescalation->contacts;
+	    temp_contactsmember != NULL;
+	    temp_contactsmember = temp_contactsmember->next) {
+		json_array_append_string(json_contacts,
+		                         temp_contactsmember->contact_name);
 	}
+	json_object_append_array(json_details, "contacts", json_contacts);
+}
 
 int json_object_hostdependency_passes_selection(
-		hostdependency *temp_hostdependency, host *master_host,
-		hostgroup *master_hostgroup, host *dependent_host,
-		hostgroup *dependent_hostgroup) {
+    hostdependency *temp_hostdependency, host *master_host,
+    hostgroup *master_hostgroup, host *dependent_host,
+    hostgroup *dependent_hostgroup)
+{
 
 	host *temp_host = NULL;
 
 	/* Skip if the hostdependency does not have the specified master host */
 	if(NULL != master_host &&
-			strcmp(temp_hostdependency->host_name, master_host->name)) {
+	   strcmp(temp_hostdependency->host_name, master_host->name)) {
 		return 0;
-		}
+	}
 
 	/* Skip if the hostdependency does not have a master host in the
 		specified hostgroup*/
 	if(NULL != master_hostgroup) {
 		temp_host = find_host(temp_hostdependency->host_name);
 		if((NULL != temp_host) && (FALSE ==
-				is_host_member_of_hostgroup(master_hostgroup, temp_host))) {
+		                           is_host_member_of_hostgroup(master_hostgroup, temp_host))) {
 			return 0;
-			}
 		}
+	}
 
 	/* Skip if the hostdependency does not have the specified dependent host */
 	if(NULL != dependent_host &&
-			strcmp(temp_hostdependency->dependent_host_name,
-			dependent_host->name)) {
+	   strcmp(temp_hostdependency->dependent_host_name,
+	          dependent_host->name)) {
 		return 0;
-		}
+	}
 
 	/* Skip if the hostdependency does not have a dependent host in the
 		specified hostgroup*/
 	if(NULL != dependent_hostgroup) {
 		temp_host = find_host(temp_hostdependency->dependent_host_name);
 		if((NULL != temp_host) && (FALSE ==
-				is_host_member_of_hostgroup(dependent_hostgroup, temp_host))) {
+		                           is_host_member_of_hostgroup(dependent_hostgroup, temp_host))) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
+	return 1;
+}
+
 json_object *json_object_hostdependency_selectors(int start, int count,
-		host *master_host, hostgroup *master_hostgroup, host *dependent_host,
-		hostgroup *dependent_hostgroup) {
+        host *master_host, hostgroup *master_hostgroup, host *dependent_host,
+        hostgroup *dependent_hostgroup)
+{
 
 	json_object *json_selectors;
 
@@ -5580,33 +5645,34 @@ json_object *json_object_hostdependency_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if(NULL != master_host) {
 		json_object_append_string(json_selectors, "masterhostname",
-				master_host->name);
-		}
+		                          master_host->name);
+	}
 	if(NULL != master_hostgroup) {
 		json_object_append_string(json_selectors, "masterhostgroupname",
-				master_hostgroup->group_name);
-		}
+		                          master_hostgroup->group_name);
+	}
 	if(NULL != dependent_host) {
 		json_object_append_string(json_selectors, "dependenthostname",
-				dependent_host->name);
-		}
+		                          dependent_host->name);
+	}
 	if(NULL != dependent_hostgroup) {
 		json_object_append_string(json_selectors, "dependenthostgroupname",
-				dependent_hostgroup->group_name);
-		}
-
-	return json_selectors;
+		                          dependent_hostgroup->group_name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_object_hostdependencycount(host *master_host,
-		hostgroup *master_hostgroup, host *dependent_host,
-		hostgroup *dependent_hostgroup) {
+        hostgroup *master_hostgroup, host *dependent_host,
+        hostgroup *dependent_hostgroup)
+{
 
 	json_object *json_data;
 #ifdef JSON_NAGIOS_4X
@@ -5616,34 +5682,35 @@ json_object *json_object_hostdependencycount(host *master_host,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_hostdependency_selectors(0, 0, master_host,
-			master_hostgroup, dependent_host, dependent_hostgroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_hostdependency_selectors(0, 0, master_host,
+	                                  master_hostgroup, dependent_host, dependent_hostgroup));
 
 #ifdef JSON_NAGIOS_4X
 	for(x = 0; x < num_objects.hostdependencies; x++) {
 		temp_hostdependency = hostdependency_ary[ x];
 #else
-	for(temp_hostdependency = hostdependency_list; 
-			temp_hostdependency != NULL; 
-			temp_hostdependency = temp_hostdependency->next) {
+	for(temp_hostdependency = hostdependency_list;
+	    temp_hostdependency != NULL;
+	    temp_hostdependency = temp_hostdependency->next) {
 #endif
 
 		if(json_object_hostdependency_passes_selection(
-				temp_hostdependency, master_host, master_hostgroup,
-				dependent_host, dependent_hostgroup)) {
+		       temp_hostdependency, master_host, master_hostgroup,
+		       dependent_host, dependent_hostgroup)) {
 			count++;
-			}
 		}
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
 json_object *json_object_hostdependencylist(unsigned format_options, int start,
-		int count, host *master_host, hostgroup *master_hostgroup,
-		host *dependent_host, hostgroup *dependent_hostgroup) {
+        int count, host *master_host, hostgroup *master_hostgroup,
+        host *dependent_host, hostgroup *dependent_hostgroup)
+{
 
 	json_object *json_data;
 	json_array *json_hostdependencylist;
@@ -5656,10 +5723,10 @@ json_object *json_object_hostdependencylist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_hostdependency_selectors(start, count,
-			master_host, master_hostgroup, dependent_host,
-			dependent_hostgroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_hostdependency_selectors(start, count,
+	                                  master_host, master_hostgroup, dependent_host,
+	                                  dependent_hostgroup));
 
 	json_hostdependencylist = json_new_array();
 
@@ -5667,132 +5734,134 @@ json_object *json_object_hostdependencylist(unsigned format_options, int start,
 	for(x = 0; x < num_objects.hostdependencies; x++) {
 		temp_hostdependency = hostdependency_ary[ x];
 #else
-	for(temp_hostdependency = hostdependency_list; 
-			temp_hostdependency != NULL; 
-			temp_hostdependency = temp_hostdependency->next) {
+	for(temp_hostdependency = hostdependency_list;
+	    temp_hostdependency != NULL;
+	    temp_hostdependency = temp_hostdependency->next) {
 #endif
 
 		if(!json_object_hostdependency_passes_selection(
-				temp_hostdependency, master_host, master_hostgroup,
-				dependent_host, dependent_hostgroup)) {
+		       temp_hostdependency, master_host, master_hostgroup,
+		       dependent_host, dependent_hostgroup)) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			json_hostdependency_details = json_new_object();
-			json_object_hostdependency_details(json_hostdependency_details, 
-					format_options, temp_hostdependency);
-			json_array_append_object(json_hostdependencylist, 
-					json_hostdependency_details);	
-			}
-			counted++;
-		current++; 
+			json_object_hostdependency_details(json_hostdependency_details,
+			                                   format_options, temp_hostdependency);
+			json_array_append_object(json_hostdependencylist,
+			                         json_hostdependency_details);
 		}
-
-	json_object_append_array(json_data, "hostdependencylist", 
-			json_hostdependencylist);
-
-	return json_data;
+		counted++;
+		current++;
 	}
 
-void json_object_hostdependency_details(json_object *json_details,
-		unsigned format_options, hostdependency *temp_hostdependency) {
+	json_object_append_array(json_data, "hostdependencylist",
+	                         json_hostdependencylist);
 
-	json_object_append_integer(json_details, "dependency_type", 
-			temp_hostdependency->dependency_type);
-	json_object_append_string(json_details, "dependent_host_name", 
-			temp_hostdependency->dependent_host_name);
-	json_object_append_string(json_details, "host_name", 
-			temp_hostdependency->host_name);
-	json_object_append_string(json_details, "dependency_period", 
-			temp_hostdependency->dependency_period);
-	json_object_append_boolean(json_details, "inherits_parent", 
-			temp_hostdependency->inherits_parent);
+	return json_data;
+}
+
+void json_object_hostdependency_details(json_object *json_details,
+                                        unsigned format_options, hostdependency *temp_hostdependency)
+{
+
+	json_object_append_integer(json_details, "dependency_type",
+	                           temp_hostdependency->dependency_type);
+	json_object_append_string(json_details, "dependent_host_name",
+	                          temp_hostdependency->dependent_host_name);
+	json_object_append_string(json_details, "host_name",
+	                          temp_hostdependency->host_name);
+	json_object_append_string(json_details, "dependency_period",
+	                          temp_hostdependency->dependency_period);
+	json_object_append_boolean(json_details, "inherits_parent",
+	                           temp_hostdependency->inherits_parent);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "fail_on_up", 
-				flag_isset(temp_hostdependency->failure_options, OPT_UP));
-		json_object_append_boolean(json_details, "fail_on_down", 
-				flag_isset(temp_hostdependency->failure_options, OPT_DOWN));
-		json_object_append_boolean(json_details, "fail_on_unreachable", 
-				flag_isset(temp_hostdependency->failure_options, 
-				OPT_UNREACHABLE));
-		json_object_append_boolean(json_details, "fail_on_pending", 
-				flag_isset(temp_hostdependency->failure_options, OPT_PENDING));
-		}
-	else {
+		json_object_append_boolean(json_details, "fail_on_up",
+		                           flag_isset(temp_hostdependency->failure_options, OPT_UP));
+		json_object_append_boolean(json_details, "fail_on_down",
+		                           flag_isset(temp_hostdependency->failure_options, OPT_DOWN));
+		json_object_append_boolean(json_details, "fail_on_unreachable",
+		                           flag_isset(temp_hostdependency->failure_options,
+		                                      OPT_UNREACHABLE));
+		json_object_append_boolean(json_details, "fail_on_pending",
+		                           flag_isset(temp_hostdependency->failure_options, OPT_PENDING));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "failure_options",
-				temp_hostdependency->failure_options, svm_option_types);
+		             temp_hostdependency->failure_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "fail_on_up", 
-			temp_hostdependency->fail_on_up);
-	json_object_append_boolean(json_details, "fail_on_down", 
-			temp_hostdependency->fail_on_down);
-	json_object_append_boolean(json_details, "fail_on_unreachable", 
-			temp_hostdependency->fail_on_unreachable);
-	json_object_append_boolean(json_details, "fail_on_pending", 
-			temp_hostdependency->fail_on_pending);
+	json_object_append_boolean(json_details, "fail_on_up",
+	                           temp_hostdependency->fail_on_up);
+	json_object_append_boolean(json_details, "fail_on_down",
+	                           temp_hostdependency->fail_on_down);
+	json_object_append_boolean(json_details, "fail_on_unreachable",
+	                           temp_hostdependency->fail_on_unreachable);
+	json_object_append_boolean(json_details, "fail_on_pending",
+	                           temp_hostdependency->fail_on_pending);
 #endif
-	}
+}
 
-int json_object_hostescalation_passes_selection(hostescalation *temp_hostescalation, 
-		host *match_host, hostgroup *match_hostgroup, contact *match_contact,
-		contactgroup *match_contactgroup) {
+int json_object_hostescalation_passes_selection(hostescalation *temp_hostescalation,
+        host *match_host, hostgroup *match_hostgroup, contact *match_contact,
+        contactgroup *match_contactgroup)
+{
 
 	int found;
 	hostsmember *temp_hostsmember;
 
 	/* Skip if the hostescalation is not for the specified host */
-	if( NULL != match_host && 
-			strcmp( temp_hostescalation->host_name, match_host->name)) {
+	if( NULL != match_host &&
+	    strcmp( temp_hostescalation->host_name, match_host->name)) {
 		return 0;
-		}
+	}
 
 	if(NULL != match_hostgroup) {
 		found = 0;
 		for(temp_hostsmember = match_hostgroup->members;
-				temp_hostsmember != NULL;
-				temp_hostsmember = temp_hostsmember->next) {
+		    temp_hostsmember != NULL;
+		    temp_hostsmember = temp_hostsmember->next) {
 			if(!strcmp(temp_hostsmember->host_name,
-					temp_hostescalation->host_name)) {
+			           temp_hostescalation->host_name)) {
 				found = 1;
 				break;
-				}
 			}
-			if(0 == found) {
-				return 0;
-				}
 		}
+		if(0 == found) {
+			return 0;
+		}
+	}
 
 	/* If a contact was specified, skip this host escalation if it does
 		not have the contact specified */
 	if( NULL != match_contact &&
-			( FALSE == is_contact_for_host_escalation(temp_hostescalation,
-			match_contact))) {
+	    ( FALSE == is_contact_for_host_escalation(temp_hostescalation,
+	            match_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a contactgroup was specified, skip this host escalation if
 		it does not have the contactgroup specified */
 	if(NULL != match_contactgroup && (FALSE ==
-			is_contactgroup_for_host_escalation(temp_hostescalation,
-			 match_contactgroup))) {
+	                                  is_contactgroup_for_host_escalation(temp_hostescalation,
+	                                          match_contactgroup))) {
 		return 0;
-		}
-
-	return 1;
 	}
 
-json_object *json_object_hostescalation_selectors(int start, int count, 
-		host *match_host, hostgroup *match_hostgroup, contact *match_contact,
-		contactgroup *match_contactgroup) {
+	return 1;
+}
+
+json_object *json_object_hostescalation_selectors(int start, int count,
+        host *match_host, hostgroup *match_hostgroup, contact *match_contact,
+        contactgroup *match_contactgroup)
+{
 
 	json_object *json_selectors;
 
@@ -5800,32 +5869,33 @@ json_object *json_object_hostescalation_selectors(int start, int count,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( NULL != match_host) {
 		json_object_append_string(json_selectors, "hostname", match_host->name);
-		}
+	}
 	if(NULL != match_hostgroup) {
 		json_object_append_string(json_selectors, "hostgroup",
-				match_hostgroup->group_name);
-		}
+		                          match_hostgroup->group_name);
+	}
 	if( NULL != match_contact) {
 		json_object_append_string(json_selectors, "contact",
-				match_contact->name);
-		}
+		                          match_contact->name);
+	}
 	if( NULL != match_contactgroup) {
 		json_object_append_string(json_selectors, "contactgroup",
-				match_contactgroup->group_name);
-		}
-
-	return json_selectors;
+		                          match_contactgroup->group_name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_object_hostescalationcount(host *match_host,
-		hostgroup *match_hostgroup, contact *match_contact,
-		contactgroup *match_contactgroup) {
+        hostgroup *match_hostgroup, contact *match_contact,
+        contactgroup *match_contactgroup)
+{
 
 	json_object *json_data;
 #ifdef JSON_NAGIOS_4X
@@ -5835,35 +5905,36 @@ json_object *json_object_hostescalationcount(host *match_host,
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_hostescalation_selectors(0, 0, match_host,
-			match_hostgroup, match_contact, match_contactgroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_hostescalation_selectors(0, 0, match_host,
+	                                  match_hostgroup, match_contact, match_contactgroup));
 
 #ifdef JSON_NAGIOS_4X
 	for(x = 0; x < num_objects.hostescalations; x++) {
 		temp_hostescalation = hostescalation_ary[ x];
 #else
-	for(temp_hostescalation = hostescalation_list; 
-			temp_hostescalation != NULL; 
-			temp_hostescalation = temp_hostescalation->next) {
+	for(temp_hostescalation = hostescalation_list;
+	    temp_hostescalation != NULL;
+	    temp_hostescalation = temp_hostescalation->next) {
 #endif
 		if(json_object_hostescalation_passes_selection(temp_hostescalation,
-				match_host, match_hostgroup, match_contact,
-				match_contactgroup) == 0) {
+		        match_host, match_hostgroup, match_contact,
+		        match_contactgroup) == 0) {
 			continue;
-			}
-
-		count++; 
 		}
+
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_object_hostescalationlist(unsigned format_options, int start, 
-		int count, host *match_host, hostgroup *match_hostgroup,
-		contact *match_contact, contactgroup *match_contactgroup) {
+json_object *json_object_hostescalationlist(unsigned format_options, int start,
+        int count, host *match_host, hostgroup *match_hostgroup,
+        contact *match_contact, contactgroup *match_contactgroup)
+{
 
 	json_object *json_data;
 	json_array *json_hostescalationlist;
@@ -5876,9 +5947,9 @@ json_object *json_object_hostescalationlist(unsigned format_options, int start,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_object_hostescalation_selectors(start, count, match_host,
-			match_hostgroup, match_contact, match_contactgroup));
+	json_object_append_object(json_data, "selectors",
+	                          json_object_hostescalation_selectors(start, count, match_host,
+	                                  match_hostgroup, match_contact, match_contactgroup));
 
 	json_hostescalationlist = json_new_array();
 
@@ -5886,97 +5957,97 @@ json_object *json_object_hostescalationlist(unsigned format_options, int start,
 	for(x = 0; x < num_objects.hostescalations; x++) {
 		temp_hostescalation = hostescalation_ary[ x];
 #else
-	for(temp_hostescalation = hostescalation_list; 
-			temp_hostescalation != NULL; 
-			temp_hostescalation = temp_hostescalation->next) {
+	for(temp_hostescalation = hostescalation_list;
+	    temp_hostescalation != NULL;
+	    temp_hostescalation = temp_hostescalation->next) {
 #endif
 		if(json_object_hostescalation_passes_selection(temp_hostescalation,
-				match_host, match_hostgroup, match_contact,
-				match_contactgroup) == 0) {
+		        match_host, match_hostgroup, match_contact,
+		        match_contactgroup) == 0) {
 			continue;
-			}
+		}
 
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			json_hostescalation_details = json_new_object();
-			json_object_hostescalation_details(json_hostescalation_details, 
-					format_options, temp_hostescalation);
-			json_array_append_object(json_hostescalationlist, 
-					json_hostescalation_details);
-			}
-			counted++;
-		current++; 
+			json_object_hostescalation_details(json_hostescalation_details,
+			                                   format_options, temp_hostescalation);
+			json_array_append_object(json_hostescalationlist,
+			                         json_hostescalation_details);
 		}
-
-	json_object_append_array(json_data, "hostescalationlist", 
-			json_hostescalationlist);
-
-	return json_data;
+		counted++;
+		current++;
 	}
 
+	json_object_append_array(json_data, "hostescalationlist",
+	                         json_hostescalationlist);
+
+	return json_data;
+}
+
 void json_object_hostescalation_details(json_object *json_details,
-		unsigned format_options, hostescalation *temp_hostescalation) {
+                                        unsigned format_options, hostescalation *temp_hostescalation)
+{
 
 	json_array *json_contactgroups;
 	json_array *json_contacts;
 	contactgroupsmember *temp_contact_groupsmember;
 	contactsmember *temp_contactsmember;
 
-	json_object_append_string(json_details, "host_name", 
-			temp_hostescalation->host_name);
-	json_object_append_integer(json_details, "first_notification", 
-			temp_hostescalation->first_notification);
-	json_object_append_integer(json_details, "last_notification", 
-			temp_hostescalation->last_notification);
-	json_object_append_real(json_details, "notification_interval", 
-			temp_hostescalation->notification_interval);
-	json_object_append_string(json_details, "escalation_period", 
-			temp_hostescalation->escalation_period);
+	json_object_append_string(json_details, "host_name",
+	                          temp_hostescalation->host_name);
+	json_object_append_integer(json_details, "first_notification",
+	                           temp_hostescalation->first_notification);
+	json_object_append_integer(json_details, "last_notification",
+	                           temp_hostescalation->last_notification);
+	json_object_append_real(json_details, "notification_interval",
+	                        temp_hostescalation->notification_interval);
+	json_object_append_string(json_details, "escalation_period",
+	                          temp_hostescalation->escalation_period);
 
 #ifdef JSON_NAGIOS_4X
 #if 0
 	if( CORE3_COMPATIBLE) {
-		json_object_append_boolean(json_details, "escalate_on_recovery", 
-				flag_isset(temp_hostescalation->escalation_options, 
-				OPT_RECOVERY));
-		json_object_append_boolean(json_details, "escalate_on_down", 
-				flag_isset(temp_hostescalation->escalation_options, OPT_DOWN));
-		json_object_append_boolean(json_details, "escalate_on_unreachable", 
-				flag_isset(temp_hostescalation->escalation_options, 
-				OPT_UNREACHABLE));
-		}
-	else {
+		json_object_append_boolean(json_details, "escalate_on_recovery",
+		                           flag_isset(temp_hostescalation->escalation_options,
+		                                      OPT_RECOVERY));
+		json_object_append_boolean(json_details, "escalate_on_down",
+		                           flag_isset(temp_hostescalation->escalation_options, OPT_DOWN));
+		json_object_append_boolean(json_details, "escalate_on_unreachable",
+		                           flag_isset(temp_hostescalation->escalation_options,
+		                                      OPT_UNREACHABLE));
+	} else {
 #endif
 		json_bitmask(json_details, format_options, "escalation_options",
-				temp_hostescalation->escalation_options, svm_option_types);
+		             temp_hostescalation->escalation_options, svm_option_types);
 #if 0
-		}
+	}
 #endif
 #else
-	json_object_append_boolean(json_details, "escalate_on_recovery", 
-			temp_hostescalation->escalate_on_recovery);
-	json_object_append_boolean(json_details, "escalate_on_down", 
-			temp_hostescalation->escalate_on_down);
-	json_object_append_boolean(json_details, "escalate_on_unreachable", 
-			temp_hostescalation->escalate_on_unreachable);
+	json_object_append_boolean(json_details, "escalate_on_recovery",
+	                           temp_hostescalation->escalate_on_recovery);
+	json_object_append_boolean(json_details, "escalate_on_down",
+	                           temp_hostescalation->escalate_on_down);
+	json_object_append_boolean(json_details, "escalate_on_unreachable",
+	                           temp_hostescalation->escalate_on_unreachable);
 #endif
 
 	json_contactgroups = json_new_array();
-	for(temp_contact_groupsmember = temp_hostescalation->contact_groups; 
-			temp_contact_groupsmember != NULL; 
-			temp_contact_groupsmember = temp_contact_groupsmember->next) {
+	for(temp_contact_groupsmember = temp_hostescalation->contact_groups;
+	    temp_contact_groupsmember != NULL;
+	    temp_contact_groupsmember = temp_contact_groupsmember->next) {
 		json_array_append_string(json_contactgroups, NULL,
-				temp_contact_groupsmember->group_name);
-		}
+		                         temp_contact_groupsmember->group_name);
+	}
 	json_object_append_array(json_details, "contact_groups", json_contactgroups);
 
 	json_contacts = json_new_array();
-	for(temp_contactsmember = temp_hostescalation->contacts; 
-			temp_contactsmember != NULL; 
-			temp_contactsmember = temp_contactsmember->next) {
-		json_array_append_string(json_contacts, NULL, 
-				temp_contactsmember->contact_name);
-		}
-	json_object_append_array(json_details, "contacts", json_contacts);
+	for(temp_contactsmember = temp_hostescalation->contacts;
+	    temp_contactsmember != NULL;
+	    temp_contactsmember = temp_contactsmember->next) {
+		json_array_append_string(json_contacts, NULL,
+		                         temp_contactsmember->contact_name);
 	}
+	json_object_append_array(json_details, "contacts", json_contacts);
+}

--- a/cgi/outages.c
+++ b/cgi/outages.c
@@ -55,14 +55,14 @@ typedef struct hostoutage_struct {
 	unsigned long time_unreachable;
 	float percent_time_unreachable;
 	struct hostoutage_struct *next;
-	} hostoutage;
+} hostoutage;
 
 
 /* HOSTOUTAGESORT structure */
 typedef struct hostoutagesort_struct {
 	hostoutage *outage;
 	struct hostoutagesort_struct *next;
-	} hostoutagesort;
+} hostoutagesort;
 
 
 void document_header(int);
@@ -94,7 +94,8 @@ int display_header = TRUE;
 
 
 
-int main(void) {
+int main(void)
+{
 	/* get the arguments passed in the URL */
 	process_cgivars();
 
@@ -135,7 +136,7 @@ int main(void) {
 		printf("</tr>\n");
 		printf("</table>\n");
 
-		}
+	}
 
 
 	/* display network outage info */
@@ -150,11 +151,12 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -186,7 +188,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>", url_stylesheets_path, OUTAGES_CSS);
-		}
+	}
 
 	printf("</head>\n");
 
@@ -196,10 +198,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(OUTAGES_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -211,10 +214,11 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -226,7 +230,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the service severity divisor option */
 		if(!strcmp(variables[x], "service_divisor")) {
@@ -234,12 +238,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			service_severity_divisor = atoi(variables[x]);
 			if(service_severity_divisor < 1)
 				service_severity_divisor = 1;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -248,19 +252,20 @@ int process_cgivars(void) {
 		/* we found the noheader option */
 		else if(!strcmp(variables[x], "noheader"))
 			display_header = FALSE;
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 
 /* shows all hosts that are causing network outages */
-void display_network_outages(void) {
+void display_network_outages(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	int number_of_problem_hosts = 0;
 	int number_of_blocking_problem_hosts = 0;
@@ -288,7 +293,7 @@ void display_network_outages(void) {
 		printf("and check the authorization options in your CGI configuration file.</DIV></P>\n");
 
 		return;
-		}
+	}
 
 	/* find all hosts that are causing network outages */
 	find_hosts_causing_outages();
@@ -304,7 +309,7 @@ void display_network_outages(void) {
 		number_of_problem_hosts++;
 		if(temp_hostoutage->affected_child_hosts > 1)
 			number_of_blocking_problem_hosts++;
-		}
+	}
 
 	/* display the problem hosts... */
 	printf("<P><DIV ALIGN=CENTER>\n");
@@ -338,11 +343,10 @@ void display_network_outages(void) {
 		if(odd == 0) {
 			odd = 1;
 			bg_class = "dataOdd";
-			}
-		else {
+		} else {
 			odd = 0;
 			bg_class = "dataEven";
-			}
+		}
 
 		if(temp_hoststatus->status == SD_HOST_UNREACHABLE)
 			status = "UNREACHABLE";
@@ -360,8 +364,7 @@ void display_network_outages(void) {
 			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "This host has %d comment%s associated with it", total_comments, (total_comments == 1) ? "" : "s");
 			temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 			printf("<TD CLASS='%s'><A HREF='%s?type=%d&host=%s#comments'><IMG SRC='%s%s' BORDER=0 ALT='%s' TITLE='%s'></A></TD>\n", bg_class, EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_hostoutage->hst->name), url_images_path, COMMENT_ICON, temp_buffer, temp_buffer);
-			}
-		else
+		} else
 			printf("<TD CLASS='%s'>N/A</TD>\n", bg_class);
 
 
@@ -395,7 +398,7 @@ void display_network_outages(void) {
 		printf("</TD>\n");
 
 		printf("</TR>\n");
-		}
+	}
 
 	printf("</TABLE>\n");
 
@@ -409,14 +412,15 @@ void display_network_outages(void) {
 	free_hostoutagesort_list();
 
 	return;
-	}
+}
 
 
 
 
 
 /* determine what hosts are causing network outages */
-void find_hosts_causing_outages(void) {
+void find_hosts_causing_outages(void)
+{
 	hoststatus *temp_hoststatus;
 	host *temp_host;
 
@@ -435,18 +439,19 @@ void find_hosts_causing_outages(void) {
 			/* if the route to this host is not blocked, it is a causing an outage */
 			if(is_route_to_host_blocked(temp_host) == FALSE)
 				add_hostoutage(temp_host);
-			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 
 
 
 /* adds a host outage entry */
-void add_hostoutage(host *hst) {
+void add_hostoutage(host *hst)
+{
 	hostoutage *new_hostoutage;
 
 	/* allocate memory for a new structure */
@@ -465,12 +470,13 @@ void add_hostoutage(host *hst) {
 	hostoutage_list = new_hostoutage;
 
 	return;
-	}
+}
 
 
 
 /* frees all memory allocated to the host outage list */
-void free_hostoutage_list(void) {
+void free_hostoutage_list(void)
+{
 	hostoutage *this_hostoutage;
 	hostoutage *next_hostoutage;
 
@@ -478,18 +484,19 @@ void free_hostoutage_list(void) {
 	for(this_hostoutage = hostoutage_list; this_hostoutage != NULL; this_hostoutage = next_hostoutage) {
 		next_hostoutage = this_hostoutage->next;
 		free(this_hostoutage);
-		}
+	}
 
 	/* reset list pointer */
 	hostoutage_list = NULL;
 
 	return;
-	}
+}
 
 
 
 /* frees all memory allocated to the host outage sort list */
-void free_hostoutagesort_list(void) {
+void free_hostoutagesort_list(void)
+{
 	hostoutagesort *this_hostoutagesort;
 	hostoutagesort *next_hostoutagesort;
 
@@ -497,18 +504,19 @@ void free_hostoutagesort_list(void) {
 	for(this_hostoutagesort = hostoutagesort_list; this_hostoutagesort != NULL; this_hostoutagesort = next_hostoutagesort) {
 		next_hostoutagesort = this_hostoutagesort->next;
 		free(this_hostoutagesort);
-		}
+	}
 
 	/* reset list pointer */
 	hostoutagesort_list = NULL;
 
 	return;
-	}
+}
 
 
 
 /* calculates network outage effect of all hosts that are causing blockages */
-void calculate_outage_effects(void) {
+void calculate_outage_effects(void)
+{
 	hostoutage *temp_hostoutage;
 
 	/* check all hosts causing problems */
@@ -518,16 +526,17 @@ void calculate_outage_effects(void) {
 		calculate_outage_effect_of_host(temp_hostoutage->hst, &temp_hostoutage->affected_child_hosts, &temp_hostoutage->affected_child_services);
 
 		temp_hostoutage->severity = (temp_hostoutage->affected_child_hosts + (temp_hostoutage->affected_child_services / service_severity_divisor));
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 
 /* calculates network outage effect of a particular host being down or unreachable */
-void calculate_outage_effect_of_host(host *hst, int *affected_hosts, int *affected_services) {
+void calculate_outage_effect_of_host(host *hst, int *affected_hosts, int *affected_services)
+{
 	int total_child_hosts_affected = 0;
 	int total_child_services_affected = 0;
 	int temp_child_hosts_affected = 0;
@@ -548,18 +557,19 @@ void calculate_outage_effect_of_host(host *hst, int *affected_hosts, int *affect
 		/* keep a running total of outage effects */
 		total_child_hosts_affected += temp_child_hosts_affected;
 		total_child_services_affected += temp_child_services_affected;
-		}
+	}
 
 	*affected_hosts = total_child_hosts_affected + 1;
 	*affected_services = total_child_services_affected + number_of_host_services(hst);
 
 	return;
-	}
+}
 
 
 
 /* tests whether or not a host is "blocked" by upstream parents (host is already assumed to be down or unreachable) */
-int is_route_to_host_blocked(host *hst) {
+int is_route_to_host_blocked(host *hst)
+{
 	hostsmember *temp_hostsmember;
 	hoststatus *temp_hoststatus;
 
@@ -579,15 +589,16 @@ int is_route_to_host_blocked(host *hst) {
 		/* at least one parent it up (or pending), so this host is not blocked */
 		if(temp_hoststatus->status == SD_HOST_UP || temp_hoststatus->status == HOST_PENDING)
 			return FALSE;
-		}
+	}
 
 	return TRUE;
-	}
+}
 
 
 
 /* calculates the number of services associated a particular host */
-int number_of_host_services(host *hst) {
+int number_of_host_services(host *hst)
+{
 	int total_services = 0;
 	service *temp_service;
 
@@ -596,15 +607,16 @@ int number_of_host_services(host *hst) {
 
 		if(!strcmp(temp_service->host_name, hst->name))
 			total_services++;
-		}
+	}
 
 	return total_services;
-	}
+}
 
 
 
 /* sort the host outages by severity */
-void sort_hostoutages(void) {
+void sort_hostoutages(void)
+{
 	hostoutagesort *last_hostoutagesort;
 	hostoutagesort *new_hostoutagesort;
 	hostoutagesort *temp_hostoutagesort;
@@ -633,20 +645,18 @@ void sort_hostoutages(void) {
 				else
 					last_hostoutagesort->next = new_hostoutagesort;
 				break;
-				}
-			else
+			} else
 				last_hostoutagesort = temp_hostoutagesort;
-			}
+		}
 
 		if(hostoutagesort_list == NULL) {
 			new_hostoutagesort->next = NULL;
 			hostoutagesort_list = new_hostoutagesort;
-			}
-		else if(temp_hostoutagesort == NULL) {
+		} else if(temp_hostoutagesort == NULL) {
 			new_hostoutagesort->next = NULL;
 			last_hostoutagesort->next = new_hostoutagesort;
-			}
 		}
+	}
 
 	return;
-	}
+}

--- a/cgi/showlog.c
+++ b/cgi/showlog.c
@@ -56,7 +56,8 @@ int display_frills = TRUE;
 int display_timebreaks = TRUE;
 
 
-int main(void) {
+int main(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 
 
@@ -124,7 +125,7 @@ int main(void) {
 		printf("</table>\n");
 		printf("</p>\n");
 
-		}
+	}
 
 
 	/* display the contents of the log file */
@@ -136,12 +137,13 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -172,7 +174,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, SHOWLOG_CSS);
-		}
+	}
 
 	printf("</HEAD>\n");
 	printf("<BODY CLASS='showlog'>\n");
@@ -181,10 +183,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(SHOWLOG_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -196,10 +199,11 @@ void document_footer(void) {
 	printf("</HTML>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -211,7 +215,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the archive argument */
 		else if(!strcmp(variables[x], "archive")) {
@@ -219,17 +223,17 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			log_archive = atoi(variables[x]);
 			if(log_archive < 0)
 				log_archive = 0;
-			}
+		}
 
 		/* we found the order argument */
 		else if(!strcmp(variables[x], "oldestfirst")) {
 			use_lifo = FALSE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -251,18 +255,19 @@ int process_cgivars(void) {
 		else
 			error = TRUE;
 
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* display the contents of the log file */
-int display_log(void) {
+int display_log(void)
+{
 	char *input = NULL;
 	char image[MAX_INPUT_BUFFER];
 	char image_alt[MAX_INPUT_BUFFER];
@@ -283,7 +288,7 @@ int display_log(void) {
 		printf("<DIV CLASS='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>and check the authorization options in your CGI configuration file.</DIV>\n");
 		printf("<HR>\n");
 		return ERROR;
-		}
+	}
 
 	error = FALSE;
 
@@ -293,14 +298,12 @@ int display_log(void) {
 			if(error == LIFO_ERROR_MEMORY) {
 				printf("<P><DIV CLASS='warningMessage'>Not enough memory to reverse log file - displaying log in natural order...</DIV></P>");
 				error = FALSE;
-				}
-			else
+			} else
 				error = TRUE;
 			use_lifo = FALSE;
-			}
-		else
+		} else
 			error = FALSE;
-		}
+	}
 
 	if(use_lifo == FALSE) {
 
@@ -309,8 +312,8 @@ int display_log(void) {
 			printf("<P><DIV CLASS='errorMessage'>Error: Could not open log file '%s' for reading!</DIV></P>", log_file_to_use);
 			printf("<HR>\n");
 			error = TRUE;
-			}
 		}
+	}
 
 	if(error == FALSE) {
 
@@ -323,8 +326,7 @@ int display_log(void) {
 			if(use_lifo == TRUE) {
 				if((input = pop_lifo()) == NULL)
 					break;
-				}
-			else if((input = mmap_fgets(thefile)) == NULL)
+			} else if((input = mmap_fgets(thefile)) == NULL)
 				break;
 
 			strip(input);
@@ -332,139 +334,106 @@ int display_log(void) {
 			if(strstr(input, " starting...")) {
 				strcpy(image, START_ICON);
 				strcpy(image_alt, START_ICON_ALT);
-				}
-			else if(strstr(input, " shutting down...")) {
+			} else if(strstr(input, " shutting down...")) {
 				strcpy(image, STOP_ICON);
 				strcpy(image_alt, STOP_ICON_ALT);
-				}
-			else if(strstr(input, "Bailing out")) {
+			} else if(strstr(input, "Bailing out")) {
 				strcpy(image, STOP_ICON);
 				strcpy(image_alt, STOP_ICON_ALT);
-				}
-			else if(strstr(input, " restarting...")) {
+			} else if(strstr(input, " restarting...")) {
 				strcpy(image, RESTART_ICON);
 				strcpy(image_alt, RESTART_ICON_ALT);
-				}
-			else if(strstr(input, "HOST ALERT:") && strstr(input, ";DOWN;")) {
+			} else if(strstr(input, "HOST ALERT:") && strstr(input, ";DOWN;")) {
 				strcpy(image, HOST_DOWN_ICON);
 				strcpy(image_alt, HOST_DOWN_ICON_ALT);
-				}
-			else if(strstr(input, "HOST ALERT:") && strstr(input, ";UNREACHABLE;")) {
+			} else if(strstr(input, "HOST ALERT:") && strstr(input, ";UNREACHABLE;")) {
 				strcpy(image, HOST_UNREACHABLE_ICON);
 				strcpy(image_alt, HOST_UNREACHABLE_ICON_ALT);
-				}
-			else if(strstr(input, "HOST ALERT:") && (strstr(input, ";RECOVERY;") || strstr(input, ";UP;"))) {
+			} else if(strstr(input, "HOST ALERT:") && (strstr(input, ";RECOVERY;") || strstr(input, ";UP;"))) {
 				strcpy(image, HOST_UP_ICON);
 				strcpy(image_alt, HOST_UP_ICON_ALT);
-				}
-			else if(strstr(input, "HOST NOTIFICATION:")) {
+			} else if(strstr(input, "HOST NOTIFICATION:")) {
 				strcpy(image, HOST_NOTIFICATION_ICON);
 				strcpy(image_alt, HOST_NOTIFICATION_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE ALERT:") && strstr(input, ";CRITICAL;")) {
+			} else if(strstr(input, "SERVICE ALERT:") && strstr(input, ";CRITICAL;")) {
 				strcpy(image, CRITICAL_ICON);
 				strcpy(image_alt, CRITICAL_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE ALERT:") && strstr(input, ";WARNING;")) {
+			} else if(strstr(input, "SERVICE ALERT:") && strstr(input, ";WARNING;")) {
 				strcpy(image, WARNING_ICON);
 				strcpy(image_alt, WARNING_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE ALERT:") && strstr(input, ";UNKNOWN;")) {
+			} else if(strstr(input, "SERVICE ALERT:") && strstr(input, ";UNKNOWN;")) {
 				strcpy(image, UNKNOWN_ICON);
 				strcpy(image_alt, UNKNOWN_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE ALERT:") && (strstr(input, ";RECOVERY;") || strstr(input, ";OK;"))) {
+			} else if(strstr(input, "SERVICE ALERT:") && (strstr(input, ";RECOVERY;") || strstr(input, ";OK;"))) {
 				strcpy(image, OK_ICON);
 				strcpy(image_alt, OK_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE NOTIFICATION:")) {
+			} else if(strstr(input, "SERVICE NOTIFICATION:")) {
 				strcpy(image, NOTIFICATION_ICON);
 				strcpy(image_alt, NOTIFICATION_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE EVENT HANDLER:")) {
+			} else if(strstr(input, "SERVICE EVENT HANDLER:")) {
 				strcpy(image, SERVICE_EVENT_ICON);
 				strcpy(image_alt, SERVICE_EVENT_ICON_ALT);
-				}
-			else if(strstr(input, "HOST EVENT HANDLER:")) {
+			} else if(strstr(input, "HOST EVENT HANDLER:")) {
 				strcpy(image, HOST_EVENT_ICON);
 				strcpy(image_alt, HOST_EVENT_ICON_ALT);
-				}
-			else if(strstr(input, "EXTERNAL COMMAND:")) {
+			} else if(strstr(input, "EXTERNAL COMMAND:")) {
 				strcpy(image, EXTERNAL_COMMAND_ICON);
 				strcpy(image_alt, EXTERNAL_COMMAND_ICON_ALT);
-				}
-			else if(strstr(input, "PASSIVE SERVICE CHECK:")) {
+			} else if(strstr(input, "PASSIVE SERVICE CHECK:")) {
 				strcpy(image, PASSIVE_ICON);
 				strcpy(image_alt, "Passive Service Check");
-				}
-			else if(strstr(input, "PASSIVE HOST CHECK:")) {
+			} else if(strstr(input, "PASSIVE HOST CHECK:")) {
 				strcpy(image, PASSIVE_ICON);
 				strcpy(image_alt, "Passive Host Check");
-				}
-			else if(strstr(input, "LOG ROTATION:")) {
+			} else if(strstr(input, "LOG ROTATION:")) {
 				strcpy(image, LOG_ROTATION_ICON);
 				strcpy(image_alt, LOG_ROTATION_ICON_ALT);
-				}
-			else if(strstr(input, "active mode...")) {
+			} else if(strstr(input, "active mode...")) {
 				strcpy(image, ACTIVE_ICON);
 				strcpy(image_alt, ACTIVE_ICON_ALT);
-				}
-			else if(strstr(input, "standby mode...")) {
+			} else if(strstr(input, "standby mode...")) {
 				strcpy(image, STANDBY_ICON);
 				strcpy(image_alt, STANDBY_ICON_ALT);
-				}
-			else if(strstr(input, "SERVICE FLAPPING ALERT:") && strstr(input, ";STARTED;")) {
+			} else if(strstr(input, "SERVICE FLAPPING ALERT:") && strstr(input, ";STARTED;")) {
 				strcpy(image, FLAPPING_ICON);
 				strcpy(image_alt, "Service started flapping");
-				}
-			else if(strstr(input, "SERVICE FLAPPING ALERT:") && strstr(input, ";STOPPED;")) {
+			} else if(strstr(input, "SERVICE FLAPPING ALERT:") && strstr(input, ";STOPPED;")) {
 				strcpy(image, FLAPPING_ICON);
 				strcpy(image_alt, "Service stopped flapping");
-				}
-			else if(strstr(input, "SERVICE FLAPPING ALERT:") && strstr(input, ";DISABLED;")) {
+			} else if(strstr(input, "SERVICE FLAPPING ALERT:") && strstr(input, ";DISABLED;")) {
 				strcpy(image, FLAPPING_ICON);
 				strcpy(image_alt, "Service flap detection disabled");
-				}
-			else if(strstr(input, "HOST FLAPPING ALERT:") && strstr(input, ";STARTED;")) {
+			} else if(strstr(input, "HOST FLAPPING ALERT:") && strstr(input, ";STARTED;")) {
 				strcpy(image, FLAPPING_ICON);
 				strcpy(image_alt, "Host started flapping");
-				}
-			else if(strstr(input, "HOST FLAPPING ALERT:") && strstr(input, ";STOPPED;")) {
+			} else if(strstr(input, "HOST FLAPPING ALERT:") && strstr(input, ";STOPPED;")) {
 				strcpy(image, FLAPPING_ICON);
 				strcpy(image_alt, "Host stopped flapping");
-				}
-			else if(strstr(input, "HOST FLAPPING ALERT:") && strstr(input, ";DISABLED;")) {
+			} else if(strstr(input, "HOST FLAPPING ALERT:") && strstr(input, ";DISABLED;")) {
 				strcpy(image, FLAPPING_ICON);
 				strcpy(image_alt, "Host flap detection disabled");
-				}
-			else if(strstr(input, "SERVICE DOWNTIME ALERT:") && strstr(input, ";STARTED;")) {
+			} else if(strstr(input, "SERVICE DOWNTIME ALERT:") && strstr(input, ";STARTED;")) {
 				strcpy(image, SCHEDULED_DOWNTIME_ICON);
 				strcpy(image_alt, "Service entered a period of scheduled downtime");
-				}
-			else if(strstr(input, "SERVICE DOWNTIME ALERT:") && strstr(input, ";STOPPED;")) {
+			} else if(strstr(input, "SERVICE DOWNTIME ALERT:") && strstr(input, ";STOPPED;")) {
 				strcpy(image, SCHEDULED_DOWNTIME_ICON);
 				strcpy(image_alt, "Service exited a period of scheduled downtime");
-				}
-			else if(strstr(input, "SERVICE DOWNTIME ALERT:") && strstr(input, ";CANCELLED;")) {
+			} else if(strstr(input, "SERVICE DOWNTIME ALERT:") && strstr(input, ";CANCELLED;")) {
 				strcpy(image, SCHEDULED_DOWNTIME_ICON);
 				strcpy(image_alt, "Service scheduled downtime has been cancelled");
-				}
-			else if(strstr(input, "HOST DOWNTIME ALERT:") && strstr(input, ";STARTED;")) {
+			} else if(strstr(input, "HOST DOWNTIME ALERT:") && strstr(input, ";STARTED;")) {
 				strcpy(image, SCHEDULED_DOWNTIME_ICON);
 				strcpy(image_alt, "Host entered a period of scheduled downtime");
-				}
-			else if(strstr(input, "HOST DOWNTIME ALERT:") && strstr(input, ";STOPPED;")) {
+			} else if(strstr(input, "HOST DOWNTIME ALERT:") && strstr(input, ";STOPPED;")) {
 				strcpy(image, SCHEDULED_DOWNTIME_ICON);
 				strcpy(image_alt, "Host exited a period of scheduled downtime");
-				}
-			else if(strstr(input, "HOST DOWNTIME ALERT:") && strstr(input, ";CANCELLED;")) {
+			} else if(strstr(input, "HOST DOWNTIME ALERT:") && strstr(input, ";CANCELLED;")) {
 				strcpy(image, SCHEDULED_DOWNTIME_ICON);
 				strcpy(image_alt, "Host scheduled downtime has been cancelled");
-				}
-			else {
+			} else {
 				strcpy(image, INFO_ICON);
 				strcpy(image_alt, INFO_ICON_ALT);
-				}
+			}
 
 			temp_buffer = strtok(input, "]");
 			t = (temp_buffer == NULL) ? 0L : strtoul(temp_buffer + 1, NULL, 10);
@@ -485,7 +454,7 @@ int display_log(void) {
 				printf("<BR CLEAR='all'><DIV CLASS='logEntries'>\n");
 				strncpy(last_message_date, current_message_date, sizeof(last_message_date));
 				last_message_date[sizeof(last_message_date) - 1] = '\x0';
-				}
+			}
 
 			get_time_string(&t, date_time, (int)sizeof(date_time), SHORT_DATE_TIME);
 			strip(date_time);
@@ -498,9 +467,9 @@ int display_log(void) {
 			if(enable_splunk_integration == TRUE) {
 				printf("&nbsp;&nbsp;&nbsp;");
 				display_splunk_generic_url(temp_buffer, 2);
-				}
-			printf("<br clear='all'>\n");
 			}
+			printf("<br clear='all'>\n");
+		}
 
 		printf("</DIV></P>\n");
 		printf("<HR>\n");
@@ -509,10 +478,10 @@ int display_log(void) {
 
 		if(use_lifo == FALSE)
 			mmap_fclose(thefile);
-		}
+	}
 
 	if(use_lifo == TRUE)
 		free_lifo_memory();
 
 	return OK;
-	}
+}

--- a/cgi/status.c
+++ b/cgi/status.c
@@ -81,13 +81,13 @@ static nagios_macros *mac;
 typedef struct hostsort_struct {
 	hoststatus *hststatus;
 	struct hostsort_struct *next;
-	} hostsort;
+} hostsort;
 
 /* SERVICESORT structure */
 typedef struct servicesort_struct {
 	servicestatus *svcstatus;
 	struct servicesort_struct *next;
-	} servicesort;
+} servicesort;
 
 hostsort *hostsort_list = NULL;
 servicesort *servicesort_list = NULL;
@@ -189,7 +189,8 @@ int display_header = TRUE;
 
 
 
-int main(void) {
+int main(void)
+{
 	char *sound = NULL;
 	host *temp_host = NULL;
 	hostgroup *temp_hostgroup = NULL;
@@ -227,15 +228,13 @@ int main(void) {
 				if(host_name[i] == '*') {
 					host_filter[regex_i++] = '.';
 					host_filter[regex_i] = '*';
-					}
-				else
+				} else
 					host_filter[regex_i] = host_name[i];
-				}
+			}
 			host_filter[0] = '^';
 			host_filter[regex_i++] = '$';
 			host_filter[regex_i] = '\0';
-			}
-		else {
+		} else {
 			if((temp_host = find_host(host_name)) == NULL) {
 				for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 					if(is_authorized_for_host(temp_host, &current_authdata) == FALSE)
@@ -251,8 +250,8 @@ int main(void) {
 						host_filter[regex_i++] = '$';
 						host_filter[regex_i] = '\0';
 						break;
-						}
 					}
+				}
 				if(temp_host == NULL) {
 					for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 						if(is_authorized_for_host(temp_host, &current_authdata) == FALSE)
@@ -261,10 +260,10 @@ int main(void) {
 							free(host_name);
 							host_name = strdup(temp_host->name);
 							break;
-							}
 						}
 					}
 				}
+			}
 			/* last effort, search hostgroups then servicegroups */
 			if(temp_host == NULL) {
 				if((temp_hostgroup = find_hostgroup(host_name)) != NULL) {
@@ -272,16 +271,15 @@ int main(void) {
 					show_all_hostgroups = FALSE;
 					free(host_name);
 					hostgroup_name = strdup(temp_hostgroup->group_name);
-					}
-				else if((temp_servicegroup = find_servicegroup(host_name)) != NULL) {
+				} else if((temp_servicegroup = find_servicegroup(host_name)) != NULL) {
 					display_type = DISPLAY_SERVICEGROUPS;
 					show_all_servicegroups = FALSE;
 					free(host_name);
 					servicegroup_name = strdup(temp_servicegroup->group_name);
-					}
 				}
 			}
 		}
+	}
 
 	if(display_header == TRUE) {
 
@@ -305,8 +303,7 @@ int main(void) {
 				printf("<br /><a href='%s?host=all'>View Service Status Detail For All Hosts</a>\n", STATUS_CGI);
 			else
 				printf("<br /><a href='%s?hostgroup=all&style=hostdetail'>View Host Status Detail For All Hosts</a>\n", STATUS_CGI);
-			}
-		else if(display_type == DISPLAY_SERVICEGROUPS) {
+		} else if(display_type == DISPLAY_SERVICEGROUPS) {
 			if(show_all_servicegroups == FALSE) {
 
 				if(group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_GRID || group_style_type == STYLE_SUMMARY)
@@ -327,8 +324,7 @@ int main(void) {
 				if(group_style_type == STYLE_GRID)
 					printf("<a href='%s?servicegroup=all&style=grid'>View Service Status Grid For All Service Groups</a><br>\n", STATUS_CGI);
 
-				}
-			else {
+			} else {
 				if(group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_GRID || group_style_type == STYLE_SUMMARY)
 					printf("<a href='%s?servicegroup=all&style=detail'>View Service Status Detail For All Service Groups</a><br>\n", STATUS_CGI);
 				if(group_style_type == STYLE_DETAIL || group_style_type == STYLE_GRID || group_style_type == STYLE_SUMMARY)
@@ -337,10 +333,9 @@ int main(void) {
 					printf("<a href='%s?servicegroup=all&style=summary'>View Status Summary For All Service Groups</a><br>\n", STATUS_CGI);
 				if(group_style_type == STYLE_DETAIL || group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_SUMMARY)
 					printf("<a href='%s?servicegroup=all&style=grid'>View Service Status Grid For All Service Groups</a><br>\n", STATUS_CGI);
-				}
-
 			}
-		else {
+
+		} else {
 			if(show_all_hostgroups == FALSE) {
 
 				if(group_style_type == STYLE_DETAIL)
@@ -364,8 +359,7 @@ int main(void) {
 					printf("<a href='%s?hostgroup=%s&style=summary'>View Status Summary For This Host Group</a><br>\n", STATUS_CGI, url_encode(hostgroup_name));
 				if(group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_DETAIL || group_style_type == STYLE_SUMMARY || group_style_type == STYLE_HOST_DETAIL)
 					printf("<a href='%s?hostgroup=%s&style=grid'>View Status Grid For This Host Group</a><br>\n", STATUS_CGI, url_encode(hostgroup_name));
-				}
-			else {
+			} else {
 				if(group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_SUMMARY || group_style_type == STYLE_GRID || group_style_type == STYLE_HOST_DETAIL)
 					printf("<a href='%s?hostgroup=all&style=detail'>View Service Status Detail For All Host Groups</a><br>\n", STATUS_CGI);
 				if(group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_DETAIL || group_style_type == STYLE_SUMMARY || group_style_type == STYLE_GRID)
@@ -376,8 +370,8 @@ int main(void) {
 					printf("<a href='%s?hostgroup=all&style=summary'>View Status Summary For All Host Groups</a><br>\n", STATUS_CGI);
 				if(group_style_type == STYLE_OVERVIEW || group_style_type == STYLE_DETAIL || group_style_type == STYLE_SUMMARY || group_style_type == STYLE_HOST_DETAIL)
 					printf("<a href='%s?hostgroup=all&style=grid'>View Status Grid For All Host Groups</a><br>\n", STATUS_CGI);
-				}
 			}
+		}
 
 		printf("</td></tr>\n");
 		printf("</table>\n");
@@ -407,8 +401,7 @@ int main(void) {
 				display_context_help(CONTEXTHELP_STATUS_SGSUMMARY);
 			else if(group_style_type == STYLE_GRID)
 				display_context_help(CONTEXTHELP_STATUS_SGGRID);
-			}
-		else {
+		} else {
 			if(group_style_type == STYLE_HOST_DETAIL)
 				display_context_help(CONTEXTHELP_STATUS_HOST_DETAIL);
 			else if(group_style_type == STYLE_OVERVIEW)
@@ -417,13 +410,13 @@ int main(void) {
 				display_context_help(CONTEXTHELP_STATUS_HGSUMMARY);
 			else if(group_style_type == STYLE_GRID)
 				display_context_help(CONTEXTHELP_STATUS_HGGRID);
-			}
+		}
 		printf("</td>\n");
 
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 
 	/* embed sound tag if necessary... */
@@ -445,7 +438,7 @@ int main(void) {
 		printf("<param name=\"autostart\" value=\"true\">");
 		printf("<param name=\"playcount\" value=\"1\">");
 		printf("</object>");
-		}
+	}
 
 
 	/* bottom portion of screen - service or hostgroup detail */
@@ -462,8 +455,7 @@ int main(void) {
 			show_host_detail();
 		else
 			show_service_detail();
-		}
-	else {
+	} else {
 		if(group_style_type == STYLE_OVERVIEW)
 			show_hostgroup_overviews();
 		else if(group_style_type == STYLE_SUMMARY)
@@ -474,7 +466,7 @@ int main(void) {
 			show_host_detail();
 		else
 			show_service_detail();
-		}
+	}
 
 	document_footer();
 
@@ -487,10 +479,11 @@ int main(void) {
 	free_hostsort_list();
 
 	return OK;
-	}
+}
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t expire_time;
 
@@ -520,7 +513,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<link rel='stylesheet' type='text/css' href='%s%s' />\n", url_stylesheets_path, COMMON_CSS);
 		printf("<link rel='stylesheet' type='text/css' href='%s%s' />\n", url_stylesheets_path, STATUS_CSS);
-		}
+	}
 
 	/* added jquery library 1/31/2012 */
 	printf("<script type='text/javascript' src='%s%s'></script>\n",url_js_path, JQUERY_JS);
@@ -538,10 +531,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(STATUS_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -553,10 +547,11 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -568,7 +563,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the navbar search argument */
 		else if(!strcmp(variables[x], "navbarsearch")) {
@@ -576,9 +571,9 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
-			navbar_search = TRUE;
 			}
+			navbar_search = TRUE;
+		}
 
 		/* we found the hostgroup argument */
 		else if(!strcmp(variables[x], "hostgroup")) {
@@ -587,7 +582,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			hostgroup_name = (char *)strdup(variables[x]);
 			strip_html_brackets(hostgroup_name);
@@ -596,7 +591,7 @@ int process_cgivars(void) {
 				show_all_hostgroups = TRUE;
 			else
 				show_all_hostgroups = FALSE;
-			}
+		}
 
 		/* we found the servicegroup argument */
 		else if(!strcmp(variables[x], "servicegroup")) {
@@ -605,7 +600,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			servicegroup_name = strdup(variables[x]);
 			strip_html_brackets(servicegroup_name);
@@ -614,7 +609,7 @@ int process_cgivars(void) {
 				show_all_servicegroups = TRUE;
 			else
 				show_all_servicegroups = FALSE;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -623,7 +618,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			host_name = strdup(variables[x]);
 			strip_html_brackets(host_name);
@@ -632,7 +627,7 @@ int process_cgivars(void) {
 				show_all_hosts = TRUE;
 			else
 				show_all_hosts = FALSE;
-			}
+		}
 
 		/* we found the columns argument */
 		else if(!strcmp(variables[x], "columns")) {
@@ -640,12 +635,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			overview_columns = atoi(variables[x]);
 			if(overview_columns <= 0)
 				overview_columns = 1;
-			}
+		}
 
 		/* we found the service status type argument */
 		else if(!strcmp(variables[x], "servicestatustypes")) {
@@ -653,10 +648,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			service_status_types = atoi(variables[x]);
-			}
+		}
 
 		/* we found the host status type argument */
 		else if(!strcmp(variables[x], "hoststatustypes")) {
@@ -664,10 +659,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			host_status_types = atoi(variables[x]);
-			}
+		}
 
 		/* we found the service properties argument */
 		else if(!strcmp(variables[x], "serviceprops")) {
@@ -675,10 +670,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			service_properties = strtoul(variables[x], NULL, 10);
-			}
+		}
 
 		/* we found the host properties argument */
 		else if(!strcmp(variables[x], "hostprops")) {
@@ -686,10 +681,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			host_properties = strtoul(variables[x], NULL, 10);
-			}
+		}
 
 		/* we found the host or service group style argument */
 		else if(!strcmp(variables[x], "style")) {
@@ -697,7 +692,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "overview"))
 				group_style_type = STYLE_OVERVIEW;
@@ -711,7 +706,7 @@ int process_cgivars(void) {
 				group_style_type = STYLE_HOST_DETAIL;
 			else
 				group_style_type = STYLE_DETAIL;
-			}
+		}
 
 		/* we found the sort type argument */
 		else if(!strcmp(variables[x], "sorttype")) {
@@ -719,10 +714,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			sort_type = atoi(variables[x]);
-			}
+		}
 
 		/* we found the sort option argument */
 		else if(!strcmp(variables[x], "sortoption")) {
@@ -730,10 +725,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			sort_option = atoi(variables[x]);
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -749,10 +744,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			service_filter = strdup(variables[x]);
 			strip_html_brackets(service_filter);
-			}
+		}
 
 		/* experimental page limit feature */
 		else if(!strcmp(variables[x], "start")) {
@@ -760,35 +755,35 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
-			page_start = atoi(variables[x]);
 			}
-		else if(!strcmp(variables[x], "limit")) {
+			page_start = atoi(variables[x]);
+		} else if(!strcmp(variables[x], "limit")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			temp_result_limit = atoi(variables[x]);
 			if(temp_result_limit == 0)
 				limit_results = FALSE;
 			else
 				limit_results = TRUE;
-			}
-
 		}
+
+	}
 
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* display table with service status totals... */
-void show_service_status_totals(void) {
+void show_service_status_totals(void)
+{
 	int total_ok = 0;
 	int total_warning = 0;
 	int total_unknown = 0;
@@ -828,25 +823,22 @@ void show_service_status_totals(void) {
 				total_critical++;
 				if(temp_servicestatus->problem_has_been_acknowledged == FALSE && (temp_servicestatus->checks_enabled == TRUE || temp_servicestatus->accept_passive_checks == TRUE) && temp_servicestatus->notifications_enabled == TRUE && temp_servicestatus->scheduled_downtime_depth == 0)
 					problem_services_critical++;
-				}
-			else if(temp_servicestatus->status == SERVICE_WARNING) {
+			} else if(temp_servicestatus->status == SERVICE_WARNING) {
 				total_warning++;
 				if(temp_servicestatus->problem_has_been_acknowledged == FALSE && (temp_servicestatus->checks_enabled == TRUE || temp_servicestatus->accept_passive_checks == TRUE) && temp_servicestatus->notifications_enabled == TRUE && temp_servicestatus->scheduled_downtime_depth == 0)
 					problem_services_warning++;
-				}
-			else if(temp_servicestatus->status == SERVICE_UNKNOWN) {
+			} else if(temp_servicestatus->status == SERVICE_UNKNOWN) {
 				total_unknown++;
 				if(temp_servicestatus->problem_has_been_acknowledged == FALSE && (temp_servicestatus->checks_enabled == TRUE || temp_servicestatus->accept_passive_checks == TRUE) && temp_servicestatus->notifications_enabled == TRUE && temp_servicestatus->scheduled_downtime_depth == 0)
 					problem_services_unknown++;
-				}
-			else if(temp_servicestatus->status == SERVICE_OK)
+			} else if(temp_servicestatus->status == SERVICE_OK)
 				total_ok++;
 			else if(temp_servicestatus->status == SERVICE_PENDING)
 				total_pending++;
 			else
 				total_ok++;
-			}
 		}
+	}
 
 	total_services = total_ok + total_unknown + total_warning + total_critical + total_pending;
 	total_problems = total_unknown + total_warning + total_critical;
@@ -862,7 +854,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -877,7 +869,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -892,7 +884,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -907,7 +899,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -922,7 +914,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -966,7 +958,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -981,7 +973,7 @@ void show_service_status_totals(void) {
 
 	printf("<th class='serviceTotals'>");
 	printf("<a class='serviceTotals' href='%s?", STATUS_CGI);
-		/* paging */
+	/* paging */
 	if(temp_result_limit)
 		printf("limit=%i&",temp_result_limit);
 	if(display_type == DISPLAY_HOSTS)
@@ -1011,11 +1003,12 @@ void show_service_status_totals(void) {
 	printf("</div>\n");
 
 	return;
-	}
+}
 
 
 /* display a table with host status totals... */
-void show_host_status_totals(void) {
+void show_host_status_totals(void)
+{
 	int total_up = 0;
 	int total_down = 0;
 	int total_unreachable = 0;
@@ -1044,12 +1037,10 @@ void show_host_status_totals(void) {
 		else if(display_type == DISPLAY_SERVICEGROUPS) {
 			if(show_all_servicegroups == TRUE) {
 				count_host = 1;
-				}
-			else if(is_host_member_of_servicegroup(find_servicegroup(servicegroup_name), temp_host) == TRUE) {
+			} else if(is_host_member_of_servicegroup(find_servicegroup(servicegroup_name), temp_host) == TRUE) {
 				count_host = 1;
-				}
 			}
-		else if(display_type == DISPLAY_HOSTGROUPS && (show_all_hostgroups == TRUE || (is_host_member_of_hostgroup(find_hostgroup(hostgroup_name), temp_host) == TRUE)))
+		} else if(display_type == DISPLAY_HOSTGROUPS && (show_all_hostgroups == TRUE || (is_host_member_of_hostgroup(find_hostgroup(hostgroup_name), temp_host) == TRUE)))
 			count_host = 1;
 
 		if(count_host) {
@@ -1060,19 +1051,18 @@ void show_host_status_totals(void) {
 				total_down++;
 				if(temp_hoststatus->problem_has_been_acknowledged == FALSE && temp_hoststatus->notifications_enabled == TRUE && temp_hoststatus->checks_enabled == TRUE && temp_hoststatus->scheduled_downtime_depth == 0)
 					problem_hosts_down++;
-				}
-			else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
+			} else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 				total_unreachable++;
 				if(temp_hoststatus->problem_has_been_acknowledged == FALSE && temp_hoststatus->notifications_enabled == TRUE && temp_hoststatus->checks_enabled == TRUE && temp_hoststatus->scheduled_downtime_depth == 0)
 					problem_hosts_unreachable++;
-				}
+			}
 
 			else if(temp_hoststatus->status == HOST_PENDING)
 				total_pending++;
 			else
 				total_up++;
-			}
 		}
+	}
 
 	total_hosts = total_up + total_down + total_unreachable + total_pending;
 	total_problems = total_down + total_unreachable;
@@ -1101,7 +1091,7 @@ void show_host_status_totals(void) {
 			printf("&style=detail");
 		else if(group_style_type == STYLE_HOST_DETAIL)
 			printf("&style=hostdetail");
-		}
+	}
 	if(service_status_types != all_service_status_types)
 		printf("&servicestatustypes=%d", service_status_types);
 	printf("&hoststatustypes=%d'>", SD_HOST_UP);
@@ -1122,7 +1112,7 @@ void show_host_status_totals(void) {
 			printf("&style=detail");
 		else if(group_style_type == STYLE_HOST_DETAIL)
 			printf("&style=hostdetail");
-		}
+	}
 	if(service_status_types != all_service_status_types)
 		printf("&servicestatustypes=%d", service_status_types);
 	printf("&hoststatustypes=%d'>", SD_HOST_DOWN);
@@ -1143,7 +1133,7 @@ void show_host_status_totals(void) {
 			printf("&style=detail");
 		else if(group_style_type == STYLE_HOST_DETAIL)
 			printf("&style=hostdetail");
-		}
+	}
 	if(service_status_types != all_service_status_types)
 		printf("&servicestatustypes=%d", service_status_types);
 	printf("&hoststatustypes=%d'>", SD_HOST_UNREACHABLE);
@@ -1164,7 +1154,7 @@ void show_host_status_totals(void) {
 			printf("&style=detail");
 		else if(group_style_type == STYLE_HOST_DETAIL)
 			printf("&style=hostdetail");
-		}
+	}
 	if(service_status_types != all_service_status_types)
 		printf("&servicestatustypes=%d", service_status_types);
 	printf("&hoststatustypes=%d'>", HOST_PENDING);
@@ -1210,7 +1200,7 @@ void show_host_status_totals(void) {
 			printf("&style=detail");
 		else if(group_style_type == STYLE_HOST_DETAIL)
 			printf("&style=hostdetail");
-		}
+	}
 	if(service_status_types != all_service_status_types)
 		printf("&servicestatustypes=%d", service_status_types);
 	printf("&hoststatustypes=%d'>", SD_HOST_DOWN | SD_HOST_UNREACHABLE);
@@ -1231,7 +1221,7 @@ void show_host_status_totals(void) {
 			printf("&style=detail");
 		else if(group_style_type == STYLE_HOST_DETAIL)
 			printf("&style=hostdetail");
-		}
+	}
 	if(service_status_types != all_service_status_types)
 		printf("&servicestatustypes=%d", service_status_types);
 	printf("'>");
@@ -1254,12 +1244,13 @@ void show_host_status_totals(void) {
 	printf("</div>\n");
 
 	return;
-	}
+}
 
 
 
 /* display a detailed listing of the status of all services... */
-void show_service_detail(void) {
+void show_service_detail(void)
+{
 	regex_t preg, preg_hostname;
 	time_t t;
 	char date_time[MAX_DATETIME_LENGTH];
@@ -1303,8 +1294,7 @@ void show_service_detail(void) {
 			use_sort = FALSE;
 		else
 			use_sort = TRUE;
-		}
-	else
+	} else
 		use_sort = FALSE;
 
 
@@ -1326,19 +1316,17 @@ void show_service_detail(void) {
 			printf("All Hosts");
 		else
 			printf("Host '%s'", host_name);
-		}
-	else if(display_type == DISPLAY_SERVICEGROUPS) {
+	} else if(display_type == DISPLAY_SERVICEGROUPS) {
 		if(show_all_servicegroups == TRUE)
 			printf("All Service Groups");
 		else
 			printf("Service Group '%s'", url_encode(servicegroup_name));
-		}
-	else {
+	} else {
 		if(show_all_hostgroups == TRUE)
 			printf("All Host Groups");
 		else
 			printf("Host Group '%s'", hostgroup_name);
-		}
+	}
 	printf("</div>\n");
 
 	if(use_sort == TRUE) {
@@ -1357,7 +1345,7 @@ void show_service_detail(void) {
 			printf("state duration");
 		printf("</b> (%s)\n", (sort_type == SORT_ASCENDING) ? "ascending" : "descending");
 		printf("</div>\n");
-		}
+	}
 
 	if(service_filter != NULL)
 		printf("<div align='center' class='statusSort'>Filtered By Services Matching \'%s\'</div>", service_filter);
@@ -1378,7 +1366,7 @@ void show_service_detail(void) {
 	snprintf(temp_url, sizeof(temp_url) - 1, "%s?", STATUS_CGI);
 	temp_url[sizeof(temp_url) - 1] = '\x0';
 	if(display_type == DISPLAY_HOSTS)
-	     snprintf(temp_buffer, sizeof(temp_buffer) - 1, "%shost=%s", (navbar_search == TRUE) ? "&navbarsearch=1&" : "", (host_name == NULL) ? "all" : url_encode(host_name));
+		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "%shost=%s", (navbar_search == TRUE) ? "&navbarsearch=1&" : "", (host_name == NULL) ? "all" : url_encode(host_name));
 	else if(display_type == DISPLAY_SERVICEGROUPS)
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "servicegroup=%s&style=detail", url_encode(servicegroup_name));
 	else
@@ -1391,25 +1379,25 @@ void show_service_detail(void) {
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	if(host_status_types != all_host_status_types) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&hoststatustypes=%d", host_status_types);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	if(service_properties != 0) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&serviceprops=%lu", service_properties);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	if(host_properties != 0) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&hostprops=%lu", host_properties);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	/*
 	if(temp_result_limit) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&limit=%i", temp_result_limit);
@@ -1467,13 +1455,12 @@ void show_service_detail(void) {
 			if(temp_servicesort == NULL)
 				break;
 			temp_status = temp_servicesort->svcstatus;
-			}
-		else {
+		} else {
 			if(first_entry == TRUE)
 				temp_status = servicestatus_list;
 			else
 				temp_status = temp_status->next;
-			}
+		}
 
 		if(temp_status == NULL)
 			break;
@@ -1537,21 +1524,21 @@ void show_service_detail(void) {
 				show_service = TRUE;
 			else if(navbar_search_aliases == TRUE && !strcmp(host_name, temp_host->alias))
 				show_service = TRUE;
-			}
+		}
 
 		else if(display_type == DISPLAY_HOSTGROUPS) {
 			if(show_all_hostgroups == TRUE)
 				show_service = TRUE;
 			else if(is_host_member_of_hostgroup(temp_hostgroup, temp_host) == TRUE)
 				show_service = TRUE;
-			}
+		}
 
 		else if(display_type == DISPLAY_SERVICEGROUPS) {
 			if(show_all_servicegroups == TRUE)
 				show_service = TRUE;
 			else if(is_service_member_of_servicegroup(temp_servicegroup, temp_service) == TRUE)
 				show_service = TRUE;
-			}
+		}
 
 		/* final checks for display visibility, add to total results.  Used for page numbers */
 		if(result_limit == 0)
@@ -1560,7 +1547,7 @@ void show_service_detail(void) {
 		if( (limit_results == TRUE && show_service== TRUE)  && ( (total_entries < page_start) || (total_entries >= (page_start + result_limit)) )  ) {
 			total_entries++;
 			show_service = FALSE;
-			}
+		}
 
 		/* a visible entry */
 		if(show_service == TRUE) {
@@ -1573,8 +1560,8 @@ void show_service_detail(void) {
 				if(strcmp(last_host, "")) {
 					printf("<tr><td colspan='6'></td></tr>\n");
 					printf("<tr><td colspan='6'></td></tr>\n");
-					}
 				}
+			}
 
 			if(odd)
 				odd = 0;
@@ -1595,13 +1582,11 @@ void show_service_detail(void) {
 				strncpy(status, "PENDING", sizeof(status));
 				status_class = "PENDING";
 				status_bg_class = (odd) ? "Even" : "Odd";
-				}
-			else if(temp_status->status == SERVICE_OK) {
+			} else if(temp_status->status == SERVICE_OK) {
 				strncpy(status, "OK", sizeof(status));
 				status_class = "OK";
 				status_bg_class = (odd) ? "Even" : "Odd";
-				}
-			else if(temp_status->status == SERVICE_WARNING) {
+			} else if(temp_status->status == SERVICE_WARNING) {
 				strncpy(status, "WARNING", sizeof(status));
 				status_class = "WARNING";
 				if(temp_status->problem_has_been_acknowledged == TRUE)
@@ -1610,8 +1595,7 @@ void show_service_detail(void) {
 					status_bg_class = "BGWARNINGSCHED";
 				else
 					status_bg_class = "BGWARNING";
-				}
-			else if(temp_status->status == SERVICE_UNKNOWN) {
+			} else if(temp_status->status == SERVICE_UNKNOWN) {
 				strncpy(status, "UNKNOWN", sizeof(status));
 				status_class = "UNKNOWN";
 				if(temp_status->problem_has_been_acknowledged == TRUE)
@@ -1620,8 +1604,7 @@ void show_service_detail(void) {
 					status_bg_class = "BGUNKNOWNSCHED";
 				else
 					status_bg_class = "BGUNKNOWN";
-				}
-			else if(temp_status->status == SERVICE_CRITICAL) {
+			} else if(temp_status->status == SERVICE_CRITICAL) {
 				strncpy(status, "CRITICAL", sizeof(status));
 				status_class = "CRITICAL";
 				if(temp_status->problem_has_been_acknowledged == TRUE)
@@ -1630,7 +1613,7 @@ void show_service_detail(void) {
 					status_bg_class = "BGCRITICALSCHED";
 				else
 					status_bg_class = "BGCRITICAL";
-				}
+			}
 			status[sizeof(status) - 1] = '\x0';
 
 
@@ -1649,16 +1632,14 @@ void show_service_detail(void) {
 						host_status_bg_class = "HOSTDOWNSCHED";
 					else
 						host_status_bg_class = "HOSTDOWN";
-					}
-				else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
+				} else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 					if(temp_hoststatus->problem_has_been_acknowledged == TRUE)
 						host_status_bg_class = "HOSTUNREACHABLEACK";
 					else if(temp_hoststatus->scheduled_downtime_depth > 0)
 						host_status_bg_class = "HOSTUNREACHABLESCHED";
 					else
 						host_status_bg_class = "HOSTUNREACHABLE";
-					}
-				else
+				} else
 					host_status_bg_class = (odd) ? "Even" : "Odd";
 
 				printf("<td class='status%s'>", host_status_bg_class);
@@ -1678,24 +1659,24 @@ void show_service_detail(void) {
 				total_comments = number_of_host_comments(temp_host->name);
 				if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 					printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s#comments'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host problem has been acknowledged' TITLE='This host problem has been acknowledged'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, ACKNOWLEDGEMENT_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-					}
+				}
 				/* only show comments if this is a non-read-only user */
 				if(is_authorized_for_read_only(&current_authdata) == FALSE) {
 					if(total_comments > 0)
 						printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s#comments'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host has %d comment%s associated with it' TITLE='This host has %d comment%s associated with it'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, COMMENT_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, total_comments, (total_comments == 1) ? "" : "s", total_comments, (total_comments == 1) ? "" : "s");
-					}
+				}
 				if(temp_hoststatus->notifications_enabled == FALSE) {
 					printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Notifications for this host have been disabled' TITLE='Notifications for this host have been disabled'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, NOTIFICATIONS_DISABLED_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-					}
+				}
 				if(temp_hoststatus->checks_enabled == FALSE) {
 					printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Checks of this host have been disabled'd TITLE='Checks of this host have been disabled'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, DISABLED_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-					}
+				}
 				if(temp_hoststatus->is_flapping == TRUE) {
 					printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host is flapping between states' TITLE='This host is flapping between states'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, FLAPPING_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-					}
+				}
 				if(temp_hoststatus->scheduled_downtime_depth > 0) {
 					printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host is currently in a period of scheduled downtime' TITLE='This host is currently in a period of scheduled downtime'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, SCHEDULED_DOWNTIME_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-					}
+				}
 				if(temp_host->notes_url != NULL) {
 					printf("<td align=center valign=center>");
 					printf("<a href='");
@@ -1706,7 +1687,7 @@ void show_service_detail(void) {
 					printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, NOTES_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "View Extra Host Notes", "View Extra Host Notes");
 					printf("</a>");
 					printf("</td>\n");
-					}
+				}
 				if(temp_host->action_url != NULL) {
 					printf("<td align=center valign=center>");
 					printf("<a href='");
@@ -1717,7 +1698,7 @@ void show_service_detail(void) {
 					printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, ACTION_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Perform Extra Host Actions", "Perform Extra Host Actions");
 					printf("</a>");
 					printf("</td>\n");
-					}
+				}
 				if(temp_host->icon_image != NULL) {
 					printf("<td align=center valign=center>");
 					printf("<a href='%s?type=%d&host=%s'>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name));
@@ -1728,14 +1709,13 @@ void show_service_detail(void) {
 					printf("' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt);
 					printf("</a>");
 					printf("</td>\n");
-					}
+				}
 				printf("</tr>\n");
 				printf("</table>\n");
 				printf("</td>\n");
 				printf("</tr>\n");
 				printf("</table>\n");
-				}
-			else
+			} else
 				printf("<td>");
 			printf("</td>\n");
 
@@ -1764,32 +1744,31 @@ void show_service_detail(void) {
 				if(total_comments > 0) {
 					printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 					printf("&service=%s#comments'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This service has %d comment%s associated with it' TITLE='This service has %d comment%s associated with it'></a></td>", url_encode(temp_status->description), url_images_path, COMMENT_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, total_comments, (total_comments == 1) ? "" : "s", total_comments, (total_comments == 1) ? "" : "s");
-					}
 				}
+			}
 			if(temp_status->problem_has_been_acknowledged == TRUE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 				printf("&service=%s#comments'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This service problem has been acknowledged' TITLE='This service problem has been acknowledged'></a></td>", url_encode(temp_status->description), url_images_path, ACKNOWLEDGEMENT_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->checks_enabled == FALSE && temp_status->accept_passive_checks == FALSE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 				printf("&service=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Active and passive checks have been disabled for this service' TITLE='Active and passive checks have been disabled for this service'></a></td>", url_encode(temp_status->description), url_images_path, DISABLED_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
-			else if(temp_status->checks_enabled == FALSE) {
+			} else if(temp_status->checks_enabled == FALSE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 				printf("&service=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Active checks of the service have been disabled - only passive checks are being accepted' TITLE='Active checks of the service have been disabled - only passive checks are being accepted'></a></td>", url_encode(temp_status->description), url_images_path, PASSIVE_ONLY_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->notifications_enabled == FALSE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 				printf("&service=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Notifications for this service have been disabled' TITLE='Notifications for this service have been disabled'></a></td>", url_encode(temp_status->description), url_images_path, NOTIFICATIONS_DISABLED_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->is_flapping == TRUE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 				printf("&service=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This service is flapping between states' TITLE='This service is flapping between states'></a></td>", url_encode(temp_status->description), url_images_path, FLAPPING_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->scheduled_downtime_depth > 0) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_status->host_name));
 				printf("&service=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This service is currently in a period of scheduled downtime' TITLE='This service is currently in a period of scheduled downtime'></a></td>", url_encode(temp_status->description), url_images_path, SCHEDULED_DOWNTIME_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_service->notes_url != NULL) {
 				printf("<td align=center valign=center>");
 				printf("<a href='");
@@ -1800,7 +1779,7 @@ void show_service_detail(void) {
 				printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, NOTES_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "View Extra Service Notes", "View Extra Service Notes");
 				printf("</a>");
 				printf("</td>\n");
-				}
+			}
 			if(temp_service->action_url != NULL) {
 				printf("<td align=center valign=center>");
 				printf("<a href='");
@@ -1811,7 +1790,7 @@ void show_service_detail(void) {
 				printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, ACTION_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Perform Extra Service Actions", "Perform Extra Service Actions");
 				printf("</a>");
 				printf("</td>\n");
-				}
+			}
 			if(temp_service->icon_image != NULL) {
 				printf("<td ALIGN=center valign=center>");
 				printf("<a href='%s?type=%d&host=%s", EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_service->host_name));
@@ -1823,12 +1802,12 @@ void show_service_detail(void) {
 				printf("' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, (temp_service->icon_image_alt == NULL) ? "" : temp_service->icon_image_alt, (temp_service->icon_image_alt == NULL) ? "" : temp_service->icon_image_alt);
 				printf("</a>");
 				printf("</td>\n");
-				}
+			}
 			if(enable_splunk_integration == TRUE) {
 				printf("<td ALIGN=center valign=center>");
 				display_splunk_service_url(temp_service);
 				printf("</td>\n");
-				}
+			}
 			printf("</tr>\n");
 			printf("</table>\n");
 			printf("</td>\n");
@@ -1844,13 +1823,12 @@ void show_service_detail(void) {
 					duration_error = TRUE;
 				else
 					t = current_time - program_start;
-				}
-			else {
+			} else {
 				if(temp_status->last_state_change > current_time)
 					duration_error = TRUE;
 				else
 					t = current_time - temp_status->last_state_change;
-				}
+			}
 			get_time_breakdown((unsigned long)t, &days, &hours, &minutes, &seconds);
 			if(duration_error == TRUE)
 				snprintf(state_duration, sizeof(state_duration) - 1, "???");
@@ -1876,9 +1854,9 @@ void show_service_detail(void) {
 			/* mod to account for paging */
 			if(visible_entries != 0)
 				last_host = temp_status->host_name;
-			}
-
 		}
+
+	}
 
 	printf("</table>\n");
 
@@ -1889,25 +1867,24 @@ void show_service_detail(void) {
 			printf("<P><div class='errorMessage'>It appears as though you do not have permission to view information for any of the services you requested...</div></P>\n");
 			printf("<P><div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div></P>\n");
-			}
-		else {
+		} else {
 			printf("<p><div class='infoMessage'>There doesn't appear to be any service status information in the status log...<br><br>\n");
 			printf("Make sure that Nagios is running and that you have specified the location of you status log correctly in the configuration files.</div></p>\n");
-			}
 		}
-	else {
+	} else {
 		/* do page numbers if applicable */
 		create_pagenumbers(total_entries,temp_url,TRUE);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 
 /* display a detailed listing of the status of all hosts... */
-void show_host_detail(void) {
+void show_host_detail(void)
+{
 	time_t t;
 	char date_time[MAX_DATETIME_LENGTH];
 	char state_duration[48];
@@ -1944,8 +1921,7 @@ void show_host_detail(void) {
 			use_sort = FALSE;
 		else
 			use_sort = TRUE;
-		}
-	else
+	} else
 		use_sort = FALSE;
 
 
@@ -1987,7 +1963,7 @@ void show_host_detail(void) {
 			printf("state duration");
 		printf("</b> (%s)\n", (sort_type == SORT_ASCENDING) ? "ascending" : "descending");
 		printf("</div>\n");
-		}
+	}
 
 	printf("<br>");
 
@@ -2013,25 +1989,25 @@ void show_host_detail(void) {
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	if(host_status_types != all_host_status_types) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&hoststatustypes=%d", host_status_types);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	if(service_properties != 0) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&serviceprops=%lu", service_properties);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	if(host_properties != 0) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&hostprops=%lu", host_properties);
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 		strncat(temp_url, temp_buffer, sizeof(temp_url) - strlen(temp_url) - 1);
 		temp_url[sizeof(temp_url) - 1] = '\x0';
-		}
+	}
 	/*
 	if(temp_result_limit) {
 		snprintf(temp_buffer, sizeof(temp_buffer) - 1, "&limit=%i", temp_result_limit);
@@ -2079,13 +2055,12 @@ void show_host_detail(void) {
 			if(temp_hostsort == NULL)
 				break;
 			temp_status = temp_hostsort->hststatus;
-			}
-		else {
+		} else {
 			if(first_entry == TRUE)
 				temp_status = hoststatus_list;
 			else
 				temp_status = temp_status->next;
-			}
+		}
 
 		if(temp_status == NULL)
 			break;
@@ -2121,7 +2096,7 @@ void show_host_detail(void) {
 				continue;
 			if(is_host_member_of_hostgroup(temp_hostgroup, temp_host) == FALSE)
 				continue;
-			}
+		}
 
 
 
@@ -2133,7 +2108,7 @@ void show_host_detail(void) {
 
 		if( (limit_results == TRUE) && ( (total_entries < page_start) || (total_entries >= (page_start + result_limit)) )  ) {
 			continue;
-			}
+		}
 
 		visible_entries++;
 
@@ -2160,13 +2135,11 @@ void show_host_detail(void) {
 				strncpy(status, "PENDING", sizeof(status));
 				status_class = "PENDING";
 				status_bg_class = (odd) ? "Even" : "Odd";
-				}
-			else if(temp_status->status == SD_HOST_UP) {
+			} else if(temp_status->status == SD_HOST_UP) {
 				strncpy(status, "UP", sizeof(status));
 				status_class = "HOSTUP";
 				status_bg_class = (odd) ? "Even" : "Odd";
-				}
-			else if(temp_status->status == SD_HOST_DOWN) {
+			} else if(temp_status->status == SD_HOST_DOWN) {
 				strncpy(status, "DOWN", sizeof(status));
 				status_class = "HOSTDOWN";
 				if(temp_status->problem_has_been_acknowledged == TRUE)
@@ -2175,8 +2148,7 @@ void show_host_detail(void) {
 					status_bg_class = "BGDOWNSCHED";
 				else
 					status_bg_class = "BGDOWN";
-				}
-			else if(temp_status->status == SD_HOST_UNREACHABLE) {
+			} else if(temp_status->status == SD_HOST_UNREACHABLE) {
 				strncpy(status, "UNREACHABLE", sizeof(status));
 				status_class = "HOSTUNREACHABLE";
 				if(temp_status->problem_has_been_acknowledged == TRUE)
@@ -2185,7 +2157,7 @@ void show_host_detail(void) {
 					status_bg_class = "BGUNREACHABLESCHED";
 				else
 					status_bg_class = "BGUNREACHABLE";
-				}
+			}
 			status[sizeof(status) - 1] = '\x0';
 
 
@@ -2211,21 +2183,21 @@ void show_host_detail(void) {
 			total_comments = number_of_host_comments(temp_host->name);
 			if(temp_status->problem_has_been_acknowledged == TRUE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s#comments'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host problem has been acknowledged' TITLE='This host problem has been acknowledged'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, ACKNOWLEDGEMENT_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(total_comments > 0)
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s#comments'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host has %d comment%s associated with it' TITLE='This host has %d comment%s associated with it'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, COMMENT_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, total_comments, (total_comments == 1) ? "" : "s", total_comments, (total_comments == 1) ? "" : "s");
 			if(temp_status->notifications_enabled == FALSE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Notifications for this host have been disabled' TITLE='Notifications for this host have been disabled'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, NOTIFICATIONS_DISABLED_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->checks_enabled == FALSE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='Checks of this host have been disabled' TITLE='Checks of this host have been disabled'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, DISABLED_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->is_flapping == TRUE) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host is flapping between states' TITLE='This host is flapping between states'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, FLAPPING_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_status->scheduled_downtime_depth > 0) {
 				printf("<td ALIGN=center valign=center><a href='%s?type=%d&host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='This host is currently in a period of scheduled downtime' TITLE='This host is currently in a period of scheduled downtime'></a></td>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name), url_images_path, SCHEDULED_DOWNTIME_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT);
-				}
+			}
 			if(temp_host->notes_url != NULL) {
 				printf("<td align=center valign=center>");
 				printf("<a href='");
@@ -2236,7 +2208,7 @@ void show_host_detail(void) {
 				printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, NOTES_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "View Extra Host Notes", "View Extra Host Notes");
 				printf("</a>");
 				printf("</td>\n");
-				}
+			}
 			if(temp_host->action_url != NULL) {
 				printf("<td align=center valign=center>");
 				printf("<a href='");
@@ -2247,7 +2219,7 @@ void show_host_detail(void) {
 				printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, ACTION_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Perform Extra Host Actions", "Perform Extra Host Actions");
 				printf("</a>");
 				printf("</td>\n");
-				}
+			}
 			if(temp_host->icon_image != NULL) {
 				printf("<td align=center valign=center>");
 				printf("<a href='%s?type=%d&host=%s'>", EXTINFO_CGI, DISPLAY_HOST_INFO, url_encode(temp_status->host_name));
@@ -2258,12 +2230,12 @@ void show_host_detail(void) {
 				printf("' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt);
 				printf("</a>");
 				printf("</td>\n");
-				}
+			}
 			if(enable_splunk_integration == TRUE) {
 				printf("<td ALIGN=center valign=center>");
 				display_splunk_host_url(temp_host);
 				printf("</td>\n");
-				}
+			}
 			printf("<td>");
 			printf("<a href='%s?host=%s'><img src='%s%s' border=0 alt='View Service Details For This Host' title='View Service Details For This Host'></a>", STATUS_CGI, url_encode(temp_status->host_name), url_images_path, STATUS_DETAIL_ICON);
 			printf("</td>\n");
@@ -2284,13 +2256,12 @@ void show_host_detail(void) {
 					duration_error = TRUE;
 				else
 					t = current_time - program_start;
-				}
-			else {
+			} else {
 				if(temp_status->last_state_change > current_time)
 					duration_error = TRUE;
 				else
 					t = current_time - temp_status->last_state_change;
-				}
+			}
 			get_time_breakdown((unsigned long)t, &days, &hours, &minutes, &seconds);
 			if(duration_error == TRUE)
 				snprintf(state_duration, sizeof(state_duration) - 1, "???");
@@ -2311,9 +2282,9 @@ void show_host_detail(void) {
 			printf("</td>\n");
 
 			printf("</tr>\n");
-			}
-
 		}
+
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
@@ -2325,25 +2296,25 @@ void show_host_detail(void) {
 			printf("<P><div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div></P>\n");
 			printf("<P><div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div></P>\n");
-			}
-		else {
+		} else {
 			printf("<P><div class='infoMessage'>There doesn't appear to be any host status information in the status log...<br><br>\n");
 			printf("Make sure that Nagios is running and that you have specified the location of you status log correctly in the configuration files.</div></P>\n");
-			}
 		}
+	}
 
 	else {
 		/* do page numbers if applicable */
 		create_pagenumbers(total_entries,temp_url,FALSE);
-		}
-	return;
 	}
+	return;
+}
 
 
 
 
 /* show an overview of servicegroup(s)... */
-void show_servicegroup_overviews(void) {
+void show_servicegroup_overviews(void)
+{
 	servicegroup *temp_servicegroup = NULL;
 	int current_column;
 	int user_has_seen_something = FALSE;
@@ -2414,18 +2385,18 @@ void show_servicegroup_overviews(void) {
 				current_column++;
 			else
 				current_column = 1;
-			}
+		}
 
 		if(current_column != 1) {
 
 			for(; current_column <= overview_columns; current_column++)
 				printf("<td></td>\n");
 			printf("</tr>\n");
-			}
+		}
 
 		printf("</table>\n");
 		printf("</div>\n");
-		}
+	}
 
 	/* else display overview for just a specific servicegroup */
 	else {
@@ -2442,17 +2413,16 @@ void show_servicegroup_overviews(void) {
 				show_servicegroup_overview(temp_servicegroup);
 
 				user_has_seen_something = TRUE;
-				}
+			}
 
 			printf("</td></tr></table>\n");
 			printf("</div>\n");
 			//printf("</P>\n");
-			}
-		else {
+		} else {
 			printf("<div class='errorMessage'>Sorry, but service group '%s' doesn't seem to exist...</div>", servicegroup_name);
 			servicegroup_error = TRUE;
-			}
 		}
+	}
 
 	/* if user couldn't see anything, print out some helpful info... */
 	if(user_has_seen_something == FALSE && servicegroup_error == FALSE) {
@@ -2464,22 +2434,22 @@ void show_servicegroup_overviews(void) {
 			printf("<div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div>\n");
 			printf("<div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div>\n");
-			}
-		else {
+		} else {
 			printf("<div class='errorMessage'>There are no service groups defined.</div>\n");
-			}
+		}
 
 		printf("</div>\n");
 		//printf("</p>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* shows an overview of a specific servicegroup... */
-void show_servicegroup_overview(servicegroup *temp_servicegroup) {
+void show_servicegroup_overview(servicegroup *temp_servicegroup)
+{
 	servicesmember *temp_member;
 	host *temp_host;
 	host *last_host;
@@ -2537,18 +2507,19 @@ void show_servicegroup_overview(servicegroup *temp_servicegroup) {
 		show_servicegroup_hostgroup_member_overview(temp_hoststatus, odd, temp_servicegroup);
 
 		last_host = temp_host;
-		}
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
 
 	return;
-	}
+}
 
 
 
 /* show a summary of servicegroup(s)... */
-void show_servicegroup_summaries(void) {
+void show_servicegroup_summaries(void)
+{
 	servicegroup *temp_servicegroup = NULL;
 	int user_has_seen_something = FALSE;
 	int servicegroup_error = FALSE;
@@ -2613,9 +2584,9 @@ void show_servicegroup_summaries(void) {
 			show_servicegroup_summary(temp_servicegroup, odd);
 
 			user_has_seen_something = TRUE;
-			}
-
 		}
+
+	}
 
 	/* else just show summary for a specific servicegroup */
 	else {
@@ -2625,8 +2596,8 @@ void show_servicegroup_summaries(void) {
 		else {
 			show_servicegroup_summary(temp_servicegroup, 1);
 			user_has_seen_something = TRUE;
-			}
 		}
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
@@ -2640,28 +2611,28 @@ void show_servicegroup_summaries(void) {
 			printf("<div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div>\n");
 			printf("<div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div>\n");
-			}
-		else {
+		} else {
 			printf("<div class='errorMessage'>There are no service groups defined.</div>\n");
-			}
+		}
 
 		printf("</div></P>\n");
-		}
+	}
 
 	/* we couldn't find the servicegroup */
 	else if(servicegroup_error == TRUE) {
 		printf("<P><div align='center'>\n");
 		printf("<div class='errorMessage'>Sorry, but servicegroup '%s' doesn't seem to exist...</div>\n", servicegroup_name);
 		printf("</div></P>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* displays status summary information for a specific servicegroup */
-void show_servicegroup_summary(servicegroup *temp_servicegroup, int odd) {
+void show_servicegroup_summary(servicegroup *temp_servicegroup, int odd)
+{
 	const char *status_bg_class = "";
 
 	if(odd == 1)
@@ -2685,12 +2656,13 @@ void show_servicegroup_summary(servicegroup *temp_servicegroup, int odd) {
 	printf("</tr>\n");
 
 	return;
-	}
+}
 
 
 
 /* shows host total summary information for a specific servicegroup */
-void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup) {
+void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup)
+{
 	servicesmember *temp_member;
 	int hosts_up = 0;
 	int hosts_down = 0;
@@ -2747,43 +2719,43 @@ void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup) {
 			if(temp_hoststatus->scheduled_downtime_depth > 0) {
 				hosts_down_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 				hosts_down_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->checks_enabled == FALSE) {
 				hosts_down_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				hosts_down_unacknowledged++;
 			hosts_down++;
-			}
+		}
 
 		else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 			if(temp_hoststatus->scheduled_downtime_depth > 0) {
 				hosts_unreachable_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 				hosts_unreachable_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->checks_enabled == FALSE) {
 				hosts_unreachable_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				hosts_unreachable_unacknowledged++;
 			hosts_unreachable++;
-			}
+		}
 
 		else
 			hosts_pending++;
 
 		last_host = temp_host;
-		}
+	}
 
 	printf("<table border='0'>\n");
 
@@ -2791,7 +2763,7 @@ void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup) {
 		printf("<tr>");
 		printf("<td class='miniStatusUP'><a href='%s?servicegroup=%s&style=detail&&hoststatustypes=%d&hostprops=%lu'>%d UP</a></td>", STATUS_CGI, url_encode(temp_servicegroup->group_name), SD_HOST_UP, host_properties, hosts_up);
 		printf("</tr>\n");
-		}
+	}
 
 	if(hosts_down > 0) {
 		printf("<tr>\n");
@@ -2819,7 +2791,7 @@ void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(hosts_unreachable > 0) {
 		printf("<tr>\n");
@@ -2847,7 +2819,7 @@ void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(hosts_pending > 0)
 		printf("<tr><td class='miniStatusPENDING'><a href='%s?servicegroup=%s&style=detail&hoststatustypes=%d&hostprops=%lu'>%d PENDING</a></td></tr>\n", STATUS_CGI, url_encode(temp_servicegroup->group_name), HOST_PENDING, host_properties, hosts_pending);
@@ -2859,12 +2831,13 @@ void show_servicegroup_host_totals_summary(servicegroup *temp_servicegroup) {
 
 	return;
 	return;
-	}
+}
 
 
 
 /* shows service total summary information for a specific servicegroup */
-void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
+void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup)
+{
 	int services_ok = 0;
 	int services_warning = 0;
 	int services_unknown = 0;
@@ -2945,75 +2918,75 @@ void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_warning_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_warning_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_warning_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_warning_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_warning_unacknowledged++;
 			services_warning++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_UNKNOWN) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_unknown_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_unknown_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_unknown_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_unknown_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_unknown_unacknowledged++;
 			services_unknown++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_CRITICAL) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_critical_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_critical_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_critical_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_critical_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_critical_unacknowledged++;
 			services_critical++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_PENDING)
 			services_pending++;
 
 		last_service = temp_service;
-		}
+	}
 
 
 	printf("<table border=0>\n");
@@ -3050,7 +3023,7 @@ void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(services_unknown > 0) {
 		printf("<tr>\n");
@@ -3081,7 +3054,7 @@ void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(services_critical > 0) {
 		printf("<tr>\n");
@@ -3112,7 +3085,7 @@ void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(services_pending > 0)
 		printf("<tr><td class='miniStatusPENDING'><a href='%s?servicegroup=%s&style=detail&servicestatustypes=%d&hoststatustypes=%d&serviceprops=%lu&hostprops=%lu'>%d PENDING</a></td></tr>\n", STATUS_CGI, url_encode(temp_servicegroup->group_name), SERVICE_PENDING, host_status_types, service_properties, host_properties, services_pending);
@@ -3123,12 +3096,13 @@ void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
 		printf("No matching services");
 
 	return;
-	}
+}
 
 
 
 /* show a grid layout of servicegroup(s)... */
-void show_servicegroup_grids(void) {
+void show_servicegroup_grids(void)
+{
 	servicegroup *temp_servicegroup = NULL;
 	int user_has_seen_something = FALSE;
 	int servicegroup_error = FALSE;
@@ -3186,9 +3160,9 @@ void show_servicegroup_grids(void) {
 			show_servicegroup_grid(temp_servicegroup);
 
 			user_has_seen_something = TRUE;
-			}
-
 		}
+
+	}
 
 	/* else just show grid for a specific servicegroup */
 	else {
@@ -3198,8 +3172,8 @@ void show_servicegroup_grids(void) {
 		else {
 			show_servicegroup_grid(temp_servicegroup);
 			user_has_seen_something = TRUE;
-			}
 		}
+	}
 
 	/* if user couldn't see anything, print out some helpful info... */
 	if(user_has_seen_something == FALSE && servicegroup_error == FALSE) {
@@ -3210,27 +3184,27 @@ void show_servicegroup_grids(void) {
 			printf("<div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div>\n");
 			printf("<div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div>\n");
-			}
-		else {
+		} else {
 			printf("<div class='errorMessage'>There are no service groups defined.</div>\n");
-			}
+		}
 
 		printf("</div></P>\n");
-		}
+	}
 
 	/* we couldn't find the servicegroup */
 	else if(servicegroup_error == TRUE) {
 		printf("<P><div align='center'>\n");
 		printf("<div class='errorMessage'>Sorry, but servicegroup '%s' doesn't seem to exist...</div>\n", servicegroup_name);
 		printf("</div></P>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* displays status grid for a specific servicegroup */
-void show_servicegroup_grid(servicegroup *temp_servicegroup) {
+void show_servicegroup_grid(servicegroup *temp_servicegroup)
+{
 	const char *status_bg_class = "";
 	const char *host_status_class = "";
 	const char *service_status_class = "";
@@ -3279,11 +3253,10 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 		if(odd == 1) {
 			status_bg_class = "Even";
 			odd = 0;
-			}
-		else {
+		} else {
 			status_bg_class = "Odd";
 			odd = 1;
-			}
+		}
 
 		printf("<tr class='status%s'>\n", status_bg_class);
 
@@ -3321,7 +3294,7 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 			printf("' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt);
 			printf("</a>");
 			printf("<td>\n");
-			}
+		}
 
 		printf("</tr>\n");
 		printf("</table>\n");
@@ -3344,7 +3317,7 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 			if(current_item > max_grid_width && max_grid_width > 0) {
 				printf("<BR>\n");
 				current_item = 1;
-				}
+			}
 
 			/* get the status of the service */
 			temp_servicestatus = find_servicestatus(temp_member2->host_name, temp_member2->service_description);
@@ -3365,7 +3338,7 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 			printf("&service=%s' class='status%s'>%s</a>&nbsp;", url_encode(temp_servicestatus->description), service_status_class, temp_servicestatus->description);
 
 			current_item++;
-			}
+		}
 
 		/* actions */
 		printf("<td class='status%s'>", host_status_class);
@@ -3385,7 +3358,7 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 			printf("' TARGET='%s'>", (notes_url_target == NULL) ? "_blank" : notes_url_target);
 			printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, NOTES_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "View Extra Host Notes", "View Extra Host Notes");
 			printf("</a>");
-			}
+		}
 		if(temp_host->action_url != NULL) {
 			printf("<a href='");
 			process_macros_r(mac, temp_host->action_url, &processed_string, 0);
@@ -3394,7 +3367,7 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 			printf("' TARGET='%s'>", (action_url_target == NULL) ? "blank" : action_url_target);
 			printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, ACTION_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Perform Extra Host Actions", "Perform Extra Host Actions");
 			printf("</a>");
-			}
+		}
 
 		printf("<a href='%s?host=%s'><img src='%s%s' border=0 alt='View Service Details For This Host' title='View Service Details For This Host'></a>\n", STATUS_CGI, url_encode(temp_host->name), url_images_path, STATUS_DETAIL_ICON);
 
@@ -3405,19 +3378,20 @@ void show_servicegroup_grid(servicegroup *temp_servicegroup) {
 		printf("</tr>\n");
 
 		last_host = temp_host;
-		}
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
 /* show an overview of hostgroup(s)... */
-void show_hostgroup_overviews(void) {
+void show_hostgroup_overviews(void)
+{
 	hostgroup *temp_hostgroup = NULL;
 	int current_column;
 	int user_has_seen_something = FALSE;
@@ -3488,18 +3462,18 @@ void show_hostgroup_overviews(void) {
 				current_column++;
 			else
 				current_column = 1;
-			}
+		}
 
 		if(current_column != 1) {
 
 			for(; current_column <= overview_columns; current_column++)
 				printf("<td></td>\n");
 			printf("</tr>\n");
-			}
+		}
 
 		printf("</table>\n");
 		printf("</div>\n");
-		}
+	}
 
 	/* else display overview for just a specific hostgroup */
 	else {
@@ -3516,17 +3490,16 @@ void show_hostgroup_overviews(void) {
 				show_hostgroup_overview(temp_hostgroup);
 
 				user_has_seen_something = TRUE;
-				}
+			}
 
 			printf("</td></tr></table>\n");
 			printf("</div>\n");
 			printf("</P>\n");
-			}
-		else {
+		} else {
 			printf("<div class='errorMessage'>Sorry, but host group '%s' doesn't seem to exist...</div>", hostgroup_name);
 			hostgroup_error = TRUE;
-			}
 		}
+	}
 
 	/* if user couldn't see anything, print out some helpful info... */
 	if(user_has_seen_something == FALSE && hostgroup_error == FALSE) {
@@ -3538,23 +3511,23 @@ void show_hostgroup_overviews(void) {
 			printf("<div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div>\n");
 			printf("<div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div>\n");
-			}
-		else {
+		} else {
 			printf("<div class='infoMessage'>There doesn't appear to be any host status information in the status log...<br><br>\n");
 			printf("Make sure that Nagios is running and that you have specified the location of you status log correctly in the configuration files.</div>\n");
-			}
+		}
 
 		printf("</div>\n");
 		printf("</p>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* shows an overview of a specific hostgroup... */
-void show_hostgroup_overview(hostgroup *hstgrp) {
+void show_hostgroup_overview(hostgroup *hstgrp)
+{
 	hostsmember *temp_member = NULL;
 	host *temp_host = NULL;
 	hoststatus *temp_hoststatus = NULL;
@@ -3603,18 +3576,19 @@ void show_hostgroup_overview(hostgroup *hstgrp) {
 			odd = 1;
 
 		show_servicegroup_hostgroup_member_overview(temp_hoststatus, odd, NULL);
-		}
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
 
 	return;
-	}
+}
 
 
 
 /* shows a host status overview... */
-void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd, void *data) {
+void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd, void *data)
+{
 	char status[MAX_INPUT_BUFFER];
 	const char *status_bg_class = "";
 	const char *status_class = "";
@@ -3630,22 +3604,19 @@ void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd,
 		strncpy(status, "PENDING", sizeof(status));
 		status_class = "HOSTPENDING";
 		status_bg_class = (odd) ? "Even" : "Odd";
-		}
-	else if(hststatus->status == SD_HOST_UP) {
+	} else if(hststatus->status == SD_HOST_UP) {
 		strncpy(status, "UP", sizeof(status));
 		status_class = "HOSTUP";
 		status_bg_class = (odd) ? "Even" : "Odd";
-		}
-	else if(hststatus->status == SD_HOST_DOWN) {
+	} else if(hststatus->status == SD_HOST_DOWN) {
 		strncpy(status, "DOWN", sizeof(status));
 		status_class = "HOStdOWN";
 		status_bg_class = "HOStdOWN";
-		}
-	else if(hststatus->status == SD_HOST_UNREACHABLE) {
+	} else if(hststatus->status == SD_HOST_UNREACHABLE) {
 		strncpy(status, "UNREACHABLE", sizeof(status));
 		status_class = "HOSTUNREACHABLE";
 		status_bg_class = "HOSTUNREACHABLE";
-		}
+	}
 
 	status[sizeof(status) - 1] = '\x0';
 
@@ -3668,7 +3639,7 @@ void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd,
 		printf("' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt);
 		printf("</a>");
 		printf("</td>\n");
-		}
+	}
 	printf("</tr>\n");
 	printf("</table>\n");
 	printf("</td>\n");
@@ -3689,7 +3660,7 @@ void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd,
 		printf("' TARGET='%s'>", (notes_url_target == NULL) ? "_blank" : notes_url_target);
 		printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, NOTES_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "View Extra Host Notes", "View Extra Host Notes");
 		printf("</a>");
-		}
+	}
 	if(temp_host->action_url != NULL) {
 		printf("<a href='");
 		process_macros_r(mac, temp_host->action_url, &processed_string, 0);
@@ -3698,7 +3669,7 @@ void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd,
 		printf("' TARGET='%s'>", (action_url_target == NULL) ? "_blank" : action_url_target);
 		printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, ACTION_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Perform Extra Host Actions", "Perform Extra Host Actions");
 		printf("</a>");
-		}
+	}
 	printf("<a href='%s?host=%s'><img src='%s%s' border=0 alt='View Service Details For This Host' title='View Service Details For This Host'></a>\n", STATUS_CGI, url_encode(hststatus->host_name), url_images_path, STATUS_DETAIL_ICON);
 #ifdef USE_STATUSMAP
 	printf("<a href='%s?host=%s'><IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'></a>", STATUSMAP_CGI, url_encode(hststatus->host_name), url_images_path, STATUSMAP_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Locate Host On Map", "Locate Host On Map");
@@ -3708,11 +3679,12 @@ void show_servicegroup_hostgroup_member_overview(hoststatus *hststatus, int odd,
 	printf("</tr>\n");
 
 	return;
-	}
+}
 
 
 
-void show_servicegroup_hostgroup_member_service_status_totals(char *hst_name, void *data) {
+void show_servicegroup_hostgroup_member_service_status_totals(char *hst_name, void *data)
+{
 	int total_ok = 0;
 	int total_warning = 0;
 	int total_unknown = 0;
@@ -3742,7 +3714,7 @@ void show_servicegroup_hostgroup_member_service_status_totals(char *hst_name, vo
 				/* is this service a member of the servicegroup? */
 				if(is_service_member_of_servicegroup(temp_servicegroup, temp_service) == FALSE)
 					continue;
-				}
+			}
 
 			/* make sure we only display services of the specified status levels */
 			if(!(service_status_types & temp_servicestatus->status))
@@ -3764,8 +3736,8 @@ void show_servicegroup_hostgroup_member_service_status_totals(char *hst_name, vo
 				total_pending++;
 			else
 				total_ok++;
-			}
 		}
+	}
 
 
 	printf("<table border=0 WIDTH=100%%>\n");
@@ -3793,12 +3765,13 @@ void show_servicegroup_hostgroup_member_service_status_totals(char *hst_name, vo
 		printf("No matching services");
 
 	return;
-	}
+}
 
 
 
 /* show a summary of hostgroup(s)... */
-void show_hostgroup_summaries(void) {
+void show_hostgroup_summaries(void)
+{
 	hostgroup *temp_hostgroup = NULL;
 	int user_has_seen_something = FALSE;
 	int hostgroup_error = FALSE;
@@ -3863,9 +3836,9 @@ void show_hostgroup_summaries(void) {
 			show_hostgroup_summary(temp_hostgroup, odd);
 
 			user_has_seen_something = TRUE;
-			}
-
 		}
+
+	}
 
 	/* else just show summary for a specific hostgroup */
 	else {
@@ -3875,8 +3848,8 @@ void show_hostgroup_summaries(void) {
 		else {
 			show_hostgroup_summary(temp_hostgroup, 1);
 			user_has_seen_something = TRUE;
-			}
 		}
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
@@ -3890,29 +3863,29 @@ void show_hostgroup_summaries(void) {
 			printf("<div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div>\n");
 			printf("<div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div>\n");
-			}
-		else {
+		} else {
 			printf("<div class='infoMessage'>There doesn't appear to be any host status information in the status log...<br><br>\n");
 			printf("Make sure that Nagios is running and that you have specified the location of you status log correctly in the configuration files.</div>\n");
-			}
+		}
 
 		printf("</div></P>\n");
-		}
+	}
 
 	/* we couldn't find the hostgroup */
 	else if(hostgroup_error == TRUE) {
 		printf("<P><div align='center'>\n");
 		printf("<div class='errorMessage'>Sorry, but hostgroup '%s' doesn't seem to exist...</div>\n", hostgroup_name);
 		printf("</div></P>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* displays status summary information for a specific hostgroup */
-void show_hostgroup_summary(hostgroup *temp_hostgroup, int odd) {
+void show_hostgroup_summary(hostgroup *temp_hostgroup, int odd)
+{
 	const char *status_bg_class = "";
 
 	if(odd == 1)
@@ -3936,12 +3909,13 @@ void show_hostgroup_summary(hostgroup *temp_hostgroup, int odd) {
 	printf("</tr>\n");
 
 	return;
-	}
+}
 
 
 
 /* shows host total summary information for a specific hostgroup */
-void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup) {
+void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup)
+{
 	hostsmember *temp_member;
 	int hosts_up = 0;
 	int hosts_down = 0;
@@ -3989,41 +3963,41 @@ void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup) {
 			if(temp_hoststatus->scheduled_downtime_depth > 0) {
 				hosts_down_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 				hosts_down_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->checks_enabled == FALSE) {
 				hosts_down_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				hosts_down_unacknowledged++;
 			hosts_down++;
-			}
+		}
 
 		else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 			if(temp_hoststatus->scheduled_downtime_depth > 0) {
 				hosts_unreachable_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 				hosts_unreachable_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->checks_enabled == FALSE) {
 				hosts_unreachable_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				hosts_unreachable_unacknowledged++;
 			hosts_unreachable++;
-			}
+		}
 
 		else
 			hosts_pending++;
-		}
+	}
 
 	printf("<table border='0'>\n");
 
@@ -4031,7 +4005,7 @@ void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup) {
 		printf("<tr>");
 		printf("<td class='miniStatusUP'><a href='%s?hostgroup=%s&style=hostdetail&&hoststatustypes=%d&hostprops=%lu'>%d UP</a></td>", STATUS_CGI, url_encode(temp_hostgroup->group_name), SD_HOST_UP, host_properties, hosts_up);
 		printf("</tr>\n");
-		}
+	}
 
 	if(hosts_down > 0) {
 		printf("<tr>\n");
@@ -4059,7 +4033,7 @@ void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(hosts_unreachable > 0) {
 		printf("<tr>\n");
@@ -4087,7 +4061,7 @@ void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(hosts_pending > 0)
 		printf("<tr><td class='miniStatusPENDING'><a href='%s?hostgroup=%s&style=hostdetail&hoststatustypes=%d&hostprops=%lu'>%d PENDING</a></td></tr>\n", STATUS_CGI, url_encode(temp_hostgroup->group_name), HOST_PENDING, host_properties, hosts_pending);
@@ -4098,12 +4072,13 @@ void show_hostgroup_host_totals_summary(hostgroup *temp_hostgroup) {
 		printf("No matching hosts");
 
 	return;
-	}
+}
 
 
 
 /* shows service total summary information for a specific hostgroup */
-void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup) {
+void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup)
+{
 	int services_ok = 0;
 	int services_warning = 0;
 	int services_unknown = 0;
@@ -4178,73 +4153,73 @@ void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup) {
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_warning_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_warning_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_warning_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_warning_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_warning_unacknowledged++;
 			services_warning++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_UNKNOWN) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_unknown_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_unknown_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_unknown_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_unknown_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_unknown_unacknowledged++;
 			services_unknown++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_CRITICAL) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_critical_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_critical_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_critical_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_critical_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_critical_unacknowledged++;
 			services_critical++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_PENDING)
 			services_pending++;
-		}
+	}
 
 
 	printf("<table border=0>\n");
@@ -4281,7 +4256,7 @@ void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(services_unknown > 0) {
 		printf("<tr>\n");
@@ -4312,7 +4287,7 @@ void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(services_critical > 0) {
 		printf("<tr>\n");
@@ -4343,7 +4318,7 @@ void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup) {
 		printf("</tr>\n");
 		printf("</table></td>\n");
 		printf("</tr>\n");
-		}
+	}
 
 	if(services_pending > 0)
 		printf("<tr><td class='miniStatusPENDING'><a href='%s?hostgroup=%s&style=detail&servicestatustypes=%d&hoststatustypes=%d&serviceprops=%lu&hostprops=%lu'>%d PENDING</a></td></tr>\n", STATUS_CGI, url_encode(temp_hostgroup->group_name), SERVICE_PENDING, host_status_types, service_properties, host_properties, services_pending);
@@ -4354,12 +4329,13 @@ void show_hostgroup_service_totals_summary(hostgroup *temp_hostgroup) {
 		printf("No matching services");
 
 	return;
-	}
+}
 
 
 
 /* show a grid layout of hostgroup(s)... */
-void show_hostgroup_grids(void) {
+void show_hostgroup_grids(void)
+{
 	hostgroup *temp_hostgroup = NULL;
 	int user_has_seen_something = FALSE;
 	int hostgroup_error = FALSE;
@@ -4417,9 +4393,9 @@ void show_hostgroup_grids(void) {
 			show_hostgroup_grid(temp_hostgroup);
 
 			user_has_seen_something = TRUE;
-			}
-
 		}
+
+	}
 
 	/* else just show grid for a specific hostgroup */
 	else {
@@ -4429,8 +4405,8 @@ void show_hostgroup_grids(void) {
 		else {
 			show_hostgroup_grid(temp_hostgroup);
 			user_has_seen_something = TRUE;
-			}
 		}
+	}
 
 	/* if user couldn't see anything, print out some helpful info... */
 	if(user_has_seen_something == FALSE && hostgroup_error == FALSE) {
@@ -4441,28 +4417,28 @@ void show_hostgroup_grids(void) {
 			printf("<div class='errorMessage'>It appears as though you do not have permission to view information for any of the hosts you requested...</div>\n");
 			printf("<div class='errorDescription'>If you believe this is an error, check the HTTP server authentication requirements for accessing this CGI<br>");
 			printf("and check the authorization options in your CGI configuration file.</div>\n");
-			}
-		else {
+		} else {
 			printf("<div class='infoMessage'>There doesn't appear to be any host status information in the status log...<br><br>\n");
 			printf("Make sure that Nagios is running and that you have specified the location of you status log correctly in the configuration files.</div>\n");
-			}
+		}
 
 		printf("</div></P>\n");
-		}
+	}
 
 	/* we couldn't find the hostgroup */
 	else if(hostgroup_error == TRUE) {
 		printf("<P><div align='center'>\n");
 		printf("<div class='errorMessage'>Sorry, but hostgroup '%s' doesn't seem to exist...</div>\n", hostgroup_name);
 		printf("</div></P>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* displays status grid for a specific hostgroup */
-void show_hostgroup_grid(hostgroup *temp_hostgroup) {
+void show_hostgroup_grid(hostgroup *temp_hostgroup)
+{
 	hostsmember *temp_member;
 	const char *status_bg_class = "";
 	const char *host_status_class = "";
@@ -4504,11 +4480,10 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 		if(odd == 1) {
 			status_bg_class = "Even";
 			odd = 0;
-			}
-		else {
+		} else {
 			status_bg_class = "Odd";
 			odd = 1;
-			}
+		}
 
 		printf("<tr class='status%s'>\n", status_bg_class);
 
@@ -4547,7 +4522,7 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 			printf("' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt, (temp_host->icon_image_alt == NULL) ? "" : temp_host->icon_image_alt);
 			printf("</a>");
 			printf("<td>\n");
-			}
+		}
 		printf("<td>\n");
 
 		printf("</tr>\n");
@@ -4571,7 +4546,7 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 			if(current_item > max_grid_width && max_grid_width > 0) {
 				printf("<BR>\n");
 				current_item = 1;
-				}
+			}
 
 			/* grab macros */
 			grab_service_macros_r(mac, temp_service);
@@ -4595,7 +4570,7 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 			printf("&service=%s' class='status%s'>%s</a>&nbsp;", url_encode(temp_servicestatus->description), service_status_class, temp_servicestatus->description);
 
 			current_item++;
-			}
+		}
 
 		printf("</td>\n");
 
@@ -4614,7 +4589,7 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 			printf("' TARGET='%s'>", (notes_url_target == NULL) ? "_blank" : notes_url_target);
 			printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, NOTES_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "View Extra Host Notes", "View Extra Host Notes");
 			printf("</a>");
-			}
+		}
 		if(temp_host->action_url != NULL) {
 			printf("<a href='");
 			process_macros_r(mac, temp_host->action_url, &processed_string, 0);
@@ -4623,7 +4598,7 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 			printf("' TARGET='%s'>", (action_url_target == NULL) ? "_blank" : action_url_target);
 			printf("<IMG SRC='%s%s' border=0 WIDTH=%d HEIGHT=%d ALT='%s' TITLE='%s'>", url_images_path, ACTION_ICON, STATUS_ICON_WIDTH, STATUS_ICON_HEIGHT, "Perform Extra Host Actions", "Perform Extra Host Actions");
 			printf("</a>");
-			}
+		}
 
 		printf("<a href='%s?host=%s'><img src='%s%s' border=0 alt='View Service Details For This Host' title='View Service Details For This Host'></a>\n", STATUS_CGI, url_encode(temp_host->name), url_images_path, STATUS_DETAIL_ICON);
 #ifdef USE_STATUSMAP
@@ -4632,14 +4607,14 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 		printf("</td>\n");
 
 		printf("</tr>\n");
-		}
+	}
 
 	printf("</table>\n");
 	printf("</div>\n");
 	printf("</P>\n");
 
 	return;
-	}
+}
 
 
 
@@ -4650,7 +4625,8 @@ void show_hostgroup_grid(hostgroup *temp_hostgroup) {
 
 
 /* sorts the service list */
-int sort_services(int s_type, int s_option) {
+int sort_services(int s_type, int s_option)
+{
 	servicesort *new_servicesort;
 	servicesort *last_servicesort;
 	servicesort *temp_servicesort;
@@ -4682,26 +4658,25 @@ int sort_services(int s_type, int s_option) {
 				else
 					last_servicesort->next = new_servicesort;
 				break;
-				}
-			else
+			} else
 				last_servicesort = temp_servicesort;
-			}
+		}
 
 		if(servicesort_list == NULL) {
 			new_servicesort->next = NULL;
 			servicesort_list = new_servicesort;
-			}
-		else if(temp_servicesort == NULL) {
+		} else if(temp_servicesort == NULL) {
 			new_servicesort->next = NULL;
 			last_servicesort->next = new_servicesort;
-			}
 		}
-
-	return OK;
 	}
 
+	return OK;
+}
 
-int compare_servicesort_entries(int s_type, int s_option, servicesort *new_servicesort, servicesort *temp_servicesort) {
+
+int compare_servicesort_entries(int s_type, int s_option, servicesort *new_servicesort, servicesort *temp_servicesort)
+{
 	servicestatus *new_svcstatus;
 	servicestatus *temp_svcstatus;
 	time_t nt;
@@ -4717,32 +4692,27 @@ int compare_servicesort_entries(int s_type, int s_option, servicesort *new_servi
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_CURRENTATTEMPT) {
+		} else if(s_option == SORT_CURRENTATTEMPT) {
 			if(new_svcstatus->current_attempt < temp_svcstatus->current_attempt)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICESTATUS) {
+		} else if(s_option == SORT_SERVICESTATUS) {
 			if(new_svcstatus->status <= temp_svcstatus->status)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTNAME) {
+		} else if(s_option == SORT_HOSTNAME) {
 			if(strcasecmp(new_svcstatus->host_name, temp_svcstatus->host_name) < 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICENAME) {
+		} else if(s_option == SORT_SERVICENAME) {
 			if(strcasecmp(new_svcstatus->description, temp_svcstatus->description) < 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_STATEDURATION) {
+		} else if(s_option == SORT_STATEDURATION) {
 			if(new_svcstatus->last_state_change == (time_t)0)
 				nt = (program_start > current_time) ? 0 : (current_time - program_start);
 			else
@@ -4755,40 +4725,34 @@ int compare_servicesort_entries(int s_type, int s_option, servicesort *new_servi
 				return TRUE;
 			else
 				return FALSE;
-			}
 		}
-	else {
+	} else {
 		if(s_option == SORT_LASTCHECKTIME) {
 			if(new_svcstatus->last_check > temp_svcstatus->last_check)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_CURRENTATTEMPT) {
+		} else if(s_option == SORT_CURRENTATTEMPT) {
 			if(new_svcstatus->current_attempt > temp_svcstatus->current_attempt)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICESTATUS) {
+		} else if(s_option == SORT_SERVICESTATUS) {
 			if(new_svcstatus->status > temp_svcstatus->status)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTNAME) {
+		} else if(s_option == SORT_HOSTNAME) {
 			if(strcasecmp(new_svcstatus->host_name, temp_svcstatus->host_name) > 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_SERVICENAME) {
+		} else if(s_option == SORT_SERVICENAME) {
 			if(strcasecmp(new_svcstatus->description, temp_svcstatus->description) > 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_STATEDURATION) {
+		} else if(s_option == SORT_STATEDURATION) {
 			if(new_svcstatus->last_state_change == (time_t)0)
 				nt = (program_start > current_time) ? 0 : (current_time - program_start);
 			else
@@ -4801,16 +4765,17 @@ int compare_servicesort_entries(int s_type, int s_option, servicesort *new_servi
 				return TRUE;
 			else
 				return FALSE;
-			}
 		}
+	}
 
 	return TRUE;
-	}
+}
 
 
 
 /* sorts the host list */
-int sort_hosts(int s_type, int s_option) {
+int sort_hosts(int s_type, int s_option)
+{
 	hostsort *new_hostsort;
 	hostsort *last_hostsort;
 	hostsort *temp_hostsort;
@@ -4842,26 +4807,25 @@ int sort_hosts(int s_type, int s_option) {
 				else
 					last_hostsort->next = new_hostsort;
 				break;
-				}
-			else
+			} else
 				last_hostsort = temp_hostsort;
-			}
+		}
 
 		if(hostsort_list == NULL) {
 			new_hostsort->next = NULL;
 			hostsort_list = new_hostsort;
-			}
-		else if(temp_hostsort == NULL) {
+		} else if(temp_hostsort == NULL) {
 			new_hostsort->next = NULL;
 			last_hostsort->next = new_hostsort;
-			}
 		}
-
-	return OK;
 	}
 
+	return OK;
+}
 
-int compare_hostsort_entries(int s_type, int s_option, hostsort *new_hostsort, hostsort *temp_hostsort) {
+
+int compare_hostsort_entries(int s_type, int s_option, hostsort *new_hostsort, hostsort *temp_hostsort)
+{
 	hoststatus *new_hststatus;
 	hoststatus *temp_hststatus;
 	time_t nt;
@@ -4877,26 +4841,22 @@ int compare_hostsort_entries(int s_type, int s_option, hostsort *new_hostsort, h
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTSTATUS) {
+		} else if(s_option == SORT_HOSTSTATUS) {
 			if(new_hststatus->status <= temp_hststatus->status)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTURGENCY) {
+		} else if(s_option == SORT_HOSTURGENCY) {
 			if(HOST_URGENCY(new_hststatus->status) <= HOST_URGENCY(temp_hststatus->status))
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTNAME) {
+		} else if(s_option == SORT_HOSTNAME) {
 			if(strcasecmp(new_hststatus->host_name, temp_hststatus->host_name) < 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_STATEDURATION) {
+		} else if(s_option == SORT_STATEDURATION) {
 			if(new_hststatus->last_state_change == (time_t)0)
 				nt = (program_start > current_time) ? 0 : (current_time - program_start);
 			else
@@ -4909,34 +4869,29 @@ int compare_hostsort_entries(int s_type, int s_option, hostsort *new_hostsort, h
 				return TRUE;
 			else
 				return FALSE;
-			}
 		}
-	else {
+	} else {
 		if(s_option == SORT_LASTCHECKTIME) {
 			if(new_hststatus->last_check > temp_hststatus->last_check)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTSTATUS) {
+		} else if(s_option == SORT_HOSTSTATUS) {
 			if(new_hststatus->status > temp_hststatus->status)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTURGENCY) {
+		} else if(s_option == SORT_HOSTURGENCY) {
 			if(HOST_URGENCY(new_hststatus->status) > HOST_URGENCY(temp_hststatus->status))
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_HOSTNAME) {
+		} else if(s_option == SORT_HOSTNAME) {
 			if(strcasecmp(new_hststatus->host_name, temp_hststatus->host_name) > 0)
 				return TRUE;
 			else
 				return FALSE;
-			}
-		else if(s_option == SORT_STATEDURATION) {
+		} else if(s_option == SORT_STATEDURATION) {
 			if(new_hststatus->last_state_change == (time_t)0)
 				nt = (program_start > current_time) ? 0 : (current_time - program_start);
 			else
@@ -4949,16 +4904,17 @@ int compare_hostsort_entries(int s_type, int s_option, hostsort *new_hostsort, h
 				return TRUE;
 			else
 				return FALSE;
-			}
 		}
+	}
 
 	return TRUE;
-	}
+}
 
 
 
 /* free all memory allocated to the servicesort structures */
-void free_servicesort_list(void) {
+void free_servicesort_list(void)
+{
 	servicesort *this_servicesort;
 	servicesort *next_servicesort;
 
@@ -4966,14 +4922,15 @@ void free_servicesort_list(void) {
 	for(this_servicesort = servicesort_list; this_servicesort != NULL; this_servicesort = next_servicesort) {
 		next_servicesort = this_servicesort->next;
 		free(this_servicesort);
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* free all memory allocated to the hostsort structures */
-void free_hostsort_list(void) {
+void free_hostsort_list(void)
+{
 	hostsort *this_hostsort;
 	hostsort *next_hostsort;
 
@@ -4981,15 +4938,16 @@ void free_hostsort_list(void) {
 	for(this_hostsort = hostsort_list; this_hostsort != NULL; this_hostsort = next_hostsort) {
 		next_hostsort = this_hostsort->next;
 		free(this_hostsort);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* check host properties filter */
-int passes_host_properties_filter(hoststatus *temp_hoststatus) {
+int passes_host_properties_filter(hoststatus *temp_hoststatus)
+{
 
 	if((host_properties & HOST_SCHEDULED_DOWNTIME) && temp_hoststatus->scheduled_downtime_depth <= 0)
 		return FALSE;
@@ -5052,12 +5010,13 @@ int passes_host_properties_filter(hoststatus *temp_hoststatus) {
 		return FALSE;
 
 	return TRUE;
-	}
+}
 
 
 
 /* check service properties filter */
-int passes_service_properties_filter(servicestatus *temp_servicestatus) {
+int passes_service_properties_filter(servicestatus *temp_servicestatus)
+{
 
 	if((service_properties & SERVICE_SCHEDULED_DOWNTIME) && temp_servicestatus->scheduled_downtime_depth <= 0)
 		return FALSE;
@@ -5120,12 +5079,13 @@ int passes_service_properties_filter(servicestatus *temp_servicestatus) {
 		return FALSE;
 
 	return TRUE;
-	}
+}
 
 
 
 /* shows service and host filters in use */
-void show_filters(void) {
+void show_filters(void)
+{
 	int found = 0;
 
 	/* show filters box if necessary */
@@ -5146,18 +5106,18 @@ void show_filters(void) {
 			if(host_status_types & HOST_PENDING) {
 				printf(" Pending");
 				found = 1;
-				}
+			}
 			if(host_status_types & SD_HOST_UP) {
 				printf("%s Up", (found == 1) ? " |" : "");
 				found = 1;
-				}
+			}
 			if(host_status_types & SD_HOST_DOWN) {
 				printf("%s Down", (found == 1) ? " |" : "");
 				found = 1;
-				}
+			}
 			if(host_status_types & SD_HOST_UNREACHABLE)
 				printf("%s Unreachable", (found == 1) ? " |" : "");
-			}
+		}
 		printf("</td></tr>");
 		printf("<tr><td valign=top align=left class='filterName'>Host Properties:</td>");
 		printf("<td valign=top align=left class='filterValue'>");
@@ -5168,84 +5128,84 @@ void show_filters(void) {
 			if(host_properties & HOST_SCHEDULED_DOWNTIME) {
 				printf(" In Scheduled Downtime");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_NO_SCHEDULED_DOWNTIME) {
 				printf("%s Not In Scheduled Downtime", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_STATE_ACKNOWLEDGED) {
 				printf("%s Has Been Acknowledged", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_STATE_UNACKNOWLEDGED) {
 				printf("%s Has Not Been Acknowledged", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_CHECKS_DISABLED) {
 				printf("%s Checks Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_CHECKS_ENABLED) {
 				printf("%s Checks Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_EVENT_HANDLER_DISABLED) {
 				printf("%s Event Handler Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_EVENT_HANDLER_ENABLED) {
 				printf("%s Event Handler Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_FLAP_DETECTION_DISABLED) {
 				printf("%s Flap Detection Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_FLAP_DETECTION_ENABLED) {
 				printf("%s Flap Detection Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_IS_FLAPPING) {
 				printf("%s Is Flapping", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_IS_NOT_FLAPPING) {
 				printf("%s Is Not Flapping", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_NOTIFICATIONS_DISABLED) {
 				printf("%s Notifications Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_NOTIFICATIONS_ENABLED) {
 				printf("%s Notifications Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_PASSIVE_CHECKS_DISABLED) {
 				printf("%s Passive Checks Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_PASSIVE_CHECKS_ENABLED) {
 				printf("%s Passive Checks Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_PASSIVE_CHECK) {
 				printf("%s Passive Checks", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_ACTIVE_CHECK) {
 				printf("%s Active Checks", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_HARD_STATE) {
 				printf("%s In Hard State", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(host_properties & HOST_SOFT_STATE) {
 				printf("%s In Soft State", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
 			}
+		}
 		printf("</td>");
 		printf("</tr>\n");
 
@@ -5261,24 +5221,24 @@ void show_filters(void) {
 			if(service_status_types & SERVICE_PENDING) {
 				printf(" Pending");
 				found = 1;
-				}
+			}
 			if(service_status_types & SERVICE_OK) {
 				printf("%s Ok", (found == 1) ? " |" : "");
 				found = 1;
-				}
+			}
 			if(service_status_types & SERVICE_UNKNOWN) {
 				printf("%s Unknown", (found == 1) ? " |" : "");
 				found = 1;
-				}
+			}
 			if(service_status_types & SERVICE_WARNING) {
 				printf("%s Warning", (found == 1) ? " |" : "");
 				found = 1;
-				}
+			}
 			if(service_status_types & SERVICE_CRITICAL) {
 				printf("%s Critical", (found == 1) ? " |" : "");
 				found = 1;
-				}
 			}
+		}
 		printf("</td></tr>");
 		printf("<tr><td valign=top align=left class='filterName'>Service Properties:</td>");
 		printf("<td valign=top align=left class='filterValue'>");
@@ -5289,95 +5249,96 @@ void show_filters(void) {
 			if(service_properties & SERVICE_SCHEDULED_DOWNTIME) {
 				printf(" In Scheduled Downtime");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_NO_SCHEDULED_DOWNTIME) {
 				printf("%s Not In Scheduled Downtime", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_STATE_ACKNOWLEDGED) {
 				printf("%s Has Been Acknowledged", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_STATE_UNACKNOWLEDGED) {
 				printf("%s Has Not Been Acknowledged", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_CHECKS_DISABLED) {
 				printf("%s Active Checks Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_CHECKS_ENABLED) {
 				printf("%s Active Checks Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_EVENT_HANDLER_DISABLED) {
 				printf("%s Event Handler Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_EVENT_HANDLER_ENABLED) {
 				printf("%s Event Handler Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_FLAP_DETECTION_DISABLED) {
 				printf("%s Flap Detection Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_FLAP_DETECTION_ENABLED) {
 				printf("%s Flap Detection Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_IS_FLAPPING) {
 				printf("%s Is Flapping", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_IS_NOT_FLAPPING) {
 				printf("%s Is Not Flapping", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_NOTIFICATIONS_DISABLED) {
 				printf("%s Notifications Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_NOTIFICATIONS_ENABLED) {
 				printf("%s Notifications Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_PASSIVE_CHECKS_DISABLED) {
 				printf("%s Passive Checks Disabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_PASSIVE_CHECKS_ENABLED) {
 				printf("%s Passive Checks Enabled", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_PASSIVE_CHECK) {
 				printf("%s Passive Checks", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_ACTIVE_CHECK) {
 				printf("%s Active Checks", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_HARD_STATE) {
 				printf("%s In Hard State", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
+			}
 			if(service_properties & SERVICE_SOFT_STATE) {
 				printf("%s In Soft State", (found == 1) ? " &amp;" : "");
 				found = 1;
-				}
 			}
-		printf("</td></tr>");
-		printf("</table>\n");
-
-		printf("</td></tr>");
-		printf("</table>\n");
 		}
+		printf("</td></tr>");
+		printf("</table>\n");
 
-	return;
+		printf("</td></tr>");
+		printf("</table>\n");
 	}
 
-void create_pagenumbers(int total_entries,char *temp_url,int type_service) {
+	return;
+}
+
+void create_pagenumbers(int total_entries,char *temp_url,int type_service)
+{
 
 	int pages = 1;
 	int tmp_start;
@@ -5399,7 +5360,7 @@ void create_pagenumbers(int total_entries,char *temp_url,int type_service) {
 				printf("<div class='pagenumber current_page'> %i </div>\n",(i+1));
 			else
 				printf("<a class='pagenumber' href='%s&start=%i&limit=%i' title='Page %i'> %i </a>\n",temp_url,tmp_start,result_limit,(i+1),(i+1));
-			}
+		}
 
 		printf("<a href='%s&start=%i&limit=%i' class='pagenumber' title='Next Page'><img src='%s%s' height='15' width='10' alt='>' /></a>\n",temp_url,(page_start+result_limit),result_limit,url_images_path,NEXT_PAGE_ICON);
 		printf("<a href='%s&start=%i&limit=%i' class='pagenumber' title='Last Page'><img src='%s%s' height='15' width='15' alt='>>' /></a>\n",temp_url,((pages)*result_limit),result_limit,url_images_path,LAST_PAGE_ICON);
@@ -5410,21 +5371,21 @@ void create_pagenumbers(int total_entries,char *temp_url,int type_service) {
 			printf("<br /><div class='itemTotalsTitle'>Results %i - %i of %d Matching Hosts</div>\n\n",page_start,((page_start+result_limit) > total_entries ? total_entries :(page_start+result_limit) ),total_entries );
 
 		printf("</div> <!-- end bottom_page_numbers div -->\n\n");
-		}
-	else {
+	} else {
 		if(type_service == TRUE)
 			printf("<br /><div class='itemTotalsTitle'>Results %i - %i of %d Matching Services</div>\n</div>\n",1,total_entries,total_entries);
 		else
 			printf("<br /><div class='itemTotalsTitle'>Results %i - %i of %d Matching Hosts</div>\n\n",1,total_entries,total_entries);
 
-		}
+	}
 
 	/* show total results displayed */
 	//printf("<br /><div class='itemTotalsTitle'>Results %i - %i of %d Matching Services</div>\n</div>\n",page_start,((page_start+result_limit) > total_entries ? total_entries :(page_start+result_limit) ),total_entries );
 
-	}
+}
 
-void create_page_limiter(int limit,char *temp_url) {
+void create_page_limiter(int limit,char *temp_url)
+{
 
 	/*  Result Limit Select Box   */
 	printf("<div id='pagelimit'>\n<div id='result_limit'>\n");
@@ -5438,4 +5399,4 @@ void create_page_limiter(int limit,char *temp_url) {
 	printf("</select></div>\n");
 	printf("<div id='top_page_numbers'></div>\n</div>\n");
 	//page numbers
-	}
+}

--- a/cgi/statusjson.c
+++ b/cgi/statusjson.c
@@ -116,46 +116,82 @@ int validate_arguments(json_object *, status_json_cgi_data *, time_t);
 authdata current_authdata;
 
 const string_value_mapping valid_queries[] = {
-	{ "hostcount", STATUS_QUERY_HOSTCOUNT,
-		"Return the number of hosts in each state" },
-	{ "hostlist", STATUS_QUERY_HOSTLIST,
-		"Return a list of hosts and their current status" },
-	{ "host", STATUS_QUERY_HOST, 
-		"Return the status of a single host." },
-	{ "servicecount", STATUS_QUERY_SERVICECOUNT,
-		"Return the number of services in each state" },
-	{ "servicelist", STATUS_QUERY_SERVICELIST,
-		"Return a list of services and their current status" },
-	{ "service", STATUS_QUERY_SERVICE,
-		"Return the status of a single service" },
+	{
+		"hostcount", STATUS_QUERY_HOSTCOUNT,
+		"Return the number of hosts in each state"
+	},
+	{
+		"hostlist", STATUS_QUERY_HOSTLIST,
+		"Return a list of hosts and their current status"
+	},
+	{
+		"host", STATUS_QUERY_HOST,
+		"Return the status of a single host."
+	},
+	{
+		"servicecount", STATUS_QUERY_SERVICECOUNT,
+		"Return the number of services in each state"
+	},
+	{
+		"servicelist", STATUS_QUERY_SERVICELIST,
+		"Return a list of services and their current status"
+	},
+	{
+		"service", STATUS_QUERY_SERVICE,
+		"Return the status of a single service"
+	},
 #if 0
-	{ "contactcount", STATUS_QUERY_CONTACTCOUNT,
-		"Return the number of contacts" },
-	{ "contactlist", STATUS_QUERY_CONTACTLIST,
-		"Return a list of of contacts and their current status" },
-	{ "contact", STATUS_QUERY_CONTACT,
-		"Return a single contact" },
+	{
+		"contactcount", STATUS_QUERY_CONTACTCOUNT,
+		"Return the number of contacts"
+	},
+	{
+		"contactlist", STATUS_QUERY_CONTACTLIST,
+		"Return a list of of contacts and their current status"
+	},
+	{
+		"contact", STATUS_QUERY_CONTACT,
+		"Return a single contact"
+	},
 #endif
-	{ "commentcount", STATUS_QUERY_COMMENTCOUNT,
-		"Return the number of comments" },
-	{ "commentlist", STATUS_QUERY_COMMENTLIST,
-		"Return a list of comments" },
-	{ "comment", STATUS_QUERY_COMMENT,
-		"Return a single comment" },
-	{ "downtimecount", STATUS_QUERY_DOWNTIMECOUNT,
-		"Return the number of downtimes" },
-	{ "downtimelist", STATUS_QUERY_DOWNTIMELIST,
-		"Return a list of downtimes" },
-	{ "downtime", STATUS_QUERY_DOWNTIME,
-		"Return a single downtime" },
-	{ "programstatus", STATUS_QUERY_PROGRAMSTATUS,
-		"Return the Nagios Core program status" },
-	{ "performancedata", STATUS_QUERY_PERFORMANCEDATA,
-		"Return the Nagios Core performance data" },
-	{ "help", STATUS_QUERY_HELP, 
-		"Display help for this CGI" },
+	{
+		"commentcount", STATUS_QUERY_COMMENTCOUNT,
+		"Return the number of comments"
+	},
+	{
+		"commentlist", STATUS_QUERY_COMMENTLIST,
+		"Return a list of comments"
+	},
+	{
+		"comment", STATUS_QUERY_COMMENT,
+		"Return a single comment"
+	},
+	{
+		"downtimecount", STATUS_QUERY_DOWNTIMECOUNT,
+		"Return the number of downtimes"
+	},
+	{
+		"downtimelist", STATUS_QUERY_DOWNTIMELIST,
+		"Return a list of downtimes"
+	},
+	{
+		"downtime", STATUS_QUERY_DOWNTIME,
+		"Return a single downtime"
+	},
+	{
+		"programstatus", STATUS_QUERY_PROGRAMSTATUS,
+		"Return the Nagios Core program status"
+	},
+	{
+		"performancedata", STATUS_QUERY_PERFORMANCEDATA,
+		"Return the Nagios Core performance data"
+	},
+	{
+		"help", STATUS_QUERY_HELP,
+		"Display help for this CGI"
+	},
 	{ NULL, -1, NULL},
-	};
+};
 
 static const int query_status[][2] = {
 	{ STATUS_QUERY_HOSTCOUNT, QUERY_STATUS_BETA },
@@ -179,109 +215,121 @@ static const int query_status[][2] = {
 	{ STATUS_QUERY_PERFORMANCEDATA, QUERY_STATUS_BETA },
 	{ STATUS_QUERY_HELP, QUERY_STATUS_BETA },
 	{ -1, -1},
-	};
+};
 
 const string_value_mapping svm_host_time_fields[] = {
 	{ "lastupdate", STATUS_TIME_LAST_UPDATE, "Last Update" },
 	{ "lastcheck", STATUS_TIME_LAST_CHECK, "Last Check" },
 	{ "nextcheck", STATUS_TIME_NEXT_CHECK, "Next Check" },
 	{ "laststatechange", STATUS_TIME_LAST_STATE_CHANGE, "Last State Change" },
-	{ "lasthardstatechange", STATUS_TIME_LAST_HARD_STATE_CHANGE, 
-			"Last Hard State Change" },
+	{
+		"lasthardstatechange", STATUS_TIME_LAST_HARD_STATE_CHANGE,
+		"Last Hard State Change"
+	},
 	{ "lasttimeup", STATUS_TIME_LAST_TIME_UP, "Last Time Up" },
 	{ "lasttimedown", STATUS_TIME_LAST_TIME_DOWN, "Last Time Down" },
-	{ "lasttimeunreachable", STATUS_TIME_LAST_TIME_UNREACHABLE, 
-			"Last Time Unreachable" },
+	{
+		"lasttimeunreachable", STATUS_TIME_LAST_TIME_UNREACHABLE,
+		"Last Time Unreachable"
+	},
 	{ "lastnotification", STATUS_TIME_LAST_NOTIFICATION, "Last Notification" },
 	{ "nextnotification", STATUS_TIME_NEXT_NOTIFICATION, "Next Notification" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_service_time_fields[] = {
 	{ "lastupdate", STATUS_TIME_LAST_UPDATE, "Last Update" },
 	{ "lastcheck", STATUS_TIME_LAST_CHECK, "Last Check" },
 	{ "nextcheck", STATUS_TIME_NEXT_CHECK, "Next Check" },
 	{ "laststatechange", STATUS_TIME_LAST_STATE_CHANGE, "Last State Change" },
-	{ "lasthardstatechange", STATUS_TIME_LAST_HARD_STATE_CHANGE, 
-			"Last Hard State Change" },
+	{
+		"lasthardstatechange", STATUS_TIME_LAST_HARD_STATE_CHANGE,
+		"Last Hard State Change"
+	},
 	{ "lasttimeok", STATUS_TIME_LAST_TIME_OK, "Last Time OK" },
 	{ "lasttimewarning", STATUS_TIME_LAST_TIME_WARNING, "Last Time Warning" },
-	{ "lasttimecritical", STATUS_TIME_LAST_TIME_CRITICAL, 
-			"Last Time Critical" },
+	{
+		"lasttimecritical", STATUS_TIME_LAST_TIME_CRITICAL,
+		"Last Time Critical"
+	},
 	{ "lasttimeunknown", STATUS_TIME_LAST_TIME_UNKNOWN, "Last Time Unknown" },
 	{ "lastnotification", STATUS_TIME_LAST_NOTIFICATION, "Last Notification" },
 	{ "nextnotification", STATUS_TIME_NEXT_NOTIFICATION, "Next Notification" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_comment_types[] = {
 	{ "host", COMMENT_TYPE_HOST, "Host Comment" },
 	{ "service", COMMENT_TYPE_SERVICE, "Service Comment" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_comment_entry_types[] = {
 	{ "user", COMMENT_ENTRY_USER, "User Comment" },
 	{ "downtime", COMMENT_ENTRY_DOWNTIME, "Downtime Comment" },
 	{ "flapping", COMMENT_ENTRY_FLAPPING, "Flapping Comment" },
-	{ "acknowledgement", COMMENT_ENTRY_ACKNOWLEDGEMENT, 
-			"Acknowledgement Comment" },
+	{
+		"acknowledgement", COMMENT_ENTRY_ACKNOWLEDGEMENT,
+		"Acknowledgement Comment"
+	},
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_persistence[] = {
 	{ "yes", BOOLEAN_TRUE, "Persistent Comment" },
 	{ "no", BOOLEAN_FALSE, "Non-Persistent Comment" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_expiration[] = {
 	{ "yes", BOOLEAN_TRUE, "Comment Expires" },
 	{ "no", BOOLEAN_FALSE, "Comment Does Not Expire" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_comment_time_fields[] = {
 	{ "entrytime", STATUS_TIME_ENTRY_TIME, "Entry Time" },
 	{ "expiretime", STATUS_TIME_EXPIRE_TIME, "Expiration Time" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_downtime_time_fields[] = {
 	{ "entrytime", STATUS_TIME_ENTRY_TIME, "Entry Time" },
 	{ "starttime", STATUS_TIME_START_TIME, "Start Time" },
-	{ "flexdowntimestart", STATUS_TIME_FLEX_DOWNTIME_START, 
-			"Flex Downtime Start" },
+	{
+		"flexdowntimestart", STATUS_TIME_FLEX_DOWNTIME_START,
+		"Flex Downtime Start"
+	},
 	{ "endtime", STATUS_TIME_END_TIME, "End Time" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_downtime_object_types[] = {
 	{ "host", DOWNTIME_OBJECT_TYPE_HOST, "Host Downtime" },
 	{ "service", DOWNTIME_OBJECT_TYPE_SERVICE, "Service Downtime" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_downtime_types[] = {
 	{ "fixed", DOWNTIME_TYPE_FIXED, "Fixed Downtime" },
 	{ "flexible", DOWNTIME_TYPE_FLEXIBLE, "Flexible Downtime" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_triggered_status[] = {
 	{ "yes", BOOLEAN_TRUE, "Downtime Triggered" },
 	{ "no", BOOLEAN_FALSE, "Downtime Not Triggered" },
 	{ NULL, -1, NULL },
-	};
+};
 
 const string_value_mapping svm_valid_in_effect_status[] = {
 	{ "yes", BOOLEAN_TRUE, "Downtime In Effect" },
 	{ "no", BOOLEAN_FALSE, "Downtime Not In Effect" },
 	{ NULL, -1, NULL },
-	};
+};
 
 option_help status_json_help[] = {
-	{ 
+	{
 		"query",
 		"Query",
 		"enumeration",
@@ -290,8 +338,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Specifies the type of query to be executed.",
 		valid_queries
-		},
-	{ 
+	},
+	{
 		"formatoptions",
 		"Format Options",
 		"list",
@@ -300,8 +348,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Specifies the formatting options to be used when displaying the results. Multiple options are allowed and are separated by a plus (+) sign..",
 		svm_format_options
-		},
-	{ 
+	},
+	{
 		"start",
 		"Start",
 		"integer",
@@ -310,8 +358,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Specifies the index (zero-based) of the first object in the list to be returned.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"count",
 		"Count",
 		"integer",
@@ -320,8 +368,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Specifies the number of objects in the list to be returned.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"parenthost",
 		"Parent Host",
 		"nagios:objectjson/hostlist",
@@ -330,8 +378,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Limits the hosts or serivces returned to those whose host parent is specified. A value of 'none' returns all hosts or services reachable directly by the Nagios core host.",
 		parent_host_extras
-		},
-	{ 
+	},
+	{
 		"childhost",
 		"Child Host",
 		"nagios:objectjson/hostlist",
@@ -340,8 +388,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Limits the hosts or serivces returned to those whose having the host specified as a child host. A value of 'none' returns all hosts or services with no child hosts.",
 		child_host_extras
-		},
-	{ 
+	},
+	{
 		"details",
 		"Show Details",
 		"boolean",
@@ -350,8 +398,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Returns the details for all entities in the list.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"dateformat",
 		"Date Format",
 		"string",
@@ -360,8 +408,8 @@ option_help status_json_help[] = {
 		NULL,
 		"strftime format string for values of type time_t. In the absence of a format, the Javascript default format of the number of milliseconds since the beginning of the Unix epoch is used. Because of URL encoding, percent signs must be encoded as %25 and a space must be encoded as a plus (+) sign.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hostname",
 		"Host Name",
 		"nagios:objectjson/hostlist",
@@ -370,8 +418,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Name for the host requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hostgroup",
 		"Host Group",
 		"nagios:objectjson/hostgrouplist",
@@ -380,8 +428,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Returns information applicable to the hostgroup or the hosts in the hostgroup depending on the query.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hoststatus",
 		"Host Status",
 		"list",
@@ -390,8 +438,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Limits returned information to those hosts whose status matches this list. Host statuses are space separated.",
 		svm_host_statuses
-		},
-	{ 
+	},
+	{
 		"servicegroup",
 		"Service Group",
 		"nagios:objectjson/servicegrouplist",
@@ -400,8 +448,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Returns information applicable to the servicegroup or the services in the servicegroup depending on the query.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicestatus",
 		"Service Status",
 		"list",
@@ -410,7 +458,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Limits returned information to those services whose status matches this list. Service statuses are space separated.",
 		svm_service_statuses
-		},
+	},
 	{
 		"parentservice",
 		"Parent Service",
@@ -420,7 +468,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Limits the serivces returned to those whose service parent has the name specified. A value of 'none' returns all services with no service parent.",
 		parent_service_extras
-		},
+	},
 	{
 		"childservice",
 		"Child Service",
@@ -430,8 +478,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Limits the serivces returned to those whose having the named service as a child service. A value of 'none' returns all services with no child services.",
 		child_service_extras
-		},
-	{ 
+	},
+	{
 		"contactgroup",
 		"Contact Group",
 		"nagios:objectjson/contactgrouplist",
@@ -440,8 +488,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Returns information applicable to the contactgroup or the contacts in the contactgroup depending on the query.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"servicedescription",
 		"Service Description",
 		"nagios:objectjson/servicelist",
@@ -451,8 +499,8 @@ option_help status_json_help[] = {
 		"hostname",
 		"Description for the service requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"checktimeperiod",
 		"Check Timeperiod Name",
 		"nagios:objectjson/timeperiodlist",
@@ -461,7 +509,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Name of a check timeperiod to be used as selection criteria.",
 		NULL
-		},
+	},
 	{
 		"hostnotificationtimeperiod",
 		"Host Notification Timeperiod Name",
@@ -471,7 +519,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Name of a host notification timeperiod to be used as selection criteria.",
 		NULL
-		},
+	},
 	{
 		"servicenotificationtimeperiod",
 		"Service Notification Timeperiod Name",
@@ -481,7 +529,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Name of a service notification timeperiod to be used as selection criteria.",
 		NULL
-		},
+	},
 	{
 		"checkcommand",
 		"Check Command Name",
@@ -491,7 +539,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Name of a check command to be be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"eventhandler",
 		"Event Handler Name",
@@ -501,7 +549,7 @@ option_help status_json_help[] = {
 		NULL,
 		"Name of an event handler to be be used as a selector.",
 		NULL
-		},
+	},
 	{
 		"commenttypes",
 		"Comment Type",
@@ -511,8 +559,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Comment type for the comment requested.",
 		svm_valid_comment_types
-		},
-	{ 
+	},
+	{
 		"entrytypes",
 		"Entry Type",
 		"list",
@@ -521,8 +569,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Entry type for the comment requested.",
 		svm_valid_comment_entry_types
-		},
-	{ 
+	},
+	{
 		"persistence",
 		"Comment Persistence",
 		"list",
@@ -531,8 +579,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Persistence for the comment requested.",
 		svm_valid_persistence
-		},
-	{ 
+	},
+	{
 		"expiring",
 		"Comment Expiration",
 		"list",
@@ -541,8 +589,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Whether or not the comment expires.",
 		svm_valid_expiration
-		},
-	{ 
+	},
+	{
 		"downtimeobjecttypes",
 		"Downtime Object Type",
 		"list",
@@ -551,8 +599,8 @@ option_help status_json_help[] = {
 		NULL,
 		"The type of object to which the downtime applies.",
 		svm_valid_downtime_object_types
-		},
-	{ 
+	},
+	{
 		"downtimetypes",
 		"Downtime Type",
 		"list",
@@ -561,8 +609,8 @@ option_help status_json_help[] = {
 		NULL,
 		"The type of the downtime.",
 		svm_valid_downtime_types
-		},
-	{ 
+	},
+	{
 		"triggered",
 		"Downtime Triggered",
 		"list",
@@ -571,8 +619,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Whether or not the downtime is triggered.",
 		svm_valid_triggered_status
-		},
-	{ 
+	},
+	{
 		"triggeredby",
 		"Triggered By",
 		"nagios:statusjson/downtimelist",
@@ -581,8 +629,8 @@ option_help status_json_help[] = {
 		NULL,
 		"ID of the downtime which triggers other downtimes.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"ineffect",
 		"Downtime In Effect",
 		"list",
@@ -591,8 +639,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Whether or not the downtime is in effect.",
 		svm_valid_in_effect_status
-		},
-	{ 
+	},
+	{
 		"commentid",
 		"Comment ID",
 		"nagios:statusjson/commentlist",
@@ -601,8 +649,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Comment ID for the comment requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"downtimeid",
 		"Downtime ID",
 		"nagios:statusjson/downtimelist",
@@ -611,8 +659,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Downtime ID for the downtime requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"contactname",
 		"Contact Name",
 		"nagios:objectjson/contactlist",
@@ -621,8 +669,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Name for the contact requested.",
 		NULL
-		},
-	{ 
+	},
+	{
 		"hosttimefield",
 		"Host Time Field",
 		"enumeration",
@@ -631,8 +679,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Field to use when comparing times on a hostlist query.",
 		svm_host_time_fields
-		},
-	{ 
+	},
+	{
 		"servicetimefield",
 		"Service Time Field",
 		"enumeration",
@@ -641,8 +689,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Field to use when comparing times on a servicelist query.",
 		svm_service_time_fields
-		},
-	{ 
+	},
+	{
 		"commenttimefield",
 		"Comment Time Field",
 		"enumeration",
@@ -651,8 +699,8 @@ option_help status_json_help[] = {
 		NULL,
 		"Field to use when comparing times on a commentlist query.",
 		svm_comment_time_fields
-		},
-	{ 
+	},
+	{
 		"downtimetimefield",
 		"Downtime Time Field",
 		"enumeration",
@@ -661,29 +709,33 @@ option_help status_json_help[] = {
 		NULL,
 		"Field to use when comparing times on a downtimelist query.",
 		svm_downtime_time_fields
-		},
-	{ 
+	},
+	{
 		"starttime",
 		"Start Time",
 		"integer",
 		{ NULL },
-		{ "hostcount", "hostlist", "servicecount", "servicelist", "commentcount", 
-				"commentlist", "downtimecount", "downtimelist", NULL },
+		{
+			"hostcount", "hostlist", "servicecount", "servicelist", "commentcount",
+			"commentlist", "downtimecount", "downtimelist", NULL
+		},
 		NULL,
 		"Starting time to use when querying based on a time range. Not specifying a start time implies all entries since the beginning of time. Supplying a plus or minus sign means times relative to the query time.",
 		NULL,
-		},
-	{ 
+	},
+	{
 		"endtime",
 		"End Time",
 		"integer",
 		{ NULL },
-		{ "hostcount", "hostlist", "servicecount", "servicelist", "commentcount", 
-				"commentlist", "downtimecount", "downtimelist", NULL },
+		{
+			"hostcount", "hostlist", "servicecount", "servicelist", "commentcount",
+			"commentlist", "downtimecount", "downtimelist", NULL
+		},
 		NULL,
 		"Ending time to use when querying based on a time range. Not specifying an end time implies all entries until the time of the query. Specifying plus or minus sign means times relative to the query time.",
 		NULL,
-		},
+	},
 	{ /* The last entry must contain all NULL entries */
 		NULL,
 		NULL,
@@ -693,38 +745,39 @@ option_help status_json_help[] = {
 		NULL,
 		NULL,
 		NULL
-		},
-	};
+	},
+};
 
-int json_status_host_passes_selection(host *, int, host *, int, host *, 
-		hostgroup *, contact *, hoststatus *, int, time_t, time_t,
-		contactgroup *, timeperiod *, timeperiod *, command *, command *);
+int json_status_host_passes_selection(host *, int, host *, int, host *,
+                                      hostgroup *, contact *, hoststatus *, int, time_t, time_t,
+                                      contactgroup *, timeperiod *, timeperiod *, command *, command *);
 json_object *json_status_host_display_selectors(unsigned, int, int, int, host *,
-		int, host *, hostgroup *, int, contact *, int, time_t, time_t,
-		contactgroup *, timeperiod *, timeperiod *, command *, command *);
+        int, host *, hostgroup *, int, contact *, int, time_t, time_t,
+        contactgroup *, timeperiod *, timeperiod *, command *, command *);
 
-int json_status_service_passes_host_selection(host *, int, host *, int, host *, 
-		hostgroup *, host *, int);
-int json_status_service_passes_service_selection(service *, servicegroup *, 
-		contact *, servicestatus *, int, time_t, time_t, char *, char *,
-		char *, contactgroup *, timeperiod *, timeperiod *, command *,
-		command *);
+int json_status_service_passes_host_selection(host *, int, host *, int, host *,
+        hostgroup *, host *, int);
+int json_status_service_passes_service_selection(service *, servicegroup *,
+        contact *, servicestatus *, int, time_t, time_t, char *, char *,
+        char *, contactgroup *, timeperiod *, timeperiod *, command *,
+        command *);
 json_object *json_status_service_selectors(unsigned, int, int, int, host *, int,
-		host *, hostgroup *, host *, servicegroup *, int, int, contact *, int, 
-		time_t, time_t, char *, char *, char *, contactgroup *, timeperiod *,
-		timeperiod *, command *, command *);
+        host *, hostgroup *, host *, servicegroup *, int, int, contact *, int,
+        time_t, time_t, char *, char *, char *, contactgroup *, timeperiod *,
+        timeperiod *, command *, command *);
 
 int json_status_comment_passes_selection(comment *, int, time_t, time_t,
-		unsigned, unsigned, unsigned, unsigned, char *, char *);
-json_object *json_status_comment_selectors(unsigned, int, int, int, time_t, 
-		time_t, unsigned, unsigned, unsigned, unsigned, char *, char *);
+        unsigned, unsigned, unsigned, unsigned, char *, char *);
+json_object *json_status_comment_selectors(unsigned, int, int, int, time_t,
+        time_t, unsigned, unsigned, unsigned, unsigned, char *, char *);
 
-int json_status_downtime_passes_selection(scheduled_downtime *, int, time_t, 
-		time_t, unsigned, unsigned, unsigned, int, unsigned, char *, char *);
-json_object *json_status_downtime_selectors(unsigned, int, int, int, time_t, 
-		time_t, unsigned, unsigned, unsigned, int, unsigned, char *, char *);
+int json_status_downtime_passes_selection(scheduled_downtime *, int, time_t,
+        time_t, unsigned, unsigned, unsigned, int, unsigned, char *, char *);
+json_object *json_status_downtime_selectors(unsigned, int, int, int, time_t,
+        time_t, unsigned, unsigned, unsigned, int, unsigned, char *, char *);
 
-int main(void) {
+int main(void)
+{
 	int result = OK;
 	time_t query_time;
 	status_json_cgi_data	cgi_data;
@@ -742,9 +795,9 @@ int main(void) {
 	if(NULL == json_root) {
 		printf( "Failed to create new json object\n");
 		exit( 1);
-		}
-	json_object_append_integer(json_root, "format_version", 
-			OUTPUT_FORMAT_VERSION);
+	}
+	json_object_append_integer(json_root, "format_version",
+	                           OUTPUT_FORMAT_VERSION);
 
 	init_cgi_data(&cgi_data);
 
@@ -754,11 +807,11 @@ int main(void) {
 	result = process_cgivars(json_root, &cgi_data, query_time);
 	if(result != RESULT_SUCCESS) {
 		json_object_append_object(json_root, "data", json_help(status_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 	whitespace = cgi_data.format_options & JSON_FORMAT_WHITESPACE;
 
 	/* reset internal variables */
@@ -767,97 +820,97 @@ int main(void) {
 	/* read the CGI configuration file */
 	result = read_cgi_config_file(get_cgi_config_location());
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not open CGI configuration file '%s' for reading!", 
-				get_cgi_config_location()));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not open CGI configuration file '%s' for reading!",
+		                                      get_cgi_config_location()));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not open main configuration file '%s' for reading!", 
-				main_config_file));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not open main configuration file '%s' for reading!",
+		                                      main_config_file));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all object configuration data */
-	result = read_all_object_configuration_data(main_config_file, 
-			READ_ALL_OBJECT_DATA);
+	result = read_all_object_configuration_data(main_config_file,
+	         READ_ALL_OBJECT_DATA);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not read some or all object configuration data!"));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not read some or all object configuration data!"));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* Get the update time on the status data file. This needs to occur before
 		the status data is read because the read_all_status_data() function
 		clears the name of the status file */
 	if(stat(status_file, &sdstat) < 0) {
 		json_object_append_object(json_root, "result",
-				json_result(query_time, THISCGI,
-				svm_get_string_from_value(cgi_data.query, valid_queries),
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not obtain status data file status: %s!",
-				strerror(errno)));
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not obtain status data file status: %s!",
+		                                      strerror(errno)));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
 		document_footer();
 		return ERROR;
-		}
+	}
 	last_status_data_update = sdstat.st_mtime;
 
 	/* read all status data */
-	result = read_all_status_data(get_cgi_config_location(), 
-			READ_ALL_STATUS_DATA);
+	result = read_all_status_data(get_cgi_config_location(),
+	                              READ_ALL_STATUS_DATA);
 	if(result == ERROR) {
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
-				"Error: Could not read host and service status information!"));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, NULL, RESULT_FILE_OPEN_READ_ERROR,
+		                                      "Error: Could not read host and service status information!"));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* validate arguments in URL */
 	result = validate_arguments(json_root, &cgi_data, query_time);
 	if(result != RESULT_SUCCESS) {
 		json_object_append_object(json_root, "data", json_help(status_json_help));
-		json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-				cgi_data.format_options);
+		json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+		                  cgi_data.format_options);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* get authentication information */
 	get_authentication_information(&current_authdata);
@@ -865,286 +918,284 @@ int main(void) {
 	/* Return something to the user */
 	switch( cgi_data.query) {
 	case STATUS_QUERY_HOSTCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_hostcount(cgi_data.format_options, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.host_statuses, cgi_data.contact,
-				cgi_data.host_time_field, cgi_data.start_time, 
-				cgi_data.end_time, cgi_data.contactgroup,
-				cgi_data.check_timeperiod,
-				cgi_data.host_notification_timeperiod, cgi_data.check_command,
-				cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_hostcount(cgi_data.format_options,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.host_statuses, cgi_data.contact,
+		                                  cgi_data.host_time_field, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.contactgroup,
+		                                  cgi_data.check_timeperiod,
+		                                  cgi_data.host_notification_timeperiod, cgi_data.check_command,
+		                                  cgi_data.event_handler));
 		break;
 	case STATUS_QUERY_HOSTLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_hostlist(cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details, cgi_data.use_parent_host, 
-				cgi_data.parent_host, cgi_data.use_child_host, 
-				cgi_data.child_host, cgi_data.hostgroup, cgi_data.host_statuses,
-				cgi_data.contact, cgi_data.host_time_field, cgi_data.start_time,
-				cgi_data.end_time, cgi_data.contactgroup,
-				cgi_data.check_timeperiod,
-				cgi_data.host_notification_timeperiod, cgi_data.check_command,
-				cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_hostlist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details, cgi_data.use_parent_host,
+		                                  cgi_data.parent_host, cgi_data.use_child_host,
+		                                  cgi_data.child_host, cgi_data.hostgroup, cgi_data.host_statuses,
+		                                  cgi_data.contact, cgi_data.host_time_field, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.contactgroup,
+		                                  cgi_data.check_timeperiod,
+		                                  cgi_data.host_notification_timeperiod, cgi_data.check_command,
+		                                  cgi_data.event_handler));
 		break;
 	case STATUS_QUERY_HOST:
 		temp_hoststatus = find_hoststatus(cgi_data.host_name);
 		if( NULL == temp_hoststatus) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					(time_t)-1, &current_authdata, RESULT_OPTION_VALUE_INVALID,
-					"The status for host '%s' could not be found.", 
-					cgi_data.host_name));
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      (time_t)-1, &current_authdata, RESULT_OPTION_VALUE_INVALID,
+			                                      "The status for host '%s' could not be found.",
+			                                      cgi_data.host_name));
 			result = ERROR;
-			}
-		else {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_status_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			json_object_append_object(json_root, "data", 
-					json_status_host(cgi_data.format_options, cgi_data.host, 
-					temp_hoststatus));
-			}
+		} else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_status_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+			json_object_append_object(json_root, "data",
+			                          json_status_host(cgi_data.format_options, cgi_data.host,
+			                                  temp_hoststatus));
+		}
 		break;
 	case STATUS_QUERY_SERVICECOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_servicecount(cgi_data.format_options, cgi_data.host, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.servicegroup, 
-				cgi_data.host_statuses, cgi_data.service_statuses, 
-				cgi_data.contact, cgi_data.service_time_field, 
-				cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.service_description, cgi_data.parent_service_name,
-				cgi_data.child_service_name, cgi_data.contactgroup,
-				cgi_data.check_timeperiod,
-				cgi_data.service_notification_timeperiod,
-				cgi_data.check_command, cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_servicecount(cgi_data.format_options, cgi_data.host,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.servicegroup,
+		                                  cgi_data.host_statuses, cgi_data.service_statuses,
+		                                  cgi_data.contact, cgi_data.service_time_field,
+		                                  cgi_data.start_time, cgi_data.end_time,
+		                                  cgi_data.service_description, cgi_data.parent_service_name,
+		                                  cgi_data.child_service_name, cgi_data.contactgroup,
+		                                  cgi_data.check_timeperiod,
+		                                  cgi_data.service_notification_timeperiod,
+		                                  cgi_data.check_command, cgi_data.event_handler));
 		break;
 	case STATUS_QUERY_SERVICELIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_servicelist(cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details, cgi_data.host, 
-				cgi_data.use_parent_host, cgi_data.parent_host, 
-				cgi_data.use_child_host, cgi_data.child_host, 
-				cgi_data.hostgroup, cgi_data.servicegroup,
-				cgi_data.host_statuses, cgi_data.service_statuses, 
-				cgi_data.contact, cgi_data.service_time_field, 
-				cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.service_description, cgi_data.parent_service_name,
-				cgi_data.child_service_name, cgi_data.contactgroup,
-				cgi_data.check_timeperiod,
-				cgi_data.service_notification_timeperiod,
-				cgi_data.check_command, cgi_data.event_handler));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_servicelist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details, cgi_data.host,
+		                                  cgi_data.use_parent_host, cgi_data.parent_host,
+		                                  cgi_data.use_child_host, cgi_data.child_host,
+		                                  cgi_data.hostgroup, cgi_data.servicegroup,
+		                                  cgi_data.host_statuses, cgi_data.service_statuses,
+		                                  cgi_data.contact, cgi_data.service_time_field,
+		                                  cgi_data.start_time, cgi_data.end_time,
+		                                  cgi_data.service_description, cgi_data.parent_service_name,
+		                                  cgi_data.child_service_name, cgi_data.contactgroup,
+		                                  cgi_data.check_timeperiod,
+		                                  cgi_data.service_notification_timeperiod,
+		                                  cgi_data.check_command, cgi_data.event_handler));
 		break;
 	case STATUS_QUERY_SERVICE:
-		temp_servicestatus = find_servicestatus(cgi_data.host_name, 
-				cgi_data.service_description);
+		temp_servicestatus = find_servicestatus(cgi_data.host_name,
+		                                        cgi_data.service_description);
 		if( NULL == temp_servicestatus) {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					(time_t)-1, &current_authdata, RESULT_OPTION_VALUE_INVALID,
-					"The status for service '%s' on host '%s' could not be found.", 
-					cgi_data.service_description, cgi_data.host_name));
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      (time_t)-1, &current_authdata, RESULT_OPTION_VALUE_INVALID,
+			                                      "The status for service '%s' on host '%s' could not be found.",
+			                                      cgi_data.service_description, cgi_data.host_name));
 			result = ERROR;
-			}
-		else {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data.query, valid_queries), 
-					get_query_status(query_status, cgi_data.query),
-					last_status_data_update, &current_authdata,
-					RESULT_SUCCESS, ""));
-			json_object_append_object(json_root, "data", 
-					json_status_service(cgi_data.format_options, 
-					cgi_data.service, temp_servicestatus));
-			}
+		} else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+			                                      get_query_status(query_status, cgi_data.query),
+			                                      last_status_data_update, &current_authdata,
+			                                      RESULT_SUCCESS, ""));
+			json_object_append_object(json_root, "data",
+			                          json_status_service(cgi_data.format_options,
+			                                  cgi_data.service, temp_servicestatus));
+		}
 		break;
 #if 0
 	case STATUS_QUERY_CONTACTCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_status_contactcount(1, cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details, cgi_data.contactgroup);
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_status_contactcount(1, cgi_data.format_options, cgi_data.start,
+		                         cgi_data.count, cgi_data.details, cgi_data.contactgroup);
 		break;
 	case STATUS_QUERY_CONTACTLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_status_contactlist(1, cgi_data.format_options, cgi_data.start, 
-				cgi_data.count, cgi_data.details, cgi_data.contactgroup);
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_status_contactlist(1, cgi_data.format_options, cgi_data.start,
+		                        cgi_data.count, cgi_data.details, cgi_data.contactgroup);
 		break;
 	case STATUS_QUERY_CONTACT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_status_contact(1, cgi_data.format_options, cgi_data.contact);
 		break;
 #endif
 	case STATUS_QUERY_COMMENTCOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_commentcount(cgi_data.format_options, 
-				cgi_data.comment_time_field, cgi_data.start_time, 
-				cgi_data.end_time, cgi_data.comment_types,
-				cgi_data.entry_types, cgi_data.persistence,
-				cgi_data.expiring, cgi_data.host_name,
-				cgi_data.service_description));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_commentcount(cgi_data.format_options,
+		                                  cgi_data.comment_time_field, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.comment_types,
+		                                  cgi_data.entry_types, cgi_data.persistence,
+		                                  cgi_data.expiring, cgi_data.host_name,
+		                                  cgi_data.service_description));
 		break;
 	case STATUS_QUERY_COMMENTLIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_commentlist(cgi_data.format_options, cgi_data.start,
-				cgi_data.count, cgi_data.details, cgi_data.comment_time_field, 
-				cgi_data.start_time, cgi_data.end_time, 
-				cgi_data.comment_types, cgi_data.entry_types, 
-				cgi_data.persistence, cgi_data.expiring, cgi_data.host_name,
-				cgi_data.service_description));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_commentlist(cgi_data.format_options, cgi_data.start,
+		                                  cgi_data.count, cgi_data.details, cgi_data.comment_time_field,
+		                                  cgi_data.start_time, cgi_data.end_time,
+		                                  cgi_data.comment_types, cgi_data.entry_types,
+		                                  cgi_data.persistence, cgi_data.expiring, cgi_data.host_name,
+		                                  cgi_data.service_description));
 		break;
 	case STATUS_QUERY_COMMENT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_comment(cgi_data.format_options, cgi_data.comment));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_comment(cgi_data.format_options, cgi_data.comment));
 		break;
 	case STATUS_QUERY_DOWNTIMECOUNT:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_downtimecount(cgi_data.format_options, 
-				cgi_data.downtime_time_field, cgi_data.start_time, 
-				cgi_data.end_time, cgi_data.downtime_object_types, 
-				cgi_data.downtime_types, cgi_data.triggered,
-				cgi_data.triggered_by, cgi_data.in_effect, cgi_data.host_name,
-				cgi_data.service_description));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_downtimecount(cgi_data.format_options,
+		                                  cgi_data.downtime_time_field, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.downtime_object_types,
+		                                  cgi_data.downtime_types, cgi_data.triggered,
+		                                  cgi_data.triggered_by, cgi_data.in_effect, cgi_data.host_name,
+		                                  cgi_data.service_description));
 		break;
 	case STATUS_QUERY_DOWNTIMELIST:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_downtimelist(cgi_data.format_options, 
-				cgi_data.start, cgi_data.count, cgi_data.details,
-				cgi_data.downtime_time_field, cgi_data.start_time, 
-				cgi_data.end_time, cgi_data.downtime_object_types, 
-				cgi_data.downtime_types, cgi_data.triggered,
-				cgi_data.triggered_by, cgi_data.in_effect, cgi_data.host_name,
-				cgi_data.service_description));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_downtimelist(cgi_data.format_options,
+		                                  cgi_data.start, cgi_data.count, cgi_data.details,
+		                                  cgi_data.downtime_time_field, cgi_data.start_time,
+		                                  cgi_data.end_time, cgi_data.downtime_object_types,
+		                                  cgi_data.downtime_types, cgi_data.triggered,
+		                                  cgi_data.triggered_by, cgi_data.in_effect, cgi_data.host_name,
+		                                  cgi_data.service_description));
 		break;
 	case STATUS_QUERY_DOWNTIME:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_downtime(cgi_data.format_options, cgi_data.downtime));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_downtime(cgi_data.format_options, cgi_data.downtime));
 		break;
 	case STATUS_QUERY_PROGRAMSTATUS:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
-		json_object_append_object(json_root, "data", 
-				json_status_program(cgi_data.format_options));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "data",
+		                          json_status_program(cgi_data.format_options));
 		break;
 	case STATUS_QUERY_PERFORMANCEDATA:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				last_status_data_update, &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      last_status_data_update, &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data", json_status_performance());
 		break;
 	case STATUS_QUERY_HELP:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				compile_time(__DATE__, __TIME__), &current_authdata,
-				RESULT_SUCCESS, ""));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      compile_time(__DATE__, __TIME__), &current_authdata,
+		                                      RESULT_SUCCESS, ""));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
 		break;
 	default:
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data.query, valid_queries), 
-				get_query_status(query_status, cgi_data.query),
-				(time_t)-1, &current_authdata, RESULT_OPTION_MISSING,
-				"Error: Object Type not specified. See data for help."));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data.query, valid_queries),
+		                                      get_query_status(query_status, cgi_data.query),
+		                                      (time_t)-1, &current_authdata, RESULT_OPTION_MISSING,
+		                                      "Error: Object Type not specified. See data for help."));
 		json_object_append_object(json_root, "data", json_help(status_json_help));
 		break;
-		}
+	}
 
-	json_object_print(json_root, 0, 1, cgi_data.strftime_format, 
-			cgi_data.format_options);
+	json_object_print(json_root, 0, 1, cgi_data.strftime_format,
+	                  cgi_data.format_options);
 	document_footer();
 
 	/* free all allocated memory */
@@ -1153,9 +1204,10 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
-void document_header(int whitespace) {
+void document_header(int whitespace)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t expire_time;
 	time_t current_time;
@@ -1175,18 +1227,20 @@ void document_header(int whitespace) {
 	printf("Content-type: application/json; charset=utf-8\r\n\r\n");
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	printf( "\n");
 
 	return;
-	}
+}
 
 
-void init_cgi_data(status_json_cgi_data *cgi_data) {
+void init_cgi_data(status_json_cgi_data *cgi_data)
+{
 	cgi_data->format_options = 0;
 	cgi_data->query = STATUS_QUERY_INVALID;
 	cgi_data->start = 0;
@@ -1246,7 +1300,8 @@ void init_cgi_data(status_json_cgi_data *cgi_data) {
 	cgi_data->in_effect = BOOLEAN_EITHER;
 }
 
-void free_cgi_data( status_json_cgi_data *cgi_data) {
+void free_cgi_data( status_json_cgi_data *cgi_data)
+{
 	if( NULL != cgi_data->parent_host_name) free( cgi_data->parent_host_name);
 	if( NULL != cgi_data->child_host_name) free( cgi_data->child_host_name);
 	if( NULL != cgi_data->host_name) free( cgi_data->host_name);
@@ -1262,11 +1317,12 @@ void free_cgi_data( status_json_cgi_data *cgi_data) {
 	if( NULL != cgi_data->service_notification_timeperiod_name) free(cgi_data->service_notification_timeperiod_name);
 	if( NULL != cgi_data->check_command_name) free(cgi_data->check_command_name);
 	if( NULL != cgi_data->event_handler_name) free(cgi_data->event_handler_name);
-	}
+}
 
 
 int process_cgivars(json_object *json_root, status_json_cgi_data *cgi_data,
-		time_t query_time) {
+                    time_t query_time)
+{
 	char **variables;
 	int result = RESULT_SUCCESS;
 	int x;
@@ -1285,531 +1341,532 @@ int process_cgivars(json_object *json_root, status_json_cgi_data *cgi_data,
 
 		/* we found the query argument */
 		if(!strcmp(variables[x], "query")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], valid_queries, &(cgi_data->query)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], valid_queries, &(cgi_data->query)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "formatoptions")) {
 			cgi_data->format_options = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_format_options,
-					&(cgi_data->format_options))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_format_options,
+			                                  &(cgi_data->format_options))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "start")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->start))) != RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->start))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "count")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->count))) != RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->count))) != RESULT_SUCCESS) {
 				break;
-				}
+			}
 
 			if(cgi_data->count == 0) {
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries),
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
-						"The count option value is invalid. "
-						"It must be an integer greater than zero"));
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, RESULT_OPTION_VALUE_INVALID,
+				                                      "The count option value is invalid. "
+				                                      "It must be an integer greater than zero"));
 				result = RESULT_OPTION_VALUE_INVALID;
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "parenthost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->parent_host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->parent_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "childhost")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->child_host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->child_host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostname")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->host_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->host_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostgroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->hostgroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->hostgroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hoststatus")) {
 			cgi_data->host_statuses = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_host_statuses,
-					&(cgi_data->host_statuses))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_host_statuses,
+			                                  &(cgi_data->host_statuses))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicegroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->servicegroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->servicegroup_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicestatus")) {
 			cgi_data->service_statuses = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_service_statuses,
-					&(cgi_data->service_statuses))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_service_statuses,
+			                                  &(cgi_data->service_statuses))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "parentservice")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->parent_service_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->parent_service_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "childservice")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->child_service_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->child_service_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "checktimeperiod")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->check_timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->check_timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hostnotificationtimeperiod")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1],
-					&(cgi_data->host_notification_timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1],
+			                                 &(cgi_data->host_notification_timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicenotificationtimeperiod")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1],
-					&(cgi_data->service_notification_timeperiod_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1],
+			                                 &(cgi_data->service_notification_timeperiod_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "checkcommand")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->check_command_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->check_command_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "eventhandler")) {
 			if((result = parse_string_cgivar(THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->event_handler_name)))
-					!= RESULT_SUCCESS) {
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->event_handler_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "commenttypes")) {
 			cgi_data->comment_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_comment_types,
-					&(cgi_data->comment_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_comment_types,
+			                                  &(cgi_data->comment_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "entrytypes")) {
 			cgi_data->entry_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_comment_entry_types,
-					&(cgi_data->entry_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_comment_entry_types,
+			                                  &(cgi_data->entry_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "persistence")) {
 			cgi_data->persistence = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_persistence,
-					&(cgi_data->persistence))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_persistence,
+			                                  &(cgi_data->persistence))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "expiring")) {
 			cgi_data->expiring = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_expiration,
-					&(cgi_data->expiring))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_expiration,
+			                                  &(cgi_data->expiring))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "commentid")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->comment_id)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->comment_id)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "downtimeid")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->downtime_id)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->downtime_id)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "downtimeobjecttypes")) {
 			cgi_data->downtime_object_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_downtime_object_types,
-					&(cgi_data->downtime_object_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_downtime_object_types,
+			                                  &(cgi_data->downtime_object_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "downtimetypes")) {
 			cgi_data->downtime_types = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_downtime_types,
-					&(cgi_data->downtime_types))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_downtime_types,
+			                                  &(cgi_data->downtime_types))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "triggered")) {
 			cgi_data->triggered = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_triggered_status,
-					&(cgi_data->triggered))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_triggered_status,
+			                                  &(cgi_data->triggered))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "triggeredby")) {
-			if((result = parse_int_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->triggered_by)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_int_cgivar(THISCGI,
+			                              svm_get_string_from_value(cgi_data->query, valid_queries),
+			                              get_query_status(query_status, cgi_data->query),
+			                              json_root, query_time, authinfo, variables[x],
+			                              variables[x+1], &(cgi_data->triggered_by)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "ineffect")) {
 			cgi_data->in_effect = 0;
-			if((result = parse_bitmask_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_valid_in_effect_status,
-					&(cgi_data->in_effect))) != RESULT_SUCCESS) {
+			if((result = parse_bitmask_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], svm_valid_in_effect_status,
+			                                  &(cgi_data->in_effect))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactgroup")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contactgroup_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contactgroup_name)))
+			   != RESULT_SUCCESS) {
 				result = ERROR;
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicedescription")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->service_description)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->service_description)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "contactname")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->contact_name)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->contact_name)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "details")) {
-			if((result = parse_boolean_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->details))) != RESULT_SUCCESS) {
+			if((result = parse_boolean_cgivar(THISCGI,
+			                                  svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                  get_query_status(query_status, cgi_data->query),
+			                                  json_root, query_time, authinfo, variables[x],
+			                                  variables[x+1], &(cgi_data->details))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "dateformat")) {
-			if((result = parse_string_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->strftime_format)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_string_cgivar(THISCGI,
+			                                 svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                 get_query_status(query_status, cgi_data->query),
+			                                 json_root, query_time, authinfo, variables[x],
+			                                 variables[x+1], &(cgi_data->strftime_format)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "hosttimefield")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_host_time_fields,
-					&(cgi_data->host_time_field))) != RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], svm_host_time_fields,
+			                                      &(cgi_data->host_time_field))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "servicetimefield")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_service_time_fields,
-					&(cgi_data->service_time_field))) != RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], svm_service_time_fields,
+			                                      &(cgi_data->service_time_field))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "commenttimefield")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_comment_time_fields,
-					&(cgi_data->comment_time_field))) != RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], svm_comment_time_fields,
+			                                      &(cgi_data->comment_time_field))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "downtimetimefield")) {
-			if((result = parse_enumeration_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], svm_downtime_time_fields,
-					&(cgi_data->downtime_time_field))) != RESULT_SUCCESS) {
+			if((result = parse_enumeration_cgivar(THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      json_root, query_time, authinfo, variables[x],
+			                                      variables[x+1], svm_downtime_time_fields,
+			                                      &(cgi_data->downtime_time_field))) != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "starttime")) {
-			if((result = parse_time_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->start_time)))
-					!= RESULT_SUCCESS) {
+			if((result = parse_time_cgivar(THISCGI,
+			                               svm_get_string_from_value(cgi_data->query, valid_queries),
+			                               get_query_status(query_status, cgi_data->query),
+			                               json_root, query_time, authinfo, variables[x],
+			                               variables[x+1], &(cgi_data->start_time)))
+			   != RESULT_SUCCESS) {
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], "endtime")) {
-			if((result = parse_time_cgivar(THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					json_root, query_time, authinfo, variables[x],
-					variables[x+1], &(cgi_data->end_time))) != RESULT_SUCCESS) {
+			if((result = parse_time_cgivar(THISCGI,
+			                               svm_get_string_from_value(cgi_data->query, valid_queries),
+			                               get_query_status(query_status, cgi_data->query),
+			                               json_root, query_time, authinfo, variables[x],
+			                               variables[x+1], &(cgi_data->end_time))) != RESULT_SUCCESS) {
 				result = ERROR;
 				break;
-				}
-			x++;
 			}
+			x++;
+		}
 
 		else if(!strcmp(variables[x], ""));
 
 		else {
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, RESULT_OPTION_INVALID,
-					"Invalid option: '%s'.", variables[x]));
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, RESULT_OPTION_INVALID,
+			                                      "Invalid option: '%s'.", variables[x]));
 			result = RESULT_OPTION_INVALID;
 			break;
-			}
 		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return result;
-	}
+}
 
 int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
-		time_t query_time) {
+                       time_t query_time)
+{
 	int result = RESULT_SUCCESS;
 	host *temp_host = NULL;
 	hostgroup *temp_hostgroup = NULL;
@@ -1831,111 +1888,111 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 	case STATUS_QUERY_HOSTCOUNT:
 		break;
 	case STATUS_QUERY_HOSTLIST:
-		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) && 
-				(STATUS_TIME_INVALID == cgi_data->host_time_field)) {
+		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) &&
+		   (STATUS_TIME_INVALID == cgi_data->host_time_field)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time supplied, but time field specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time supplied, but time field specified."));
+		}
 		break;
 	case STATUS_QUERY_HOST:
 		if( NULL == cgi_data->host_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Host information requested, but no host name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Host information requested, but no host name specified."));
+		}
 		break;
 	case STATUS_QUERY_SERVICECOUNT:
 		break;
 	case STATUS_QUERY_SERVICELIST:
-		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) && 
-				(STATUS_TIME_INVALID == cgi_data->service_time_field)) {
+		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) &&
+		   (STATUS_TIME_INVALID == cgi_data->service_time_field)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time supplied, but time field specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time supplied, but time field specified."));
+		}
 		break;
 	case STATUS_QUERY_SERVICE:
 		if( NULL == cgi_data->host_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Service information requested, but no host name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Service information requested, but no host name specified."));
+		}
 		if( NULL == cgi_data->service_description) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Service information requested, but no service description specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Service information requested, but no service description specified."));
+		}
 		break;
 	case STATUS_QUERY_COMMENTCOUNT:
 		break;
 	case STATUS_QUERY_COMMENTLIST:
-		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) && 
-				(STATUS_TIME_INVALID == cgi_data->comment_time_field)) {
+		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) &&
+		   (STATUS_TIME_INVALID == cgi_data->comment_time_field)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time supplied, but time field specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time supplied, but time field specified."));
+		}
 		break;
 	case STATUS_QUERY_COMMENT:
 		if( -1 == cgi_data->comment_id) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Comment information requested, but no id specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Comment information requested, but no id specified."));
+		}
 		break;
 	case STATUS_QUERY_DOWNTIMECOUNT:
 		break;
 	case STATUS_QUERY_DOWNTIMELIST:
-		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) && 
-				(STATUS_TIME_INVALID == cgi_data->downtime_time_field)) {
+		if(((cgi_data->start_time > 0) || (cgi_data->end_time > 0)) &&
+		   (STATUS_TIME_INVALID == cgi_data->downtime_time_field)) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Start and/or end time supplied, but time field specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Start and/or end time supplied, but time field specified."));
+		}
 		break;
 	case STATUS_QUERY_DOWNTIME:
 		if( -1 == cgi_data->downtime_id) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Downtime information requested, but no id specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Downtime information requested, but no id specified."));
+		}
 		break;
 	case STATUS_QUERY_PROGRAMSTATUS:
 		break;
@@ -1949,27 +2006,27 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 	case STATUS_QUERY_CONTACT:
 		if( NULL == cgi_data->contact_name) {
 			result = RESULT_OPTION_MISSING;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"Contact information requested, but no contact name specified."));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "Contact information requested, but no contact name specified."));
+		}
 		break;
 #endif
 	case STATUS_QUERY_HELP:
 		break;
 	default:
 		result = RESULT_OPTION_MISSING;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result, "Missing validation for object type %u.", 
-				cgi_data->query));
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result, "Missing validation for object type %u.",
+		                                      cgi_data->query));
 		break;
-		}
+	}
 
 	/* Validate the requested parent host */
 	if( NULL != cgi_data->parent_host_name) {
@@ -1980,20 +2037,19 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 			if( NULL == temp_host) {
 				cgi_data->use_parent_host = 0;
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries),
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The parenthost '%s' could not be found.", 
-						cgi_data->parent_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The parenthost '%s' could not be found.",
+				                                      cgi_data->parent_host_name));
+			} else {
 				cgi_data->parent_host = temp_host;
-				}
 			}
 		}
+	}
 
 	/* Validate the requested child host */
 	if( NULL != cgi_data->child_host_name) {
@@ -2004,113 +2060,107 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 			if( NULL == temp_host) {
 				cgi_data->use_child_host = 0;
 				result = RESULT_OPTION_VALUE_INVALID;
-				json_object_append_object(json_root, "result", 
-						json_result(query_time, THISCGI, 
-						svm_get_string_from_value(cgi_data->query,
-						valid_queries),
-						get_query_status(query_status, cgi_data->query),
-						(time_t)-1, authinfo, result,
-						"The childhost '%s' could not be found.", 
-						cgi_data->child_host_name));
-				}
-			else {
+				json_object_append_object(json_root, "result",
+				                          json_result(query_time, THISCGI,
+				                                      svm_get_string_from_value(cgi_data->query,
+				                                              valid_queries),
+				                                      get_query_status(query_status, cgi_data->query),
+				                                      (time_t)-1, authinfo, result,
+				                                      "The childhost '%s' could not be found.",
+				                                      cgi_data->child_host_name));
+			} else {
 				cgi_data->child_host = temp_host;
-				}
 			}
 		}
+	}
 
 	/* Validate the requested host */
 	if( NULL != cgi_data->host_name) {
 		temp_host = find_host(cgi_data->host_name);
 		if( NULL == temp_host) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The host '%s' could not be found.", cgi_data->host_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The host '%s' could not be found.", cgi_data->host_name));
+		} else {
 			cgi_data->host = temp_host;
-			}
 		}
+	}
 
 	/* Validate the requested hostgroup */
 	if( NULL != cgi_data->hostgroup_name) {
 		temp_hostgroup = find_hostgroup(cgi_data->hostgroup_name);
 		if( NULL == temp_hostgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The hostgroup '%s' could not be found.", 
-					cgi_data->hostgroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The hostgroup '%s' could not be found.",
+			                                      cgi_data->hostgroup_name));
+		} else {
 			cgi_data->hostgroup = temp_hostgroup;
-			}
 		}
+	}
 
 	/* Validate the requested servicegroup */
 	if( NULL != cgi_data->servicegroup_name) {
 		temp_servicegroup = find_servicegroup(cgi_data->servicegroup_name);
 		if( NULL == temp_servicegroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The servicegroup '%s' could not be found.", 
-					cgi_data->servicegroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The servicegroup '%s' could not be found.",
+			                                      cgi_data->servicegroup_name));
+		} else {
 			cgi_data->servicegroup = temp_servicegroup;
-			}
 		}
+	}
 
 	/* Validate the requested contactgroup */
 	if( NULL != cgi_data->contactgroup_name) {
 		temp_contactgroup = find_contactgroup(cgi_data->contactgroup_name);
 		if( NULL == temp_contactgroup) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The contactgroup '%s' could not be found.", 
-					cgi_data->contactgroup_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The contactgroup '%s' could not be found.",
+			                                      cgi_data->contactgroup_name));
+		} else {
 			cgi_data->contactgroup = temp_contactgroup;
-			}
 		}
+	}
 
 	/* Validate the requested service. Because a service description may be
 		requested without specifying a host name, it may not make sense
 		to look for a specific service object */
-	if((NULL != cgi_data->service_description) && 
-			(NULL != cgi_data->host_name)) {
-		temp_service = find_service(cgi_data->host_name, 
-				cgi_data->service_description);
+	if((NULL != cgi_data->service_description) &&
+	   (NULL != cgi_data->host_name)) {
+		temp_service = find_service(cgi_data->host_name,
+		                            cgi_data->service_description);
 		if( NULL == temp_service) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The service '%s' on host '%s' could not be found.",
-					cgi_data->service_description, cgi_data->host_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The service '%s' on host '%s' could not be found.",
+			                                      cgi_data->service_description, cgi_data->host_name));
+		} else {
 			cgi_data->service = temp_service;
-			}
 		}
+	}
 
 	/* Validate the requested check timeperiod */
 	if( NULL != cgi_data->check_timeperiod_name) {
@@ -2118,55 +2168,52 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The check timeperiod '%s' could not be found.",
-					cgi_data->check_timeperiod_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The check timeperiod '%s' could not be found.",
+			                                      cgi_data->check_timeperiod_name));
+		} else {
 			cgi_data->check_timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested host notification timeperiod */
 	if( NULL != cgi_data->host_notification_timeperiod_name) {
 		temp_timeperiod =
-				find_timeperiod(cgi_data->host_notification_timeperiod_name);
+		    find_timeperiod(cgi_data->host_notification_timeperiod_name);
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The host notification timeperiod '%s' could not be found.",
-					cgi_data->host_notification_timeperiod_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The host notification timeperiod '%s' could not be found.",
+			                                      cgi_data->host_notification_timeperiod_name));
+		} else {
 			cgi_data->host_notification_timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested service notification timeperiod */
 	if( NULL != cgi_data->service_notification_timeperiod_name) {
 		temp_timeperiod =
-				find_timeperiod(cgi_data->service_notification_timeperiod_name);
+		    find_timeperiod(cgi_data->service_notification_timeperiod_name);
 		if( NULL == temp_timeperiod) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The service notification timeperiod '%s' could not be found.",
-					cgi_data->service_notification_timeperiod_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The service notification timeperiod '%s' could not be found.",
+			                                      cgi_data->service_notification_timeperiod_name));
+		} else {
 			cgi_data->service_notification_timeperiod = temp_timeperiod;
-			}
 		}
+	}
 
 	/* Validate the requested check command */
 	if( NULL != cgi_data->check_command_name) {
@@ -2174,17 +2221,16 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 		if( NULL == temp_command) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The check command '%s' could not be found.",
-					cgi_data->check_command_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The check command '%s' could not be found.",
+			                                      cgi_data->check_command_name));
+		} else {
 			cgi_data->check_command = temp_command;
-			}
 		}
+	}
 
 	/* Validate the requested event_handler */
 	if( NULL != cgi_data->event_handler_name) {
@@ -2192,111 +2238,108 @@ int validate_arguments(json_object *json_root, status_json_cgi_data *cgi_data,
 		if( NULL == temp_command) {
 			result = RESULT_OPTION_VALUE_INVALID;
 			json_object_append_object(json_root, "result",
-					json_result(query_time, THISCGI,
-					svm_get_string_from_value(cgi_data->query, valid_queries),
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The event_handler '%s' could not be found.",
-					cgi_data->event_handler_name));
-			}
-		else {
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The event_handler '%s' could not be found.",
+			                                      cgi_data->event_handler_name));
+		} else {
 			cgi_data->event_handler = temp_command;
-			}
 		}
+	}
 
 	/* Validate the requested comment */
 	if(-1 != cgi_data->comment_id) {
 		temp_comment = find_host_comment(cgi_data->comment_id);
 		if(NULL == temp_comment) {
 			temp_comment = find_service_comment(cgi_data->comment_id);
-			}
+		}
 		if(NULL == temp_comment) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The comment with ID '%d' could not be found.", 
-					cgi_data->comment_id));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The comment with ID '%d' could not be found.",
+			                                      cgi_data->comment_id));
+		} else {
 			cgi_data->comment = temp_comment;
-			}
 		}
+	}
 
 	/* Validate the requested downtime */
 	if(-1 != cgi_data->downtime_id) {
 		temp_downtime = find_downtime(ANY_DOWNTIME, cgi_data->downtime_id);
 		if(NULL == temp_downtime) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The downtime with ID '%d' could not be found.", 
-					cgi_data->downtime_id));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The downtime with ID '%d' could not be found.",
+			                                      cgi_data->downtime_id));
+		} else {
 			cgi_data->downtime = temp_downtime;
-			}
 		}
+	}
 
 	/* Validate the requested triggered-by downtime */
 	if(-1 != cgi_data->triggered_by) {
 		temp_downtime = find_downtime(ANY_DOWNTIME, cgi_data->triggered_by);
 		if(NULL == temp_downtime) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result,
-					"The triggering downtime with ID '%d' could not be found.", 
-					cgi_data->triggered_by));
-			}
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result,
+			                                      "The triggering downtime with ID '%d' could not be found.",
+			                                      cgi_data->triggered_by));
 		}
+	}
 
 	/* Validate the requested contact */
 	if( NULL != cgi_data->contact_name) {
 		temp_contact = find_contact(cgi_data->contact_name);
 		if( NULL == temp_contact) {
 			result = RESULT_OPTION_VALUE_INVALID;
-			json_object_append_object(json_root, "result", 
-					json_result(query_time, THISCGI, 
-					svm_get_string_from_value(cgi_data->query, valid_queries), 
-					get_query_status(query_status, cgi_data->query),
-					(time_t)-1, authinfo, result, "The contact '%s' could not be found.", 
-					cgi_data->contact_name));
-			}
-		else {
+			json_object_append_object(json_root, "result",
+			                          json_result(query_time, THISCGI,
+			                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+			                                      get_query_status(query_status, cgi_data->query),
+			                                      (time_t)-1, authinfo, result, "The contact '%s' could not be found.",
+			                                      cgi_data->contact_name));
+		} else {
 			cgi_data->contact = temp_contact;
-			}
 		}
+	}
 
 	/* Validate the requested start time is before the requested end time */
 	if((cgi_data->start_time > 0) && (cgi_data->end_time > 0) && (
-			cgi_data->start_time >= cgi_data->end_time)) {
+	       cgi_data->start_time >= cgi_data->end_time)) {
 		result = RESULT_OPTION_VALUE_INVALID;
-		json_object_append_object(json_root, "result", 
-				json_result(query_time, THISCGI, 
-				svm_get_string_from_value(cgi_data->query, valid_queries), 
-				get_query_status(query_status, cgi_data->query),
-				(time_t)-1, authinfo, result,
-				"The requested start time must be before the end time."));
-		}
-
-	return result;
+		json_object_append_object(json_root, "result",
+		                          json_result(query_time, THISCGI,
+		                                      svm_get_string_from_value(cgi_data->query, valid_queries),
+		                                      get_query_status(query_status, cgi_data->query),
+		                                      (time_t)-1, authinfo, result,
+		                                      "The requested start time must be before the end time."));
 	}
 
+	return result;
+}
+
 int json_status_host_passes_selection(host *temp_host, int use_parent_host,
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *temp_hostgroup, contact *temp_contact, 
-		hoststatus *temp_hoststatus, int time_field, time_t start_time, 
-		time_t end_time, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+                                      host *parent_host, int use_child_host, host *child_host,
+                                      hostgroup *temp_hostgroup, contact *temp_contact,
+                                      hoststatus *temp_hoststatus, int time_field, time_t start_time,
+                                      time_t end_time, contactgroup *temp_contactgroup,
+                                      timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+                                      command *check_command, command *event_handler)
+{
 
 	host *temp_host2;
 
@@ -2305,188 +2348,189 @@ int json_status_host_passes_selection(host *temp_host, int use_parent_host,
 		return 0;
 	}
 
-	/* If the host parent was specified, skip the hosts whose parent is 
+	/* If the host parent was specified, skip the hosts whose parent is
 		not the parent host specified */
-	if( 1 == use_parent_host && 
-			FALSE == is_host_immediate_child_of_host(parent_host, temp_host)) {
+	if( 1 == use_parent_host &&
+	    FALSE == is_host_immediate_child_of_host(parent_host, temp_host)) {
 		return 0;
-		}
+	}
 
 	/* If the hostgroup was specified, skip the hosts that are not members
 		of the hostgroup specified */
-	if( NULL != temp_hostgroup && 
-			( FALSE == is_host_member_of_hostgroup(temp_hostgroup, 
-			temp_host))) {
+	if( NULL != temp_hostgroup &&
+	    ( FALSE == is_host_member_of_hostgroup(temp_hostgroup,
+	            temp_host))) {
 		return 0;
-		}
+	}
 
 	/* If the contact was specified, skip the hosts that do not have
 		the contact specified */
-	if( NULL != temp_contact && 
-			( FALSE == is_contact_for_host(temp_host, temp_contact))) {
+	if( NULL != temp_contact &&
+	    ( FALSE == is_contact_for_host(temp_host, temp_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a contactgroup was specified, skip the hosts that do not have
 		the contactgroup specified */
 	if(NULL != temp_contactgroup &&
-			(FALSE == is_contactgroup_for_host(temp_host, temp_contactgroup))) {
+	   (FALSE == is_contactgroup_for_host(temp_host, temp_contactgroup))) {
 		return 0;
-		}
+	}
 
 	switch(time_field) {
-	case STATUS_TIME_INVALID: 
+	case STATUS_TIME_INVALID:
 		break;
 	case STATUS_TIME_LAST_UPDATE:
 		if((start_time > 0) && (temp_hoststatus->last_update < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->last_update > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_CHECK:
 		if((start_time > 0) && (temp_hoststatus->last_check < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->last_check > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_NEXT_CHECK:
 		if((start_time > 0) && (temp_hoststatus->next_check < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->next_check > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_STATE_CHANGE:
-		if((start_time > 0) && (temp_hoststatus->last_state_change < 
-				start_time)) {
+		if((start_time > 0) && (temp_hoststatus->last_state_change <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->last_state_change > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_HARD_STATE_CHANGE:
-		if((start_time > 0) && (temp_hoststatus->last_hard_state_change < 
-				start_time)) {
+		if((start_time > 0) && (temp_hoststatus->last_hard_state_change <
+		                        start_time)) {
 			return 0;
-			}
-		if((end_time > 0) && (temp_hoststatus->last_hard_state_change > 
-				end_time)) {
+		}
+		if((end_time > 0) && (temp_hoststatus->last_hard_state_change >
+		                      end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_UP:
 		if((start_time > 0) && (temp_hoststatus->last_time_up < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->last_time_up > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_DOWN:
 		if((start_time > 0) && (temp_hoststatus->last_time_down < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->last_time_down > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_UNREACHABLE:
-		if((start_time > 0) && (temp_hoststatus->last_time_unreachable < 
-				start_time)) {
+		if((start_time > 0) && (temp_hoststatus->last_time_unreachable <
+		                        start_time)) {
 			return 0;
-			}
-		if((end_time > 0) && (temp_hoststatus->last_time_unreachable > 
-				end_time)) {
+		}
+		if((end_time > 0) && (temp_hoststatus->last_time_unreachable >
+		                      end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_NOTIFICATION:
-		if((start_time > 0) && (temp_hoststatus->last_notification < 
-				start_time)) {
+		if((start_time > 0) && (temp_hoststatus->last_notification <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->last_notification > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_NEXT_NOTIFICATION:
-		if((start_time > 0) && (temp_hoststatus->next_notification < 
-				start_time)) {
+		if((start_time > 0) && (temp_hoststatus->next_notification <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_hoststatus->next_notification > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	default:
 		return 0;
-		}
+	}
 
 	/* If a check timeperiod was specified, skip this host if it does not have
 		the check timeperiod specified */
 	if(NULL != check_timeperiod &&
-			(check_timeperiod != temp_host->check_period_ptr)) {
+	   (check_timeperiod != temp_host->check_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a notification timeperiod was specified, skip this host if it
 		does not have the notification timeperiod specified */
 	if(NULL != notification_timeperiod &&
-			(notification_timeperiod != temp_host->notification_period_ptr)) {
+	   (notification_timeperiod != temp_host->notification_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a check command was specified, skip this host if it does not
 		have the check command specified */
 	if(NULL != check_command &&
-			(check_command != temp_host->check_command_ptr)) {
+	   (check_command != temp_host->check_command_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If an event handler was specified, skip this host if it does not
 		have the event handler specified */
 	if(NULL != event_handler &&
-			(event_handler != temp_host->event_handler_ptr)) {
+	   (event_handler != temp_host->event_handler_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a child host was specified... (leave this for last since it is the
 		most expensive check) */
-	if(1 == use_child_host) { 
+	if(1 == use_child_host) {
 		/* If the child host is "none", skip this host if it has children */
 		if(NULL == child_host) {
-			for(temp_host2 = host_list; temp_host2 != NULL; 
-					temp_host2 = temp_host2->next) {
-				if(TRUE == is_host_immediate_child_of_host(temp_host, 
-						temp_host2)) {
+			for(temp_host2 = host_list; temp_host2 != NULL;
+			    temp_host2 = temp_host2->next) {
+				if(TRUE == is_host_immediate_child_of_host(temp_host,
+				        temp_host2)) {
 					return 0;
-					}
 				}
 			}
+		}
 		/* Otherwise, skip this host if it does not have the specified host
 			as a child */
 		else if(FALSE == is_host_immediate_child_of_host(temp_host, child_host)) {
 			return 0;
-			}
 		}
+	}
 
 	return 1;
 
-	}
+}
 
-json_object *json_status_host_selectors(unsigned format_options, int start, 
-		int count, int use_parent_host, host *parent_host, int use_child_host, 
-		host *child_host, hostgroup *temp_hostgroup, int host_statuses, 
-		contact *temp_contact, int time_field, time_t start_time, 
-		time_t end_time, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+json_object *json_status_host_selectors(unsigned format_options, int start,
+                                        int count, int use_parent_host, host *parent_host, int use_child_host,
+                                        host *child_host, hostgroup *temp_hostgroup, int host_statuses,
+                                        contact *temp_contact, int time_field, time_t start_time,
+                                        time_t end_time, contactgroup *temp_contactgroup,
+                                        timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+                                        command *check_command, command *event_handler)
+{
 
 	json_object *json_selectors;
 
@@ -2494,71 +2538,72 @@ json_object *json_status_host_selectors(unsigned format_options, int start,
 
 	if(start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if(count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if(1 == use_parent_host) {
-		json_object_append_string(json_selectors, "parenthost", 
-				( NULL == parent_host ? "none" : parent_host->name));
-		}
+		json_object_append_string(json_selectors, "parenthost",
+		                          ( NULL == parent_host ? "none" : parent_host->name));
+	}
 	if(1 == use_child_host) {
-		json_object_append_string(json_selectors, "childhost", 
-				( NULL == child_host ? "none" : child_host->name));
-		}
+		json_object_append_string(json_selectors, "childhost",
+		                          ( NULL == child_host ? "none" : child_host->name));
+	}
 	if(NULL != temp_hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				temp_hostgroup->group_name);
-		}
+		json_object_append_string(json_selectors, "hostgroup",
+		                          temp_hostgroup->group_name);
+	}
 	if(HOST_STATUS_ALL != host_statuses) {
-		json_bitmask(json_selectors, format_options, "hoststatus", 
-				host_statuses, svm_host_statuses);
-		}
+		json_bitmask(json_selectors, format_options, "hoststatus",
+		             host_statuses, svm_host_statuses);
+	}
 	if(NULL != temp_contact) {
 		json_object_append_string(json_selectors, "contact",
-				temp_contact->name);
-		}
+		                          temp_contact->name);
+	}
 	if(NULL != temp_contactgroup) {
 		json_object_append_string(json_selectors, "contactgroup",
-				temp_contactgroup->group_name);
-		}
+		                          temp_contactgroup->group_name);
+	}
 	if(time_field > 0) {
-		json_enumeration(json_selectors, format_options, "hosttimefield", 
-				time_field, svm_host_time_fields);
-		}
+		json_enumeration(json_selectors, format_options, "hosttimefield",
+		                 time_field, svm_host_time_fields);
+	}
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 	if( NULL != check_timeperiod) {
 		json_object_append_string(json_selectors, "checktimeperiod",
-				check_timeperiod->name);
-		}
+		                          check_timeperiod->name);
+	}
 	if( NULL != notification_timeperiod) {
 		json_object_append_string(json_selectors, "hostnotificationtimeperiod",
-				notification_timeperiod->name);
-		}
+		                          notification_timeperiod->name);
+	}
 	if( NULL != check_command) {
 		json_object_append_string(json_selectors, "checkcommand",
-				check_command->name);
-		}
+		                          check_command->name);
+	}
 	if( NULL != event_handler) {
 		json_object_append_string(json_selectors, "eventhandler",
-				event_handler->name);
-		}
-
-	return json_selectors;
+		                          event_handler->name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_status_hostcount(unsigned format_options, int use_parent_host,
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *temp_hostgroup, int host_statuses, contact *temp_contact,
-		int time_field, time_t start_time, time_t end_time,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+                                   host *parent_host, int use_child_host, host *child_host,
+                                   hostgroup *temp_hostgroup, int host_statuses, contact *temp_contact,
+                                   int time_field, time_t start_time, time_t end_time,
+                                   contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+                                   timeperiod *notification_timeperiod, command *check_command,
+                                   command *event_handler)
+{
 
 	json_object *json_data;
 	json_object *json_count;
@@ -2570,31 +2615,31 @@ json_object *json_status_hostcount(unsigned format_options, int use_parent_host,
 	int pending = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_host_selectors(format_options, 0, 0, use_parent_host, 
-			parent_host, use_child_host, child_host, temp_hostgroup, 
-			host_statuses, temp_contact, time_field, start_time, end_time,
-			temp_contactgroup, check_timeperiod, notification_timeperiod,
-			check_command, event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_host_selectors(format_options, 0, 0, use_parent_host,
+	                                  parent_host, use_child_host, child_host, temp_hostgroup,
+	                                  host_statuses, temp_contact, time_field, start_time, end_time,
+	                                  temp_contactgroup, check_timeperiod, notification_timeperiod,
+	                                  check_command, event_handler));
 
 	json_count = json_new_object();
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
-		/* If we cannot get the status of the host, skip it. This should 
+		/* If we cannot get the status of the host, skip it. This should
 			probably return an error and doing so is in the todo list. */
 		temp_hoststatus = find_hoststatus(temp_host->name);
 		if( NULL == temp_hoststatus) {
 			continue;
-			}
+		}
 
-		if(json_status_host_passes_selection(temp_host, use_parent_host, 
-				parent_host, use_child_host, child_host, temp_hostgroup, 
-				temp_contact, temp_hoststatus, time_field, start_time, 
-				end_time, temp_contactgroup, check_timeperiod,
-				notification_timeperiod, check_command, event_handler) == 0) {
+		if(json_status_host_passes_selection(temp_host, use_parent_host,
+		                                     parent_host, use_child_host, child_host, temp_hostgroup,
+		                                     temp_contact, temp_hoststatus, time_field, start_time,
+		                                     end_time, temp_contactgroup, check_timeperiod,
+		                                     notification_timeperiod, check_command, event_handler) == 0) {
 			continue;
-			}
+		}
 
 		/* Count the hosts in each state */
 		switch(temp_hoststatus->status) {
@@ -2622,8 +2667,8 @@ json_object *json_status_hostcount(unsigned format_options, int use_parent_host,
 #endif
 			down++;
 			break;
-			}
 		}
+	}
 
 #ifdef JSON_NAGIOS_4X
 	if( host_statuses & SD_HOST_UP)
@@ -2649,15 +2694,16 @@ json_object *json_status_hostcount(unsigned format_options, int use_parent_host,
 	json_object_append_object(json_data, "count", json_count);
 
 	return json_data;
-	}
+}
 
 json_object *json_status_hostlist(unsigned format_options, int start, int count,
-		int details, int use_parent_host, host *parent_host, int use_child_host,
-		host *child_host, hostgroup *temp_hostgroup, int host_statuses, 
-		contact *temp_contact, int time_field, time_t start_time, 
-		time_t end_time, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+                                  int details, int use_parent_host, host *parent_host, int use_child_host,
+                                  host *child_host, hostgroup *temp_hostgroup, int host_statuses,
+                                  contact *temp_contact, int time_field, time_t start_time,
+                                  time_t end_time, contactgroup *temp_contactgroup,
+                                  timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+                                  command *check_command, command *event_handler)
+{
 
 	json_object *json_data;
 	json_object *json_hostlist;
@@ -2668,173 +2714,175 @@ json_object *json_status_hostlist(unsigned format_options, int start, int count,
 	int counted = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_host_selectors(format_options, start, count, 
-			use_parent_host, parent_host, use_child_host, child_host, 
-			temp_hostgroup, host_statuses, temp_contact, time_field, start_time,
-			end_time, temp_contactgroup, check_timeperiod,
-			notification_timeperiod, check_command, event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_host_selectors(format_options, start, count,
+	                                  use_parent_host, parent_host, use_child_host, child_host,
+	                                  temp_hostgroup, host_statuses, temp_contact, time_field, start_time,
+	                                  end_time, temp_contactgroup, check_timeperiod,
+	                                  notification_timeperiod, check_command, event_handler));
 
 	json_hostlist = json_new_object();
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
-		/* If we cannot get the status of the host, skip it. This should 
+		/* If we cannot get the status of the host, skip it. This should
 			probably return an error and doing so is in the todo list. */
 		temp_hoststatus = find_hoststatus(temp_host->name);
 		if( NULL == temp_hoststatus) {
 			continue;
-			}
+		}
 
-		if(json_status_host_passes_selection(temp_host, use_parent_host, 
-				parent_host, use_child_host, child_host, temp_hostgroup, 
-				temp_contact, temp_hoststatus, time_field, start_time, 
-				end_time, temp_contactgroup, check_timeperiod,
-				notification_timeperiod, check_command, event_handler) == 0) {
+		if(json_status_host_passes_selection(temp_host, use_parent_host,
+		                                     parent_host, use_child_host, child_host, temp_hostgroup,
+		                                     temp_contact, temp_hoststatus, time_field, start_time,
+		                                     end_time, temp_contactgroup, check_timeperiod,
+		                                     notification_timeperiod, check_command, event_handler) == 0) {
 			continue;
-			}
+		}
 
 		/* If the status of the host does not match one of the status the
 			user requested, skip the host */
 		if(!(temp_hoststatus->status & host_statuses)) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				json_host_details = json_new_object();
-				json_status_host_details(json_host_details, format_options, 
-						temp_host, temp_hoststatus);
-				json_object_append_object(json_hostlist, temp_host->name, 
-						json_host_details);
-				}
-			else {
+				json_status_host_details(json_host_details, format_options,
+				                         temp_host, temp_hoststatus);
+				json_object_append_object(json_hostlist, temp_host->name,
+				                          json_host_details);
+			} else {
 				json_enumeration(json_hostlist, format_options, temp_host->name,
-						temp_hoststatus->status, svm_host_statuses);
-				}
-			counted++;
+				                 temp_hoststatus->status, svm_host_statuses);
 			}
-		current++; 
+			counted++;
 		}
+		current++;
+	}
 
 	json_object_append_object(json_data, "hostlist", json_hostlist);
 
 	return json_data;
-	}
+}
 
-json_object *json_status_host(unsigned format_options, host *temp_host, 
-		hoststatus *temp_hoststatus) {
+json_object *json_status_host(unsigned format_options, host *temp_host,
+                              hoststatus *temp_hoststatus)
+{
 
 	json_object *json_host = json_new_object();
 	json_object *json_details = json_new_object();
 
 	json_object_append_string(json_details, "name", temp_host->name);
-	json_status_host_details(json_details, format_options, temp_host, 
-			temp_hoststatus);
+	json_status_host_details(json_details, format_options, temp_host,
+	                         temp_hoststatus);
 	json_object_append_object(json_host, "host", json_details);
 
 	return json_host;
-	}
+}
 
-void json_status_host_details(json_object *json_details, unsigned format_options, 
-		host *temp_host, hoststatus *temp_hoststatus) {
+void json_status_host_details(json_object *json_details, unsigned format_options,
+                              host *temp_host, hoststatus *temp_hoststatus)
+{
 
 	json_object_append_string(json_details, "name", temp_host->name);
-	json_object_append_string(json_details, "plugin_output", 
-			temp_hoststatus->plugin_output);
-	json_object_append_string(json_details, "long_plugin_output", 
-			temp_hoststatus->long_plugin_output);
-	json_object_append_string(json_details, "perf_data", 
-			temp_hoststatus->perf_data);
-	json_enumeration(json_details, format_options, "status", 
-			temp_hoststatus->status, svm_host_statuses);
-	json_object_append_time_t(json_details, "last_update", 
-			temp_hoststatus->last_update);
-	json_object_append_boolean(json_details, "has_been_checked", 
-			temp_hoststatus->has_been_checked);
-	json_object_append_boolean(json_details, "should_be_scheduled", 
-			temp_hoststatus->should_be_scheduled);
-	json_object_append_integer(json_details, "current_attempt", 
-			temp_hoststatus->current_attempt);
-	json_object_append_integer(json_details, "max_attempts", 
-			temp_hoststatus->max_attempts);
-	json_object_append_time_t(json_details, "last_check", 
-			temp_hoststatus->last_check);
-	json_object_append_time_t(json_details, "next_check", 
-			temp_hoststatus->next_check);
+	json_object_append_string(json_details, "plugin_output",
+	                          temp_hoststatus->plugin_output);
+	json_object_append_string(json_details, "long_plugin_output",
+	                          temp_hoststatus->long_plugin_output);
+	json_object_append_string(json_details, "perf_data",
+	                          temp_hoststatus->perf_data);
+	json_enumeration(json_details, format_options, "status",
+	                 temp_hoststatus->status, svm_host_statuses);
+	json_object_append_time_t(json_details, "last_update",
+	                          temp_hoststatus->last_update);
+	json_object_append_boolean(json_details, "has_been_checked",
+	                           temp_hoststatus->has_been_checked);
+	json_object_append_boolean(json_details, "should_be_scheduled",
+	                           temp_hoststatus->should_be_scheduled);
+	json_object_append_integer(json_details, "current_attempt",
+	                           temp_hoststatus->current_attempt);
+	json_object_append_integer(json_details, "max_attempts",
+	                           temp_hoststatus->max_attempts);
+	json_object_append_time_t(json_details, "last_check",
+	                          temp_hoststatus->last_check);
+	json_object_append_time_t(json_details, "next_check",
+	                          temp_hoststatus->next_check);
 	json_bitmask(json_details, format_options, "check_options",
-			temp_hoststatus->check_options, svm_check_options);
+	             temp_hoststatus->check_options, svm_check_options);
 	json_enumeration(json_details, format_options, "check_type",
-			temp_hoststatus->check_type, svm_host_check_types);
-	json_object_append_time_t(json_details, "last_state_change", 
-			temp_hoststatus->last_state_change);
-	json_object_append_time_t(json_details, "last_hard_state_change", 
-			temp_hoststatus->last_hard_state_change);
-	json_enumeration(json_details, format_options, "last_hard_state", 
-			temp_hoststatus->last_hard_state, svm_host_states);
-	json_object_append_time_t(json_details, "last_time_up", 
-			temp_hoststatus->last_time_up);
+	                 temp_hoststatus->check_type, svm_host_check_types);
+	json_object_append_time_t(json_details, "last_state_change",
+	                          temp_hoststatus->last_state_change);
+	json_object_append_time_t(json_details, "last_hard_state_change",
+	                          temp_hoststatus->last_hard_state_change);
+	json_enumeration(json_details, format_options, "last_hard_state",
+	                 temp_hoststatus->last_hard_state, svm_host_states);
+	json_object_append_time_t(json_details, "last_time_up",
+	                          temp_hoststatus->last_time_up);
 	json_object_append_time_t(json_details, "last_time_down",
-			temp_hoststatus->last_time_down);
-	json_object_append_time_t(json_details, "last_time_unreachable", 
-			temp_hoststatus->last_time_unreachable);
-	json_enumeration(json_details, format_options, "state_type", 
-			temp_hoststatus->state_type, svm_state_types);
-	json_object_append_time_t(json_details, "last_notification", 
-			temp_hoststatus->last_notification);
-	json_object_append_time_t(json_details, "next_notification", 
-			temp_hoststatus->next_notification);
-	json_object_append_boolean(json_details, "no_more_notifications", 
-			temp_hoststatus->no_more_notifications);
-	json_object_append_boolean(json_details, "notifications_enabled", 
-			temp_hoststatus->notifications_enabled);
-	json_object_append_boolean(json_details, "problem_has_been_acknowledged", 
-			temp_hoststatus->problem_has_been_acknowledged);
-	json_enumeration(json_details, format_options, "acknowledgement_type", 
-			temp_hoststatus->acknowledgement_type, svm_acknowledgement_types);
-	json_object_append_integer(json_details, "current_notification_number", 
-			temp_hoststatus->current_notification_number);
+	                          temp_hoststatus->last_time_down);
+	json_object_append_time_t(json_details, "last_time_unreachable",
+	                          temp_hoststatus->last_time_unreachable);
+	json_enumeration(json_details, format_options, "state_type",
+	                 temp_hoststatus->state_type, svm_state_types);
+	json_object_append_time_t(json_details, "last_notification",
+	                          temp_hoststatus->last_notification);
+	json_object_append_time_t(json_details, "next_notification",
+	                          temp_hoststatus->next_notification);
+	json_object_append_boolean(json_details, "no_more_notifications",
+	                           temp_hoststatus->no_more_notifications);
+	json_object_append_boolean(json_details, "notifications_enabled",
+	                           temp_hoststatus->notifications_enabled);
+	json_object_append_boolean(json_details, "problem_has_been_acknowledged",
+	                           temp_hoststatus->problem_has_been_acknowledged);
+	json_enumeration(json_details, format_options, "acknowledgement_type",
+	                 temp_hoststatus->acknowledgement_type, svm_acknowledgement_types);
+	json_object_append_integer(json_details, "current_notification_number",
+	                           temp_hoststatus->current_notification_number);
 #ifdef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "accept_passive_checks", 
-			temp_hoststatus->accept_passive_checks);
+	json_object_append_boolean(json_details, "accept_passive_checks",
+	                           temp_hoststatus->accept_passive_checks);
 #else
-	json_object_append_boolean(json_details, "accept_passive_host_checks", 
-			temp_hoststatus->accept_passive_host_checks);
+	json_object_append_boolean(json_details, "accept_passive_host_checks",
+	                           temp_hoststatus->accept_passive_host_checks);
 #endif
-	json_object_append_boolean(json_details, "event_handler_enabled", 
-			temp_hoststatus->event_handler_enabled);
-	json_object_append_boolean(json_details, "checks_enabled", 
-			temp_hoststatus->checks_enabled);
-	json_object_append_boolean(json_details, "flap_detection_enabled", 
-			temp_hoststatus->flap_detection_enabled);
-	json_object_append_boolean(json_details, "is_flapping", 
-			temp_hoststatus->is_flapping);
-	json_object_append_real(json_details, "percent_state_change", 
-			temp_hoststatus->percent_state_change);
+	json_object_append_boolean(json_details, "event_handler_enabled",
+	                           temp_hoststatus->event_handler_enabled);
+	json_object_append_boolean(json_details, "checks_enabled",
+	                           temp_hoststatus->checks_enabled);
+	json_object_append_boolean(json_details, "flap_detection_enabled",
+	                           temp_hoststatus->flap_detection_enabled);
+	json_object_append_boolean(json_details, "is_flapping",
+	                           temp_hoststatus->is_flapping);
+	json_object_append_real(json_details, "percent_state_change",
+	                        temp_hoststatus->percent_state_change);
 	json_object_append_real(json_details, "latency", temp_hoststatus->latency);
-	json_object_append_real(json_details, "execution_time", 
-			temp_hoststatus->execution_time);
-	json_object_append_integer(json_details, "scheduled_downtime_depth", 
-			temp_hoststatus->scheduled_downtime_depth);
+	json_object_append_real(json_details, "execution_time",
+	                        temp_hoststatus->execution_time);
+	json_object_append_integer(json_details, "scheduled_downtime_depth",
+	                           temp_hoststatus->scheduled_downtime_depth);
 #ifndef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "failure_prediction_enabled", 
-			temp_hoststatus->failure_prediction_enabled);
+	json_object_append_boolean(json_details, "failure_prediction_enabled",
+	                           temp_hoststatus->failure_prediction_enabled);
 #endif
-	json_object_append_boolean(json_details, "process_performance_data", 
-			temp_hoststatus->process_performance_data);
+	json_object_append_boolean(json_details, "process_performance_data",
+	                           temp_hoststatus->process_performance_data);
 #ifdef JSON_NAGIOS_4X
 	json_object_append_boolean(json_details, "obsess", temp_hoststatus->obsess);
 #else
-	json_object_append_boolean(json_details, "obsess_over_host", 
-			temp_hoststatus->obsess_over_host);
+	json_object_append_boolean(json_details, "obsess_over_host",
+	                           temp_hoststatus->obsess_over_host);
 #endif
-	}
+}
 
-int json_status_service_passes_host_selection(host *temp_host, 
-		int use_parent_host, host *parent_host, int use_child_host, 
-		host *child_host, hostgroup *temp_hostgroup, host *match_host, 
-		int host_statuses) {
+int json_status_service_passes_host_selection(host *temp_host,
+        int use_parent_host, host *parent_host, int use_child_host,
+        host *child_host, hostgroup *temp_hostgroup, host *match_host,
+        int host_statuses)
+{
 
 	hoststatus *temp_hoststatus;
 	host *temp_host2;
@@ -2844,235 +2892,236 @@ int json_status_service_passes_host_selection(host *temp_host,
 		return 0;
 	}
 
-	/* If the host parent was specified, skip the services whose host is 
+	/* If the host parent was specified, skip the services whose host is
 		not a child of the parent host specified */
-	if( 1 == use_parent_host && NULL != temp_host && 
-			FALSE == is_host_immediate_child_of_host(parent_host, 
-			temp_host)) {
+	if( 1 == use_parent_host && NULL != temp_host &&
+	    FALSE == is_host_immediate_child_of_host(parent_host,
+	            temp_host)) {
 		return 0;
-		}
+	}
 
-	/* If the hostgroup was specified, skip the services on hosts that 
+	/* If the hostgroup was specified, skip the services on hosts that
 		are not members of the hostgroup specified */
 	if( NULL != temp_hostgroup && NULL != temp_host &&
-			( FALSE == is_host_member_of_hostgroup(temp_hostgroup, 
-					temp_host))) {
+	    ( FALSE == is_host_member_of_hostgroup(temp_hostgroup,
+	            temp_host))) {
 		return 0;
-		}
+	}
 
 	/* If the host was specified, skip the services not on the host
 		specified */
 	if( NULL != match_host && NULL != temp_host &&
-			temp_host != match_host) {
+	    temp_host != match_host) {
 		return 0;
-		}
+	}
 
-	/* If we cannot get the status of the host, skip it. This should 
+	/* If we cannot get the status of the host, skip it. This should
 		probably return an error and doing so is in the todo list. */
 	temp_hoststatus = find_hoststatus(temp_host->name);
 	if( NULL == temp_hoststatus) {
 		return 0;
-		}
+	}
 
 	/* If a child host was specified... */
-	if(1 == use_child_host) { 
+	if(1 == use_child_host) {
 		/* If the child host is "none", skip this host if it has children */
 		if(NULL == child_host) {
-			for(temp_host2 = host_list; temp_host2 != NULL; 
-					temp_host2 = temp_host2->next) {
-				if(TRUE == is_host_immediate_child_of_host(temp_host, 
-						temp_host2)) {
+			for(temp_host2 = host_list; temp_host2 != NULL;
+			    temp_host2 = temp_host2->next) {
+				if(TRUE == is_host_immediate_child_of_host(temp_host,
+				        temp_host2)) {
 					return 0;
-					}
 				}
 			}
+		}
 		/* Otherwise, skip this host if it does not have the specified host
 			as a child */
 		else if(FALSE == is_host_immediate_child_of_host(temp_host, child_host)) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
-int json_status_service_passes_service_selection(service *temp_service, 
-		servicegroup *temp_servicegroup, contact *temp_contact, 
-		servicestatus *temp_servicestatus, int time_field, time_t start_time, 
-		time_t end_time, char *service_description, char *parent_service_name,
-		char *child_service_name, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+	return 1;
+}
+
+int json_status_service_passes_service_selection(service *temp_service,
+        servicegroup *temp_servicegroup, contact *temp_contact,
+        servicestatus *temp_servicestatus, int time_field, time_t start_time,
+        time_t end_time, char *service_description, char *parent_service_name,
+        char *child_service_name, contactgroup *temp_contactgroup,
+        timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+        command *check_command, command *event_handler)
+{
 
 	servicesmember *temp_servicesmember;
 
 	/* Skip if user is not authorized for this service */
-	if(FALSE == is_authorized_for_service(temp_service, 
-			&current_authdata)) {
+	if(FALSE == is_authorized_for_service(temp_service,
+	                                      &current_authdata)) {
 		return 0;
 	}
 
-	/* If the servicegroup was specified, skip the services that are not 
+	/* If the servicegroup was specified, skip the services that are not
 		members of the servicegroup specified */
-	if( NULL != temp_servicegroup && 
-			( FALSE == is_service_member_of_servicegroup(temp_servicegroup, 
-			temp_service))) {
+	if( NULL != temp_servicegroup &&
+	    ( FALSE == is_service_member_of_servicegroup(temp_servicegroup,
+	            temp_service))) {
 		return 0;
-		}
+	}
 
 	/* If the contact was specified, skip the services that do not have
 		the contact specified */
-	if( NULL != temp_contact && 
-			( FALSE == is_contact_for_service(temp_service, temp_contact))) {
+	if( NULL != temp_contact &&
+	    ( FALSE == is_contact_for_service(temp_service, temp_contact))) {
 		return 0;
-		}
+	}
 
 	/* If a contactgroup was specified, skip the services that do not have
 		the contactgroup specified */
 	if(NULL != temp_contactgroup &&
-			(FALSE == is_contactgroup_for_service(temp_service,
-			temp_contactgroup))) {
+	   (FALSE == is_contactgroup_for_service(temp_service,
+	           temp_contactgroup))) {
 		return 0;
-		}
+	}
 
 	switch(time_field) {
-	case STATUS_TIME_INVALID: 
+	case STATUS_TIME_INVALID:
 		break;
 	case STATUS_TIME_LAST_UPDATE:
 		if((start_time > 0) && (temp_servicestatus->last_update < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_update > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_CHECK:
 		if((start_time > 0) && (temp_servicestatus->last_check < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_check > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_NEXT_CHECK:
 		if((start_time > 0) && (temp_servicestatus->next_check < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->next_check > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_STATE_CHANGE:
-		if((start_time > 0) && (temp_servicestatus->last_state_change < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->last_state_change <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_state_change > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_HARD_STATE_CHANGE:
-		if((start_time > 0) && (temp_servicestatus->last_hard_state_change < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->last_hard_state_change <
+		                        start_time)) {
 			return 0;
-			}
-		if((end_time > 0) && (temp_servicestatus->last_hard_state_change > 
-				end_time)) {
+		}
+		if((end_time > 0) && (temp_servicestatus->last_hard_state_change >
+		                      end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_OK:
 		if((start_time > 0) && (temp_servicestatus->last_time_ok < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_time_ok > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_WARNING:
-		if((start_time > 0) && (temp_servicestatus->last_time_warning < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->last_time_warning <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_time_warning > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_CRITICAL:
-		if((start_time > 0) && (temp_servicestatus->last_time_critical < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->last_time_critical <
+		                        start_time)) {
 			return 0;
-			}
-		if((end_time > 0) && (temp_servicestatus->last_time_critical > 
-				end_time)) {
+		}
+		if((end_time > 0) && (temp_servicestatus->last_time_critical >
+		                      end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_TIME_UNKNOWN:
-		if((start_time > 0) && (temp_servicestatus->last_time_unknown < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->last_time_unknown <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_time_unknown > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_LAST_NOTIFICATION:
-		if((start_time > 0) && (temp_servicestatus->last_notification < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->last_notification <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->last_notification > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_NEXT_NOTIFICATION:
-		if((start_time > 0) && (temp_servicestatus->next_notification < 
-				start_time)) {
+		if((start_time > 0) && (temp_servicestatus->next_notification <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_servicestatus->next_notification > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	default:
 		return 0;
-		}
+	}
 
-	/* If a service description was specified, skip the services that do not 
+	/* If a service description was specified, skip the services that do not
 		have the service description specified */
-	if(NULL != service_description && 
-			strcmp(temp_service->description, service_description)) {
+	if(NULL != service_description &&
+	   strcmp(temp_service->description, service_description)) {
 		return 0;
-		}
+	}
 
 	/* If a check timeperiod was specified, skip this service if it does
 		not have the check timeperiod specified */
 	if(NULL != check_timeperiod &&
-			(check_timeperiod != temp_service->check_period_ptr)) {
+	   (check_timeperiod != temp_service->check_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a notification timeperiod was specified, skip this service if it does
 		not have the notification timeperiod specified */
 	if(NULL != notification_timeperiod && (notification_timeperiod !=
-			temp_service->notification_period_ptr)) {
+	                                       temp_service->notification_period_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a check command was specified, skip this service if it does not
 		have the check command specified */
 	if(NULL != check_command &&
-			(check_command != temp_service->check_command_ptr)) {
+	   (check_command != temp_service->check_command_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a event handler was specified, skip this service if it does not
 		have the event handler specified */
 	if(NULL != event_handler &&
-			(event_handler != temp_service->event_handler_ptr)) {
+	   (event_handler != temp_service->event_handler_ptr)) {
 		return 0;
-		}
+	}
 
 	/* If a parent service was specified... */
 	if(NULL != parent_service_name) {
@@ -3081,25 +3130,25 @@ int json_status_service_passes_service_selection(service *temp_service,
 		if(!strcmp(parent_service_name,"none")) {
 			if(NULL != temp_service->parents) {
 				return 0;
-				}
 			}
+		}
 		/* Otherwise, skip this service if it does not have the specified
 			service as a parent */
 		else {
 			int found = 0;
 			for(temp_servicesmember = temp_service->parents;
-					temp_servicesmember != NULL;
-					temp_servicesmember = temp_servicesmember->next) {
+			    temp_servicesmember != NULL;
+			    temp_servicesmember = temp_servicesmember->next) {
 				if(!strcmp(temp_servicesmember->service_description,
-						parent_service_name)) {
+				           parent_service_name)) {
 					found = 1;
-					}
-				}
-			if(0 == found) {
-				return 0;
 				}
 			}
+			if(0 == found) {
+				return 0;
+			}
 		}
+	}
 
 	/* If a child service was specified... */
 	if(NULL != child_service_name) {
@@ -3108,39 +3157,40 @@ int json_status_service_passes_service_selection(service *temp_service,
 		if(!strcmp(child_service_name,"none")) {
 			if(NULL != temp_service->children) {
 				return 0;
-				}
 			}
+		}
 		/* Otherwise, skip this service if it does not have the specified
 			service as a child */
 		else {
 			int found = 0;
 			for(temp_servicesmember = temp_service->children;
-					temp_servicesmember != NULL;
-					temp_servicesmember = temp_servicesmember->next) {
+			    temp_servicesmember != NULL;
+			    temp_servicesmember = temp_servicesmember->next) {
 				if(!strcmp(temp_servicesmember->service_description,
-						child_service_name)) {
+				           child_service_name)) {
 					found = 1;
-					}
-				}
-			if(0 == found) {
-				return 0;
 				}
 			}
+			if(0 == found) {
+				return 0;
+			}
 		}
-
-	return 1;
 	}
 
-json_object *json_status_service_selectors(unsigned format_options, 
-		int start, int count, int use_parent_host, host *parent_host, 
-		int use_child_host, host *child_host, hostgroup *temp_hostgroup, 
-		host *match_host, servicegroup *temp_servicegroup, int host_statuses, 
-		int service_statuses, contact *temp_contact, int time_field, 
-		time_t start_time, time_t end_time, char *service_description,
-		char *parent_service_name, char *child_service_name,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+	return 1;
+}
+
+json_object *json_status_service_selectors(unsigned format_options,
+        int start, int count, int use_parent_host, host *parent_host,
+        int use_child_host, host *child_host, hostgroup *temp_hostgroup,
+        host *match_host, servicegroup *temp_servicegroup, int host_statuses,
+        int service_statuses, contact *temp_contact, int time_field,
+        time_t start_time, time_t end_time, char *service_description,
+        char *parent_service_name, char *child_service_name,
+        contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+        timeperiod *notification_timeperiod, command *check_command,
+        command *event_handler)
+{
 
 	json_object *json_selectors;
 
@@ -3148,94 +3198,95 @@ json_object *json_status_service_selectors(unsigned format_options,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if( 1 == use_parent_host) {
-		json_object_append_string(json_selectors, "parenthost", 
-				( NULL == parent_host ? "none" : parent_host->name));
-		}
+		json_object_append_string(json_selectors, "parenthost",
+		                          ( NULL == parent_host ? "none" : parent_host->name));
+	}
 	if( 1 == use_child_host) {
-		json_object_append_string(json_selectors, "childhost", 
-				( NULL == child_host ? "none" : child_host->name));
-		}
+		json_object_append_string(json_selectors, "childhost",
+		                          ( NULL == child_host ? "none" : child_host->name));
+	}
 	if( NULL != temp_hostgroup) {
-		json_object_append_string(json_selectors, "hostgroup", 
-				temp_hostgroup->group_name);
-		}
+		json_object_append_string(json_selectors, "hostgroup",
+		                          temp_hostgroup->group_name);
+	}
 	if( NULL != temp_servicegroup) {
-		json_object_append_string(json_selectors, "servicegroup", 
-				temp_servicegroup->group_name);
-		}
+		json_object_append_string(json_selectors, "servicegroup",
+		                          temp_servicegroup->group_name);
+	}
 	if(HOST_STATUS_ALL != host_statuses) {
-		json_bitmask(json_selectors, format_options, "host_status", 
-				host_statuses, svm_host_statuses);
-		}
+		json_bitmask(json_selectors, format_options, "host_status",
+		             host_statuses, svm_host_statuses);
+	}
 	if(SERVICE_STATUS_ALL != service_statuses) {
-		json_bitmask(json_selectors, format_options, "service_status", 
-				service_statuses, svm_service_statuses);
-		}
+		json_bitmask(json_selectors, format_options, "service_status",
+		             service_statuses, svm_service_statuses);
+	}
 	if(NULL != temp_contact) {
 		json_object_append_string(json_selectors, "contact",
-				temp_contact->name);
-		}
+		                          temp_contact->name);
+	}
 	if(NULL != temp_contactgroup) {
 		json_object_append_string(json_selectors, "contactgroup",
-				temp_contactgroup->group_name);
-		}
+		                          temp_contactgroup->group_name);
+	}
 	if(time_field > 0) {
-		json_enumeration(json_selectors, format_options, "servicetimefield", 
-				time_field, svm_service_time_fields);
-		}
+		json_enumeration(json_selectors, format_options, "servicetimefield",
+		                 time_field, svm_service_time_fields);
+	}
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 	if(NULL != service_description) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				service_description);
-		}
+		json_object_append_string(json_selectors, "servicedescription",
+		                          service_description);
+	}
 	if( NULL != parent_service_name) {
 		json_object_append_string(json_selectors, "parentservice",
-				parent_service_name);
-		}
+		                          parent_service_name);
+	}
 	if( NULL != child_service_name) {
 		json_object_append_string(json_selectors, "childservice",
-				child_service_name);
-		}
+		                          child_service_name);
+	}
 	if( NULL != check_timeperiod) {
 		json_object_append_string(json_selectors, "checktimeperiod",
-				check_timeperiod->name);
-		}
+		                          check_timeperiod->name);
+	}
 	if( NULL != notification_timeperiod) {
 		json_object_append_string(json_selectors,
-				"servicenotificationtimeperiod", notification_timeperiod->name);
-		}
+		                          "servicenotificationtimeperiod", notification_timeperiod->name);
+	}
 	if( NULL != check_command) {
 		json_object_append_string(json_selectors, "checkcommand",
-				check_command->name);
-		}
+		                          check_command->name);
+	}
 	if( NULL != event_handler) {
 		json_object_append_string(json_selectors, "eventhandler",
-				event_handler->name);
-		}
-
-	return json_selectors;
+		                          event_handler->name);
 	}
 
+	return json_selectors;
+}
+
 json_object *json_status_servicecount(unsigned format_options, host *match_host,
-		int use_parent_host, host *parent_host, int use_child_host, 
-		host *child_host, hostgroup *temp_hostgroup, 
-		servicegroup *temp_servicegroup, int host_statuses, 
-		int service_statuses, contact *temp_contact, int time_field, 
-		time_t start_time, time_t end_time, char *service_description,
-		char *parent_service_name, char *child_service_name,
-		contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
-		timeperiod *notification_timeperiod, command *check_command,
-		command *event_handler) {
+                                      int use_parent_host, host *parent_host, int use_child_host,
+                                      host *child_host, hostgroup *temp_hostgroup,
+                                      servicegroup *temp_servicegroup, int host_statuses,
+                                      int service_statuses, contact *temp_contact, int time_field,
+                                      time_t start_time, time_t end_time, char *service_description,
+                                      char *parent_service_name, char *child_service_name,
+                                      contactgroup *temp_contactgroup, timeperiod *check_timeperiod,
+                                      timeperiod *notification_timeperiod, command *check_command,
+                                      command *event_handler)
+{
 
 	json_object *json_data;
 	json_object *json_count;
@@ -3249,48 +3300,48 @@ json_object *json_status_servicecount(unsigned format_options, host *match_host,
 	int pending = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_service_selectors(format_options, 0, 0, use_parent_host,
-			parent_host, use_child_host, child_host, temp_hostgroup, match_host,
-			temp_servicegroup, host_statuses, service_statuses, temp_contact, 
-			time_field, start_time, end_time, service_description,
-			parent_service_name, child_service_name, temp_contactgroup,
-			check_timeperiod, notification_timeperiod, check_command,
-			event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_service_selectors(format_options, 0, 0, use_parent_host,
+	                                  parent_host, use_child_host, child_host, temp_hostgroup, match_host,
+	                                  temp_servicegroup, host_statuses, service_statuses, temp_contact,
+	                                  time_field, start_time, end_time, service_description,
+	                                  parent_service_name, child_service_name, temp_contactgroup,
+	                                  check_timeperiod, notification_timeperiod, check_command,
+	                                  event_handler));
 
 	json_count = json_new_object();
 
-	for(temp_service = service_list; temp_service != NULL; 
-			temp_service = temp_service->next) {
+	for(temp_service = service_list; temp_service != NULL;
+	    temp_service = temp_service->next) {
 
 		temp_host = find_host(temp_service->host_name);
 		if(NULL == temp_host) {
 			continue;
-			}
+		}
 
-		if(!json_status_service_passes_host_selection(temp_host, 
-				use_parent_host, parent_host, use_child_host, child_host, 
-				temp_hostgroup, match_host, host_statuses)) {
+		if(!json_status_service_passes_host_selection(temp_host,
+		        use_parent_host, parent_host, use_child_host, child_host,
+		        temp_hostgroup, match_host, host_statuses)) {
 			continue;
-			}
+		}
 
-		/* Get the service status. If we cannot get the status of 
-			the service, skip it. This should probably return an 
+		/* Get the service status. If we cannot get the status of
+			the service, skip it. This should probably return an
 			error and doing so is in the todo list. */
-		temp_servicestatus = find_servicestatus(temp_service->host_name, 
-				temp_service->description);
+		temp_servicestatus = find_servicestatus(temp_service->host_name,
+		                                        temp_service->description);
 		if( NULL == temp_servicestatus) {
 			continue;
-			}
+		}
 
-		if(!json_status_service_passes_service_selection(temp_service, 
-				temp_servicegroup, temp_contact, temp_servicestatus, 
-				time_field, start_time, end_time, service_description,
-				parent_service_name, child_service_name, temp_contactgroup,
-				check_timeperiod, notification_timeperiod, check_command,
-				event_handler)) {
+		if(!json_status_service_passes_service_selection(temp_service,
+		        temp_servicegroup, temp_contact, temp_servicestatus,
+		        time_field, start_time, end_time, service_description,
+		        parent_service_name, child_service_name, temp_contactgroup,
+		        check_timeperiod, notification_timeperiod, check_command,
+		        event_handler)) {
 			continue;
-			}
+		}
 
 		/* Count the services in each state */
 		switch(temp_servicestatus->status) {
@@ -3309,8 +3360,8 @@ json_object *json_status_servicecount(unsigned format_options, host *match_host,
 		case SERVICE_UNKNOWN:
 			unknown++;
 			break;
-			}
 		}
+	}
 
 	if( service_statuses & SERVICE_OK)
 		json_object_append_integer(json_count, "ok", ok);
@@ -3326,18 +3377,19 @@ json_object *json_status_servicecount(unsigned format_options, host *match_host,
 	json_object_append_object(json_data, "count", json_count);
 
 	return json_data;
-	}
+}
 
-json_object *json_status_servicelist(unsigned format_options, int start, 
-		int count, int details, host *match_host, int use_parent_host, 
-		host *parent_host, int use_child_host, host *child_host, 
-		hostgroup *temp_hostgroup, servicegroup *temp_servicegroup, 
-		int host_statuses, int service_statuses, contact *temp_contact,
-		int time_field, time_t start_time, time_t end_time, 
-		char *service_description, char *parent_service_name,
-		char *child_service_name, contactgroup *temp_contactgroup,
-		timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
-		command *check_command, command *event_handler) {
+json_object *json_status_servicelist(unsigned format_options, int start,
+                                     int count, int details, host *match_host, int use_parent_host,
+                                     host *parent_host, int use_child_host, host *child_host,
+                                     hostgroup *temp_hostgroup, servicegroup *temp_servicegroup,
+                                     int host_statuses, int service_statuses, contact *temp_contact,
+                                     int time_field, time_t start_time, time_t end_time,
+                                     char *service_description, char *parent_service_name,
+                                     char *child_service_name, contactgroup *temp_contactgroup,
+                                     timeperiod *check_timeperiod, timeperiod *notification_timeperiod,
+                                     command *check_command, command *event_handler)
+{
 
 	json_object *json_data;
 	json_object *json_hostlist;
@@ -3351,60 +3403,60 @@ json_object *json_status_servicelist(unsigned format_options, int start,
 	int service_count; /* number of services on a host */
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_service_selectors(format_options, start, count, 
-			use_parent_host, parent_host, use_child_host, child_host, 
-			temp_hostgroup, match_host, temp_servicegroup, host_statuses, 
-			service_statuses, temp_contact, time_field, start_time, end_time, 
-			service_description, parent_service_name, child_service_name,
-			temp_contactgroup, check_timeperiod, notification_timeperiod,
-			check_command, event_handler));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_service_selectors(format_options, start, count,
+	                                  use_parent_host, parent_host, use_child_host, child_host,
+	                                  temp_hostgroup, match_host, temp_servicegroup, host_statuses,
+	                                  service_statuses, temp_contact, time_field, start_time, end_time,
+	                                  service_description, parent_service_name, child_service_name,
+	                                  temp_contactgroup, check_timeperiod, notification_timeperiod,
+	                                  check_command, event_handler));
 
 	json_hostlist = json_new_object();
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 
-		if(json_status_service_passes_host_selection(temp_host, 
-				use_parent_host, parent_host, use_child_host, child_host, 
-				temp_hostgroup, match_host, host_statuses) == 0) {
+		if(json_status_service_passes_host_selection(temp_host,
+		        use_parent_host, parent_host, use_child_host, child_host,
+		        temp_hostgroup, match_host, host_statuses) == 0) {
 			continue;
-			}
+		}
 
 		json_servicelist = json_new_object();
 
 		service_count = 0;
 
-		for(temp_service = service_list; temp_service != NULL; 
-				temp_service = temp_service->next) {
+		for(temp_service = service_list; temp_service != NULL;
+		    temp_service = temp_service->next) {
 
-			/* If this service isn't on the host we're currently working with, 
+			/* If this service isn't on the host we're currently working with,
 					skip it */
 			if( strcmp( temp_host->name, temp_service->host_name)) continue;
 
-			/* Get the service status. If we cannot get the status of 
-				the service, skip it. This should probably return an 
+			/* Get the service status. If we cannot get the status of
+				the service, skip it. This should probably return an
 				error and doing so is in the todo list. */
-			temp_servicestatus = find_servicestatus(temp_service->host_name, 
-					temp_service->description);
+			temp_servicestatus = find_servicestatus(temp_service->host_name,
+			                                        temp_service->description);
 			if( NULL == temp_servicestatus) {
 				continue;
-				}
+			}
 
-			if(json_status_service_passes_service_selection(temp_service, 
-					temp_servicegroup, temp_contact, temp_servicestatus, 
-					time_field, start_time, end_time, 
-					service_description, parent_service_name,
-					child_service_name, temp_contactgroup,
-					check_timeperiod, notification_timeperiod,
-					check_command, event_handler) == 0) {
+			if(json_status_service_passes_service_selection(temp_service,
+			        temp_servicegroup, temp_contact, temp_servicestatus,
+			        time_field, start_time, end_time,
+			        service_description, parent_service_name,
+			        child_service_name, temp_contactgroup,
+			        check_timeperiod, notification_timeperiod,
+			        check_command, event_handler) == 0) {
 				continue;
-				}
+			}
 
 			/* If the status of the service does not match one of the status the
 				user requested, skip the service */
 			if(!(temp_servicestatus->status & service_statuses)) {
 				continue;
-				}
+			}
 
 			service_count++;
 
@@ -3412,272 +3464,275 @@ json_object *json_status_servicelist(unsigned format_options, int start,
 			if( passes_start_and_count_limits(start, count, current, counted)) {
 				if( details > 0) {
 					json_service_details = json_new_object();
-					json_status_service_details(json_service_details, 
-							format_options, 
-							temp_service, temp_servicestatus);
-					json_object_append_object(json_servicelist, 
-							temp_service->description, 
-							json_service_details);
-					}
-				else {
-					json_enumeration(json_servicelist, format_options, 
-							temp_service->description,
-							temp_servicestatus->status, 
-							svm_service_statuses);
-					}
-				counted++;
+					json_status_service_details(json_service_details,
+					                            format_options,
+					                            temp_service, temp_servicestatus);
+					json_object_append_object(json_servicelist,
+					                          temp_service->description,
+					                          json_service_details);
+				} else {
+					json_enumeration(json_servicelist, format_options,
+					                 temp_service->description,
+					                 temp_servicestatus->status,
+					                 svm_service_statuses);
 				}
-			current++; 
+				counted++;
 			}
+			current++;
+		}
 
 		if( service_count > 0) {
-			json_object_append_object(json_hostlist, temp_host->name, 
-					json_servicelist);
-			}
+			json_object_append_object(json_hostlist, temp_host->name,
+			                          json_servicelist);
 		}
+	}
 
 	json_object_append_object(json_data, "servicelist", json_hostlist);
 
 	return json_data;
-	}
+}
 
-json_object *json_status_service(unsigned format_options, service *temp_service, 
-		servicestatus *temp_servicestatus) {
+json_object *json_status_service(unsigned format_options, service *temp_service,
+                                 servicestatus *temp_servicestatus)
+{
 
 	json_object *json_service = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_string(json_details, "host_name", 
-			temp_service->host_name);
-	json_object_append_string(json_details, "description", 
-			temp_service->description);
-	json_status_service_details(json_details, format_options, temp_service, 
-			temp_servicestatus);
+	json_object_append_string(json_details, "host_name",
+	                          temp_service->host_name);
+	json_object_append_string(json_details, "description",
+	                          temp_service->description);
+	json_status_service_details(json_details, format_options, temp_service,
+	                            temp_servicestatus);
 	json_object_append_object(json_service, "service", json_details);
 
 	return json_service;
-	}
+}
 
-void json_status_service_details(json_object *json_details, 
-		unsigned format_options, service *temp_service, 
-		servicestatus *temp_servicestatus) {
+void json_status_service_details(json_object *json_details,
+                                 unsigned format_options, service *temp_service,
+                                 servicestatus *temp_servicestatus)
+{
 
-	json_object_append_string(json_details, "host_name", 
-			temp_service->host_name);
-	json_object_append_string(json_details, "description", 
-			temp_service->description);
-	json_object_append_string(json_details, "plugin_output", 
-			temp_servicestatus->plugin_output);
-	json_object_append_string(json_details, "long_plugin_output", 
-			temp_servicestatus->long_plugin_output);
-	json_object_append_string(json_details, "perf_data", 
-			temp_servicestatus->perf_data);
-	json_object_append_integer(json_details, "max_attemps", 
-			temp_servicestatus->max_attempts);
-	json_object_append_integer(json_details, "current_attempt", 
-			temp_servicestatus->current_attempt);
-	json_enumeration(json_details, format_options, "status", 
-			temp_servicestatus->status, svm_service_statuses);
-	json_object_append_time_t(json_details, "last_update", 
-			temp_servicestatus->last_update);
-	json_object_append_boolean(json_details, "has_been_checked", 
-			temp_servicestatus->has_been_checked);
-	json_object_append_boolean(json_details, "should_be_scheduled", 
-			temp_servicestatus->should_be_scheduled);
-	json_object_append_time_t(json_details, "last_check", 
-			temp_servicestatus->last_check);
+	json_object_append_string(json_details, "host_name",
+	                          temp_service->host_name);
+	json_object_append_string(json_details, "description",
+	                          temp_service->description);
+	json_object_append_string(json_details, "plugin_output",
+	                          temp_servicestatus->plugin_output);
+	json_object_append_string(json_details, "long_plugin_output",
+	                          temp_servicestatus->long_plugin_output);
+	json_object_append_string(json_details, "perf_data",
+	                          temp_servicestatus->perf_data);
+	json_object_append_integer(json_details, "max_attemps",
+	                           temp_servicestatus->max_attempts);
+	json_object_append_integer(json_details, "current_attempt",
+	                           temp_servicestatus->current_attempt);
+	json_enumeration(json_details, format_options, "status",
+	                 temp_servicestatus->status, svm_service_statuses);
+	json_object_append_time_t(json_details, "last_update",
+	                          temp_servicestatus->last_update);
+	json_object_append_boolean(json_details, "has_been_checked",
+	                           temp_servicestatus->has_been_checked);
+	json_object_append_boolean(json_details, "should_be_scheduled",
+	                           temp_servicestatus->should_be_scheduled);
+	json_object_append_time_t(json_details, "last_check",
+	                          temp_servicestatus->last_check);
 	json_bitmask(json_details, format_options, "check_options",
-			temp_servicestatus->check_options, svm_check_options);
+	             temp_servicestatus->check_options, svm_check_options);
 	json_enumeration(json_details, format_options, "check_type",
-			temp_servicestatus->check_type, svm_service_check_types);
-	json_object_append_boolean(json_details, "checks_enabled", 
-			temp_servicestatus->checks_enabled);
-	json_object_append_time_t(json_details, "last_state_change", 
-			temp_servicestatus->last_state_change);
-	json_object_append_time_t(json_details, "last_hard_state_change", 
-			temp_servicestatus->last_hard_state_change);
-	json_enumeration(json_details, format_options, "last_hard_state", 
-			temp_servicestatus->last_hard_state, svm_service_states);
-	json_object_append_time_t(json_details, "last_time_ok", 
-			temp_servicestatus->last_time_ok);
-	json_object_append_time_t(json_details, "last_time_warning", 
-			temp_servicestatus->last_time_warning);
-	json_object_append_time_t(json_details, "last_time_unknown", 
-			temp_servicestatus->last_time_unknown);
-	json_object_append_time_t(json_details, "last_time_critical", 
-			temp_servicestatus->last_time_critical);
-	json_enumeration(json_details, format_options, "state_type", 
-			temp_servicestatus->state_type, svm_state_types);
-	json_object_append_time_t(json_details, "last_notification", 
-			temp_servicestatus->last_notification);
-	json_object_append_time_t(json_details, "next_notification", 
-			temp_servicestatus->next_notification);
-	json_object_append_boolean(json_details, "no_more_notifications", 
-			temp_servicestatus->no_more_notifications);
-	json_object_append_boolean(json_details, "notifications_enabled", 
-			temp_servicestatus->notifications_enabled);
-	json_object_append_boolean(json_details, "problem_has_been_acknowledged", 
-			temp_servicestatus->problem_has_been_acknowledged);
-	json_enumeration(json_details, format_options, "acknowledgement_type", 
-			temp_servicestatus->acknowledgement_type, 
-			svm_acknowledgement_types);
-	json_object_append_integer(json_details, "current_notification_number", 
-			temp_servicestatus->current_notification_number);
+	                 temp_servicestatus->check_type, svm_service_check_types);
+	json_object_append_boolean(json_details, "checks_enabled",
+	                           temp_servicestatus->checks_enabled);
+	json_object_append_time_t(json_details, "last_state_change",
+	                          temp_servicestatus->last_state_change);
+	json_object_append_time_t(json_details, "last_hard_state_change",
+	                          temp_servicestatus->last_hard_state_change);
+	json_enumeration(json_details, format_options, "last_hard_state",
+	                 temp_servicestatus->last_hard_state, svm_service_states);
+	json_object_append_time_t(json_details, "last_time_ok",
+	                          temp_servicestatus->last_time_ok);
+	json_object_append_time_t(json_details, "last_time_warning",
+	                          temp_servicestatus->last_time_warning);
+	json_object_append_time_t(json_details, "last_time_unknown",
+	                          temp_servicestatus->last_time_unknown);
+	json_object_append_time_t(json_details, "last_time_critical",
+	                          temp_servicestatus->last_time_critical);
+	json_enumeration(json_details, format_options, "state_type",
+	                 temp_servicestatus->state_type, svm_state_types);
+	json_object_append_time_t(json_details, "last_notification",
+	                          temp_servicestatus->last_notification);
+	json_object_append_time_t(json_details, "next_notification",
+	                          temp_servicestatus->next_notification);
+	json_object_append_boolean(json_details, "no_more_notifications",
+	                           temp_servicestatus->no_more_notifications);
+	json_object_append_boolean(json_details, "notifications_enabled",
+	                           temp_servicestatus->notifications_enabled);
+	json_object_append_boolean(json_details, "problem_has_been_acknowledged",
+	                           temp_servicestatus->problem_has_been_acknowledged);
+	json_enumeration(json_details, format_options, "acknowledgement_type",
+	                 temp_servicestatus->acknowledgement_type,
+	                 svm_acknowledgement_types);
+	json_object_append_integer(json_details, "current_notification_number",
+	                           temp_servicestatus->current_notification_number);
 #ifdef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "accept_passive_checks", 
-			temp_servicestatus->accept_passive_checks);
+	json_object_append_boolean(json_details, "accept_passive_checks",
+	                           temp_servicestatus->accept_passive_checks);
 #else
-	json_object_append_boolean(json_details, "accept_passive_service_checks", 
-			temp_servicestatus->accept_passive_service_checks);
+	json_object_append_boolean(json_details, "accept_passive_service_checks",
+	                           temp_servicestatus->accept_passive_service_checks);
 #endif
-	json_object_append_boolean(json_details, "event_handler_enabled", 
-			temp_servicestatus->event_handler_enabled);
-	json_object_append_boolean(json_details, "flap_detection_enabled", 
-			temp_servicestatus->flap_detection_enabled);
-	json_object_append_boolean(json_details, "is_flapping", 
-			temp_servicestatus->is_flapping);
-	json_object_append_real(json_details, "percent_state_change", 
-			temp_servicestatus->percent_state_change);
+	json_object_append_boolean(json_details, "event_handler_enabled",
+	                           temp_servicestatus->event_handler_enabled);
+	json_object_append_boolean(json_details, "flap_detection_enabled",
+	                           temp_servicestatus->flap_detection_enabled);
+	json_object_append_boolean(json_details, "is_flapping",
+	                           temp_servicestatus->is_flapping);
+	json_object_append_real(json_details, "percent_state_change",
+	                        temp_servicestatus->percent_state_change);
 	json_object_append_real(json_details, "latency", temp_servicestatus->latency);
-	json_object_append_real(json_details, "execution_time", 
-			temp_servicestatus->execution_time);
-	json_object_append_integer(json_details, "scheduled_downtime_depth", 
-			temp_servicestatus->scheduled_downtime_depth);
+	json_object_append_real(json_details, "execution_time",
+	                        temp_servicestatus->execution_time);
+	json_object_append_integer(json_details, "scheduled_downtime_depth",
+	                           temp_servicestatus->scheduled_downtime_depth);
 #ifndef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "failure_prediction_enabled", 
-			temp_servicestatus->failure_prediction_enabled);
+	json_object_append_boolean(json_details, "failure_prediction_enabled",
+	                           temp_servicestatus->failure_prediction_enabled);
 #endif
-	json_object_append_boolean(json_details, "process_performance_data", 
-			temp_servicestatus->process_performance_data);
+	json_object_append_boolean(json_details, "process_performance_data",
+	                           temp_servicestatus->process_performance_data);
 #ifdef JSON_NAGIOS_4X
-	json_object_append_boolean(json_details, "obsess", 
-			temp_servicestatus->obsess);
+	json_object_append_boolean(json_details, "obsess",
+	                           temp_servicestatus->obsess);
 #else
-	json_object_append_boolean(json_details, "obsess_over_service", 
-			temp_servicestatus->obsess_over_service);
+	json_object_append_boolean(json_details, "obsess_over_service",
+	                           temp_servicestatus->obsess_over_service);
 #endif
-	}
+}
 
-int json_status_comment_passes_selection(comment *temp_comment, int time_field, 
-		time_t start_time, time_t end_time, unsigned comment_types,
-		unsigned entry_types, unsigned persistence, unsigned expiring,
-		char *host_name, char *service_description) {
+int json_status_comment_passes_selection(comment *temp_comment, int time_field,
+        time_t start_time, time_t end_time, unsigned comment_types,
+        unsigned entry_types, unsigned persistence, unsigned expiring,
+        char *host_name, char *service_description)
+{
 
 	switch(time_field) {
-	case STATUS_TIME_INVALID: 
+	case STATUS_TIME_INVALID:
 		break;
 	case STATUS_TIME_ENTRY_TIME:
 		if((start_time > 0) && (temp_comment->entry_time < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_comment->entry_time > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_EXPIRE_TIME:
 		if((start_time > 0) && (temp_comment->expire_time < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_comment->expire_time > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	default:
 		return 0;
-		}
+	}
 
 	if(comment_types != COMMENT_TYPE_ALL) {
 		switch(temp_comment->comment_type) {
 		case HOST_COMMENT:
 			if(!(comment_types & COMMENT_TYPE_HOST)) {
 				return 0;
-				}
+			}
 			break;
 		case SERVICE_COMMENT:
 			if(!(comment_types & COMMENT_TYPE_SERVICE)) {
 				return 0;
-				}
-			break;
 			}
+			break;
 		}
+	}
 
 	if(entry_types != COMMENT_ENTRY_ALL) {
 		switch(temp_comment->entry_type) {
 		case USER_COMMENT:
 			if(!(entry_types & COMMENT_ENTRY_USER)) {
 				return 0;
-				}
+			}
 			break;
 		case DOWNTIME_COMMENT:
 			if(!(entry_types & COMMENT_ENTRY_DOWNTIME)) {
 				return 0;
-				}
+			}
 			break;
 		case FLAPPING_COMMENT:
 			if(!(entry_types & COMMENT_ENTRY_FLAPPING)) {
 				return 0;
-				}
+			}
 			break;
 		case ACKNOWLEDGEMENT_COMMENT:
 			if(!(entry_types & COMMENT_ENTRY_ACKNOWLEDGEMENT)) {
 				return 0;
-				}
-			break;
 			}
+			break;
 		}
+	}
 
 	if(persistence != BOOLEAN_EITHER) {
 		switch(temp_comment->persistent) {
 		case 0: /* false */
 			if(!(persistence & BOOLEAN_FALSE)) {
 				return 0;
-				}
+			}
 			break;
 		case 1: /* true */
 			if(!(persistence & BOOLEAN_TRUE)) {
 				return 0;
-				}
-			break;
 			}
+			break;
 		}
+	}
 
 	if(expiring != BOOLEAN_EITHER) {
 		switch(temp_comment->expires) {
 		case 0: /* false */
 			if(!(expiring & BOOLEAN_FALSE)) {
 				return 0;
-				}
+			}
 			break;
 		case 1: /* true */
 			if(!(expiring & BOOLEAN_TRUE)) {
 				return 0;
-				}
-			break;
 			}
+			break;
 		}
+	}
 
 	if(NULL != host_name) {
 		if((NULL == temp_comment->host_name) ||
-				strcmp(temp_comment->host_name, host_name)) {
+		   strcmp(temp_comment->host_name, host_name)) {
 			return 0;
-			}
 		}
+	}
 
 	if(NULL != service_description) {
 		if((NULL == temp_comment->service_description) ||
-				strcmp(temp_comment->service_description,
-				service_description)) {
+		   strcmp(temp_comment->service_description,
+		          service_description)) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
-json_object *json_status_comment_selectors(unsigned format_options, int start, 
-		int count, int time_field, time_t start_time, time_t end_time,
-		unsigned comment_types, unsigned entry_types, unsigned persistence,
-		unsigned expiring, char *host_name, char *service_description) {
+	return 1;
+}
+
+json_object *json_status_comment_selectors(unsigned format_options, int start,
+        int count, int time_field, time_t start_time, time_t end_time,
+        unsigned comment_types, unsigned entry_types, unsigned persistence,
+        unsigned expiring, char *host_name, char *service_description)
+{
 
 	json_object *json_selectors;
 
@@ -3685,82 +3740,84 @@ json_object *json_status_comment_selectors(unsigned format_options, int start,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if(time_field > 0) {
-		json_enumeration(json_selectors, format_options, "commenttimefield", 
-				time_field, svm_comment_time_fields);
-		}
+		json_enumeration(json_selectors, format_options, "commenttimefield",
+		                 time_field, svm_comment_time_fields);
+	}
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 	if(comment_types != COMMENT_TYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "commenttypes", 
-				comment_types, svm_valid_comment_types);
-		}
+		json_bitmask(json_selectors, format_options, "commenttypes",
+		             comment_types, svm_valid_comment_types);
+	}
 	if(entry_types != COMMENT_ENTRY_ALL) {
-		json_bitmask(json_selectors, format_options, "entrytypes", 
-				entry_types, svm_valid_comment_entry_types);
-		}
+		json_bitmask(json_selectors, format_options, "entrytypes",
+		             entry_types, svm_valid_comment_entry_types);
+	}
 	if(persistence != BOOLEAN_EITHER) {
-		json_bitmask(json_selectors, format_options, "persistence", 
-				persistence, svm_valid_persistence);
-		}
+		json_bitmask(json_selectors, format_options, "persistence",
+		             persistence, svm_valid_persistence);
+	}
 	if(expiring != BOOLEAN_EITHER) {
-		json_bitmask(json_selectors, format_options, "expiring", 
-				expiring, svm_valid_expiration);
-		}
+		json_bitmask(json_selectors, format_options, "expiring",
+		             expiring, svm_valid_expiration);
+	}
 	if(NULL != host_name) {
 		json_object_append_string(json_selectors, "hostname", host_name);
-		}
+	}
 	if(NULL != service_description) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				service_description);
-		}
-
-	return json_selectors;
+		json_object_append_string(json_selectors, "servicedescription",
+		                          service_description);
 	}
 
-json_object *json_status_commentcount(unsigned format_options, int time_field, 
-		time_t start_time, time_t end_time, unsigned comment_types,
-		unsigned entry_types, unsigned persistence, unsigned expiring,
-		char *host_name, char *service_description) {
+	return json_selectors;
+}
+
+json_object *json_status_commentcount(unsigned format_options, int time_field,
+                                      time_t start_time, time_t end_time, unsigned comment_types,
+                                      unsigned entry_types, unsigned persistence, unsigned expiring,
+                                      char *host_name, char *service_description)
+{
 
 	json_object *json_data;
 	comment *temp_comment;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_comment_selectors(format_options, 0, 0, time_field, 
-			start_time, end_time, comment_types, entry_types, persistence,
-			expiring, host_name, service_description));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_comment_selectors(format_options, 0, 0, time_field,
+	                                  start_time, end_time, comment_types, entry_types, persistence,
+	                                  expiring, host_name, service_description));
 
-	for(temp_comment = comment_list; temp_comment != NULL; 
-			temp_comment = temp_comment->next) {
-		if(json_status_comment_passes_selection(temp_comment, time_field, 
-				start_time, end_time, comment_types, entry_types,
-				persistence, expiring, host_name, service_description) == 0) {
+	for(temp_comment = comment_list; temp_comment != NULL;
+	    temp_comment = temp_comment->next) {
+		if(json_status_comment_passes_selection(temp_comment, time_field,
+		                                        start_time, end_time, comment_types, entry_types,
+		                                        persistence, expiring, host_name, service_description) == 0) {
 			continue;
-			}
-		count++;
 		}
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_status_commentlist(unsigned format_options, int start, 
-		int count, int details, int time_field, time_t start_time, 
-		time_t end_time, unsigned comment_types, unsigned entry_types,
-		unsigned persistence, unsigned expiring, char *host_name,
-		char *service_description) {
+json_object *json_status_commentlist(unsigned format_options, int start,
+                                     int count, int details, int time_field, time_t start_time,
+                                     time_t end_time, unsigned comment_types, unsigned entry_types,
+                                     unsigned persistence, unsigned expiring, char *host_name,
+                                     char *service_description)
+{
 
 	json_object *json_data;
 	json_object *json_commentlist_object = NULL;
@@ -3772,227 +3829,225 @@ json_object *json_status_commentlist(unsigned format_options, int start,
 	char *buf;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_comment_selectors(format_options, start, count, 
-			time_field, start_time, end_time, comment_types, entry_types,
-			persistence, expiring, host_name, service_description));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_comment_selectors(format_options, start, count,
+	                                  time_field, start_time, end_time, comment_types, entry_types,
+	                                  persistence, expiring, host_name, service_description));
 
 	if(details > 0) {
 		json_commentlist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_commentlist_array = json_new_array();
-		}
+	}
 
-	for(temp_comment = comment_list; temp_comment != NULL; 
-			temp_comment = temp_comment->next) {
+	for(temp_comment = comment_list; temp_comment != NULL;
+	    temp_comment = temp_comment->next) {
 
-		if(json_status_comment_passes_selection(temp_comment, time_field, 
-				start_time, end_time, comment_types, entry_types,
-				persistence, expiring, host_name, service_description) == 0) {
+		if(json_status_comment_passes_selection(temp_comment, time_field,
+		                                        start_time, end_time, comment_types, entry_types,
+		                                        persistence, expiring, host_name, service_description) == 0) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				asprintf(&buf, "%lu", temp_comment->comment_id);
 				json_comment_details = json_new_object();
-				json_status_comment_details(json_comment_details, format_options, 
-						temp_comment);
+				json_status_comment_details(json_comment_details, format_options,
+				                            temp_comment);
 				json_object_append_object(json_commentlist_object, buf,
-						json_comment_details);
-				}
-			else {
-				json_array_append_integer(json_commentlist_array, 
-						temp_comment->comment_id); 
-				}
-			counted++;
+				                          json_comment_details);
+			} else {
+				json_array_append_integer(json_commentlist_array,
+				                          temp_comment->comment_id);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "commentlist", 
-				json_commentlist_object);
-		}
-	else {
-		json_object_append_array(json_data, "commentlist", 
-				json_commentlist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object *json_status_comment(unsigned format_options, comment *temp_comment) {
+	if(details > 0) {
+		json_object_append_object(json_data, "commentlist",
+		                          json_commentlist_object);
+	} else {
+		json_object_append_array(json_data, "commentlist",
+		                         json_commentlist_array);
+	}
+
+	return json_data;
+}
+
+json_object *json_status_comment(unsigned format_options, comment *temp_comment)
+{
 
 	json_object *json_comment = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_integer(json_details, "comment_id", 
-			temp_comment->comment_id);
-	json_status_comment_details(json_details, format_options, temp_comment); 
+	json_object_append_integer(json_details, "comment_id",
+	                           temp_comment->comment_id);
+	json_status_comment_details(json_details, format_options, temp_comment);
 	json_object_append_object(json_comment, "comment", json_details);
 
 	return json_comment;
-	}
+}
 
-void json_status_comment_details(json_object *json_details, 
-		unsigned format_options, comment *temp_comment) {
+void json_status_comment_details(json_object *json_details,
+                                 unsigned format_options, comment *temp_comment)
+{
 
-	json_object_append_integer(json_details, "comment_id", 
-			temp_comment->comment_id);
+	json_object_append_integer(json_details, "comment_id",
+	                           temp_comment->comment_id);
 	json_enumeration(json_details, format_options, "comment_type",
-			temp_comment->comment_type, svm_comment_types);
+	                 temp_comment->comment_type, svm_comment_types);
 	json_enumeration(json_details, format_options, "entry_type",
-			temp_comment->entry_type, svm_comment_entry_types);
+	                 temp_comment->entry_type, svm_comment_entry_types);
 	json_object_append_integer(json_details,  "source", temp_comment->source);
-	json_object_append_boolean(json_details, "persistent", 
-			temp_comment->persistent);
-	json_object_append_time_t(json_details, "entry_time", 
-			temp_comment->entry_time);
+	json_object_append_boolean(json_details, "persistent",
+	                           temp_comment->persistent);
+	json_object_append_time_t(json_details, "entry_time",
+	                          temp_comment->entry_time);
 	json_object_append_boolean(json_details, "expires", temp_comment->expires);
-	json_object_append_time_t(json_details, "expire_time", 
-			temp_comment->expire_time);
+	json_object_append_time_t(json_details, "expire_time",
+	                          temp_comment->expire_time);
 	json_object_append_string(json_details, "host_name", temp_comment->host_name);
 	if(SERVICE_COMMENT == temp_comment->comment_type) {
-		json_object_append_string(json_details,  "service_description", 
-				temp_comment->service_description);
-		}
-	json_object_append_string(json_details,  "author", temp_comment->author);
-	json_object_append_string(json_details,  "comment_data", 
-			temp_comment->comment_data);
+		json_object_append_string(json_details,  "service_description",
+		                          temp_comment->service_description);
 	}
+	json_object_append_string(json_details,  "author", temp_comment->author);
+	json_object_append_string(json_details,  "comment_data",
+	                          temp_comment->comment_data);
+}
 
-int json_status_downtime_passes_selection(scheduled_downtime *temp_downtime, 
-		int time_field, time_t start_time, time_t end_time, 
-		unsigned object_types, unsigned downtime_types, unsigned triggered,
-		int triggered_by, unsigned in_effect, char *host_name,
-		char *service_description) {
+int json_status_downtime_passes_selection(scheduled_downtime *temp_downtime,
+        int time_field, time_t start_time, time_t end_time,
+        unsigned object_types, unsigned downtime_types, unsigned triggered,
+        int triggered_by, unsigned in_effect, char *host_name,
+        char *service_description)
+{
 
 	switch(time_field) {
-	case STATUS_TIME_INVALID: 
+	case STATUS_TIME_INVALID:
 		break;
 	case STATUS_TIME_ENTRY_TIME:
 		if((start_time > 0) && (temp_downtime->entry_time < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_downtime->entry_time > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_START_TIME:
 		if((start_time > 0) && (temp_downtime->start_time < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_downtime->start_time > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_FLEX_DOWNTIME_START:
-		if((start_time > 0) && (temp_downtime->flex_downtime_start < 
-					start_time)) {
+		if((start_time > 0) && (temp_downtime->flex_downtime_start <
+		                        start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_downtime->flex_downtime_start > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	case STATUS_TIME_END_TIME:
 		if((start_time > 0) && (temp_downtime->end_time < start_time)) {
 			return 0;
-			}
+		}
 		if((end_time > 0) && (temp_downtime->end_time > end_time)) {
 			return 0;
-			}
+		}
 		break;
 	default:
 		return 0;
-		}
+	}
 
 	if(object_types != DOWNTIME_OBJECT_TYPE_ALL) {
 		switch(temp_downtime->type) {
 		case HOST_DOWNTIME:
 			if(!(object_types & DOWNTIME_OBJECT_TYPE_HOST)) {
 				return 0;
-				}
+			}
 			break;
 		case SERVICE_DOWNTIME:
 			if(!(object_types & DOWNTIME_OBJECT_TYPE_SERVICE)) {
 				return 0;
-				}
-			break;
 			}
+			break;
 		}
+	}
 
 	if(downtime_types != DOWNTIME_TYPE_ALL) {
 		if(temp_downtime->fixed) {
 			if(!(downtime_types & DOWNTIME_TYPE_FIXED)) {
 				return 0;
-				}
 			}
-		else {
+		} else {
 			if(!(downtime_types & DOWNTIME_TYPE_FLEXIBLE)) {
 				return 0;
-				}
 			}
 		}
+	}
 
 	if(triggered != BOOLEAN_EITHER) {
 		if(0 == temp_downtime->triggered_by) {
 			if(!(triggered & BOOLEAN_FALSE)) {
 				return 0;
-				}
 			}
-		else {
+		} else {
 			if(!(triggered & BOOLEAN_TRUE)) {
 				return 0;
-				}
 			}
 		}
+	}
 
 	if(triggered_by != -1) {
 		if(temp_downtime->triggered_by != (unsigned long)triggered_by) {
 			return 0;
-			}
 		}
+	}
 
 	if(in_effect != BOOLEAN_EITHER) {
 		if(0 == temp_downtime->is_in_effect) {
 			if(!(in_effect & BOOLEAN_FALSE)) {
 				return 0;
-				}
 			}
-		else {
+		} else {
 			if(!(in_effect & BOOLEAN_TRUE)) {
 				return 0;
-				}
 			}
 		}
+	}
 
 	if(NULL != host_name) {
 		if((NULL == temp_downtime->host_name) ||
-				strcmp(temp_downtime->host_name, host_name)) {
+		   strcmp(temp_downtime->host_name, host_name)) {
 			return 0;
-			}
 		}
+	}
 
 	if(NULL != service_description) {
 		if((NULL == temp_downtime->service_description) ||
-				strcmp(temp_downtime->service_description,
-				service_description)) {
+		   strcmp(temp_downtime->service_description,
+		          service_description)) {
 			return 0;
-			}
 		}
-
-	return 1;
 	}
 
-json_object *json_status_downtime_selectors(unsigned format_options, int start, 
-		int count, int time_field, time_t start_time, time_t end_time,
-		unsigned object_types, unsigned downtime_types, unsigned triggered,
-		int triggered_by, unsigned in_effect, char *host_name,
-		char *service_description) {
+	return 1;
+}
+
+json_object *json_status_downtime_selectors(unsigned format_options, int start,
+        int count, int time_field, time_t start_time, time_t end_time,
+        unsigned object_types, unsigned downtime_types, unsigned triggered,
+        int triggered_by, unsigned in_effect, char *host_name,
+        char *service_description)
+{
 
 	json_object *json_selectors;
 
@@ -4000,86 +4055,88 @@ json_object *json_status_downtime_selectors(unsigned format_options, int start,
 
 	if( start > 0) {
 		json_object_append_integer(json_selectors, "start", start);
-		}
+	}
 	if( count > 0) {
 		json_object_append_integer(json_selectors, "count", count);
-		}
+	}
 	if(time_field > 0) {
-		json_enumeration(json_selectors, format_options, "downtimetimefield", 
-				time_field, svm_downtime_time_fields);
-		}
+		json_enumeration(json_selectors, format_options, "downtimetimefield",
+		                 time_field, svm_downtime_time_fields);
+	}
 	if(start_time > 0) {
 		json_object_append_time_t(json_selectors, "starttime", start_time);
-		}
+	}
 	if(end_time > 0) {
 		json_object_append_time_t(json_selectors, "endtime", end_time);
-		}
+	}
 	if(object_types != DOWNTIME_OBJECT_TYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "downtimeobjecttypes", 
-				object_types, svm_valid_downtime_object_types);
-		}
+		json_bitmask(json_selectors, format_options, "downtimeobjecttypes",
+		             object_types, svm_valid_downtime_object_types);
+	}
 	if(downtime_types != DOWNTIME_TYPE_ALL) {
-		json_bitmask(json_selectors, format_options, "downtimetypes", 
-				downtime_types, svm_valid_downtime_types);
-		}
+		json_bitmask(json_selectors, format_options, "downtimetypes",
+		             downtime_types, svm_valid_downtime_types);
+	}
 	if(triggered != BOOLEAN_EITHER) {
-		json_bitmask(json_selectors, format_options, "triggered", 
-				triggered, svm_valid_triggered_status);
-		}
+		json_bitmask(json_selectors, format_options, "triggered",
+		             triggered, svm_valid_triggered_status);
+	}
 	if(triggered_by != -1) {
 		json_object_append_integer(json_selectors, "triggeredby", triggered_by);
-		}
+	}
 	if(in_effect != BOOLEAN_EITHER) {
-		json_bitmask(json_selectors, format_options, "ineffect", 
-				in_effect, svm_valid_in_effect_status);
-		}
+		json_bitmask(json_selectors, format_options, "ineffect",
+		             in_effect, svm_valid_in_effect_status);
+	}
 	if(NULL != host_name) {
 		json_object_append_string(json_selectors, "hostname", host_name);
-		}
+	}
 	if(NULL != service_description) {
-		json_object_append_string(json_selectors, "servicedescription", 
-				service_description);
-		}
-
-	return json_selectors;
+		json_object_append_string(json_selectors, "servicedescription",
+		                          service_description);
 	}
 
-json_object *json_status_downtimecount(unsigned format_options, int time_field, 
-		time_t start_time, time_t end_time, unsigned object_types,
-		unsigned downtime_types, unsigned triggered, int triggered_by,
-		unsigned in_effect, char *host_name, char *service_description) {
+	return json_selectors;
+}
+
+json_object *json_status_downtimecount(unsigned format_options, int time_field,
+                                       time_t start_time, time_t end_time, unsigned object_types,
+                                       unsigned downtime_types, unsigned triggered, int triggered_by,
+                                       unsigned in_effect, char *host_name, char *service_description)
+{
 
 	json_object *json_data;
 	scheduled_downtime *temp_downtime;
 	int count = 0;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_downtime_selectors(format_options, 0, 0, time_field, 
-			start_time, end_time, object_types, downtime_types, triggered,
-			triggered_by, in_effect, host_name, service_description));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_downtime_selectors(format_options, 0, 0, time_field,
+	                                  start_time, end_time, object_types, downtime_types, triggered,
+	                                  triggered_by, in_effect, host_name, service_description));
 
-	for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; 
-			temp_downtime = temp_downtime->next) {
-		if(!json_status_downtime_passes_selection(temp_downtime, time_field, 
-				start_time, end_time, object_types, downtime_types,
-				triggered, triggered_by, in_effect, host_name,
-				service_description)) {
+	for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL;
+	    temp_downtime = temp_downtime->next) {
+		if(!json_status_downtime_passes_selection(temp_downtime, time_field,
+		        start_time, end_time, object_types, downtime_types,
+		        triggered, triggered_by, in_effect, host_name,
+		        service_description)) {
 			continue;
-			}
-		count++;
 		}
+		count++;
+	}
 
 	json_object_append_integer(json_data, "count", count);
 
 	return json_data;
-	}
+}
 
-json_object *json_status_downtimelist(unsigned format_options, int start, 
-		int count, int details, int time_field, time_t start_time, 
-		time_t end_time, unsigned object_types, unsigned downtime_types,
-		unsigned triggered, int triggered_by, unsigned in_effect,
-		char *host_name, char *service_description) {
+json_object *json_status_downtimelist(unsigned format_options, int start,
+                                      int count, int details, int time_field, time_t start_time,
+                                      time_t end_time, unsigned object_types, unsigned downtime_types,
+                                      unsigned triggered, int triggered_by, unsigned in_effect,
+                                      char *host_name, char *service_description)
+{
 
 	json_object *json_data;
 	json_object *json_downtimelist_object = NULL;
@@ -4091,108 +4148,108 @@ json_object *json_status_downtimelist(unsigned format_options, int start,
 	char *buf;
 
 	json_data = json_new_object();
-	json_object_append_object(json_data, "selectors", 
-			json_status_downtime_selectors(format_options, start, count, 
-			time_field, start_time, end_time, object_types, downtime_types,
-			triggered, triggered_by, in_effect, host_name,
-			service_description));
+	json_object_append_object(json_data, "selectors",
+	                          json_status_downtime_selectors(format_options, start, count,
+	                                  time_field, start_time, end_time, object_types, downtime_types,
+	                                  triggered, triggered_by, in_effect, host_name,
+	                                  service_description));
 
 	if(details > 0) {
 		json_downtimelist_object = json_new_object();
-		}
-	else {
+	} else {
 		json_downtimelist_array = json_new_array();
-		}
+	}
 
-	for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; 
-			temp_downtime = temp_downtime->next) {
+	for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL;
+	    temp_downtime = temp_downtime->next) {
 
-		if(!json_status_downtime_passes_selection(temp_downtime, time_field, 
-				start_time, end_time, object_types, downtime_types,
-				triggered, triggered_by, in_effect, host_name,
-				service_description)) {
+		if(!json_status_downtime_passes_selection(temp_downtime, time_field,
+		        start_time, end_time, object_types, downtime_types,
+		        triggered, triggered_by, in_effect, host_name,
+		        service_description)) {
 			continue;
-			}
+		}
 
 		/* If the current item passes the start and limit tests, display it */
 		if( passes_start_and_count_limits(start, count, current, counted)) {
 			if( details > 0) {
 				asprintf(&buf, "%lu", temp_downtime->downtime_id);
 				json_downtime_details = json_new_object();
-				json_status_downtime_details(json_downtime_details, 
-						format_options, temp_downtime);
-				json_object_append_object(json_downtimelist_object, buf, 
-						json_downtime_details);
-				}
-			else {
-				json_array_append_integer(json_downtimelist_array, 
-						temp_downtime->downtime_id); 
-				}
-			counted++;
+				json_status_downtime_details(json_downtime_details,
+				                             format_options, temp_downtime);
+				json_object_append_object(json_downtimelist_object, buf,
+				                          json_downtime_details);
+			} else {
+				json_array_append_integer(json_downtimelist_array,
+				                          temp_downtime->downtime_id);
 			}
-		current++; 
+			counted++;
 		}
-
-	if(details > 0) {
-		json_object_append_object(json_data, "downtimelist", 
-				json_downtimelist_object);
-		}
-	else {
-		json_object_append_array(json_data, "downtimelist", 
-				json_downtimelist_array);
-		}
-
-	return json_data;
+		current++;
 	}
 
-json_object *json_status_downtime(unsigned format_options, 
-		scheduled_downtime *temp_downtime) {
+	if(details > 0) {
+		json_object_append_object(json_data, "downtimelist",
+		                          json_downtimelist_object);
+	} else {
+		json_object_append_array(json_data, "downtimelist",
+		                         json_downtimelist_array);
+	}
+
+	return json_data;
+}
+
+json_object *json_status_downtime(unsigned format_options,
+                                  scheduled_downtime *temp_downtime)
+{
 
 	json_object *json_downtime = json_new_object();
 	json_object *json_details = json_new_object();
 
-	json_object_append_integer(json_details, "downtime_id", 
-			temp_downtime->downtime_id);
-	json_status_downtime_details(json_details, format_options, temp_downtime); 
+	json_object_append_integer(json_details, "downtime_id",
+	                           temp_downtime->downtime_id);
+	json_status_downtime_details(json_details, format_options, temp_downtime);
 	json_object_append_object(json_downtime, "downtime", json_details);
 
 	return json_downtime;
-	}
+}
 
-void json_status_downtime_details(json_object *json_details, 
-		unsigned format_options, scheduled_downtime *temp_downtime) {
+void json_status_downtime_details(json_object *json_details,
+                                  unsigned format_options, scheduled_downtime *temp_downtime)
+{
 
-	json_object_append_integer(json_details, "downtime_id", 
-			temp_downtime->downtime_id);
-	json_enumeration(json_details, format_options, "type", temp_downtime->type, 
-			svm_downtime_types);
-	json_object_append_string(json_details, "host_name", 
-			temp_downtime->host_name);
+	json_object_append_integer(json_details, "downtime_id",
+	                           temp_downtime->downtime_id);
+	json_enumeration(json_details, format_options, "type", temp_downtime->type,
+	                 svm_downtime_types);
+	json_object_append_string(json_details, "host_name",
+	                          temp_downtime->host_name);
 	if(SERVICE_DOWNTIME == temp_downtime->type) {
-		json_object_append_string(json_details, "service_description", 
-				temp_downtime->service_description);
-		}
-	json_object_append_time_t(json_details, "entry_time", 
-			temp_downtime->entry_time);
-	json_object_append_time_t(json_details, "start_time", 
-			temp_downtime->start_time);
-	json_object_append_time_t(json_details, "flex_downtime_start", 
-			temp_downtime->flex_downtime_start);
+		json_object_append_string(json_details, "service_description",
+		                          temp_downtime->service_description);
+	}
+	json_object_append_time_t(json_details, "entry_time",
+	                          temp_downtime->entry_time);
+	json_object_append_time_t(json_details, "start_time",
+	                          temp_downtime->start_time);
+	json_object_append_time_t(json_details, "flex_downtime_start",
+	                          temp_downtime->flex_downtime_start);
 	json_object_append_time_t(json_details, "end_time", temp_downtime->end_time);
 	json_object_append_boolean(json_details, "fixed", temp_downtime->fixed);
-	json_object_append_integer(json_details, "triggered_by", 
-			(int)temp_downtime->triggered_by);
-	json_object_append_integer(json_details, "duration", 
-			(int)temp_downtime->duration);
-	json_object_append_boolean(json_details, "is_in_effect", 
-			temp_downtime->is_in_effect);
-	json_object_append_boolean(json_details, "start_notification_sent", 
-			temp_downtime->start_notification_sent);
+	json_object_append_integer(json_details, "triggered_by",
+	                           (int)temp_downtime->triggered_by);
+	json_object_append_integer(json_details, "duration",
+	                           (int)temp_downtime->duration);
+	json_object_append_boolean(json_details, "is_in_effect",
+	                           temp_downtime->is_in_effect);
+	json_object_append_boolean(json_details, "start_notification_sent",
+	                           temp_downtime->start_notification_sent);
 	json_object_append_string(json_details, "author", temp_downtime->author);
 	json_object_append_string(json_details, "comment", temp_downtime->comment);
-	}
+}
 
-json_object *json_status_program(unsigned format_options) {
+json_object *json_status_program(unsigned format_options)
+{
 
 	json_object *json_data;
 	json_object *json_status;
@@ -4202,131 +4259,132 @@ json_object *json_status_program(unsigned format_options) {
 	json_status = json_new_object();
 
 #if 0
-	json_object_append_unsigned(json_status, "modified_host_attributes", 
-			(unsigned long long)modified_host_process_attributes);
-	json_object_append_unsigned(json_status, 
-			"modified_service_process_attributes", 
-			(unsigned long long)modified_service_process_attributes);
+	json_object_append_unsigned(json_status, "modified_host_attributes",
+	                            (unsigned long long)modified_host_process_attributes);
+	json_object_append_unsigned(json_status,
+	                            "modified_service_process_attributes",
+	                            (unsigned long long)modified_service_process_attributes);
 #endif
 	json_object_append_string(json_status, "version", PROGRAM_VERSION);
 	json_object_append_integer(json_status, "nagios_pid", nagios_pid);
 	json_object_append_boolean(json_status, "daemon_mode", daemon_mode);
 	json_object_append_time_t(json_status, "program_start", program_start);
 #ifndef JSON_NAGIOS_4X
-	json_object_append_time_t(json_status, "last_command_check", 
-			last_command_check);
+	json_object_append_time_t(json_status, "last_command_check",
+	                          last_command_check);
 #endif
-	json_object_append_time_t(json_status, "last_log_rotation", 
-			last_log_rotation);
-	json_object_append_boolean(json_status, "enable_notifications", 
-			enable_notifications);
-	json_object_append_boolean(json_status, "execute_service_checks", 
-			execute_service_checks);
-	json_object_append_boolean(json_status, "accept_passive_service_checks", 
-			accept_passive_service_checks);
-	json_object_append_boolean(json_status, "execute_host_checks", 
-			execute_host_checks);
-	json_object_append_boolean(json_status, "accept_passive_host_checks", 
-			accept_passive_host_checks);
-	json_object_append_boolean(json_status, "enable_event_handlers", 
-			enable_event_handlers);
-	json_object_append_boolean(json_status, "obsess_over_services", 
-			obsess_over_services);
-	json_object_append_boolean(json_status, "obsess_over_hosts", 
-			obsess_over_hosts);
-	json_object_append_boolean(json_status, "check_service_freshness", 
-			check_service_freshness);
-	json_object_append_boolean(json_status, "check_host_freshness", 
-			check_host_freshness);
-	json_object_append_boolean(json_status, "enable_flap_detection", 
-			enable_flap_detection);
+	json_object_append_time_t(json_status, "last_log_rotation",
+	                          last_log_rotation);
+	json_object_append_boolean(json_status, "enable_notifications",
+	                           enable_notifications);
+	json_object_append_boolean(json_status, "execute_service_checks",
+	                           execute_service_checks);
+	json_object_append_boolean(json_status, "accept_passive_service_checks",
+	                           accept_passive_service_checks);
+	json_object_append_boolean(json_status, "execute_host_checks",
+	                           execute_host_checks);
+	json_object_append_boolean(json_status, "accept_passive_host_checks",
+	                           accept_passive_host_checks);
+	json_object_append_boolean(json_status, "enable_event_handlers",
+	                           enable_event_handlers);
+	json_object_append_boolean(json_status, "obsess_over_services",
+	                           obsess_over_services);
+	json_object_append_boolean(json_status, "obsess_over_hosts",
+	                           obsess_over_hosts);
+	json_object_append_boolean(json_status, "check_service_freshness",
+	                           check_service_freshness);
+	json_object_append_boolean(json_status, "check_host_freshness",
+	                           check_host_freshness);
+	json_object_append_boolean(json_status, "enable_flap_detection",
+	                           enable_flap_detection);
 #ifndef JSON_NAGIOS_4X
-	json_object_append_boolean(json_status, "enable_failure_prediction", 
-			enable_failure_prediction);
+	json_object_append_boolean(json_status, "enable_failure_prediction",
+	                           enable_failure_prediction);
 #endif
-	json_object_append_boolean(json_status, "process_performance_data", 
-			process_performance_data);
+	json_object_append_boolean(json_status, "process_performance_data",
+	                           process_performance_data);
 #if 0
-	json_object_append_string(json_status, "global_host_event_handler", 
-			global_host_event_handler);
-	json_object_append_string(json_status, "global_service_event_handler", 
-			global_service_event_handler);
-	json_object_append_unsigned(json_status, "next_comment_id", 
-			(unsigned long long)next_comment_id);
-	json_object_append_unsigned(json_status, "next_downtime_id", 
-			(unsigned long long)next_downtime_id);
-	json_object_append_unsigned(json_status, "next_event_id", 
-			(unsigned long long)next_event_id);
-	json_object_append_unsigned(json_status, "next_problem_id", 
-			(unsigned long long)next_problem_id);
-	json_object_append_unsigned(json_status, "next_notification_id", 
-			(unsigned long long)next_notification_id);
-	json_object_append_unsigned(json_status, 
-			"total_external_command_buffer_slots",
-			(unsigned long long)external_command_buffer_slots);
+	json_object_append_string(json_status, "global_host_event_handler",
+	                          global_host_event_handler);
+	json_object_append_string(json_status, "global_service_event_handler",
+	                          global_service_event_handler);
+	json_object_append_unsigned(json_status, "next_comment_id",
+	                            (unsigned long long)next_comment_id);
+	json_object_append_unsigned(json_status, "next_downtime_id",
+	                            (unsigned long long)next_downtime_id);
+	json_object_append_unsigned(json_status, "next_event_id",
+	                            (unsigned long long)next_event_id);
+	json_object_append_unsigned(json_status, "next_problem_id",
+	                            (unsigned long long)next_problem_id);
+	json_object_append_unsigned(json_status, "next_notification_id",
+	                            (unsigned long long)next_notification_id);
+	json_object_append_unsigned(json_status,
+	                            "total_external_command_buffer_slots",
+	                            (unsigned long long)external_command_buffer_slots);
 	json_object_append_unsigned(json_status, "used_external_command_buffer_slots",
-			(unsigned long long)used_external_command_buffer_slots);
+	                            (unsigned long long)used_external_command_buffer_slots);
 	json_object_append_unsigned(json_status, "high_external_command_buffer_slots",
-			(unsigned long long)high_external_command_buffer_slots);
-	json_object_append_string(json_status, "active_scheduled_host_check_stats", 
-			"%d,%d,%d", 
-			check_statistics[ACTIVE_SCHEDULED_HOST_CHECK_STATS].minute_stats[0],
-			check_statistics[ACTIVE_SCHEDULED_HOST_CHECK_STATS].minute_stats[1],
-			check_statistics[ACTIVE_SCHEDULED_HOST_CHECK_STATS].minute_stats[2]);
-	json_object_append_string(json_status, "active_ondemand_host_check_stats", 
-			"%d,%d,%d", 
-			check_statistics[ACTIVE_ONDEMAND_HOST_CHECK_STATS].minute_stats[0],
-			check_statistics[ACTIVE_ONDEMAND_HOST_CHECK_STATS].minute_stats[1],
-			check_statistics[ACTIVE_ONDEMAND_HOST_CHECK_STATS].minute_stats[2]);
+	                            (unsigned long long)high_external_command_buffer_slots);
+	json_object_append_string(json_status, "active_scheduled_host_check_stats",
+	                          "%d,%d,%d",
+	                          check_statistics[ACTIVE_SCHEDULED_HOST_CHECK_STATS].minute_stats[0],
+	                          check_statistics[ACTIVE_SCHEDULED_HOST_CHECK_STATS].minute_stats[1],
+	                          check_statistics[ACTIVE_SCHEDULED_HOST_CHECK_STATS].minute_stats[2]);
+	json_object_append_string(json_status, "active_ondemand_host_check_stats",
+	                          "%d,%d,%d",
+	                          check_statistics[ACTIVE_ONDEMAND_HOST_CHECK_STATS].minute_stats[0],
+	                          check_statistics[ACTIVE_ONDEMAND_HOST_CHECK_STATS].minute_stats[1],
+	                          check_statistics[ACTIVE_ONDEMAND_HOST_CHECK_STATS].minute_stats[2]);
 	json_object_append_string(json_status, "passive_host_check_stats", "%d,%d,%d",
-			check_statistics[PASSIVE_HOST_CHECK_STATS].minute_stats[0],
-			check_statistics[PASSIVE_HOST_CHECK_STATS].minute_stats[1],
-			check_statistics[PASSIVE_HOST_CHECK_STATS].minute_stats[2]);
+	                          check_statistics[PASSIVE_HOST_CHECK_STATS].minute_stats[0],
+	                          check_statistics[PASSIVE_HOST_CHECK_STATS].minute_stats[1],
+	                          check_statistics[PASSIVE_HOST_CHECK_STATS].minute_stats[2]);
 	json_object_append_string(json_status, "actine_scheduled_service_check_stats",
-			"%d,%d,%d",
-			check_statistics[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS].minute_stats[0],
-			check_statistics[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS].minute_stats[1],
-			check_statistics[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS].minute_stats[2]);
-	json_object_append_string(json_status, "active_ondemand_service_check_stats", 
-			"%d,%d,%d",
-			check_statistics[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS].minute_stats[0],
-			check_statistics[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS].minute_stats[1],
-			check_statistics[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS].minute_stats[2]);
-	json_object_append_string(json_status, "passive_service_check_stats", 
-			"%d,%d,%d",
-			check_statistics[PASSIVE_SERVICE_CHECK_STATS].minute_stats[0],
-			check_statistics[PASSIVE_SERVICE_CHECK_STATS].minute_stats[1],
-			check_statistics[PASSIVE_SERVICE_CHECK_STATS].minute_stats[2]);
+	                          "%d,%d,%d",
+	                          check_statistics[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS].minute_stats[0],
+	                          check_statistics[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS].minute_stats[1],
+	                          check_statistics[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS].minute_stats[2]);
+	json_object_append_string(json_status, "active_ondemand_service_check_stats",
+	                          "%d,%d,%d",
+	                          check_statistics[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS].minute_stats[0],
+	                          check_statistics[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS].minute_stats[1],
+	                          check_statistics[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS].minute_stats[2]);
+	json_object_append_string(json_status, "passive_service_check_stats",
+	                          "%d,%d,%d",
+	                          check_statistics[PASSIVE_SERVICE_CHECK_STATS].minute_stats[0],
+	                          check_statistics[PASSIVE_SERVICE_CHECK_STATS].minute_stats[1],
+	                          check_statistics[PASSIVE_SERVICE_CHECK_STATS].minute_stats[2]);
 	json_object_append_string(json_status, "cached_host_check_stats", "%d,%d,%d",
-			check_statistics[ACTIVE_CACHED_HOST_CHECK_STATS].minute_stats[0],
-			check_statistics[ACTIVE_CACHED_HOST_CHECK_STATS].minute_stats[1],
-			check_statistics[ACTIVE_CACHED_HOST_CHECK_STATS].minute_stats[2]);
-	json_object_append_string(json_status, "cached_service_check_stats", 
-			"%d,%d,%d",
-			check_statistics[ACTIVE_CACHED_SERVICE_CHECK_STATS].minute_stats[0],
-			check_statistics[ACTIVE_CACHED_SERVICE_CHECK_STATS].minute_stats[1],
-			check_statistics[ACTIVE_CACHED_SERVICE_CHECK_STATS].minute_stats[2]);
+	                          check_statistics[ACTIVE_CACHED_HOST_CHECK_STATS].minute_stats[0],
+	                          check_statistics[ACTIVE_CACHED_HOST_CHECK_STATS].minute_stats[1],
+	                          check_statistics[ACTIVE_CACHED_HOST_CHECK_STATS].minute_stats[2]);
+	json_object_append_string(json_status, "cached_service_check_stats",
+	                          "%d,%d,%d",
+	                          check_statistics[ACTIVE_CACHED_SERVICE_CHECK_STATS].minute_stats[0],
+	                          check_statistics[ACTIVE_CACHED_SERVICE_CHECK_STATS].minute_stats[1],
+	                          check_statistics[ACTIVE_CACHED_SERVICE_CHECK_STATS].minute_stats[2]);
 	json_object_append_string(json_status, "external_command_stats", "%d,%d,%d",
-			check_statistics[EXTERNAL_COMMAND_STATS].minute_stats[0],
-			check_statistics[EXTERNAL_COMMAND_STATS].minute_stats[1],
-			check_statistics[EXTERNAL_COMMAND_STATS].minute_stats[2]);
-	json_object_append_string(json_status, "parallel_host_check_stats", 
-			"%d,%d,%d",
-			check_statistics[PARALLEL_HOST_CHECK_STATS].minute_stats[0],
-			check_statistics[PARALLEL_HOST_CHECK_STATS].minute_stats[1],
-			check_statistics[PARALLEL_HOST_CHECK_STATS].minute_stats[2]);
+	                          check_statistics[EXTERNAL_COMMAND_STATS].minute_stats[0],
+	                          check_statistics[EXTERNAL_COMMAND_STATS].minute_stats[1],
+	                          check_statistics[EXTERNAL_COMMAND_STATS].minute_stats[2]);
+	json_object_append_string(json_status, "parallel_host_check_stats",
+	                          "%d,%d,%d",
+	                          check_statistics[PARALLEL_HOST_CHECK_STATS].minute_stats[0],
+	                          check_statistics[PARALLEL_HOST_CHECK_STATS].minute_stats[1],
+	                          check_statistics[PARALLEL_HOST_CHECK_STATS].minute_stats[2]);
 	json_object_append_string(json_status, "serial_host_check_stats", "%d,%d,%d",
-			check_statistics[SERIAL_HOST_CHECK_STATS].minute_stats[0],
-			check_statistics[SERIAL_HOST_CHECK_STATS].minute_stats[1],
-			check_statistics[SERIAL_HOST_CHECK_STATS].minute_stats[2]);
+	                          check_statistics[SERIAL_HOST_CHECK_STATS].minute_stats[0],
+	                          check_statistics[SERIAL_HOST_CHECK_STATS].minute_stats[1],
+	                          check_statistics[SERIAL_HOST_CHECK_STATS].minute_stats[2]);
 #endif
 
 	json_object_append_object(json_data, "programstatus", json_status);
 
 	return json_data;
-	}
+}
 
-json_object *json_status_performance(void) { 
+json_object *json_status_performance(void)
+{
 
 	service *temp_service = NULL;
 	servicestatus *temp_servicestatus = NULL;
@@ -4417,21 +4475,21 @@ json_object *json_status_performance(void) {
 	time(&current_time);
 
 	/* check all services */
-	for(temp_servicestatus = servicestatus_list; temp_servicestatus != NULL; 
-			temp_servicestatus = temp_servicestatus->next) {
+	for(temp_servicestatus = servicestatus_list; temp_servicestatus != NULL;
+	    temp_servicestatus = temp_servicestatus->next) {
 
 		/* find the service */
-		temp_service = find_service(temp_servicestatus->host_name, 
-				temp_servicestatus->description);
+		temp_service = find_service(temp_servicestatus->host_name,
+		                            temp_servicestatus->description);
 		if(NULL == temp_service) {
 			continue;
-			}
+		}
 
 		/* make sure the user has rights to view service information */
-		if(FALSE == is_authorized_for_service(temp_service, 
-				&current_authdata)) {
+		if(FALSE == is_authorized_for_service(temp_service,
+		                                      &current_authdata)) {
 			continue;
-			}
+		}
 
 		/* is this an active or passive check? */
 		if(SERVICE_CHECK_ACTIVE == temp_servicestatus->check_type) {
@@ -4439,47 +4497,47 @@ json_object *json_status_performance(void) {
 			total_active_service_checks++;
 
 			total_service_execution_time += temp_servicestatus->execution_time;
-			if(have_min_service_execution_time == FALSE || 
-					temp_servicestatus->execution_time < 
-					min_service_execution_time) {
+			if(have_min_service_execution_time == FALSE ||
+			   temp_servicestatus->execution_time <
+			   min_service_execution_time) {
 				have_min_service_execution_time = TRUE;
 				min_service_execution_time = temp_servicestatus->execution_time;
-				}
-			if(have_max_service_execution_time == FALSE || 
-					temp_servicestatus->execution_time > 
-					max_service_execution_time) {
+			}
+			if(have_max_service_execution_time == FALSE ||
+			   temp_servicestatus->execution_time >
+			   max_service_execution_time) {
 				have_max_service_execution_time = TRUE;
 				max_service_execution_time = temp_servicestatus->execution_time;
-				}
+			}
 
-			total_service_percent_change_a += 
-					temp_servicestatus->percent_state_change;
-			if(have_min_service_percent_change_a == FALSE || 
-					temp_servicestatus->percent_state_change < 
-					min_service_percent_change_a) {
+			total_service_percent_change_a +=
+			    temp_servicestatus->percent_state_change;
+			if(have_min_service_percent_change_a == FALSE ||
+			   temp_servicestatus->percent_state_change <
+			   min_service_percent_change_a) {
 				have_min_service_percent_change_a = TRUE;
-				min_service_percent_change_a = 
-						temp_servicestatus->percent_state_change;
-				}
-			if(have_max_service_percent_change_a == FALSE || 
-					temp_servicestatus->percent_state_change > 
-					max_service_percent_change_a) {
+				min_service_percent_change_a =
+				    temp_servicestatus->percent_state_change;
+			}
+			if(have_max_service_percent_change_a == FALSE ||
+			   temp_servicestatus->percent_state_change >
+			   max_service_percent_change_a) {
 				have_max_service_percent_change_a = TRUE;
-				max_service_percent_change_a = 
-						temp_servicestatus->percent_state_change;
-				}
+				max_service_percent_change_a =
+				    temp_servicestatus->percent_state_change;
+			}
 
 			total_service_latency += temp_servicestatus->latency;
-			if(have_min_service_latency == FALSE || 
-					temp_servicestatus->latency < min_service_latency) {
+			if(have_min_service_latency == FALSE ||
+			   temp_servicestatus->latency < min_service_latency) {
 				have_min_service_latency = TRUE;
 				min_service_latency = temp_servicestatus->latency;
-				}
-			if(have_max_service_latency == FALSE || 
-					temp_servicestatus->latency > max_service_latency) {
+			}
+			if(have_max_service_latency == FALSE ||
+			   temp_servicestatus->latency > max_service_latency) {
 				have_max_service_latency = TRUE;
 				max_service_latency = temp_servicestatus->latency;
-				}
+			}
 
 			if(temp_servicestatus->last_check >= (current_time - 60))
 				active_service_checks_1min++;
@@ -4493,27 +4551,27 @@ json_object *json_status_performance(void) {
 				active_service_checks_start++;
 			if(temp_servicestatus->last_check != (time_t)0)
 				active_service_checks_ever++;
-			}
+		}
 
 		else {
 			total_passive_service_checks++;
 
-			total_service_percent_change_b += 
-					temp_servicestatus->percent_state_change;
-			if(have_min_service_percent_change_b == FALSE || 
-					temp_servicestatus->percent_state_change < 
-					min_service_percent_change_b) {
+			total_service_percent_change_b +=
+			    temp_servicestatus->percent_state_change;
+			if(have_min_service_percent_change_b == FALSE ||
+			   temp_servicestatus->percent_state_change <
+			   min_service_percent_change_b) {
 				have_min_service_percent_change_b = TRUE;
-				min_service_percent_change_b = 
-						temp_servicestatus->percent_state_change;
-				}
-			if(have_max_service_percent_change_b == FALSE || 
-					temp_servicestatus->percent_state_change > 
-					max_service_percent_change_b) {
+				min_service_percent_change_b =
+				    temp_servicestatus->percent_state_change;
+			}
+			if(have_max_service_percent_change_b == FALSE ||
+			   temp_servicestatus->percent_state_change >
+			   max_service_percent_change_b) {
 				have_max_service_percent_change_b = TRUE;
-				max_service_percent_change_b = 
-						temp_servicestatus->percent_state_change;
-				}
+				max_service_percent_change_b =
+				    temp_servicestatus->percent_state_change;
+			}
 
 			if(temp_servicestatus->last_check >= (current_time - 60))
 				passive_service_checks_1min++;
@@ -4527,23 +4585,23 @@ json_object *json_status_performance(void) {
 				passive_service_checks_start++;
 			if(temp_servicestatus->last_check != (time_t)0)
 				passive_service_checks_ever++;
-			}
 		}
+	}
 
 	/* check all hosts */
-	for(temp_hoststatus = hoststatus_list; temp_hoststatus != NULL; 
-			temp_hoststatus = temp_hoststatus->next) {
+	for(temp_hoststatus = hoststatus_list; temp_hoststatus != NULL;
+	    temp_hoststatus = temp_hoststatus->next) {
 
 		/* find the host */
 		temp_host = find_host(temp_hoststatus->host_name);
 		if(NULL == temp_host) {
 			continue;
-			}
+		}
 
 		/* make sure the user has rights to view host information */
 		if(FALSE == is_authorized_for_host(temp_host, &current_authdata)) {
 			continue;
-			}
+		}
 
 		/* is this an active or passive check? */
 		if(temp_hoststatus->check_type == HOST_CHECK_ACTIVE) {
@@ -4551,45 +4609,45 @@ json_object *json_status_performance(void) {
 			total_active_host_checks++;
 
 			total_host_execution_time += temp_hoststatus->execution_time;
-			if(have_min_host_execution_time == FALSE || 
-					temp_hoststatus->execution_time < min_host_execution_time) {
+			if(have_min_host_execution_time == FALSE ||
+			   temp_hoststatus->execution_time < min_host_execution_time) {
 				have_min_host_execution_time = TRUE;
 				min_host_execution_time = temp_hoststatus->execution_time;
-				}
-			if(have_max_host_execution_time == FALSE || 
-					temp_hoststatus->execution_time > max_host_execution_time) {
+			}
+			if(have_max_host_execution_time == FALSE ||
+			   temp_hoststatus->execution_time > max_host_execution_time) {
 				have_max_host_execution_time = TRUE;
 				max_host_execution_time = temp_hoststatus->execution_time;
-				}
+			}
 
-			total_host_percent_change_a += 
-					temp_hoststatus->percent_state_change;
-			if(have_min_host_percent_change_a == FALSE || 
-					temp_hoststatus->percent_state_change < 
-					min_host_percent_change_a) {
+			total_host_percent_change_a +=
+			    temp_hoststatus->percent_state_change;
+			if(have_min_host_percent_change_a == FALSE ||
+			   temp_hoststatus->percent_state_change <
+			   min_host_percent_change_a) {
 				have_min_host_percent_change_a = TRUE;
-				min_host_percent_change_a = 
-						temp_hoststatus->percent_state_change;
-				}
-			if(have_max_host_percent_change_a == FALSE || 
-					temp_hoststatus->percent_state_change > 
-					max_host_percent_change_a) {
+				min_host_percent_change_a =
+				    temp_hoststatus->percent_state_change;
+			}
+			if(have_max_host_percent_change_a == FALSE ||
+			   temp_hoststatus->percent_state_change >
+			   max_host_percent_change_a) {
 				have_max_host_percent_change_a = TRUE;
-				max_host_percent_change_a = 
-						temp_hoststatus->percent_state_change;
-				}
+				max_host_percent_change_a =
+				    temp_hoststatus->percent_state_change;
+			}
 
 			total_host_latency += temp_hoststatus->latency;
-			if(have_min_host_latency == FALSE || 
-					temp_hoststatus->latency < min_host_latency) {
+			if(have_min_host_latency == FALSE ||
+			   temp_hoststatus->latency < min_host_latency) {
 				have_min_host_latency = TRUE;
 				min_host_latency = temp_hoststatus->latency;
-				}
-			if(have_max_host_latency == FALSE || 
-					temp_hoststatus->latency > max_host_latency) {
+			}
+			if(have_max_host_latency == FALSE ||
+			   temp_hoststatus->latency > max_host_latency) {
 				have_max_host_latency = TRUE;
 				max_host_latency = temp_hoststatus->latency;
-				}
+			}
 
 			if(temp_hoststatus->last_check >= (current_time - 60))
 				active_host_checks_1min++;
@@ -4603,26 +4661,26 @@ json_object *json_status_performance(void) {
 				active_host_checks_start++;
 			if(temp_hoststatus->last_check != (time_t)0)
 				active_host_checks_ever++;
-			}
+		}
 
 		else {
 			total_passive_host_checks++;
 
 			total_host_percent_change_b += temp_hoststatus->percent_state_change;
-			if(have_min_host_percent_change_b == FALSE || 
-					temp_hoststatus->percent_state_change < 
-					min_host_percent_change_b) {
+			if(have_min_host_percent_change_b == FALSE ||
+			   temp_hoststatus->percent_state_change <
+			   min_host_percent_change_b) {
 				have_min_host_percent_change_b = TRUE;
-				min_host_percent_change_b = 
-						temp_hoststatus->percent_state_change;
-				}
-			if(have_max_host_percent_change_b == FALSE || 
-					temp_hoststatus->percent_state_change > 
-					max_host_percent_change_b) {
+				min_host_percent_change_b =
+				    temp_hoststatus->percent_state_change;
+			}
+			if(have_max_host_percent_change_b == FALSE ||
+			   temp_hoststatus->percent_state_change >
+			   max_host_percent_change_b) {
 				have_max_host_percent_change_b = TRUE;
-				max_host_percent_change_b = 
-						temp_hoststatus->percent_state_change;
-				}
+				max_host_percent_change_b =
+				    temp_hoststatus->percent_state_change;
+			}
 
 			if(temp_hoststatus->last_check >= (current_time - 60))
 				passive_host_checks_1min++;
@@ -4636,22 +4694,22 @@ json_object *json_status_performance(void) {
 				passive_host_checks_start++;
 			if(temp_hoststatus->last_check != (time_t)0)
 				passive_host_checks_ever++;
-			}
 		}
+	}
 
 	/* Avoid divide by zero errors */
 	if(0 == total_active_service_checks) {
 		total_active_service_checks = 1;
-		}
+	}
 	if(0 == total_passive_service_checks) {
 		total_passive_service_checks = 1;
-		}
+	}
 	if(0 == total_active_host_checks) {
 		total_active_host_checks = 1;
-		}
+	}
 	if(0 == total_passive_host_checks) {
 		total_passive_host_checks = 1;
-		}
+	}
 
 	json_data = json_new_object();
 
@@ -4678,22 +4736,22 @@ json_object *json_status_performance(void) {
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_service_execution_time);
 	json_object_append_real(json_temp, "max", max_service_execution_time);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_service_execution_time / (double)total_active_service_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_service_execution_time / (double)total_active_service_checks));
 	json_object_append_object(json_metrics, "check_execution_time", json_temp);
 
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_service_latency);
 	json_object_append_real(json_temp, "max", max_service_latency);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_service_latency / (double)total_active_service_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_service_latency / (double)total_active_service_checks));
 	json_object_append_object(json_metrics, "check_latency", json_temp);
 
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_service_percent_change_a);
 	json_object_append_real(json_temp, "max", max_service_percent_change_a);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_service_percent_change_a / (double)total_active_service_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_service_percent_change_a / (double)total_active_service_checks));
 	json_object_append_object(json_metrics, "percent_state_change", json_temp);
 
 	json_object_append_object(json_active, "metrics", json_metrics);
@@ -4707,12 +4765,12 @@ json_object *json_status_performance(void) {
 	json_checks = json_new_object();
 	json_object_append_integer(json_checks, "1min", passive_service_checks_1min);
 	json_object_append_integer(json_checks, "5min", passive_service_checks_5min);
-	json_object_append_integer(json_checks, "15min", 
-			passive_service_checks_15min);
-	json_object_append_integer(json_checks, "1hour", 
-			passive_service_checks_1hour);
-	json_object_append_integer(json_checks, "start", 
-			passive_service_checks_start);
+	json_object_append_integer(json_checks, "15min",
+	                           passive_service_checks_15min);
+	json_object_append_integer(json_checks, "1hour",
+	                           passive_service_checks_1hour);
+	json_object_append_integer(json_checks, "start",
+	                           passive_service_checks_start);
 	json_object_append_object(json_passive, "checks", json_checks);
 
 	json_metrics = json_new_object();
@@ -4720,16 +4778,16 @@ json_object *json_status_performance(void) {
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_service_percent_change_b);
 	json_object_append_real(json_temp, "max", max_service_percent_change_b);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_service_percent_change_b / (double)total_active_service_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_service_percent_change_b / (double)total_active_service_checks));
 	json_object_append_object(json_metrics, "percent_state_change", json_temp);
 
 	json_object_append_object(json_passive, "metrics", json_metrics);
 
 	json_object_append_object(json_service_checks, "passive", json_passive);
 
-	json_object_append_object(json_programstatus, "service_checks", 
-			json_service_checks);
+	json_object_append_object(json_programstatus, "service_checks",
+	                          json_service_checks);
 
 	json_host_checks = json_new_object();
 
@@ -4750,22 +4808,22 @@ json_object *json_status_performance(void) {
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_host_execution_time);
 	json_object_append_real(json_temp, "max", max_host_execution_time);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_host_execution_time / (double)total_active_host_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_host_execution_time / (double)total_active_host_checks));
 	json_object_append_object(json_metrics, "check_execution_time", json_temp);
 
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_host_latency);
 	json_object_append_real(json_temp, "max", max_host_latency);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_host_latency / (double)total_active_host_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_host_latency / (double)total_active_host_checks));
 	json_object_append_object(json_metrics, "check_latency", json_temp);
 
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_host_percent_change_a);
 	json_object_append_real(json_temp, "max", max_host_percent_change_a);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_host_percent_change_a / (double)total_active_host_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_host_percent_change_a / (double)total_active_host_checks));
 	json_object_append_object(json_metrics, "percent_state_change", json_temp);
 
 	json_object_append_object(json_active, "metrics", json_metrics);
@@ -4789,133 +4847,133 @@ json_object *json_status_performance(void) {
 	json_temp = json_new_object();
 	json_object_append_real(json_temp, "min", min_host_percent_change_b);
 	json_object_append_real(json_temp, "max", max_host_percent_change_b);
-	json_object_append_real(json_temp, "average", 
-			(double)((double)total_host_percent_change_b / (double)total_active_host_checks));
+	json_object_append_real(json_temp, "average",
+	                        (double)((double)total_host_percent_change_b / (double)total_active_host_checks));
 	json_object_append_object(json_metrics, "percent_state_change", json_temp);
 
 	json_object_append_object(json_passive, "metrics", json_metrics);
 
 	json_object_append_object(json_host_checks, "passive", json_passive);
 
-	json_object_append_object(json_programstatus, "host_checks", 
-			json_host_checks);
+	json_object_append_object(json_programstatus, "host_checks",
+	                          json_host_checks);
 
 	/* Check Stats */
 
 	json_check_statistics = json_new_object();
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[ACTIVE_SCHEDULED_HOST_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[ACTIVE_SCHEDULED_HOST_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[ACTIVE_SCHEDULED_HOST_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"active_scheduled_host_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[ACTIVE_SCHEDULED_HOST_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[ACTIVE_SCHEDULED_HOST_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[ACTIVE_SCHEDULED_HOST_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "active_scheduled_host_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[ACTIVE_ONDEMAND_HOST_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[ACTIVE_ONDEMAND_HOST_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[ACTIVE_ONDEMAND_HOST_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"active_ondemand_host_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[ACTIVE_ONDEMAND_HOST_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[ACTIVE_ONDEMAND_HOST_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[ACTIVE_ONDEMAND_HOST_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "active_ondemand_host_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[PARALLEL_HOST_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[PARALLEL_HOST_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[PARALLEL_HOST_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"parallel_host_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[PARALLEL_HOST_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[PARALLEL_HOST_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[PARALLEL_HOST_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "parallel_host_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[SERIAL_HOST_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[SERIAL_HOST_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[SERIAL_HOST_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"serial_host_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[SERIAL_HOST_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[SERIAL_HOST_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[SERIAL_HOST_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "serial_host_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[ACTIVE_CACHED_HOST_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[ACTIVE_CACHED_HOST_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[ACTIVE_CACHED_HOST_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"cached_host_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[ACTIVE_CACHED_HOST_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[ACTIVE_CACHED_HOST_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[ACTIVE_CACHED_HOST_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "cached_host_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[PASSIVE_HOST_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[PASSIVE_HOST_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[PASSIVE_HOST_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"passive_host_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[PASSIVE_HOST_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[PASSIVE_HOST_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[PASSIVE_HOST_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "passive_host_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"active_scheduled_service_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[ACTIVE_SCHEDULED_SERVICE_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "active_scheduled_service_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"active_ondemand_service_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[ACTIVE_ONDEMAND_SERVICE_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "active_ondemand_service_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[ACTIVE_CACHED_SERVICE_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[ACTIVE_CACHED_SERVICE_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[ACTIVE_CACHED_SERVICE_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"cached_service_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[ACTIVE_CACHED_SERVICE_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[ACTIVE_CACHED_SERVICE_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[ACTIVE_CACHED_SERVICE_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "cached_service_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[PASSIVE_SERVICE_CHECK_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[PASSIVE_SERVICE_CHECK_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[PASSIVE_SERVICE_CHECK_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"passive_service_checks", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[PASSIVE_SERVICE_CHECK_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[PASSIVE_SERVICE_CHECK_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[PASSIVE_SERVICE_CHECK_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "passive_service_checks", json_temp);
 
 	json_temp = json_new_object();
-	json_object_append_integer(json_temp, "1min", 
-			program_stats[EXTERNAL_COMMAND_STATS][0]);
-	json_object_append_integer(json_temp, "5min", 
-			program_stats[EXTERNAL_COMMAND_STATS][1]);
-	json_object_append_integer(json_temp, "15min", 
-			program_stats[EXTERNAL_COMMAND_STATS][2]);
-	json_object_append_object(json_check_statistics, 
-			"external_commands", json_temp);
+	json_object_append_integer(json_temp, "1min",
+	                           program_stats[EXTERNAL_COMMAND_STATS][0]);
+	json_object_append_integer(json_temp, "5min",
+	                           program_stats[EXTERNAL_COMMAND_STATS][1]);
+	json_object_append_integer(json_temp, "15min",
+	                           program_stats[EXTERNAL_COMMAND_STATS][2]);
+	json_object_append_object(json_check_statistics,
+	                          "external_commands", json_temp);
 
-	json_object_append_object(json_programstatus, "check_statistics", 
-			json_check_statistics);
+	json_object_append_object(json_programstatus, "check_statistics",
+	                          json_check_statistics);
 
 	/* Buffer Stats */
 
@@ -4927,10 +4985,10 @@ json_object *json_status_performance(void) {
 	json_object_append_integer(json_temp, "total_available", buffer_stats[0][0]);
 	json_object_append_object(json_buffer_usage, "external_commands", json_temp);
 
-	json_object_append_object(json_programstatus, "buffer_usage", 
-			json_buffer_usage);
+	json_object_append_object(json_programstatus, "buffer_usage",
+	                          json_buffer_usage);
 
 	json_object_append_object(json_data, "programstatus", json_programstatus);
 
 	return json_data;
-	}
+}

--- a/cgi/statusmap.c
+++ b/cgi/statusmap.c
@@ -225,7 +225,8 @@ int all_layers = FALSE;
 
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 
 	mac = get_global_macros();
@@ -241,7 +242,7 @@ int main(int argc, char **argv) {
 			cgi_config_file_error(get_cgi_config_location());
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* defaults from CGI config file */
 	layout_method = default_statusmap_layout_method;
@@ -257,7 +258,7 @@ int main(int argc, char **argv) {
 			main_config_file_error(main_config_file);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all object configuration data */
 	result = read_all_object_configuration_data(main_config_file, READ_ALL_OBJECT_DATA);
@@ -267,7 +268,7 @@ int main(int argc, char **argv) {
 			object_data_error();
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all status data */
 	result = read_all_status_data(main_config_file, READ_ALL_STATUS_DATA);
@@ -278,7 +279,7 @@ int main(int argc, char **argv) {
 		document_footer();
 		free_memory();
 		return ERROR;
-		}
+	}
 
 	/* initialize macros */
 	init_macros();
@@ -299,11 +300,12 @@ int main(int argc, char **argv) {
 	free_layer_list();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -336,7 +338,7 @@ void document_header(int use_stylesheet) {
 		if(use_stylesheet == TRUE) {
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, STATUSMAP_CSS);
-			}
+		}
 
 		/* write JavaScript code for popup window */
 		write_popup_code();
@@ -349,7 +351,7 @@ void document_header(int use_stylesheet) {
 		include_ssi_files(STATUSMAP_CGI, SSI_HEADER);
 
 		printf("<div id=\"popup\" style=\"position:absolute; z-index:1; visibility: hidden\"></div>\n");
-		}
+	}
 
 	else {
 		printf("Cache-Control: no-store\n");
@@ -364,13 +366,14 @@ void document_header(int use_stylesheet) {
 		printf("Expires: %s\n", date_time);
 
 		printf("Content-Type: image/png\n\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
-void document_footer(void) {
+
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -382,14 +385,15 @@ void document_footer(void) {
 
 		printf("</body>\n");
 		printf("</html>\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
 
-int process_cgivars(void) {
+
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -401,7 +405,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -409,7 +413,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "all";
@@ -420,12 +424,12 @@ int process_cgivars(void) {
 				show_all_hosts = TRUE;
 			else
 				show_all_hosts = FALSE;
-			}
+		}
 
 		/* we found the image creation option */
 		else if(!strcmp(variables[x], "createimage")) {
 			create_type = CREATE_IMAGE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -441,19 +445,18 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			canvas_x = atoi(variables[x]);
 			user_supplied_canvas = TRUE;
-			}
-		else if(!strcmp(variables[x], "canvas_y")) {
+		} else if(!strcmp(variables[x], "canvas_y")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			canvas_y = atoi(variables[x]);
 			user_supplied_canvas = TRUE;
-			}
+		}
 
 		/* we found the canvas size */
 		else if(!strcmp(variables[x], "canvas_width")) {
@@ -461,39 +464,36 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			canvas_width = atoi(variables[x]);
 			user_supplied_canvas = TRUE;
-			}
-		else if(!strcmp(variables[x], "canvas_height")) {
+		} else if(!strcmp(variables[x], "canvas_height")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			canvas_height = atoi(variables[x]);
 			user_supplied_canvas = TRUE;
-			}
-		else if(!strcmp(variables[x], "proximity_width")) {
+		} else if(!strcmp(variables[x], "proximity_width")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			proximity_width = atoi(variables[x]);
 			if(proximity_width < 0)
 				proximity_width = DEFAULT_PROXIMITY_WIDTH;
-			}
-		else if(!strcmp(variables[x], "proximity_height")) {
+		} else if(!strcmp(variables[x], "proximity_height")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			proximity_height = atoi(variables[x]);
 			if(proximity_height < 0)
 				proximity_height = DEFAULT_PROXIMITY_HEIGHT;
-			}
+		}
 
 		/* we found the scaling factor */
 		else if(!strcmp(variables[x], "scaling_factor")) {
@@ -501,11 +501,11 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			user_scaling_factor = strtod(variables[x], NULL);
 			if(user_scaling_factor > 0.0)
 				user_supplied_scaling = TRUE;
-			}
+		}
 
 		/* we found the max image size */
 		else if(!strcmp(variables[x], "max_width")) {
@@ -513,17 +513,16 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
-			max_image_width = atoi(variables[x]);
 			}
-		else if(!strcmp(variables[x], "max_height")) {
+			max_image_width = atoi(variables[x]);
+		} else if(!strcmp(variables[x], "max_height")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
-			max_image_height = atoi(variables[x]);
 			}
+			max_image_height = atoi(variables[x]);
+		}
 
 		/* we found the layout method option */
 		else if(!strcmp(variables[x], "layout")) {
@@ -531,9 +530,9 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
-			layout_method = atoi(variables[x]);
 			}
+			layout_method = atoi(variables[x]);
+		}
 
 		/* we found the no links argument*/
 		else if(!strcmp(variables[x], "nolinks"))
@@ -557,13 +556,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "include"))
 				exclude_layers = FALSE;
 			else
 				exclude_layers = TRUE;
-			}
+		}
 
 		/* we found the layer argument */
 		else if(!strcmp(variables[x], "layer")) {
@@ -571,23 +570,24 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			strip_html_brackets(variables[x]);
 			add_layer(variables[x]);
-			}
 		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* top of page */
-void display_page_header(void) {
+void display_page_header(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	int zoom;
 	int zoom_width, zoom_height;
@@ -624,7 +624,7 @@ void display_page_header(void) {
 		if(show_all_hosts == FALSE) {
 			printf("<a href='%s?host=all&max_width=%d&max_height=%d'>View Status Map For All Hosts</a><BR>", STATUSMAP_CGI, max_image_width, max_image_height);
 			printf("<a href='%s?host=%s'>View Status Detail For This Host</a><BR>\n", STATUS_CGI, url_encode(host_name));
-			}
+		}
 		printf("<a href='%s?host=all'>View Status Detail For All Hosts</a><BR>\n", STATUS_CGI);
 		printf("<a href='%s?hostgroup=all'>View Status Overview For All Hosts</a>\n", STATUS_CGI);
 
@@ -681,14 +681,14 @@ void display_page_header(void) {
 				print_layer_url(TRUE);
 				printf("'>");
 				printf("<img src='%s%s' border=0 alt='%d' title='%d'></a></td>\n", url_images_path, (current_zoom_granularity == zoom) ? ZOOM2_ICON : ZOOM1_ICON, zoom, zoom);
-				}
+			}
 
 			printf("<td valign=center class='zoomTitle'>&nbsp;&nbsp;Zoom In</td>\n");
 			printf("</tr>\n");
 			printf("</table>\n");
 
 			printf("</div></p>\n");
-			}
+		}
 
 		printf("</td>\n");
 
@@ -761,10 +761,10 @@ void display_page_header(void) {
 				if(!strcmp(temp_layer->layer_name, temp_hostgroup->group_name)) {
 					found = 1;
 					break;
-					}
 				}
-			printf("<option value='%s' %s>%s\n", escape_string(temp_hostgroup->group_name), (found == 1) ? "SELECTED" : "", temp_hostgroup->alias);
 			}
+			printf("<option value='%s' %s>%s\n", escape_string(temp_hostgroup->group_name), (found == 1) ? "SELECTED" : "", temp_hostgroup->alias);
+		}
 		printf("</select>\n");
 		printf("</td><td CLASS='optBoxItem' valign=top>Layer mode:<br>");
 		printf("<input type='radio' name='layermode' value='include' %s>Include<br>\n", (exclude_layers == FALSE) ? "CHECKED" : "");
@@ -794,16 +794,17 @@ void display_page_header(void) {
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 
 	return;
-	}
+}
 
 
 
 /* top-level map generation... */
-void display_map(void) {
+void display_map(void)
+{
 
 	load_background_image();
 	calculate_host_coords();
@@ -840,10 +841,10 @@ void display_map(void) {
 		print_layer_url(TRUE);
 		printf("' width=%d height=%d border=0 name='statusimage' useMap='#statusmap'>\n", (int)(canvas_width * scaling_factor), (int)(canvas_height * scaling_factor));
 		printf("</DIV></P>\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
@@ -852,7 +853,8 @@ void display_map(void) {
 /******************************************************************/
 
 /* calculates host drawing coordinates */
-void calculate_host_coords(void) {
+void calculate_host_coords(void)
+{
 	host *this_host;
 	host *temp_host;
 	int child_hosts = 0;
@@ -883,10 +885,10 @@ void calculate_host_coords(void) {
 				temp_host->should_be_drawn = TRUE;
 			else
 				temp_host->should_be_drawn = FALSE;
-			}
+		}
 
 		return;
-		}
+	}
 
 
 	/*****************************/
@@ -919,13 +921,13 @@ void calculate_host_coords(void) {
 			nagios_icon_x = center_x;
 			nagios_icon_y = offset_y;
 			draw_nagios_icon = TRUE;
-			}
+		}
 
 		/* do we need to draw a link to parent(s)? */
 		if(this_host != NULL && is_host_immediate_child_of_host(NULL, this_host) == FALSE) {
 			draw_parent_links = TRUE;
 			offset_y += DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING;
-			}
+		}
 
 		/* see which hosts we should draw and calculate drawing coords */
 		for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -937,7 +939,7 @@ void calculate_host_coords(void) {
 				temp_host->x_2d = center_x - (((parent_hosts * DEFAULT_NODE_WIDTH) + ((parent_hosts - 1) * DEFAULT_NODE_HSPACING)) / 2) + (current_parent_host * (DEFAULT_NODE_WIDTH + DEFAULT_NODE_HSPACING)) + (DEFAULT_NODE_WIDTH / 2);
 				temp_host->y_2d = offset_y;
 				current_parent_host++;
-				}
+			}
 
 			/* this is the "main" host we're drawing */
 			else if(this_host == temp_host) {
@@ -945,7 +947,7 @@ void calculate_host_coords(void) {
 				temp_host->have_2d_coords = TRUE;
 				temp_host->x_2d = center_x;
 				temp_host->y_2d = DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y;
-				}
+			}
 
 			/* this is an immediate child of the "main" host we're drawing */
 			else if(is_host_immediate_child_of_host(this_host, temp_host) == TRUE) {
@@ -960,16 +962,16 @@ void calculate_host_coords(void) {
 				if(number_of_immediate_child_hosts(temp_host) > 0) {
 					bottom_margin = DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING;
 					draw_child_links = TRUE;
-					}
 				}
+			}
 
 			/* else do not draw this host */
 			else {
 				temp_host->should_be_drawn = FALSE;
 				temp_host->have_2d_coords = FALSE;
-				}
 			}
 		}
+	}
 
 
 
@@ -1003,13 +1005,13 @@ void calculate_host_coords(void) {
 			nagios_icon_x = center_x;
 			nagios_icon_y = offset_y;
 			draw_nagios_icon = TRUE;
-			}
+		}
 
 		/* do we need to draw a link to parent(s)? */
 		if(this_host != NULL && is_host_immediate_child_of_host(NULL, this_host) == FALSE) {
 			draw_parent_links = TRUE;
 			offset_y += DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING;
-			}
+		}
 
 		/* see which hosts we should draw and calculate drawing coords */
 		for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -1021,7 +1023,7 @@ void calculate_host_coords(void) {
 				temp_host->x_2d = center_x - (((parent_hosts * DEFAULT_NODE_WIDTH) + ((parent_hosts - 1) * DEFAULT_NODE_HSPACING)) / 2) + (current_parent_host * (DEFAULT_NODE_WIDTH + DEFAULT_NODE_HSPACING)) + (DEFAULT_NODE_WIDTH / 2);
 				temp_host->y_2d = offset_y;
 				current_parent_host++;
-				}
+			}
 
 			/* this is the "main" host we're drawing */
 			else if(this_host == temp_host) {
@@ -1029,14 +1031,14 @@ void calculate_host_coords(void) {
 				temp_host->have_2d_coords = TRUE;
 				temp_host->x_2d = center_x;
 				temp_host->y_2d = DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y;
-				}
+			}
 
 			/* else do not draw this host (we might if its a child - see below, but assume no for now) */
 			else {
 				temp_host->should_be_drawn = FALSE;
 				temp_host->have_2d_coords = FALSE;
-				}
 			}
+		}
 
 
 		/* TODO: REORDER CHILD LAYER MEMBERS SO THAT WE MINIMIZE LINK CROSSOVERS FROM PARENT HOSTS */
@@ -1065,11 +1067,11 @@ void calculate_host_coords(void) {
 					else
 						temp_host->y_2d = ((DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING) * (current_layer + 1)) + offset_y;
 					current_layer_member++;
-					}
 				}
 			}
-
 		}
+
+	}
 
 
 	/***** "BALANCED" TREE MODE *****/
@@ -1102,13 +1104,13 @@ void calculate_host_coords(void) {
 			nagios_icon_x = center_x;
 			nagios_icon_y = offset_y;
 			draw_nagios_icon = TRUE;
-			}
+		}
 
 		/* do we need to draw a link to parent(s)? */
 		if(this_host != NULL && is_host_immediate_child_of_host(NULL, this_host) == FALSE) {
 			draw_parent_links = TRUE;
 			offset_y += DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING;
-			}
+		}
 
 		/* see which hosts we should draw and calculate drawing coords */
 		for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -1120,7 +1122,7 @@ void calculate_host_coords(void) {
 				temp_host->x_2d = center_x - (((parent_hosts * DEFAULT_NODE_WIDTH) + ((parent_hosts - 1) * DEFAULT_NODE_HSPACING)) / 2) + (current_parent_host * (DEFAULT_NODE_WIDTH + DEFAULT_NODE_HSPACING)) + (DEFAULT_NODE_WIDTH / 2);
 				temp_host->y_2d = offset_y;
 				current_parent_host++;
-				}
+			}
 
 			/* this is the "main" host we're drawing */
 			else if(this_host == temp_host) {
@@ -1128,19 +1130,19 @@ void calculate_host_coords(void) {
 				temp_host->have_2d_coords = TRUE;
 				temp_host->x_2d = center_x;
 				temp_host->y_2d = DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y;
-				}
+			}
 
 			/* else do not draw this host (we might if its a child - see below, but assume no for now) */
 			else {
 				temp_host->should_be_drawn = FALSE;
 				temp_host->have_2d_coords = FALSE;
-				}
 			}
+		}
 
 		/* draw all children hosts */
 		calculate_balanced_tree_coords(this_host, center_x, DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y);
 
-		}
+	}
 
 
 	/***** CIRCULAR LAYOUT MODE *****/
@@ -1153,15 +1155,16 @@ void calculate_host_coords(void) {
 
 		/* calculate coordinates for all hosts */
 		calculate_circular_coords();
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* calculates max possible image dimensions */
-void calculate_total_image_bounds(void) {
+void calculate_total_image_bounds(void)
+{
 	host *temp_host;
 
 	total_image_width = 0;
@@ -1184,7 +1187,7 @@ void calculate_total_image_bounds(void) {
 			total_image_height = temp_host->y_2d;
 
 		coordinates_were_specified = TRUE;
-		}
+	}
 
 	/* add some space for icon size and overlapping text... */
 	if(coordinates_were_specified == TRUE) {
@@ -1194,7 +1197,7 @@ void calculate_total_image_bounds(void) {
 
 		/* add space for bottom margin if necessary */
 		total_image_height += bottom_margin;
-		}
+	}
 
 	/* image size should be at least as large as dimensions of background image */
 	if(total_image_width < background_image_width)
@@ -1207,14 +1210,15 @@ void calculate_total_image_bounds(void) {
 		coordinates_were_specified = FALSE;
 		total_image_width = COORDS_WARNING_WIDTH;
 		total_image_height = COORDS_WARNING_HEIGHT;
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* calculates canvas coordinates/dimensions */
-void calculate_canvas_bounds(void) {
+void calculate_canvas_bounds(void)
+{
 
 	if(user_supplied_canvas == FALSE && strcmp(host_name, "all"))
 		calculate_canvas_bounds_from_host(host_name);
@@ -1237,11 +1241,12 @@ void calculate_canvas_bounds(void) {
 		canvas_height = total_image_height - canvas_y;
 
 	return;
-	}
+}
 
 
 /* calculates canvas coordinates/dimensions around a particular host */
-void calculate_canvas_bounds_from_host(char *hname) {
+void calculate_canvas_bounds_from_host(char *hname)
+{
 	host *temp_host;
 	int zoom_width;
 	int zoom_height;
@@ -1278,11 +1283,12 @@ void calculate_canvas_bounds_from_host(char *hname) {
 
 
 	return;
-	}
+}
 
 
 /* calculates scaling factor used in image generation */
-void calculate_scaling_factor(void) {
+void calculate_scaling_factor(void)
+{
 	double x_scaling = 1.0;
 	double y_scaling = 1.0;
 
@@ -1309,11 +1315,12 @@ void calculate_scaling_factor(void) {
 		scaling_factor = user_scaling_factor;
 
 	return;
-	}
+}
 
 
 /* finds hosts that can be drawn in the canvas area */
-void find_eligible_hosts(void) {
+void find_eligible_hosts(void)
+{
 	int total_eligible_hosts = 0;
 	host *temp_host;
 
@@ -1344,11 +1351,11 @@ void find_eligible_hosts(void) {
 		else {
 			temp_host->should_be_drawn = TRUE;
 			total_eligible_hosts++;
-			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 
@@ -1358,7 +1365,8 @@ void find_eligible_hosts(void) {
 
 
 /* loads background image from file */
-void load_background_image(void) {
+void load_background_image(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 
 	/* bail out if we shouldn't be drawing a background image */
@@ -1375,18 +1383,19 @@ void load_background_image(void) {
 	if(background_image != NULL) {
 		background_image_width = background_image->sx;
 		background_image_height = background_image->sy;
-		}
+	}
 
 	/* if we are just creating the html, we don't need the image anymore */
 	if(create_type == CREATE_HTML && background_image != NULL)
 		gdImageDestroy(background_image);
 
 	return;
-	}
+}
 
 
 /* draws background image on drawing canvas */
-void draw_background_image(void) {
+void draw_background_image(void)
+{
 
 	/* bail out if we shouldn't be drawing a background image */
 	if(create_type == CREATE_HTML || layout_method != LAYOUT_USER_SUPPLIED || statusmap_background_image == NULL)
@@ -1403,12 +1412,13 @@ void draw_background_image(void) {
 	gdImageDestroy(background_image);
 
 	return;
-	}
+}
 
 
 
 /* draws background "extras" */
-void draw_background_extras(void) {
+void draw_background_extras(void)
+{
 
 	/* bail out if we shouldn't be here */
 	if(create_type == CREATE_HTML)
@@ -1419,14 +1429,15 @@ void draw_background_extras(void) {
 
 		/* draw colored sections... */
 		draw_circular_markup();
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* draws host links */
-void draw_host_links(void) {
+void draw_host_links(void)
+{
 	host *this_host;
 	host *main_host;
 	host *parent_host;
@@ -1465,7 +1476,7 @@ void draw_host_links(void) {
 			y = this_host->y_2d + (DEFAULT_NODE_WIDTH / 2) - canvas_y;
 
 			draw_line(x, y, nagios_icon_x + (DEFAULT_NODE_WIDTH / 2) - canvas_x, nagios_icon_y + (DEFAULT_NODE_WIDTH / 2) - canvas_y, color_black);
-			}
+		}
 
 		/* this is a child of the main host we're drawing in auto-layout mode... */
 		if(layout_method != LAYOUT_USER_SUPPLIED && draw_child_links == TRUE && number_of_immediate_child_hosts(this_host) > 0 && is_host_immediate_child_of_host(main_host, this_host) == TRUE) {
@@ -1476,8 +1487,7 @@ void draw_host_links(void) {
 					status_color = color_red;
 				else
 					status_color = color_black;
-				}
-			else
+			} else
 				status_color = color_black;
 
 			x = this_host->x_2d + (DEFAULT_NODE_WIDTH / 2) - canvas_x;
@@ -1488,7 +1498,7 @@ void draw_host_links(void) {
 			/* draw arrow tips */
 			draw_line(x, y + DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING, x - 5, y + DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING - 5, color_black);
 			draw_line(x, y + DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING, x + 5, y + DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING - 5, color_black);
-			}
+		}
 
 		/* this is a parent of the main host we're drawing in auto-layout mode... */
 		if(layout_method != LAYOUT_USER_SUPPLIED && draw_parent_links == TRUE && is_host_immediate_child_of_host(this_host, main_host) == TRUE) {
@@ -1501,7 +1511,7 @@ void draw_host_links(void) {
 			/* draw arrow tips */
 			draw_line(x, y - DEFAULT_NODE_HEIGHT - DEFAULT_NODE_VSPACING, x - 5, y - DEFAULT_NODE_HEIGHT - DEFAULT_NODE_VSPACING + 5, color_black);
 			draw_line(x, y - DEFAULT_NODE_HEIGHT - DEFAULT_NODE_VSPACING, x + 5, y - DEFAULT_NODE_HEIGHT - DEFAULT_NODE_VSPACING + 5, color_black);
-			}
+		}
 
 		/* draw links to all parent hosts */
 		for(temp_hostsmember = this_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
@@ -1541,8 +1551,7 @@ void draw_host_links(void) {
 					status_color = color_red;
 				else
 					status_color = color_black;
-				}
-			else
+			} else
 				status_color = color_black;
 
 			/* draw the link */
@@ -1550,17 +1559,18 @@ void draw_host_links(void) {
 				draw_dotted_line((this_host->x_2d + (DEFAULT_NODE_WIDTH / 2)) - canvas_x, (this_host->y_2d + (DEFAULT_NODE_WIDTH) / 2) - canvas_y, (parent_host->x_2d + (DEFAULT_NODE_WIDTH / 2)) - canvas_x, (parent_host->y_2d + (DEFAULT_NODE_WIDTH / 2)) - canvas_y, status_color);
 			else
 				draw_line((this_host->x_2d + (DEFAULT_NODE_WIDTH / 2)) - canvas_x, (this_host->y_2d + (DEFAULT_NODE_WIDTH) / 2) - canvas_y, (parent_host->x_2d + (DEFAULT_NODE_WIDTH / 2)) - canvas_x, (parent_host->y_2d + (DEFAULT_NODE_WIDTH / 2)) - canvas_y, status_color);
-			}
-
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 
 /* draws hosts */
-void draw_hosts(void) {
+void draw_hosts(void)
+{
 	host *temp_host;
 	int x1, x2;
 	int y1;
@@ -1587,10 +1597,10 @@ void draw_hosts(void) {
 		if(create_type == CREATE_IMAGE) {
 			draw_text("You have not supplied any host drawing coordinates, so you cannot use this layout method.", (COORDS_WARNING_WIDTH / 2), 30, color_black);
 			draw_text("Read the FAQs for more information on specifying drawing coordinates or select a different layout method.", (COORDS_WARNING_WIDTH / 2), 45, color_black);
-			}
+		}
 
 		return;
-		}
+	}
 
 	/* draw Nagios process icon if using auto-layout mode */
 	if(layout_method != LAYOUT_USER_SUPPLIED && draw_nagios_icon == TRUE) {
@@ -1611,7 +1621,7 @@ void draw_hosts(void) {
 		if(logo_image != NULL) {
 			gdImageCopy(map_image, logo_image, x1, y1, 0, 0, logo_image->sx, logo_image->sy);
 			gdImageDestroy(logo_image);
-			}
+		}
 
 		/* if we don't have an image, draw a bounding box */
 		else {
@@ -1619,11 +1629,11 @@ void draw_hosts(void) {
 			draw_line(x1, y1 + DEFAULT_NODE_WIDTH, x2, y1 + DEFAULT_NODE_WIDTH, color_black);
 			draw_line(x2, y1 + DEFAULT_NODE_WIDTH, x2, y1, color_black);
 			draw_line(x2, y1, x1, y1, color_black);
-			}
+		}
 
 		if(create_type == CREATE_IMAGE)
 			draw_text("Nagios Process", x1 + (DEFAULT_NODE_WIDTH / 2), y1 + DEFAULT_NODE_HEIGHT, color_black);
-		}
+	}
 
 	/* calculate average services per host */
 	average_host_services = 4;
@@ -1658,8 +1668,7 @@ void draw_hosts(void) {
 					status_color = color_green;
 				else if(temp_hoststatus->status == HOST_PENDING)
 					status_color = color_grey;
-				}
-			else
+			} else
 				status_color = color_black;
 
 
@@ -1723,8 +1732,8 @@ void draw_hosts(void) {
 				if(!strcmp(host_name, temp_host->name) && use_highlights == TRUE) {
 					for(current_radius = DEFAULT_NODE_WIDTH * 2; current_radius > 0; current_radius -= 10)
 						gdImageArc(map_image, x1 + (DEFAULT_NODE_WIDTH / 2), y1 + (DEFAULT_NODE_WIDTH / 2), current_radius, current_radius, 0, 360, status_color);
-					}
 				}
+			}
 
 
 			/* normal method is to use icons for hosts... */
@@ -1736,14 +1745,14 @@ void draw_hosts(void) {
 						gdImageArc(map_image, x1 + (DEFAULT_NODE_WIDTH / 2), y1 + (DEFAULT_NODE_WIDTH / 2), (DEFAULT_NODE_WIDTH * 2), (DEFAULT_NODE_WIDTH * 2), 0, 360, status_color);
 						draw_line(x1 - (DEFAULT_NODE_WIDTH / 2), y1 + (DEFAULT_NODE_WIDTH / 2), x1 + (DEFAULT_NODE_WIDTH * 3 / 2), y1 + (DEFAULT_NODE_WIDTH / 2), status_color);
 						draw_line(x1 + (DEFAULT_NODE_WIDTH / 2), y1 - (DEFAULT_NODE_WIDTH / 2), x1 + (DEFAULT_NODE_WIDTH / 2), y1 + (DEFAULT_NODE_WIDTH * 3 / 2), status_color);
-						}
 					}
+				}
 
 				/* draw circles around the selected host (if there is one) */
 				if(!strcmp(host_name, temp_host->name) && use_highlights == TRUE) {
 					for(current_radius = DEFAULT_NODE_WIDTH * 2; current_radius > 0; current_radius -= 10)
 						gdImageArc(map_image, x1 + (DEFAULT_NODE_WIDTH / 2), y1 + (DEFAULT_NODE_WIDTH / 2), current_radius, current_radius, 0, 360, status_color);
-					}
+				}
 
 
 				if(temp_host->statusmap_image != NULL)
@@ -1765,10 +1774,9 @@ void draw_hosts(void) {
 					if(logo_image != NULL) {
 						gdImageCopy(map_image, logo_image, x1, y1, 0, 0, logo_image->sx, logo_image->sy);
 						gdImageDestroy(logo_image);
-						}
-					else
+					} else
 						has_image = FALSE;
-					}
+				}
 
 				/* if the host doesn't have an image associated with it (or the user doesn't have rights to see this host), use the unknown image */
 				if(has_image == FALSE) {
@@ -1783,14 +1791,14 @@ void draw_hosts(void) {
 						draw_line(x1, y1 + DEFAULT_NODE_WIDTH, x2, y1 + DEFAULT_NODE_WIDTH, color_black);
 						draw_line(x2, y1 + DEFAULT_NODE_WIDTH, x2, y1, color_black);
 						draw_line(x2, y1, x1, y1, color_black);
-						}
 					}
 				}
+			}
 
 
 			/* draw host name, status, etc. */
 			draw_host_text(temp_host->name, x1 + (DEFAULT_NODE_WIDTH / 2), y1 + DEFAULT_NODE_HEIGHT);
-			}
+		}
 
 		/* we're creating HTML image map... */
 		else {
@@ -1808,7 +1816,7 @@ void draw_hosts(void) {
 					printf("&scaling_factor=%2.1f", user_scaling_factor);
 				print_layer_url(TRUE);
 				printf("' ");
-				}
+			}
 
 			/* popup text */
 			if(display_popups == TRUE) {
@@ -1816,19 +1824,20 @@ void draw_hosts(void) {
 				printf("onMouseOver='showPopup(\"");
 				write_host_popup_text(find_host(temp_host->name));
 				printf("\",event)' onMouseOut='hidePopup()'");
-				}
-
-			printf(">\n");
 			}
 
+			printf(">\n");
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 /* draws text */
-void draw_text(char *buffer, int x, int y, int text_color) {
+void draw_text(char *buffer, int x, int y, int text_color)
+{
 	int string_width = 0;
 	int string_height = 0;
 
@@ -1840,11 +1849,12 @@ void draw_text(char *buffer, int x, int y, int text_color) {
 	gdImageString(map_image, gdFontSmall, x - (string_width / 2), y - (2 * string_height), (unsigned char *)buffer, text_color);
 
 	return;
-	}
+}
 
 
 /* draws host text */
-void draw_host_text(char *name, int x, int y) {
+void draw_host_text(char *name, int x, int y)
+{
 	hoststatus *temp_hoststatus;
 	int status_color = color_black;
 	char temp_buffer[MAX_INPUT_BUFFER];
@@ -1868,36 +1878,33 @@ void draw_host_text(char *name, int x, int y) {
 		if(temp_hoststatus->status == SD_HOST_DOWN) {
 			strncpy(temp_buffer, "Down", sizeof(temp_buffer));
 			status_color = color_red;
-			}
-		else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
+		} else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 			strncpy(temp_buffer, "Unreachable", sizeof(temp_buffer));
 			status_color = color_red;
-			}
-		else if(temp_hoststatus->status == SD_HOST_UP) {
+		} else if(temp_hoststatus->status == SD_HOST_UP) {
 			strncpy(temp_buffer, "Up", sizeof(temp_buffer));
 			status_color = color_green;
-			}
-		else if(temp_hoststatus->status == HOST_PENDING) {
+		} else if(temp_hoststatus->status == HOST_PENDING) {
 			strncpy(temp_buffer, "Pending", sizeof(temp_buffer));
 			status_color = color_grey;
-			}
-		else {
+		} else {
 			strncpy(temp_buffer, "Unknown", sizeof(temp_buffer));
 			status_color = color_orange;
-			}
+		}
 
 		temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 
 		/* write the host status string to the generated image... */
 		draw_text(temp_buffer, x, y + gdFontSmall->h, status_color);
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* writes popup text for a specific host */
-void write_host_popup_text(host *hst) {
+void write_host_popup_text(host *hst)
+{
 	hoststatus *temp_status = NULL;
 	hostsmember *temp_hostsmember = NULL;
 	char *processed_string = NULL;
@@ -1914,14 +1921,14 @@ void write_host_popup_text(host *hst) {
 	if(hst == NULL) {
 		printf("Host data not found");
 		return;
-		}
+	}
 
 	/* find the status entry for this host */
 	temp_status = find_hoststatus(hst->name);
 	if(temp_status == NULL) {
 		printf("Host status information not found");
 		return;
-		}
+	}
 
 	/* grab macros */
 	grab_host_macros_r(mac, hst);
@@ -1938,7 +1945,7 @@ void write_host_popup_text(host *hst) {
 		process_macros_r(mac, hst->icon_image, &processed_string, 0);
 		printf("%s", processed_string);
 		free(processed_string);
-		}
+	}
 	printf("\\\" border=0 width=40 height=40></td>");
 	printf("<td class=\\\"popupText\\\"><i>%s</i></td></tr>", (hst->icon_image_alt == NULL) ? "" : html_encode(hst->icon_image_alt, TRUE));
 
@@ -1953,14 +1960,14 @@ void write_host_popup_text(host *hst) {
 		if(temp_status->problem_has_been_acknowledged == TRUE)
 			printf(" (Acknowledged)");
 		printf("</font>");
-		}
+	}
 
 	else if(temp_status->status == SD_HOST_UNREACHABLE) {
 		printf("<font color=red>Unreachable");
 		if(temp_status->problem_has_been_acknowledged == TRUE)
 			printf(" (Acknowledged)");
 		printf("</font>");
-		}
+	}
 
 	else if(temp_status->status == SD_HOST_UP)
 		printf("<font color=green>Up</font>");
@@ -1992,7 +1999,7 @@ void write_host_popup_text(host *hst) {
 	else {
 		for(temp_hostsmember = hst->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next)
 			printf("%s%s", (temp_hostsmember == hst->parent_hosts) ? "" : ", ", html_encode(temp_hostsmember->host_name, TRUE));
-		}
+	}
 	printf("</b></td></tr>");
 
 	printf("<tr><td class=\\\"popupText\\\">Immediate Child Hosts:</td><td class=\\\"popupText\\\"><b>");
@@ -2020,12 +2027,13 @@ void write_host_popup_text(host *hst) {
 		printf("- %d pending<br>", service_totals);
 
 	return;
-	}
+}
 
 
 
 /* draws a solid line */
-void draw_line(int x1, int y1, int x2, int y2, int color) {
+void draw_line(int x1, int y1, int x2, int y2, int color)
+{
 
 	if(create_type == CREATE_HTML)
 		return;
@@ -2033,11 +2041,12 @@ void draw_line(int x1, int y1, int x2, int y2, int color) {
 	gdImageLine(map_image, x1, y1, x2, y2, color);
 
 	return;
-	}
+}
 
 
 /* draws a dotted line */
-void draw_dotted_line(int x1, int y1, int x2, int y2, int color) {
+void draw_dotted_line(int x1, int y1, int x2, int y2, int color)
+{
 	int styleDotted[12];
 
 	styleDotted[0] = color;
@@ -2060,10 +2069,11 @@ void draw_dotted_line(int x1, int y1, int x2, int y2, int color) {
 	gdImageLine(map_image, x1, y1, x2, y2, gdStyled);
 
 	return;
-	}
+}
 
 /* draws a dashed line */
-void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
+void draw_dashed_line(int x1, int y1, int x2, int y2, int color)
+{
 	int styleDashed[12];
 
 	styleDashed[0] = color;
@@ -2086,7 +2096,7 @@ void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
 	gdImageLine(map_image, x1, y1, x2, y2, gdStyled);
 
 	return;
-	}
+}
 
 
 
@@ -2095,7 +2105,8 @@ void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
 /******************************************************************/
 
 /* initialize graphics */
-int initialize_graphics(void) {
+int initialize_graphics(void)
+{
 	char image_input_file[MAX_INPUT_BUFFER];
 
 	if(create_type == CREATE_HTML)
@@ -2147,12 +2158,13 @@ int initialize_graphics(void) {
 	unknown_logo_image = load_image_from_file(image_input_file);
 
 	return OK;
-	}
+}
 
 
 
 /* loads a graphic image (GD2, JPG or PNG) from file into memory */
-gdImagePtr load_image_from_file(char *filename) {
+gdImagePtr load_image_from_file(char *filename)
+{
 	FILE *fp;
 	gdImagePtr im = NULL;
 	char *ext;
@@ -2190,12 +2202,13 @@ gdImagePtr load_image_from_file(char *filename) {
 	fclose(fp);
 
 	return im;
-	}
+}
 
 
 
 /* draw graphics */
-void write_graphics(void) {
+void write_graphics(void)
+{
 	FILE *image_output_file = NULL;
 
 	if(create_type == CREATE_HTML)
@@ -2211,11 +2224,12 @@ void write_graphics(void) {
 	/*gdImageJpeg(map_image,image_output_file,99);*/
 
 	return;
-	}
+}
 
 
 /* cleanup graphics resources */
-void cleanup_graphics(void) {
+void cleanup_graphics(void)
+{
 
 	if(create_type == CREATE_HTML)
 		return;
@@ -2224,7 +2238,7 @@ void cleanup_graphics(void) {
 	gdImageDestroy(map_image);
 
 	return;
-	}
+}
 
 
 
@@ -2235,7 +2249,8 @@ void cleanup_graphics(void) {
 
 
 /* write JavaScript code an layer for popup window */
-void write_popup_code(void) {
+void write_popup_code(void)
+{
 	char *border_color = "#000000";
 	char *background_color = "#ffffcc";
 	int border = 1;
@@ -2317,12 +2332,13 @@ void write_popup_code(void) {
 	printf("</SCRIPT>\n");
 
 	return;
-	}
+}
 
 
 
 /* adds a layer to the list in memory */
-int add_layer(char *group_name) {
+int add_layer(char *group_name)
+{
 	struct layer *new_layer;
 
 	if(group_name == NULL)
@@ -2337,7 +2353,7 @@ int add_layer(char *group_name) {
 	if(new_layer->layer_name == NULL) {
 		free(new_layer);
 		return ERROR;
-		}
+	}
 
 	strcpy(new_layer->layer_name, group_name);
 
@@ -2346,12 +2362,13 @@ int add_layer(char *group_name) {
 	layer_list = new_layer;
 
 	return OK;
-	}
+}
 
 
 
 /* frees memory allocated to the layer list */
-void free_layer_list(void) {
+void free_layer_list(void)
+{
 	struct layer *this_layer, *next_layer;
 
 	return;
@@ -2360,14 +2377,15 @@ void free_layer_list(void) {
 		next_layer = this_layer->next;
 		free(this_layer->layer_name);
 		free(this_layer);
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* checks to see if a host is in the layer list */
-int is_host_in_layer_list(host *hst) {
+int is_host_in_layer_list(host *hst)
+{
 	hostgroup *temp_hostgroup;
 	struct layer *temp_layer;
 
@@ -2385,14 +2403,15 @@ int is_host_in_layer_list(host *hst) {
 		/* is the requested host a member of the hostgroup/layer? */
 		if(is_host_member_of_hostgroup(temp_hostgroup, hst) == TRUE)
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /* print layer url info */
-void print_layer_url(int get_method) {
+void print_layer_url(int get_method)
+{
 	struct layer *temp_layer;
 
 	for(temp_layer = layer_list; temp_layer != NULL; temp_layer = temp_layer->next) {
@@ -2400,7 +2419,7 @@ void print_layer_url(int get_method) {
 			printf("&layer=%s", escape_string(temp_layer->layer_name));
 		else
 			printf("<input type='hidden' name='layer' value='%s'>\n", escape_string(temp_layer->layer_name));
-		}
+	}
 
 	if(get_method == TRUE)
 		printf("&layermode=%s", (exclude_layers == TRUE) ? "exclude" : "include");
@@ -2408,7 +2427,7 @@ void print_layer_url(int get_method) {
 		printf("<input type='hidden' name='layermode' value='%s'>\n", (exclude_layers == TRUE) ? "exclude" : "include");
 
 	return;
-	}
+}
 
 
 
@@ -2418,7 +2437,8 @@ void print_layer_url(int get_method) {
 /******************************************************************/
 
 /* calculates how many "layers" separate parent and child - used by collapsed tree layout method */
-int host_child_depth_separation(host *parent, host *child) {
+int host_child_depth_separation(host *parent, host *child)
+{
 	int this_depth = 0;
 	int min_depth = 0;
 	int have_min_depth = FALSE;
@@ -2442,20 +2462,21 @@ int host_child_depth_separation(host *parent, host *child) {
 			if(this_depth >= 0 && (have_min_depth == FALSE || (have_min_depth == TRUE && (this_depth < min_depth)))) {
 				have_min_depth = TRUE;
 				min_depth = this_depth;
-				}
 			}
 		}
+	}
 
 	if(have_min_depth == FALSE)
 		return -1;
 	else
 		return min_depth + 1;
-	}
+}
 
 
 
 /* calculates how many hosts reside on a specific "layer" - used by collapsed tree layout method */
-int number_of_host_layer_members(host *parent, int layer) {
+int number_of_host_layer_members(host *parent, int layer)
+{
 	int current_layer;
 	int layer_members = 0;
 	host *temp_host;
@@ -2466,15 +2487,16 @@ int number_of_host_layer_members(host *parent, int layer) {
 
 		if(current_layer == layer)
 			layer_members++;
-		}
+	}
 
 	return layer_members;
-	}
+}
 
 
 
 /* calculate max number of members on all "layers" beneath and including parent host - used by collapsed tree layout method */
-int max_child_host_layer_members(host *parent) {
+int max_child_host_layer_members(host *parent)
+{
 	int current_layer;
 	int max_members = 1;
 	int current_members = 0;
@@ -2488,15 +2510,16 @@ int max_child_host_layer_members(host *parent) {
 
 		if(current_members > max_members)
 			max_members = current_members;
-		}
+	}
 
 	return max_members;
-	}
+}
 
 
 
 /* calculate max drawing width for host and children - used by balanced tree layout method */
-int max_child_host_drawing_width(host *parent) {
+int max_child_host_drawing_width(host *parent)
+{
 	host *temp_host;
 	int child_width = 0;
 
@@ -2505,7 +2528,7 @@ int max_child_host_drawing_width(host *parent) {
 
 		if(is_host_immediate_child_of_host(parent, temp_host) == TRUE)
 			child_width += max_child_host_drawing_width(temp_host);
-		}
+	}
 
 	/* no children, so set width to 1 for this host */
 	if(child_width == 0)
@@ -2513,12 +2536,13 @@ int max_child_host_drawing_width(host *parent) {
 
 	else
 		return child_width;
-	}
+}
 
 
 
 /* calculates number of services associated with a particular service */
-int number_of_host_services(host *hst) {
+int number_of_host_services(host *hst)
+{
 	service *temp_service;
 	int total_services = 0;
 
@@ -2529,10 +2553,10 @@ int number_of_host_services(host *hst) {
 	for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 		if(!strcmp(temp_service->host_name, hst->name))
 			total_services++;
-		}
+	}
 
 	return total_services;
-	}
+}
 
 
 
@@ -2541,7 +2565,8 @@ int number_of_host_services(host *hst) {
 /******************************************************************/
 
 /* calculates coords of a host's children - used by balanced tree layout method */
-void calculate_balanced_tree_coords(host *parent, int x, int y) {
+void calculate_balanced_tree_coords(host *parent, int x, int y)
+{
 	int parent_drawing_width;
 	int start_drawing_x;
 	int current_drawing_x;
@@ -2573,16 +2598,17 @@ void calculate_balanced_tree_coords(host *parent, int x, int y) {
 
 			/* recurse into child host ... */
 			calculate_balanced_tree_coords(temp_host, temp_host->x_2d, temp_host->y_2d);
-			}
-
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 /* calculate coords of all hosts in circular layout method */
-void calculate_circular_coords(void) {
+void calculate_circular_coords(void)
+{
 	int min_x = 0;
 	int min_y = 0;
 	int have_min_x = FALSE;
@@ -2599,12 +2625,12 @@ void calculate_circular_coords(void) {
 		if(have_min_x == FALSE || temp_host->x_2d < min_x) {
 			have_min_x = TRUE;
 			min_x = temp_host->x_2d;
-			}
+		}
 		if(have_min_y == FALSE || temp_host->y_2d < min_y) {
 			have_min_y = TRUE;
 			min_y = temp_host->y_2d;
-			}
 		}
+	}
 
 	/* offset all drawing coords by the min x,y coords we found */
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -2612,7 +2638,7 @@ void calculate_circular_coords(void) {
 			temp_host->x_2d -= min_x;
 		if(min_y < 0)
 			temp_host->y_2d -= min_y;
-		}
+	}
 
 	if(min_x < 0)
 		nagios_icon_x -= min_x;
@@ -2622,16 +2648,17 @@ void calculate_circular_coords(void) {
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 		temp_host->x_2d += (DEFAULT_NODE_WIDTH / 2);
 		temp_host->y_2d += (DEFAULT_NODE_HEIGHT / 2);
-		}
+	}
 	nagios_icon_x += (DEFAULT_NODE_WIDTH / 2);
 	nagios_icon_y += (DEFAULT_NODE_HEIGHT / 2);
 
 	return;
-	}
+}
 
 
 /* calculates coords of all hosts in a particular "layer" in circular layout method */
-void calculate_circular_layer_coords(host *parent, double start_angle, double useable_angle, int layer, int radius) {
+void calculate_circular_layer_coords(host *parent, double start_angle, double useable_angle, int layer, int radius)
+{
 	int parent_drawing_width = 0;
 	int this_drawing_width = 0;
 	int immediate_children = 0;
@@ -2698,26 +2725,28 @@ void calculate_circular_layer_coords(host *parent, double start_angle, double us
 
 			/* increment current drawing angle */
 			current_drawing_angle += available_angle;
-			}
 		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* draws background "extras" for all hosts in circular markup layout */
-void draw_circular_markup(void) {
+void draw_circular_markup(void)
+{
 
 	/* calculate all host sections, starting with first layer */
 	draw_circular_layer_markup(NULL, 0.0, 360.0, 1, CIRCULAR_DRAWING_RADIUS);
 
 	return;
-	}
+}
 
 
 /* draws background "extras" for all hosts in a particular "layer" in circular markup layout */
-void draw_circular_layer_markup(host *parent, double start_angle, double useable_angle, int layer, int radius) {
+void draw_circular_layer_markup(host *parent, double start_angle, double useable_angle, int layer, int radius)
+{
 	int parent_drawing_width = 0;
 	int this_drawing_width = 0;
 	int immediate_children = 0;
@@ -2792,7 +2821,7 @@ void draw_circular_layer_markup(host *parent, double start_angle, double useable
 
 				/* draw "rightmost" divider */
 				gdImageLine(map_image, (int)x_coord[2] + x_offset, (int)y_coord[2] + y_offset, (int)x_coord[3] + x_offset, (int)y_coord[3] + y_offset, color_lightgrey);
-				}
+			}
 
 			/* determine arc drawing angles */
 			arc_start_angle = current_drawing_angle - 90.0;
@@ -2832,8 +2861,8 @@ void draw_circular_layer_markup(host *parent, double start_angle, double useable
 
 			/* increment current drawing angle */
 			current_drawing_angle += available_angle;
-			}
 		}
+	}
 
 	return;
-	}
+}

--- a/cgi/statuswml.c
+++ b/cgi/statuswml.c
@@ -90,7 +90,8 @@ authdata current_authdata;
 
 
 
-int main(void) {
+int main(void)
+{
 	int result = OK;
 
 	/* get the arguments passed in the URL */
@@ -106,7 +107,7 @@ int main(void) {
 	if(result == ERROR) {
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read the CGI configuration file */
 	result = read_cgi_config_file(get_cgi_config_location());
@@ -114,7 +115,7 @@ int main(void) {
 		printf("<P>Error: Could not open CGI configuration file '%s' for reading!</P>\n", get_cgi_config_location());
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
@@ -122,7 +123,7 @@ int main(void) {
 		printf("<P>Error: Could not open main configuration file '%s' for reading!</P>\n", main_config_file);
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all object configuration data */
 	result = read_all_object_configuration_data(main_config_file, READ_ALL_OBJECT_DATA);
@@ -130,7 +131,7 @@ int main(void) {
 		printf("<P>Error: Could not read some or all object configuration data!</P>\n");
 		document_footer();
 		return ERROR;
-		}
+	}
 
 	/* read all status data */
 	result = read_all_status_data(main_config_file, READ_ALL_STATUS_DATA);
@@ -139,7 +140,7 @@ int main(void) {
 		document_footer();
 		free_memory();
 		return ERROR;
-		}
+	}
 
 	/* get authentication information */
 	get_authentication_information(&current_authdata);
@@ -174,10 +175,11 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
-void document_header(void) {
+void document_header(void)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t expire_time;
 	time_t current_time;
@@ -206,18 +208,20 @@ void document_header(void) {
 	printf("</head>\n");
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	printf("</wml>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -229,7 +233,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the hostgroup argument */
 		else if(!strcmp(variables[x], "hostgroup")) {
@@ -238,7 +242,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((hostgroup_name = (char *)strdup(variables[x])) == NULL)
 				hostgroup_name = "";
@@ -248,7 +252,7 @@ int process_cgivars(void) {
 				show_all_hostgroups = TRUE;
 			else
 				show_all_hostgroups = FALSE;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -257,12 +261,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "";
 			strip_html_brackets(host_name);
-			}
+		}
 
 		/* we found the service argument */
 		else if(!strcmp(variables[x], "service")) {
@@ -271,12 +275,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((service_desc = (char *)strdup(variables[x])) == NULL)
 				service_desc = "";
 			strip_html_brackets(service_desc);
-			}
+		}
 
 
 		/* we found the hostgroup style argument */
@@ -285,7 +289,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "overview"))
 				hostgroup_style = DISPLAY_HOSTGROUP_OVERVIEW;
@@ -301,7 +305,7 @@ int process_cgivars(void) {
 				display_type = DISPLAY_UNHANDLED_PROBLEMS;
 			else
 				display_type = DISPLAY_QUICKSTATS;
-			}
+		}
 
 		/* we found the ping argument */
 		else if(!strcmp(variables[x], "ping")) {
@@ -310,12 +314,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((ping_address = (char *)strdup(variables[x])) == NULL)
 				ping_address = "";
 			strip_html_brackets(ping_address);
-			}
+		}
 
 		/* we found the traceroute argument */
 		else if(!strcmp(variables[x], "traceroute")) {
@@ -324,43 +328,46 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((traceroute_address = (char *)strdup(variables[x])) == NULL)
 				traceroute_address = "";
 			strip_html_brackets(traceroute_address);
-			}
-
 		}
+
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
-int validate_arguments(void) {
+int validate_arguments(void)
+{
 	int result = OK;
 	if((strcmp(ping_address, "")) && !is_valid_hostip(ping_address)) {
 		printf("<p>Invalid host name/ip</p>\n");
 		result = ERROR;
-		}
+	}
 	if(strcmp(traceroute_address, "") && !is_valid_hostip(traceroute_address)) {
 		printf("<p>Invalid host name/ip</p>\n");
 		result = ERROR;
-		}
-	return result;
 	}
+	return result;
+}
 
-int is_valid_hostip(char *hostip) {
+int is_valid_hostip(char *hostip)
+{
 	char *valid_domain_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-";
 	if(strcmp(hostip, "") && strlen(hostip) == strspn(hostip, valid_domain_chars) && hostip[0] != '-' && hostip[strlen(hostip) - 1] != '-')
 		return TRUE;
 	return FALSE;
-	}
+}
 
 /* main intro screen */
-void display_index(void) {
+void display_index(void)
+{
 
 
 	/**** MAIN MENU SCREEN (CARD 1) ****/
@@ -459,11 +466,12 @@ void display_index(void) {
 
 
 	return;
-	}
+}
 
 
 /* displays process info */
-void display_process(void) {
+void display_process(void)
+{
 
 
 	/**** MAIN SCREEN (CARD 1) ****/
@@ -478,7 +486,7 @@ void display_process(void) {
 		printf("</p>\n");
 		printf("</card>\n");
 		return;
-		}
+	}
 
 	if(nagios_process_state == STATE_OK)
 		printf("Nagios process is running<br/>\n");
@@ -523,12 +531,13 @@ void display_process(void) {
 
 
 	return;
-	}
+}
 
 
 
 /* displays quick stats */
-void display_quick_stats(void) {
+void display_quick_stats(void)
+{
 	host *temp_host;
 	hoststatus *temp_hoststatus;
 	service *temp_service;
@@ -568,7 +577,7 @@ void display_quick_stats(void) {
 			hosts_pending++;
 		else
 			hosts_up++;
-		}
+	}
 
 	/* check all services */
 	for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
@@ -590,7 +599,7 @@ void display_quick_stats(void) {
 			services_pending++;
 		else
 			services_ok++;
-		}
+	}
 
 	printf("<p align='left' mode='nowrap'>\n");
 
@@ -614,12 +623,13 @@ void display_quick_stats(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays hostgroup status overview */
-void display_hostgroup_overview(void) {
+void display_hostgroup_overview(void)
+{
 	hostgroup *temp_hostgroup;
 	hostsmember *temp_member;
 	host *temp_host;
@@ -672,12 +682,12 @@ void display_hostgroup_overview(void) {
 				printf("???");
 			printf("<go href='%s' method='post'><postfield name='host' value='%s'/></go></anchor></td>", STATUSWML_CGI, temp_host->name);
 			printf("<td>%s</td></tr>\n", temp_host->name);
-			}
+		}
 
 		printf("</table>\n");
 
 		printf("<br/>\n");
-		}
+	}
 
 	if(show_all_hostgroups == FALSE)
 		printf("<b><anchor title='View All Hostgroups'>View All Hostgroups<go href='%s' method='post'><postfield name='hostgroup' value='all'/><postfield name='style' value='overview'/></go></anchor></b>\n", STATUSWML_CGI);
@@ -686,11 +696,12 @@ void display_hostgroup_overview(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 /* displays hostgroup status summary */
-void display_hostgroup_summary(void) {
+void display_hostgroup_summary(void)
+{
 	hostgroup *temp_hostgroup;
 	hostsmember *temp_member;
 	host *temp_host;
@@ -785,23 +796,23 @@ void display_hostgroup_summary(void) {
 					services_pending++;
 				else
 					services_ok++;
-				}
 			}
+		}
 
 		printf("<tr><td>Hosts:</td><td>");
 		found = 0;
 		if(hosts_unreachable > 0) {
 			printf("%d UNR", hosts_unreachable);
 			found = 1;
-			}
+		}
 		if(hosts_down > 0) {
 			printf("%s%d DWN", (found == 1) ? ", " : "", hosts_down);
 			found = 1;
-			}
+		}
 		if(hosts_pending > 0) {
 			printf("%s%d PND", (found == 1) ? ", " : "", hosts_pending);
 			found = 1;
-			}
+		}
 		printf("%s%d UP", (found == 1) ? ", " : "", hosts_up);
 		printf("</td></tr>\n");
 		printf("<tr><td>Services:</td><td>");
@@ -809,26 +820,26 @@ void display_hostgroup_summary(void) {
 		if(services_critical > 0) {
 			printf("%d CRI", services_critical);
 			found = 1;
-			}
+		}
 		if(services_warning > 0) {
 			printf("%s%d WRN", (found == 1) ? ", " : "", services_warning);
 			found = 1;
-			}
+		}
 		if(services_unknown > 0) {
 			printf("%s%d UNK", (found == 1) ? ", " : "", services_unknown);
 			found = 1;
-			}
+		}
 		if(services_pending > 0) {
 			printf("%s%d PND", (found == 1) ? ", " : "", services_pending);
 			found = 1;
-			}
+		}
 		printf("%s%d OK", (found == 1) ? ", " : "", services_ok);
 		printf("</td></tr>\n");
 
 		printf("</table>\n");
 
 		printf("<br/>\n");
-		}
+	}
 
 	if(show_all_hostgroups == FALSE)
 		printf("<b><anchor title='View All Hostgroups'>View All Hostgroups<go href='%s' method='post'><postfield name='hostgroup' value='all'/><postfield name='style' value='summary'/></go></anchor></b>\n", STATUSWML_CGI);
@@ -838,12 +849,13 @@ void display_hostgroup_summary(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays host status */
-void display_host(void) {
+void display_host(void)
+{
 	host *temp_host;
 	hoststatus *temp_hoststatus;
 	char last_check[MAX_DATETIME_LENGTH];
@@ -870,7 +882,7 @@ void display_host(void) {
 		printf("</p>\n");
 		printf("</card>\n");
 		return;
-		}
+	}
 
 	/* check authorization */
 	if(is_authorized_for_host(temp_host, &current_authdata) == FALSE) {
@@ -879,7 +891,7 @@ void display_host(void) {
 		printf("</p>\n");
 		printf("</card>\n");
 		return;
-		}
+	}
 
 
 	printf("<table columns='2' align='LL'>\n");
@@ -916,19 +928,19 @@ void display_host(void) {
 	if(temp_hoststatus->checks_enabled == FALSE) {
 		printf("%sChecks disabled", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(temp_hoststatus->notifications_enabled == FALSE) {
 		printf("%sNotifications disabled", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 		printf("%sProblem acknowledged", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(temp_hoststatus->scheduled_downtime_depth > 0) {
 		printf("%sIn scheduled downtime", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(found == 0)
 		printf("N/A");
 	printf("</td></tr>\n");
@@ -998,12 +1010,13 @@ void display_host(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays services on a host */
-void display_host_services(void) {
+void display_host_services(void)
+{
 	service *temp_service;
 	servicestatus *temp_servicestatus;
 
@@ -1044,7 +1057,7 @@ void display_host_services(void) {
 
 		printf("<go href='%s' method='post'><postfield name='host' value='%s'/><postfield name='service' value='%s'/></go></anchor></td>", STATUSWML_CGI, temp_service->host_name, temp_service->description);
 		printf("<td>%s</td></tr>\n", temp_service->description);
-		}
+	}
 
 	printf("</table>\n");
 
@@ -1053,12 +1066,13 @@ void display_host_services(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays service status */
-void display_service(void) {
+void display_service(void)
+{
 	service *temp_service;
 	servicestatus *temp_servicestatus;
 	char last_check[MAX_DATETIME_LENGTH];
@@ -1085,7 +1099,7 @@ void display_service(void) {
 		printf("</p>\n");
 		printf("</card>\n");
 		return;
-		}
+	}
 
 	/* check authorization */
 	if(is_authorized_for_service(temp_service, &current_authdata) == FALSE) {
@@ -1094,7 +1108,7 @@ void display_service(void) {
 		printf("</p>\n");
 		printf("</card>\n");
 		return;
-		}
+	}
 
 
 	printf("<table columns='2' align='LL'>\n");
@@ -1133,19 +1147,19 @@ void display_service(void) {
 	if(temp_servicestatus->checks_enabled == FALSE) {
 		printf("%sChecks disabled", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(temp_servicestatus->notifications_enabled == FALSE) {
 		printf("%sNotifications disabled", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 		printf("%sProblem acknowledged", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(temp_servicestatus->scheduled_downtime_depth > 0) {
 		printf("%sIn scheduled downtime", (found == 1) ? ", " : "");
 		found = 1;
-		}
+	}
 	if(found == 0)
 		printf("N/A");
 	printf("</td></tr>\n");
@@ -1170,23 +1184,21 @@ void display_service(void) {
 	if(temp_servicestatus->checks_enabled == FALSE) {
 		printf("<b><anchor title='Enable Checks'>Enable Checks<go href='%s' method='post'><postfield name='host' value='%s'/>", COMMAND_CGI, escape_string(host_name));
 		printf("<postfield name='service' value='%s'/><postfield name='cmd_typ' value='%d'/><postfield name='cmd_mod' value='%d'/><postfield name='content' value='wml'/></go></anchor></b><br/>\n", escape_string(service_desc), CMD_ENABLE_SVC_CHECK, CMDMODE_COMMIT);
-		}
-	else {
+	} else {
 		printf("<b><anchor title='Disable Checks'>Disable Checks<go href='%s' method='post'><postfield name='host' value='%s'/>", COMMAND_CGI, escape_string(host_name));
 		printf("<postfield name='service' value='%s'/><postfield name='cmd_typ' value='%d'/><postfield name='cmd_mod' value='%d'/><postfield name='content' value='wml'/></go></anchor></b><br/>\n", escape_string(service_desc), CMD_DISABLE_SVC_CHECK, CMDMODE_COMMIT);
 
 		printf("<b><anchor title='Schedule Immediate Check'>Schedule Immediate Check<go href='%s' method='post'><postfield name='host' value='%s'/>", COMMAND_CGI, escape_string(host_name));
 		printf("<postfield name='service' value='%s'/><postfield name='start_time' value='%lu'/><postfield name='cmd_typ' value='%d'/><postfield name='cmd_mod' value='%d'/><postfield name='content' value='wml'/></go></anchor></b><br/>\n", escape_string(service_desc), (unsigned long)current_time, CMD_SCHEDULE_SVC_CHECK, CMDMODE_COMMIT);
-		}
+	}
 
 	if(temp_servicestatus->notifications_enabled == FALSE) {
 		printf("<b><anchor title='Enable Notifications'>Enable Notifications<go href='%s' method='post'><postfield name='host' value='%s'/>", COMMAND_CGI, escape_string(host_name));
 		printf("<postfield name='service' value='%s'/><postfield name='cmd_typ' value='%d'/><postfield name='cmd_mod' value='%d'/><postfield name='content' value='wml'/></go></anchor></b><br/>\n", escape_string(service_desc), CMD_ENABLE_SVC_NOTIFICATIONS, CMDMODE_COMMIT);
-		}
-	else {
+	} else {
 		printf("<b><anchor title='Disable Notifications'>Disable Notifications<go href='%s' method='post'><postfield name='host' value='%s'/>", COMMAND_CGI, escape_string(host_name));
 		printf("<postfield name='service' value='%s'/><postfield name='cmd_typ' value='%d'/><postfield name='cmd_mod' value='%d'/><postfield name='content' value='wml'/></go></anchor></b><br/>\n", escape_string(service_desc), CMD_DISABLE_SVC_NOTIFICATIONS, CMDMODE_COMMIT);
-		}
+	}
 
 	printf("</p>\n");
 
@@ -1215,11 +1227,12 @@ void display_service(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 /* displays ping results */
-void display_ping(void) {
+void display_ping(void)
+{
 	char input_buffer[MAX_INPUT_BUFFER];
 	char buffer[MAX_INPUT_BUFFER];
 	char *temp_ptr;
@@ -1243,7 +1256,7 @@ void display_ping(void) {
 		printf("<go href='%s'><postfield name='ping' value='$(address)'/></go>\n", STATUSWML_CGI);
 		printf("</do>\n");
 		printf("</p>\n");
-		}
+	}
 
 	else {
 
@@ -1268,20 +1281,19 @@ void display_ping(void) {
 					if(strlen(buffer) + strlen(temp_ptr) < sizeof(buffer) - 1) {
 						strncat(buffer, temp_ptr, sizeof(buffer) - strlen(buffer) - 1);
 						buffer[sizeof(buffer) - 1] = '\x0';
-						}
-					in_macro = TRUE;
 					}
-				else {
+					in_macro = TRUE;
+				} else {
 
 					if(strlen(buffer) + strlen(temp_ptr) < sizeof(buffer) - 1) {
 
 						if(!strcmp(temp_ptr, "HOSTADDRESS"))
 							strncat(buffer, ping_address, sizeof(buffer) - strlen(buffer) - 1);
-						}
+					}
 
 					in_macro = FALSE;
-					}
 				}
+			}
 
 			/* run the ping command */
 			fp = popen(buffer, "r");
@@ -1296,30 +1308,29 @@ void display_ping(void) {
 					if(odd) {
 						odd = 0;
 						printf("%s<br/>\n", buffer);
-						}
-					else {
+					} else {
 						odd = 1;
 						printf("<b>%s</b><br/>\n", buffer);
-						}
 					}
 				}
-			else
+			} else
 				printf("Error executing ping!\n");
 
 			pclose(fp);
-			}
+		}
 
 		printf("</p>\n");
-		}
+	}
 
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 /* displays traceroute results */
-void display_traceroute(void) {
+void display_traceroute(void)
+{
 	char buffer[MAX_INPUT_BUFFER];
 	FILE *fp;
 	int odd = 0;
@@ -1340,7 +1351,7 @@ void display_traceroute(void) {
 		printf("<go href='%s'><postfield name='traceroute' value='$(address)'/></go>\n", STATUSWML_CGI);
 		printf("</do>\n");
 		printf("</p>\n");
-		}
+	}
 
 	else {
 
@@ -1365,30 +1376,29 @@ void display_traceroute(void) {
 				if(odd) {
 					odd = 0;
 					printf("%s<br/>\n", buffer);
-					}
-				else {
+				} else {
 					odd = 1;
 					printf("<b>%s</b><br/>\n", buffer);
-					}
 				}
 			}
-		else
+		} else
 			printf("Error executing traceroute!\n");
 
 		pclose(fp);
 
 		printf("</p>\n");
-		}
+	}
 
 	printf("</card>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays problems */
-void display_problems(void) {
+void display_problems(void)
+{
 	host *temp_host;
 	service *temp_service;
 	hoststatus *temp_hoststatus;
@@ -1425,7 +1435,7 @@ void display_problems(void) {
 				continue;
 			if(temp_hoststatus->scheduled_downtime_depth > 0)
 				continue;
-			}
+		}
 
 		total_host_problems++;
 
@@ -1438,7 +1448,7 @@ void display_problems(void) {
 			printf("???");
 		printf("<go href='%s' method='post'><postfield name='host' value='%s'/></go></anchor></td>", STATUSWML_CGI, temp_host->name);
 		printf("<td>%s</td></tr>\n", temp_host->name);
-		}
+	}
 
 	if(total_host_problems == 0)
 		printf("<tr><td>No problems</td></tr>\n");
@@ -1477,8 +1487,8 @@ void display_problems(void) {
 					continue;
 				if(temp_hoststatus->problem_has_been_acknowledged == TRUE)
 					continue;
-				}
 			}
+		}
 
 		total_service_problems++;
 
@@ -1493,7 +1503,7 @@ void display_problems(void) {
 			printf("???");
 		printf("<go href='%s' method='post'><postfield name='host' value='%s'/><postfield name='service' value='%s'/></go></anchor></td>", STATUSWML_CGI, temp_service->host_name, temp_service->description);
 		printf("<td>%s/%s</td></tr>\n", temp_service->host_name, temp_service->description);
-		}
+	}
 
 	if(total_service_problems == 0)
 		printf("<tr><td>No problems</td></tr>\n");
@@ -1505,4 +1515,4 @@ void display_problems(void) {
 	printf("</card>\n");
 
 	return;
-	}
+}

--- a/cgi/statuswrl.c
+++ b/cgi/statuswrl.c
@@ -128,7 +128,8 @@ int coordinates_were_specified = FALSE; /* were drawing coordinates specified wi
 
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 
 	/* reset internal variables */
@@ -139,7 +140,7 @@ int main(int argc, char **argv) {
 	if(result == ERROR) {
 		document_header();
 		return ERROR;
-		}
+	}
 
 	/* defaults from CGI config file */
 	layout_method = default_statuswrl_layout_method;
@@ -164,7 +165,7 @@ int main(int argc, char **argv) {
 	if(result == ERROR) {
 		free_memory();
 		return ERROR;
-		}
+	}
 
 	/* get authentication information */
 	get_authentication_information(&current_authdata);
@@ -176,11 +177,12 @@ int main(int argc, char **argv) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(void) {
+void document_header(void)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -200,11 +202,12 @@ void document_header(void) {
 	printf("Content-Type: x-world/x-vrml\r\n\r\n");
 
 	return;
-	}
+}
 
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -217,7 +220,7 @@ int process_cgivars(void) {
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			x++;
 			continue;
-			}
+		}
 
 
 		/* we found the host argument */
@@ -226,7 +229,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "all";
@@ -237,7 +240,7 @@ int process_cgivars(void) {
 				show_all_hosts = TRUE;
 			else
 				show_all_hosts = FALSE;
-			}
+		}
 
 		/* we found the no textures argument*/
 		else if(!strcmp(variables[x], "notextures"))
@@ -257,9 +260,9 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
-			layout_method = atoi(variables[x]);
 			}
+			layout_method = atoi(variables[x]);
+		}
 
 		/* we found custom viewpoint coord */
 		else if(!strcmp(variables[x], "viewx")) {
@@ -267,41 +270,40 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			custom_viewpoint_x = strtod(variables[x], NULL);
 			custom_viewpoint = TRUE;
-			}
-		else if(!strcmp(variables[x], "viewy")) {
+		} else if(!strcmp(variables[x], "viewy")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			custom_viewpoint_y = strtod(variables[x], NULL);
 			custom_viewpoint = TRUE;
-			}
-		else if(!strcmp(variables[x], "viewz")) {
+		} else if(!strcmp(variables[x], "viewz")) {
 			x++;
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 			custom_viewpoint_z = strtod(variables[x], NULL);
 			custom_viewpoint = TRUE;
-			}
-
 		}
+
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* top-level VRML world generation... */
-void display_world(void) {
+void display_world(void)
+{
 	host *temp_host = NULL;
 
 	/* get the url we will use to grab the logo images... */
@@ -357,7 +359,7 @@ void display_world(void) {
 
 		printf("]\n");
 		printf("}\n");
-		}
+	}
 
 	/* coordinates were specified... */
 	else {
@@ -372,10 +374,10 @@ void display_world(void) {
 
 		/* draw host links */
 		draw_host_links();
-		}
+	}
 
 	return;
-	}
+}
 
 
 
@@ -385,7 +387,8 @@ void display_world(void) {
 /******************************************************************/
 
 /* calculates how many "layers" separate parent and child - used by collapsed tree layout method */
-int host_child_depth_separation(host *parent, host *child) {
+int host_child_depth_separation(host *parent, host *child)
+{
 	int this_depth = 0;
 	int min_depth = 0;
 	int have_min_depth = FALSE;
@@ -409,20 +412,21 @@ int host_child_depth_separation(host *parent, host *child) {
 			if(this_depth >= 0 && (have_min_depth == FALSE || (have_min_depth == TRUE && (this_depth < min_depth)))) {
 				have_min_depth = TRUE;
 				min_depth = this_depth;
-				}
 			}
 		}
+	}
 
 	if(have_min_depth == FALSE)
 		return -1;
 	else
 		return min_depth + 1;
-	}
+}
 
 
 
 /* calculates how many hosts reside on a specific "layer" - used by collapsed tree layout method */
-int number_of_host_layer_members(host *parent, int layer) {
+int number_of_host_layer_members(host *parent, int layer)
+{
 	int current_layer;
 	int layer_members = 0;
 	host *temp_host;
@@ -433,15 +437,16 @@ int number_of_host_layer_members(host *parent, int layer) {
 
 		if(current_layer == layer)
 			layer_members++;
-		}
+	}
 
 	return layer_members;
-	}
+}
 
 
 
 /* calculate max number of members on all "layers" beneath and including parent host - used by collapsed tree layout method */
-int max_child_host_layer_members(host *parent) {
+int max_child_host_layer_members(host *parent)
+{
 	int current_layer;
 	int max_members = 1;
 	int current_members = 0;
@@ -455,22 +460,23 @@ int max_child_host_layer_members(host *parent) {
 
 		if(current_members > max_members)
 			max_members = current_members;
-		}
+	}
 
 	return max_members;
-	}
+}
 
 
 
 /* calculate max drawing width for host and children - used by balanced tree layout method */
-int max_child_host_drawing_width(host *parent) {
+int max_child_host_drawing_width(host *parent)
+{
 	host *temp_host;
 	int child_width = 0;
 
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 		if(is_host_immediate_child_of_host(parent, temp_host) == TRUE)
 			child_width += max_child_host_drawing_width(temp_host);
-		}
+	}
 
 	/* no children, so set width to 1 for this host */
 	if(child_width == 0)
@@ -478,7 +484,7 @@ int max_child_host_drawing_width(host *parent) {
 
 	else
 		return child_width;
-	}
+}
 
 
 
@@ -488,7 +494,8 @@ int max_child_host_drawing_width(host *parent) {
 /******************************************************************/
 
 /* calculates host drawing coordinates */
-void calculate_host_coords(void) {
+void calculate_host_coords(void)
+{
 	host *this_host;
 	host *temp_host;
 	int parent_hosts = 0;
@@ -517,10 +524,10 @@ void calculate_host_coords(void) {
 				temp_host->should_be_drawn = TRUE;
 			else
 				temp_host->should_be_drawn = FALSE;
-			}
+		}
 
 		return;
-		}
+	}
 
 	/*****************************/
 	/***** AUTO-LAYOUT MODES *****/
@@ -540,7 +547,7 @@ void calculate_host_coords(void) {
 		else
 		*/
 		temp_host->z_3d = 0.0;
-		}
+	}
 
 
 	/***** COLLAPSED TREE MODE *****/
@@ -565,7 +572,7 @@ void calculate_host_coords(void) {
 			nagios_icon_x = center_x;
 			nagios_icon_y = offset_y;
 			draw_nagios_icon = TRUE;
-			}
+		}
 
 		/* do we need to draw a link to parent(s)? */
 		if(this_host != NULL && is_host_immediate_child_of_host(NULL, this_host) == FALSE)
@@ -581,7 +588,7 @@ void calculate_host_coords(void) {
 				temp_host->x_3d = center_x - (((parent_hosts * DEFAULT_NODE_WIDTH) + ((parent_hosts - 1) * DEFAULT_NODE_HSPACING)) / 2) + (current_parent_host * (DEFAULT_NODE_WIDTH + DEFAULT_NODE_HSPACING)) + (DEFAULT_NODE_WIDTH / 2);
 				temp_host->y_3d = offset_y;
 				current_parent_host++;
-				}
+			}
 
 			/* this is the "main" host we're drawing */
 			else if(this_host == temp_host) {
@@ -589,14 +596,14 @@ void calculate_host_coords(void) {
 				temp_host->have_3d_coords = TRUE;
 				temp_host->x_3d = center_x;
 				temp_host->y_3d = DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y;
-				}
+			}
 
 			/* else do not draw this host (we might if its a child - see below, but assume no for now) */
 			else {
 				temp_host->should_be_drawn = FALSE;
 				temp_host->have_3d_coords = FALSE;
-				}
 			}
+		}
 
 
 		/* TODO: REORDER CHILD LAYER MEMBERS SO THAT WE MINIMIZE LINK CROSSOVERS FROM PARENT HOSTS */
@@ -625,11 +632,11 @@ void calculate_host_coords(void) {
 					else
 						temp_host->y_3d = ((DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING) * (current_layer + 1)) + offset_y;
 					current_layer_member++;
-					}
 				}
 			}
-
 		}
+
+	}
 
 
 	/***** "BALANCED" TREE MODE *****/
@@ -654,7 +661,7 @@ void calculate_host_coords(void) {
 			nagios_icon_x = center_x;
 			nagios_icon_y = offset_y;
 			draw_nagios_icon = TRUE;
-			}
+		}
 
 		/* do we need to draw a link to parent(s)? */
 		if(this_host != NULL && is_host_immediate_child_of_host(NULL, this_host) == FALSE)
@@ -670,7 +677,7 @@ void calculate_host_coords(void) {
 				temp_host->x_3d = center_x - (((parent_hosts * DEFAULT_NODE_WIDTH) + ((parent_hosts - 1) * DEFAULT_NODE_HSPACING)) / 2) + (current_parent_host * (DEFAULT_NODE_WIDTH + DEFAULT_NODE_HSPACING)) + (DEFAULT_NODE_WIDTH / 2);
 				temp_host->y_3d = offset_y;
 				current_parent_host++;
-				}
+			}
 
 			/* this is the "main" host we're drawing */
 			else if(this_host == temp_host) {
@@ -678,19 +685,19 @@ void calculate_host_coords(void) {
 				temp_host->have_3d_coords = TRUE;
 				temp_host->x_3d = center_x;
 				temp_host->y_3d = DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y;
-				}
+			}
 
 			/* else do not draw this host (we might if its a child - see below, but assume no for now) */
 			else {
 				temp_host->should_be_drawn = FALSE;
 				temp_host->have_3d_coords = FALSE;
-				}
 			}
+		}
 
 		/* draw all children hosts */
 		calculate_balanced_tree_coords(this_host, center_x, DEFAULT_NODE_HEIGHT + DEFAULT_NODE_VSPACING + offset_y);
 
-		}
+	}
 
 
 	/***** CIRCULAR LAYOUT MODE *****/
@@ -703,15 +710,16 @@ void calculate_host_coords(void) {
 
 		/* calculate coordinates for all hosts */
 		calculate_circular_coords();
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* calculate world dimensions */
-void calculate_world_bounds(void) {
+void calculate_world_bounds(void)
+{
 	host *temp_host;
 
 	min_x_coord = 0.0;
@@ -727,7 +735,7 @@ void calculate_world_bounds(void) {
 		if(temp_host->have_3d_coords == FALSE) {
 			temp_host->should_be_drawn = FALSE;
 			continue;
-			}
+		}
 
 		if(temp_host->should_be_drawn == FALSE)
 			continue;
@@ -746,7 +754,7 @@ void calculate_world_bounds(void) {
 			max_z_coord = temp_host->z_3d;
 
 		coordinates_were_specified = TRUE;
-		}
+	}
 
 	/* no drawing coordinates were specified */
 	if(coordinates_were_specified == FALSE) {
@@ -756,7 +764,7 @@ void calculate_world_bounds(void) {
 		max_y_coord = 0.0;
 		min_z_coord = 0.0;
 		max_z_coord = 6.0;
-		}
+	}
 
 	max_world_size = max_x_coord - min_x_coord;
 	if(max_world_size < (max_y_coord - min_y_coord))
@@ -765,7 +773,7 @@ void calculate_world_bounds(void) {
 		max_world_size = max_z_coord - min_z_coord;
 
 	return;
-	}
+}
 
 
 /******************************************************************/
@@ -774,7 +782,8 @@ void calculate_world_bounds(void) {
 
 
 /* write global VRML data */
-void write_global_vrml_data(void) {
+void write_global_vrml_data(void)
+{
 	host *temp_host;
 	float visibility_range = 0.0;
 	float viewpoint_z = 0.0;
@@ -817,7 +826,7 @@ void write_global_vrml_data(void) {
 		printf("fieldOfView 0.78\n");
 		printf("description \"Entry Viewpoint\"\n");
 		printf("}\n");
-		}
+	}
 
 	/* host close-up viewpoint */
 	if(show_all_hosts == FALSE) {
@@ -830,8 +839,8 @@ void write_global_vrml_data(void) {
 			printf("fieldOfView 0.78\n");
 			printf("description \"Host Close-Up Viewpoint\"\n");
 			printf("}\n");
-			}
 		}
+	}
 
 	/* calculate z coord for default viewpoint - don't get too close */
 	viewpoint_z = max_world_size;
@@ -885,15 +894,16 @@ void write_global_vrml_data(void) {
 		printf("Inline{\n");
 		printf("url \"%s%s\"\n", url_html_path, statuswrl_include);
 		printf("}\n");
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* draws a host */
-void draw_host(host *temp_host) {
+void draw_host(host *temp_host)
+{
 	hoststatus *temp_hoststatus = NULL;
 	char state_string[16] = "";
 	double x, y, z;
@@ -910,7 +920,7 @@ void draw_host(host *temp_host) {
 		x = temp_host->x_3d;
 		y = temp_host->y_3d;
 		z = temp_host->z_3d;
-		}
+	}
 
 	/* make the host name safe for embedding in VRML */
 	vrml_safe_hostname = (char *)strdup(temp_host->name);
@@ -920,7 +930,7 @@ void draw_host(host *temp_host) {
 		ch = vrml_safe_hostname[a];
 		if((ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9'))
 			vrml_safe_hostname[a] = '_';
-		}
+	}
 
 	/* see if user is authorized to view this host  */
 	if(is_authorized_for_host(temp_host, &current_authdata) == FALSE)
@@ -955,7 +965,7 @@ void draw_host(host *temp_host) {
 		printf("texture ImageTexture{\n");
 		printf("url \"%s%s\"\n", url_logo_images_path, temp_host->vrml_image);
 		printf("}\n");
-		}
+	}
 	printf("}\n");
 	printf("geometry Box{\n");
 	printf("size %2.2f %2.2f %2.2f\n", node_width, node_width, node_width);
@@ -985,7 +995,7 @@ void draw_host(host *temp_host) {
 				printf("font_color 0 1 0\n");
 			else if(temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)
 				printf("font_color 1 0 0\n");
-			}
+		}
 		printf("the_text [\"%s\", \"%s\", ", temp_host->name, temp_host->alias);
 		if(temp_hoststatus == NULL)
 			strcpy(state_string, "UNKNOWN");
@@ -998,13 +1008,13 @@ void draw_host(host *temp_host) {
 				strcpy(state_string, "PENDING");
 			else
 				strcpy(state_string, "UP");
-			}
+		}
 		printf("\"%s\"]\n", state_string);
 
 		printf("}\n");
 		printf("]\n");
 		printf("}\n");
-		}
+	}
 
 	/* host is down or unreachable, so make it fade in and out */
 	if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE))
@@ -1013,12 +1023,13 @@ void draw_host(host *temp_host) {
 	free(vrml_safe_hostname);
 
 	return;
-	}
+}
 
 
 
 /* draw links between hosts */
-void draw_host_links(void) {
+void draw_host_links(void)
+{
 	host *parent_host;
 	host *child_host;
 
@@ -1048,19 +1059,20 @@ void draw_host_links(void) {
 
 				/* draw the link between the child and parent hosts */
 				draw_host_link(parent_host, parent_host->x_3d, parent_host->y_3d, parent_host->z_3d, child_host->x_3d, child_host->y_3d, child_host->z_3d);
-				}
 			}
 		}
+	}
 
 
 	return;
-	}
+}
 
 
 
 
 /* draws a link from a parent host to a child host */
-void draw_host_link(host *hst, double x0, double y0, double z0, double x1, double y1, double z1) {
+void draw_host_link(host *hst, double x0, double y0, double z0, double x1, double y1, double z1)
+{
 
 	printf("\n");
 
@@ -1087,12 +1099,13 @@ void draw_host_link(host *hst, double x0, double y0, double z0, double x1, doubl
 	printf("}\n");
 
 	return;
-	}
+}
 
 
 
 /* draw process icon */
-void draw_process_icon(void) {
+void draw_process_icon(void)
+{
 	host *child_host;
 
 	if(draw_nagios_icon == FALSE)
@@ -1120,7 +1133,7 @@ void draw_process_icon(void) {
 		printf("texture ImageTexture{\n");
 		printf("url \"%s%s\"\n", url_logo_images_path, NAGIOS_VRML_IMAGE);
 		printf("}\n");
-		}
+	}
 	printf("}\n");
 	printf("geometry Box{\n");
 	printf("size %2.2f %2.2f %2.2f\n", node_width * 3.0, node_width * 3.0, node_width * 3.0);
@@ -1152,10 +1165,10 @@ void draw_process_icon(void) {
 		/* draw a link to the host */
 		if(is_host_immediate_child_of_host(NULL, child_host) == TRUE)
 			draw_host_link(NULL, nagios_icon_x, nagios_icon_y, 0.0, child_host->x_3d, child_host->y_3d, child_host->z_3d);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
@@ -1165,7 +1178,8 @@ void draw_process_icon(void) {
 /******************************************************************/
 
 /* calculates coords of a host's children - used by balanced tree layout method */
-void calculate_balanced_tree_coords(host *parent, int x, int y) {
+void calculate_balanced_tree_coords(host *parent, int x, int y)
+{
 	int parent_drawing_width;
 	int start_drawing_x;
 	int current_drawing_x;
@@ -1197,26 +1211,28 @@ void calculate_balanced_tree_coords(host *parent, int x, int y) {
 
 			/* recurse into child host ... */
 			calculate_balanced_tree_coords(temp_host, temp_host->x_3d, temp_host->y_3d);
-			}
-
 		}
 
-	return;
 	}
+
+	return;
+}
 
 
 /* calculate coords of all hosts in circular layout method */
-void calculate_circular_coords(void) {
+void calculate_circular_coords(void)
+{
 
 	/* calculate all host coords, starting with first layer */
 	calculate_circular_layer_coords(NULL, 0.0, 360.0, 1, CIRCULAR_DRAWING_RADIUS);
 
 	return;
-	}
+}
 
 
 /* calculates coords of all hosts in a particular "layer" in circular layout method */
-void calculate_circular_layer_coords(host *parent, double start_angle, double useable_angle, int layer, int radius) {
+void calculate_circular_layer_coords(host *parent, double start_angle, double useable_angle, int layer, int radius)
+{
 	int parent_drawing_width = 0;
 	int this_drawing_width = 0;
 	int immediate_children = 0;
@@ -1283,8 +1299,8 @@ void calculate_circular_layer_coords(host *parent, double start_angle, double us
 
 			/* increment current drawing angle */
 			current_drawing_angle += available_angle;
-			}
 		}
+	}
 
 	return;
-	}
+}

--- a/cgi/summary.c
+++ b/cgi/summary.c
@@ -100,7 +100,7 @@ typedef struct archived_event_struct {
 	int     state_type;
 	char    *event_info;
 	struct archived_event_struct *next;
-	} archived_event;
+} archived_event;
 
 typedef struct alert_producer_struct {
 	int     producer_type;
@@ -108,7 +108,7 @@ typedef struct alert_producer_struct {
 	char    *service_description;
 	int     total_alerts;
 	struct alert_producer_struct *next;
-	} alert_producer;
+} alert_producer;
 
 
 void read_archived_event_data(void);
@@ -194,7 +194,8 @@ int generate_report = FALSE;
 
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char start_timestring[MAX_DATETIME_LENGTH];
 	char end_timestring[MAX_DATETIME_LENGTH];
@@ -235,7 +236,7 @@ int main(int argc, char **argv) {
 		t3 = t2;
 		t2 = t1;
 		t1 = t3;
-		}
+	}
 
 	if(display_header == TRUE) {
 
@@ -282,7 +283,7 @@ int main(int argc, char **argv) {
 
 			get_time_breakdown((time_t)(t2 - t1), &days, &hours, &minutes, &seconds);
 			printf("<div align=center class='reportDuration'>Duration: %dd %dh %dm %ds</div>\n", days, hours, minutes, seconds);
-			}
+		}
 
 		printf("</td>\n");
 
@@ -324,11 +325,11 @@ int main(int argc, char **argv) {
 			if(host_states & AE_HOST_UP) {
 				printf("Up");
 				x = 1;
-				}
+			}
 			if(host_states & AE_HOST_DOWN) {
 				printf("%sDown", (x == 1) ? ", " : "");
 				x = 1;
-				}
+			}
 			if(host_states & AE_HOST_UNREACHABLE)
 				printf("%sUnreachable", (x == 1) ? ", " : "");
 			if(x == 0)
@@ -343,15 +344,15 @@ int main(int argc, char **argv) {
 			if(service_states & AE_SERVICE_OK) {
 				printf("Ok");
 				x = 1;
-				}
+			}
 			if(service_states & AE_SERVICE_WARNING) {
 				printf("%sWarning", (x == 1) ? ", " : "");
 				x = 1;
-				}
+			}
 			if(service_states & AE_SERVICE_UNKNOWN) {
 				printf("%sUnknown", (x == 1) ? ", " : "");
 				x = 1;
-				}
+			}
 			if(service_states & AE_SERVICE_CRITICAL)
 				printf("%sCritical", (x == 1) ? ", " : "");
 			if(x == 0)
@@ -386,7 +387,7 @@ int main(int argc, char **argv) {
 			printf("</td></tr>\n");
 
 			printf("</table>\n");
-			}
+		}
 
 		else {
 			printf("<table border=0>\n");
@@ -396,14 +397,14 @@ int main(int argc, char **argv) {
 			printf("</td></tr>\n");
 
 			printf("</table>\n");
-			}
+		}
 
 		printf("</td>\n");
 
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 
 	/*********************************/
@@ -413,7 +414,7 @@ int main(int argc, char **argv) {
 	if(generate_report == TRUE) {
 		read_archived_event_data();
 		display_report();
-		}
+	}
 
 	/* ask user for report options */
 	else {
@@ -553,7 +554,7 @@ int main(int argc, char **argv) {
 		for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
 			if(is_authorized_for_hostgroup(temp_hostgroup, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s\n", escape_string(temp_hostgroup->group_name), temp_hostgroup->group_name);
-			}
+		}
 		printf("</select>\n");
 		printf("</td></tr>\n");
 
@@ -563,7 +564,7 @@ int main(int argc, char **argv) {
 		for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next) {
 			if(is_authorized_for_servicegroup(temp_servicegroup, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s\n", escape_string(temp_servicegroup->group_name), temp_servicegroup->group_name);
-			}
+		}
 		printf("</select>\n");
 		printf("</td></tr>\n");
 
@@ -574,7 +575,7 @@ int main(int argc, char **argv) {
 		for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 			if(is_authorized_for_host(temp_host, &current_authdata) == TRUE)
 				printf("<option value='%s'>%s\n", escape_string(temp_host->name), temp_host->name);
-			}
+		}
 		printf("</select>\n");
 		printf("</td></tr>\n");
 
@@ -630,7 +631,7 @@ int main(int argc, char **argv) {
 
 		printf("</form>\n");
 		printf("</DIV>\n");
-		}
+	}
 
 
 	document_footer();
@@ -641,11 +642,12 @@ int main(int argc, char **argv) {
 	free_producer_list();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -666,7 +668,7 @@ void document_header(int use_stylesheet) {
 	else {
 		printf("Content-type: text/plain\r\n\r\n");
 		return;
-		}
+	}
 
 	if(embedded == TRUE || output_format == CSV_OUTPUT)
 		return;
@@ -681,7 +683,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, SUMMARY_CSS);
-		}
+	}
 
 	printf("</head>\n");
 
@@ -691,11 +693,12 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(SUMMARY_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(output_format != HTML_OUTPUT)
 		return;
@@ -710,11 +713,12 @@ void document_footer(void) {
 	printf("</html>\n");
 
 	return;
-	}
+}
 
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -726,7 +730,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t1")) {
@@ -734,12 +738,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t1 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = FALSE;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t2")) {
@@ -747,12 +751,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t2 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = FALSE;
-			}
+		}
 
 		/* we found the standard timeperiod argument */
 		else if(!strcmp(variables[x], "timeperiod")) {
@@ -760,7 +764,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "today"))
 				timeperiod_type = TIMEPERIOD_TODAY;
@@ -795,7 +799,7 @@ int process_cgivars(void) {
 
 			convert_timeperiod_to_times(timeperiod_type);
 			compute_time_from_parts = FALSE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -811,7 +815,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -819,7 +823,7 @@ int process_cgivars(void) {
 			start_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "sday")) {
@@ -827,7 +831,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -835,7 +839,7 @@ int process_cgivars(void) {
 			start_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "syear")) {
@@ -843,7 +847,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -851,7 +855,7 @@ int process_cgivars(void) {
 			start_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smin")) {
@@ -859,7 +863,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -867,7 +871,7 @@ int process_cgivars(void) {
 			start_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ssec")) {
@@ -875,7 +879,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -883,7 +887,7 @@ int process_cgivars(void) {
 			start_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "shour")) {
@@ -891,7 +895,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -899,7 +903,7 @@ int process_cgivars(void) {
 			start_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 
 		/* we found time argument */
@@ -908,7 +912,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -916,7 +920,7 @@ int process_cgivars(void) {
 			end_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eday")) {
@@ -924,7 +928,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -932,7 +936,7 @@ int process_cgivars(void) {
 			end_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eyear")) {
@@ -940,7 +944,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -948,7 +952,7 @@ int process_cgivars(void) {
 			end_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "emin")) {
@@ -956,7 +960,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -964,7 +968,7 @@ int process_cgivars(void) {
 			end_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "esec")) {
@@ -972,7 +976,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -980,7 +984,7 @@ int process_cgivars(void) {
 			end_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ehour")) {
@@ -988,7 +992,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -996,7 +1000,7 @@ int process_cgivars(void) {
 			end_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found the item limit argument */
 		else if(!strcmp(variables[x], "limit")) {
@@ -1004,10 +1008,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			item_limit = atoi(variables[x]);
-			}
+		}
 
 		/* we found the state types argument */
 		else if(!strcmp(variables[x], "statetypes")) {
@@ -1015,10 +1019,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			state_types = atoi(variables[x]);
-			}
+		}
 
 		/* we found the alert types argument */
 		else if(!strcmp(variables[x], "alerttypes")) {
@@ -1026,10 +1030,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			alert_types = atoi(variables[x]);
-			}
+		}
 
 		/* we found the host states argument */
 		else if(!strcmp(variables[x], "hoststates")) {
@@ -1037,10 +1041,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			host_states = atoi(variables[x]);
-			}
+		}
 
 		/* we found the service states argument */
 		else if(!strcmp(variables[x], "servicestates")) {
@@ -1048,10 +1052,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			service_states = atoi(variables[x]);
-			}
+		}
 
 		/* we found the generate report argument */
 		else if(!strcmp(variables[x], "report")) {
@@ -1059,10 +1063,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			generate_report = (atoi(variables[x]) > 0) ? TRUE : FALSE;
-			}
+		}
 
 
 		/* we found the display type argument */
@@ -1071,10 +1075,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			display_type = atoi(variables[x]);
-			}
+		}
 
 		/* we found the standard report argument */
 		else if(!strcmp(variables[x], "standardreport")) {
@@ -1082,10 +1086,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			standard_report = atoi(variables[x]);
-			}
+		}
 
 		/* we found the hostgroup argument */
 		else if(!strcmp(variables[x], "hostgroup")) {
@@ -1093,7 +1097,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((target_hostgroup_name = (char *)strdup(variables[x])) == NULL)
 				target_hostgroup_name = "";
@@ -1104,8 +1108,8 @@ int process_cgivars(void) {
 			else {
 				show_all_hostgroups = FALSE;
 				target_hostgroup = find_hostgroup(target_hostgroup_name);
-				}
 			}
+		}
 
 		/* we found the servicegroup argument */
 		else if(!strcmp(variables[x], "servicegroup")) {
@@ -1113,7 +1117,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((target_servicegroup_name = (char *)strdup(variables[x])) == NULL)
 				target_servicegroup_name = "";
@@ -1124,8 +1128,8 @@ int process_cgivars(void) {
 			else {
 				show_all_servicegroups = FALSE;
 				target_servicegroup = find_servicegroup(target_servicegroup_name);
-				}
 			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -1133,7 +1137,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((target_host_name = (char *)strdup(variables[x])) == NULL)
 				target_host_name = "";
@@ -1144,20 +1148,21 @@ int process_cgivars(void) {
 			else {
 				show_all_hosts = FALSE;
 				target_host = find_host(target_host_name);
-				}
 			}
 		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* reads log files for archived event data */
-void read_archived_event_data(void) {
+void read_archived_event_data(void)
+{
 	char filename[MAX_FILENAME_LENGTH];
 	int oldest_archive = 0;
 	int newest_archive = 0;
@@ -1180,15 +1185,16 @@ void read_archived_event_data(void) {
 
 		/* scan the log file for archived state data */
 		scan_log_file_for_archived_event_data(filename);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* grabs archived event data from a log file */
-void scan_log_file_for_archived_event_data(char *filename) {
+void scan_log_file_for_archived_event_data(char *filename)
+{
 	char *input = NULL;
 	char *input2 = NULL;
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -1259,7 +1265,7 @@ void scan_log_file_for_archived_event_data(char *filename) {
 				continue;
 
 			add_archived_event(AE_HOST_ALERT, time_stamp, state, state_type, entry_host_name, NULL, plugin_output);
-			}
+		}
 
 		/* service alerts */
 		if(strstr(input, "SERVICE ALERT:")) {
@@ -1300,8 +1306,8 @@ void scan_log_file_for_archived_event_data(char *filename) {
 				continue;
 
 			add_archived_event(AE_SERVICE_ALERT, time_stamp, state, state_type, entry_host_name, entry_svc_description, plugin_output);
-			}
 		}
+	}
 
 	/* free memory and close the file */
 	free(input);
@@ -1309,12 +1315,13 @@ void scan_log_file_for_archived_event_data(char *filename) {
 	mmap_fclose(thefile);
 
 	return;
-	}
+}
 
 
 
 
-void convert_timeperiod_to_times(int type) {
+void convert_timeperiod_to_times(int type)
+{
 	time_t current_time;
 	struct tm *t;
 
@@ -1329,79 +1336,79 @@ void convert_timeperiod_to_times(int type) {
 	t->tm_isdst = -1;
 
 	switch(type) {
-		case TIMEPERIOD_LAST24HOURS:
-			t1 = current_time - (60 * 60 * 24);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_TODAY:
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_YESTERDAY:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24));
-			t2 = (time_t)mktime(t);
-			break;
-		case TIMEPERIOD_THISWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
-			t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			break;
-		case TIMEPERIOD_THISMONTH:
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTMONTH:
-			t->tm_mday = 1;
-			t2 = mktime(t);
-			if(t->tm_mon == 0) {
-				t->tm_mon = 11;
-				t->tm_year--;
-				}
-			else
-				t->tm_mon--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_THISQUARTER:
-			/* not implemented */
-			break;
-		case TIMEPERIOD_LASTQUARTER:
-			/* not implemented */
-			break;
-		case TIMEPERIOD_THISYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t2 = mktime(t);
+	case TIMEPERIOD_LAST24HOURS:
+		t1 = current_time - (60 * 60 * 24);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_TODAY:
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_YESTERDAY:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24));
+		t2 = (time_t)mktime(t);
+		break;
+	case TIMEPERIOD_THISWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
+		t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		break;
+	case TIMEPERIOD_THISMONTH:
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTMONTH:
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		if(t->tm_mon == 0) {
+			t->tm_mon = 11;
 			t->tm_year--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_LAST7DAYS:
-			t2 = current_time;
-			t1 = current_time - (7 * 24 * 60 * 60);
-			break;
-		case TIMEPERIOD_LAST31DAYS:
-			t2 = current_time;
-			t1 = current_time - (31 * 24 * 60 * 60);
-			break;
-		default:
-			break;
-		}
-
-	return;
+		} else
+			t->tm_mon--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_THISQUARTER:
+		/* not implemented */
+		break;
+	case TIMEPERIOD_LASTQUARTER:
+		/* not implemented */
+		break;
+	case TIMEPERIOD_THISYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		t->tm_year--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_LAST7DAYS:
+		t2 = current_time;
+		t1 = current_time - (7 * 24 * 60 * 60);
+		break;
+	case TIMEPERIOD_LAST31DAYS:
+		t2 = current_time;
+		t1 = current_time - (31 * 24 * 60 * 60);
+		break;
+	default:
+		break;
 	}
 
+	return;
+}
 
 
-void compute_report_times(void) {
+
+void compute_report_times(void)
+{
 	time_t current_time;
 	struct tm *st;
 	struct tm *et;
@@ -1432,11 +1439,12 @@ void compute_report_times(void) {
 	et->tm_isdst = -1;
 
 	t2 = mktime(et);
-	}
+}
 
 
 
-void free_event_list(void) {
+void free_event_list(void)
+{
 	archived_event *this_event = NULL;
 	archived_event *next_event = NULL;
 
@@ -1450,16 +1458,17 @@ void free_event_list(void) {
 			free(this_event->event_info);
 		free(this_event);
 		this_event = next_event;
-		}
+	}
 
 	event_list = NULL;
 
 	return;
-	}
+}
 
 
 /* adds an archived event entry to the list in memory */
-void add_archived_event(int event_type, time_t time_stamp, int entry_type, int state_type, char *host_name, char *svc_description, char *event_info) {
+void add_archived_event(int event_type, time_t time_stamp, int entry_type, int state_type, char *host_name, char *svc_description, char *event_info)
+{
 	archived_event *last_event = NULL;
 	archived_event *temp_event = NULL;
 	archived_event *new_event = NULL;
@@ -1483,11 +1492,10 @@ void add_archived_event(int event_type, time_t time_stamp, int entry_type, int s
 	if(event_type == AE_HOST_ALERT) {
 		if(!(host_states & entry_type))
 			return;
-		}
-	else {
+	} else {
 		if(!(service_states & entry_type))
 			return;
-		}
+	}
 
 	/* find the host this entry is associated with */
 	temp_host = find_host(host_name);
@@ -1502,28 +1510,26 @@ void add_archived_event(int event_type, time_t time_stamp, int entry_type, int s
 			return;
 		if(strcmp(target_host->name, temp_host->name))
 			return;
-		}
+	}
 
 	/* check servicegroup math (valid filter for all reports) */
 	if(event_type == AE_SERVICE_ALERT) {
 		temp_service = find_service(host_name, svc_description);
 		if(show_all_servicegroups == FALSE && is_service_member_of_servicegroup(target_servicegroup, temp_service) == FALSE)
 			return;
-		}
-	else {
+	} else {
 		if(show_all_servicegroups == FALSE && is_host_member_of_servicegroup(target_servicegroup, temp_host) == FALSE)
 			return;
-		}
+	}
 
 	/* check authorization */
 	if(event_type == AE_SERVICE_ALERT) {
 		if(is_authorized_for_service(temp_service, &current_authdata) == FALSE)
 			return;
-		}
-	else {
+	} else {
 		if(is_authorized_for_host(temp_host, &current_authdata) == FALSE)
 			return;
-		}
+	}
 
 #ifdef DEBUG
 	if(event_type == AE_HOST_ALERT)
@@ -1542,8 +1548,7 @@ void add_archived_event(int event_type, time_t time_stamp, int entry_type, int s
 		new_event->host_name = (char *)malloc(strlen(host_name) + 1);
 		if(new_event->host_name != NULL)
 			strcpy(new_event->host_name, host_name);
-		}
-	else
+	} else
 		new_event->host_name = NULL;
 
 	/* allocate memory for the service description */
@@ -1551,8 +1556,7 @@ void add_archived_event(int event_type, time_t time_stamp, int entry_type, int s
 		new_event->service_description = (char *)malloc(strlen(svc_description) + 1);
 		if(new_event->service_description != NULL)
 			strcpy(new_event->service_description, svc_description);
-		}
-	else
+	} else
 		new_event->service_description = NULL;
 
 	/* allocate memory for the event info */
@@ -1560,8 +1564,7 @@ void add_archived_event(int event_type, time_t time_stamp, int entry_type, int s
 		new_event->event_info = (char *)malloc(strlen(event_info) + 1);
 		if(new_event->event_info != NULL)
 			strcpy(new_event->event_info, event_info);
-		}
-	else
+	} else
 		new_event->event_info = NULL;
 
 	new_event->event_type = event_type;
@@ -1580,28 +1583,27 @@ void add_archived_event(int event_type, time_t time_stamp, int entry_type, int s
 			else
 				last_event->next = new_event;
 			break;
-			}
-		else
+		} else
 			last_event = temp_event;
-		}
+	}
 	if(event_list == NULL) {
 		new_event->next = NULL;
 		event_list = new_event;
-		}
-	else if(temp_event == NULL) {
+	} else if(temp_event == NULL) {
 		new_event->next = NULL;
 		last_event->next = new_event;
-		}
+	}
 
 	total_items++;
 
 	return;
-	}
+}
 
 
 
 /* determines standard report options */
-void determine_standard_report_options(void) {
+void determine_standard_report_options(void)
+{
 
 	/* report over last 7 days */
 	convert_timeperiod_to_times(TIMEPERIOD_LAST7DAYS);
@@ -1614,86 +1616,88 @@ void determine_standard_report_options(void) {
 	/* report-specific options */
 	switch(standard_report) {
 
-		case SREPORT_RECENT_ALERTS:
-			display_type = REPORT_RECENT_ALERTS;
-			alert_types = AE_HOST_ALERT + AE_SERVICE_ALERT;
-			host_states = AE_HOST_UP + AE_HOST_DOWN + AE_HOST_UNREACHABLE;
-			service_states = AE_SERVICE_OK + AE_SERVICE_WARNING + AE_SERVICE_UNKNOWN + AE_SERVICE_CRITICAL;
-			break;
+	case SREPORT_RECENT_ALERTS:
+		display_type = REPORT_RECENT_ALERTS;
+		alert_types = AE_HOST_ALERT + AE_SERVICE_ALERT;
+		host_states = AE_HOST_UP + AE_HOST_DOWN + AE_HOST_UNREACHABLE;
+		service_states = AE_SERVICE_OK + AE_SERVICE_WARNING + AE_SERVICE_UNKNOWN + AE_SERVICE_CRITICAL;
+		break;
 
-		case SREPORT_RECENT_HOST_ALERTS:
-			display_type = REPORT_RECENT_ALERTS;
-			alert_types = AE_HOST_ALERT;
-			host_states = AE_HOST_UP + AE_HOST_DOWN + AE_HOST_UNREACHABLE;
-			break;
+	case SREPORT_RECENT_HOST_ALERTS:
+		display_type = REPORT_RECENT_ALERTS;
+		alert_types = AE_HOST_ALERT;
+		host_states = AE_HOST_UP + AE_HOST_DOWN + AE_HOST_UNREACHABLE;
+		break;
 
-		case SREPORT_RECENT_SERVICE_ALERTS:
-			display_type = REPORT_RECENT_ALERTS;
-			alert_types = AE_SERVICE_ALERT;
-			service_states = AE_SERVICE_OK + AE_SERVICE_WARNING + AE_SERVICE_UNKNOWN + AE_SERVICE_CRITICAL;
-			break;
+	case SREPORT_RECENT_SERVICE_ALERTS:
+		display_type = REPORT_RECENT_ALERTS;
+		alert_types = AE_SERVICE_ALERT;
+		service_states = AE_SERVICE_OK + AE_SERVICE_WARNING + AE_SERVICE_UNKNOWN + AE_SERVICE_CRITICAL;
+		break;
 
-		case SREPORT_TOP_HOST_ALERTS:
-			display_type = REPORT_TOP_ALERTS;
-			alert_types = AE_HOST_ALERT;
-			host_states = AE_HOST_UP + AE_HOST_DOWN + AE_HOST_UNREACHABLE;
-			break;
+	case SREPORT_TOP_HOST_ALERTS:
+		display_type = REPORT_TOP_ALERTS;
+		alert_types = AE_HOST_ALERT;
+		host_states = AE_HOST_UP + AE_HOST_DOWN + AE_HOST_UNREACHABLE;
+		break;
 
-		case SREPORT_TOP_SERVICE_ALERTS:
-			display_type = REPORT_TOP_ALERTS;
-			alert_types = AE_SERVICE_ALERT;
-			service_states = AE_SERVICE_OK + AE_SERVICE_WARNING + AE_SERVICE_UNKNOWN + AE_SERVICE_CRITICAL;
-			break;
+	case SREPORT_TOP_SERVICE_ALERTS:
+		display_type = REPORT_TOP_ALERTS;
+		alert_types = AE_SERVICE_ALERT;
+		service_states = AE_SERVICE_OK + AE_SERVICE_WARNING + AE_SERVICE_UNKNOWN + AE_SERVICE_CRITICAL;
+		break;
 
-		default:
-			break;
-		}
+	default:
+		break;
+	}
 
 	return;
-	}
+}
 
 
 
 /* displays report */
-void display_report(void) {
+void display_report(void)
+{
 
 	switch(display_type) {
 
-		case REPORT_ALERT_TOTALS:
-			display_alert_totals();
-			break;
+	case REPORT_ALERT_TOTALS:
+		display_alert_totals();
+		break;
 
-		case REPORT_HOSTGROUP_ALERT_TOTALS:
-			display_hostgroup_alert_totals();
-			break;
+	case REPORT_HOSTGROUP_ALERT_TOTALS:
+		display_hostgroup_alert_totals();
+		break;
 
-		case REPORT_HOST_ALERT_TOTALS:
-			display_host_alert_totals();
-			break;
+	case REPORT_HOST_ALERT_TOTALS:
+		display_host_alert_totals();
+		break;
 
-		case REPORT_SERVICEGROUP_ALERT_TOTALS:
-			display_servicegroup_alert_totals();
-			break;
+	case REPORT_SERVICEGROUP_ALERT_TOTALS:
+		display_servicegroup_alert_totals();
+		break;
 
-		case REPORT_SERVICE_ALERT_TOTALS:
-			display_service_alert_totals();
-			break;
+	case REPORT_SERVICE_ALERT_TOTALS:
+		display_service_alert_totals();
+		break;
 
-		case REPORT_TOP_ALERTS:
-			display_top_alerts();
-			break;
+	case REPORT_TOP_ALERTS:
+		display_top_alerts();
+		break;
 
-		default:
-			display_recent_alerts();
-			break;
-		}
+	default:
+		display_recent_alerts();
+		break;
+	}
 
 	return;
-	}
+}
 
 
 /* displays recent alerts */
-void display_recent_alerts(void) {
+void display_recent_alerts(void)
+{
 	archived_event *temp_event;
 	int current_item = 0;
 	int odd = 0;
@@ -1724,11 +1728,10 @@ void display_recent_alerts(void) {
 		if(odd) {
 			odd = 0;
 			bgclass = "Odd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Even";
-			}
+		}
 
 		printf("<tr CLASS='data%s'>", bgclass);
 
@@ -1744,42 +1747,42 @@ void display_recent_alerts(void) {
 		else {
 			printf("<td CLASS='data%s'><a href='%s?type=%d&host=%s", bgclass, EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_event->host_name));
 			printf("&service=%s'>%s</a></td>", url_encode(temp_event->service_description), temp_event->service_description);
-			}
+		}
 
 		switch(temp_event->entry_type) {
-			case AE_HOST_UP:
-				status_bgclass = "hostUP";
-				status = "UP";
-				break;
-			case AE_HOST_DOWN:
-				status_bgclass = "hostDOWN";
-				status = "DOWN";
-				break;
-			case AE_HOST_UNREACHABLE:
-				status_bgclass = "hostUNREACHABLE";
-				status = "UNREACHABLE";
-				break;
-			case AE_SERVICE_OK:
-				status_bgclass = "serviceOK";
-				status = "OK";
-				break;
-			case AE_SERVICE_WARNING:
-				status_bgclass = "serviceWARNING";
-				status = "WARNING";
-				break;
-			case AE_SERVICE_UNKNOWN:
-				status_bgclass = "serviceUNKNOWN";
-				status = "UNKNOWN";
-				break;
-			case AE_SERVICE_CRITICAL:
-				status_bgclass = "serviceCRITICAL";
-				status = "CRITICAL";
-				break;
-			default:
-				status_bgclass = bgclass;
-				status = "???";
-				break;
-			}
+		case AE_HOST_UP:
+			status_bgclass = "hostUP";
+			status = "UP";
+			break;
+		case AE_HOST_DOWN:
+			status_bgclass = "hostDOWN";
+			status = "DOWN";
+			break;
+		case AE_HOST_UNREACHABLE:
+			status_bgclass = "hostUNREACHABLE";
+			status = "UNREACHABLE";
+			break;
+		case AE_SERVICE_OK:
+			status_bgclass = "serviceOK";
+			status = "OK";
+			break;
+		case AE_SERVICE_WARNING:
+			status_bgclass = "serviceWARNING";
+			status = "WARNING";
+			break;
+		case AE_SERVICE_UNKNOWN:
+			status_bgclass = "serviceUNKNOWN";
+			status = "UNKNOWN";
+			break;
+		case AE_SERVICE_CRITICAL:
+			status_bgclass = "serviceCRITICAL";
+			status = "CRITICAL";
+			break;
+		default:
+			status_bgclass = bgclass;
+			status = "???";
+			break;
+		}
 
 		printf("<td CLASS='%s'>%s</td>", status_bgclass, status);
 
@@ -1788,18 +1791,19 @@ void display_recent_alerts(void) {
 		printf("<td CLASS='data%s'>%s</td>", bgclass, temp_event->event_info);
 
 		printf("</tr>\n");
-		}
+	}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays alerts totals */
-void display_alert_totals(void) {
+void display_alert_totals(void)
+{
 	int hard_host_up_alerts = 0;
 	int soft_host_up_alerts = 0;
 	int hard_host_down_alerts = 0;
@@ -1833,16 +1837,15 @@ void display_alert_totals(void) {
 					soft_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					soft_host_unreachable_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_HOST_UP)
 					hard_host_up_alerts++;
 				else if(temp_event->entry_type == AE_HOST_DOWN)
 					hard_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					hard_host_unreachable_alerts++;
-				}
 			}
+		}
 
 		/* service alerts */
 		else {
@@ -1855,8 +1858,7 @@ void display_alert_totals(void) {
 					soft_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					soft_service_critical_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_SERVICE_OK)
 					hard_service_ok_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_WARNING)
@@ -1865,9 +1867,9 @@ void display_alert_totals(void) {
 					hard_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					hard_service_critical_alerts++;
-				}
 			}
 		}
+	}
 
 	printf("<BR>\n");
 
@@ -1897,7 +1899,7 @@ void display_alert_totals(void) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	if(alert_types & AE_SERVICE_ALERT) {
 
@@ -1919,7 +1921,7 @@ void display_alert_totals(void) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	printf("</TR>\n");
 	printf("</TABLE>\n");
@@ -1927,12 +1929,13 @@ void display_alert_totals(void) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays hostgroup alert totals  */
-void display_hostgroup_alert_totals(void) {
+void display_hostgroup_alert_totals(void)
+{
 	hostgroup *temp_hostgroup;
 
 	/**************************/
@@ -1949,16 +1952,17 @@ void display_hostgroup_alert_totals(void) {
 	else {
 		for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next)
 			display_specific_hostgroup_alert_totals(temp_hostgroup);
-		}
+	}
 
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 /* displays alert totals for a specific hostgroup */
-void display_specific_hostgroup_alert_totals(hostgroup *grp) {
+void display_specific_hostgroup_alert_totals(hostgroup *grp)
+{
 	int hard_host_up_alerts = 0;
 	int soft_host_up_alerts = 0;
 	int hard_host_down_alerts = 0;
@@ -1999,16 +2003,15 @@ void display_specific_hostgroup_alert_totals(hostgroup *grp) {
 					soft_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					soft_host_unreachable_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_HOST_UP)
 					hard_host_up_alerts++;
 				else if(temp_event->entry_type == AE_HOST_DOWN)
 					hard_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					hard_host_unreachable_alerts++;
-				}
 			}
+		}
 
 		/* service alerts */
 		else {
@@ -2021,8 +2024,7 @@ void display_specific_hostgroup_alert_totals(hostgroup *grp) {
 					soft_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					soft_service_critical_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_SERVICE_OK)
 					hard_service_ok_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_WARNING)
@@ -2031,9 +2033,9 @@ void display_specific_hostgroup_alert_totals(hostgroup *grp) {
 					hard_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					hard_service_critical_alerts++;
-				}
 			}
 		}
+	}
 
 
 	printf("<BR>\n");
@@ -2063,7 +2065,7 @@ void display_specific_hostgroup_alert_totals(hostgroup *grp) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	if(alert_types & AE_SERVICE_ALERT) {
 
@@ -2085,7 +2087,7 @@ void display_specific_hostgroup_alert_totals(hostgroup *grp) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	printf("</TR>\n");
 
@@ -2093,12 +2095,13 @@ void display_specific_hostgroup_alert_totals(hostgroup *grp) {
 	printf("</TD></TR></TABLE>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays host alert totals  */
-void display_host_alert_totals(void) {
+void display_host_alert_totals(void)
+{
 	host *temp_host;
 
 	/*********************/
@@ -2115,16 +2118,17 @@ void display_host_alert_totals(void) {
 	else {
 		for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next)
 			display_specific_host_alert_totals(temp_host);
-		}
+	}
 
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 /* displays alert totals for a specific host */
-void display_specific_host_alert_totals(host *hst) {
+void display_specific_host_alert_totals(host *hst)
+{
 	int hard_host_up_alerts = 0;
 	int soft_host_up_alerts = 0;
 	int hard_host_down_alerts = 0;
@@ -2151,7 +2155,7 @@ void display_specific_host_alert_totals(host *hst) {
 	if(show_all_hostgroups == FALSE && target_hostgroup != NULL) {
 		if(is_host_member_of_hostgroup(target_hostgroup, hst) == FALSE)
 			return;
-		}
+	}
 
 	/* process all events */
 	for(temp_event = event_list; temp_event != NULL; temp_event = temp_event->next) {
@@ -2168,16 +2172,15 @@ void display_specific_host_alert_totals(host *hst) {
 					soft_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					soft_host_unreachable_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_HOST_UP)
 					hard_host_up_alerts++;
 				else if(temp_event->entry_type == AE_HOST_DOWN)
 					hard_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					hard_host_unreachable_alerts++;
-				}
 			}
+		}
 
 		/* service alerts */
 		else {
@@ -2190,8 +2193,7 @@ void display_specific_host_alert_totals(host *hst) {
 					soft_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					soft_service_critical_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_SERVICE_OK)
 					hard_service_ok_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_WARNING)
@@ -2200,9 +2202,9 @@ void display_specific_host_alert_totals(host *hst) {
 					hard_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					hard_service_critical_alerts++;
-				}
 			}
 		}
+	}
 
 
 	printf("<BR>\n");
@@ -2232,7 +2234,7 @@ void display_specific_host_alert_totals(host *hst) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	if(alert_types & AE_SERVICE_ALERT) {
 
@@ -2254,7 +2256,7 @@ void display_specific_host_alert_totals(host *hst) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	printf("</TR>\n");
 
@@ -2262,11 +2264,12 @@ void display_specific_host_alert_totals(host *hst) {
 	printf("</TD></TR></TABLE>\n");
 
 	return;
-	}
+}
 
 
 /* displays servicegroup alert totals  */
-void display_servicegroup_alert_totals(void) {
+void display_servicegroup_alert_totals(void)
+{
 	servicegroup *temp_servicegroup;
 
 	/**************************/
@@ -2283,16 +2286,17 @@ void display_servicegroup_alert_totals(void) {
 	else {
 		for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next)
 			display_specific_servicegroup_alert_totals(temp_servicegroup);
-		}
+	}
 
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 /* displays alert totals for a specific servicegroup */
-void display_specific_servicegroup_alert_totals(servicegroup *grp) {
+void display_specific_servicegroup_alert_totals(servicegroup *grp)
+{
 	int hard_host_up_alerts = 0;
 	int soft_host_up_alerts = 0;
 	int hard_host_down_alerts = 0;
@@ -2326,13 +2330,12 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 			temp_host = find_host(temp_event->host_name);
 			if(is_host_member_of_servicegroup(grp, temp_host) == FALSE)
 				continue;
-			}
-		else {
+		} else {
 
 			temp_service = find_service(temp_event->host_name, temp_event->service_description);
 			if(is_service_member_of_servicegroup(grp, temp_service) == FALSE)
 				continue;
-			}
+		}
 
 		/* host alerts */
 		if(temp_event->event_type == AE_HOST_ALERT) {
@@ -2343,16 +2346,15 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 					soft_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					soft_host_unreachable_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_HOST_UP)
 					hard_host_up_alerts++;
 				else if(temp_event->entry_type == AE_HOST_DOWN)
 					hard_host_down_alerts++;
 				else if(temp_event->entry_type == AE_HOST_UNREACHABLE)
 					hard_host_unreachable_alerts++;
-				}
 			}
+		}
 
 		/* service alerts */
 		else {
@@ -2365,8 +2367,7 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 					soft_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					soft_service_critical_alerts++;
-				}
-			else {
+			} else {
 				if(temp_event->entry_type == AE_SERVICE_OK)
 					hard_service_ok_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_WARNING)
@@ -2375,9 +2376,9 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 					hard_service_unknown_alerts++;
 				else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 					hard_service_critical_alerts++;
-				}
 			}
 		}
+	}
 
 
 	printf("<BR>\n");
@@ -2407,7 +2408,7 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	if(alert_types & AE_SERVICE_ALERT) {
 
@@ -2429,7 +2430,7 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	printf("</TR>\n");
 
@@ -2437,12 +2438,13 @@ void display_specific_servicegroup_alert_totals(servicegroup *grp) {
 	printf("</TD></TR></TABLE>\n");
 
 	return;
-	}
+}
 
 
 
 /* displays service alert totals  */
-void display_service_alert_totals(void) {
+void display_service_alert_totals(void)
+{
 	service *temp_service;
 
 	/************************/
@@ -2460,11 +2462,12 @@ void display_service_alert_totals(void) {
 	printf("</DIV>\n");
 
 	return;
-	}
+}
 
 
 /* displays alert totals for a specific service */
-void display_specific_service_alert_totals(service *svc) {
+void display_specific_service_alert_totals(service *svc)
+{
 	int hard_service_ok_alerts = 0;
 	int soft_service_ok_alerts = 0;
 	int hard_service_warning_alerts = 0;
@@ -2487,12 +2490,12 @@ void display_specific_service_alert_totals(service *svc) {
 		temp_host = find_host(svc->host_name);
 		if(is_host_member_of_hostgroup(target_hostgroup, temp_host) == FALSE)
 			return;
-		}
+	}
 
 	if(show_all_hosts == FALSE && target_host != NULL) {
 		if(strcmp(target_host->name, svc->host_name))
 			return;
-		}
+	}
 
 	/* process all events */
 	for(temp_event = event_list; temp_event != NULL; temp_event = temp_event->next) {
@@ -2513,8 +2516,7 @@ void display_specific_service_alert_totals(service *svc) {
 				soft_service_unknown_alerts++;
 			else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 				soft_service_critical_alerts++;
-			}
-		else {
+		} else {
 			if(temp_event->entry_type == AE_SERVICE_OK)
 				hard_service_ok_alerts++;
 			else if(temp_event->entry_type == AE_SERVICE_WARNING)
@@ -2523,8 +2525,8 @@ void display_specific_service_alert_totals(service *svc) {
 				hard_service_unknown_alerts++;
 			else if(temp_event->entry_type == AE_SERVICE_CRITICAL)
 				hard_service_critical_alerts++;
-			}
 		}
+	}
 
 
 	printf("<BR>\n");
@@ -2555,7 +2557,7 @@ void display_specific_service_alert_totals(service *svc) {
 		printf("</DIV>\n");
 
 		printf("</TD>\n");
-		}
+	}
 
 	printf("</TR>\n");
 
@@ -2563,11 +2565,12 @@ void display_specific_service_alert_totals(service *svc) {
 	printf("</TD></TR></TABLE>\n");
 
 	return;
-	}
+}
 
 
 /* find a specific alert producer */
-alert_producer *find_producer(int type, char *hname, char *sdesc) {
+alert_producer *find_producer(int type, char *hname, char *sdesc)
+{
 	alert_producer *temp_producer;
 
 	for(temp_producer = producer_list; temp_producer != NULL; temp_producer = temp_producer->next) {
@@ -2580,14 +2583,15 @@ alert_producer *find_producer(int type, char *hname, char *sdesc) {
 			continue;
 
 		return temp_producer;
-		}
+	}
 
 	return NULL;
-	}
+}
 
 
 /* adds a new producer to the list in memory */
-alert_producer *add_producer(int producer_type, char *host_name, char *service_description) {
+alert_producer *add_producer(int producer_type, char *host_name, char *service_description)
+{
 	alert_producer *new_producer = NULL;
 
 	/* allocate memory for the new entry */
@@ -2600,8 +2604,7 @@ alert_producer *add_producer(int producer_type, char *host_name, char *service_d
 		new_producer->host_name = (char *)malloc(strlen(host_name) + 1);
 		if(new_producer->host_name != NULL)
 			strcpy(new_producer->host_name, host_name);
-		}
-	else
+	} else
 		new_producer->host_name = NULL;
 
 	/* allocate memory for the service description */
@@ -2609,8 +2612,7 @@ alert_producer *add_producer(int producer_type, char *host_name, char *service_d
 		new_producer->service_description = (char *)malloc(strlen(service_description) + 1);
 		if(new_producer->service_description != NULL)
 			strcpy(new_producer->service_description, service_description);
-		}
-	else
+	} else
 		new_producer->service_description = NULL;
 
 	new_producer->producer_type = producer_type;
@@ -2621,11 +2623,12 @@ alert_producer *add_producer(int producer_type, char *host_name, char *service_d
 	producer_list = new_producer;
 
 	return new_producer;
-	}
+}
 
 
 
-void free_producer_list(void) {
+void free_producer_list(void)
+{
 	alert_producer *this_producer = NULL;
 	alert_producer *next_producer = NULL;
 
@@ -2637,17 +2640,18 @@ void free_producer_list(void) {
 			free(this_producer->service_description);
 		free(this_producer);
 		this_producer = next_producer;
-		}
+	}
 
 	producer_list = NULL;
 
 	return;
-	}
+}
 
 
 
 /* displays top alerts */
-void display_top_alerts(void) {
+void display_top_alerts(void)
+{
 	archived_event *temp_event = NULL;
 	alert_producer *temp_producer = NULL;
 	alert_producer *next_producer = NULL;
@@ -2677,7 +2681,7 @@ void display_top_alerts(void) {
 
 		/* update stats for producer */
 		temp_producer->total_alerts++;
-		}
+	}
 
 
 	/* sort the producer list by total alerts (descending) */
@@ -2695,22 +2699,20 @@ void display_top_alerts(void) {
 				else
 					last_producer->next = new_producer;
 				break;
-				}
-			else
+			} else
 				last_producer = temp_producer;
-			}
+		}
 		if(temp_list == NULL) {
 			new_producer->next = NULL;
 			temp_list = new_producer;
-			}
-		else if(temp_producer == NULL) {
+		} else if(temp_producer == NULL) {
 			new_producer->next = NULL;
 			last_producer->next = new_producer;
-			}
+		}
 
 		new_producer = next_producer;
 		total_items++;
-		}
+	}
 	producer_list = temp_list;
 
 
@@ -2738,11 +2740,10 @@ void display_top_alerts(void) {
 		if(odd) {
 			odd = 0;
 			bgclass = "Odd";
-			}
-		else {
+		} else {
 			odd = 1;
 			bgclass = "Even";
-			}
+		}
 
 		printf("<tr CLASS='data%s'>", bgclass);
 
@@ -2757,15 +2758,15 @@ void display_top_alerts(void) {
 		else {
 			printf("<td CLASS='data%s'><a href='%s?type=%d&host=%s", bgclass, EXTINFO_CGI, DISPLAY_SERVICE_INFO, url_encode(temp_producer->host_name));
 			printf("&service=%s'>%s</a></td>", url_encode(temp_producer->service_description), temp_producer->service_description);
-			}
+		}
 
 		printf("<td CLASS='data%s'>%d</td>", bgclass, temp_producer->total_alerts);
 
 		printf("</tr>\n");
-		}
+	}
 
 	printf("</TABLE>\n");
 	printf("</DIV>\n");
 
 	return;
-	}
+}

--- a/cgi/tac.c
+++ b/cgi/tac.c
@@ -41,7 +41,7 @@ typedef struct hostoutage_struct {
 	host *hst;
 	int  affected_child_hosts;
 	struct hostoutage_struct *next;
-	} hostoutage;
+} hostoutage;
 
 
 extern char   main_config_file[MAX_FILENAME_LENGTH];
@@ -179,7 +179,8 @@ int services_critical = 0;
 
 /*efine DEBUG 1*/
 
-int main(void) {
+int main(void)
+{
 	char *sound = NULL;
 
 	/* get the CGI variables passed in the URL */
@@ -219,7 +220,7 @@ int main(void) {
 		printf("</table>\n");
 		printf("</p>\n");
 
-		}
+	}
 
 	/* analyze current host and service status data for tac overview */
 	analyze_status_data();
@@ -244,7 +245,7 @@ int main(void) {
 		printf("<param name=\"autostart\" value=\"true\">");
 		printf("<param name=\"playcount\" value=\"1\">");
 		printf("</object>");
-		}
+	}
 
 
 	/**** display main tac screen ****/
@@ -259,12 +260,13 @@ int main(void) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -296,7 +298,7 @@ void document_header(int use_stylesheet) {
 	if(use_stylesheet == TRUE) {
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 		printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, TAC_CSS);
-		}
+	}
 
 	printf("</HEAD>\n");
 	printf("<BODY CLASS='tac' marginwidth=2 marginheight=2 topmargin=0 leftmargin=0 rightmargin=0>\n");
@@ -305,10 +307,11 @@ void document_header(int use_stylesheet) {
 	include_ssi_files(TAC_CGI, SSI_HEADER);
 
 	return;
-	}
+}
 
 
-void document_footer(void) {
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -320,10 +323,11 @@ void document_footer(void) {
 	printf("</HTML>\n");
 
 	return;
-	}
+}
 
 
-int process_cgivars(void) {
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -335,7 +339,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -349,17 +353,18 @@ int process_cgivars(void) {
 		else
 			error = TRUE;
 
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
-void analyze_status_data(void) {
+void analyze_status_data(void)
+{
 	servicestatus *temp_servicestatus;
 	service *temp_service;
 	hoststatus *temp_hoststatus;
@@ -410,82 +415,82 @@ void analyze_status_data(void) {
 			else
 				services_ok_unacknowledged++;
 			services_ok++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_WARNING) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_warning_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_warning_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_warning_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_warning_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_warning_unacknowledged++;
 			services_warning++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_UNKNOWN) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_unknown_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_unknown_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_unknown_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_unknown_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_unknown_unacknowledged++;
 			services_unknown++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_CRITICAL) {
 			temp_hoststatus = find_hoststatus(temp_servicestatus->host_name);
 			if(temp_hoststatus != NULL && (temp_hoststatus->status == SD_HOST_DOWN || temp_hoststatus->status == SD_HOST_UNREACHABLE)) {
 				services_critical_host_problem++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->scheduled_downtime_depth > 0) {
 				services_critical_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->problem_has_been_acknowledged == TRUE) {
 				services_critical_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_servicestatus->checks_enabled == FALSE) {
 				services_critical_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				services_critical_unacknowledged++;
 			services_critical++;
-			}
+		}
 
 		else if(temp_servicestatus->status == SERVICE_PENDING) {
 			if(temp_servicestatus->checks_enabled == FALSE)
 				services_pending_disabled++;
 			services_pending++;
-			}
+		}
 
 
 		/* get health stats */
@@ -516,13 +521,12 @@ void analyze_status_data(void) {
 
 			total_service_latency += temp_servicestatus->latency;
 			total_service_execution_time += temp_servicestatus->execution_time;
-			}
-		else
+		} else
 			total_passive_service_checks++;
 
 
 		total_services++;
-		}
+	}
 
 
 
@@ -569,49 +573,49 @@ void analyze_status_data(void) {
 			else
 				hosts_up_unacknowledged++;
 			hosts_up++;
-			}
+		}
 
 		else if(temp_hoststatus->status == SD_HOST_DOWN) {
 			if(temp_hoststatus->scheduled_downtime_depth > 0) {
 				hosts_down_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 				hosts_down_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->checks_enabled == FALSE) {
 				hosts_down_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				hosts_down_unacknowledged++;
 			hosts_down++;
-			}
+		}
 
 		else if(temp_hoststatus->status == SD_HOST_UNREACHABLE) {
 			if(temp_hoststatus->scheduled_downtime_depth > 0) {
 				hosts_unreachable_scheduled++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->problem_has_been_acknowledged == TRUE) {
 				hosts_unreachable_acknowledged++;
 				problem = FALSE;
-				}
+			}
 			if(temp_hoststatus->checks_enabled == FALSE) {
 				hosts_unreachable_disabled++;
 				problem = FALSE;
-				}
+			}
 			if(problem == TRUE)
 				hosts_unreachable_unacknowledged++;
 			hosts_unreachable++;
-			}
+		}
 
 		else if(temp_hoststatus->status == HOST_PENDING) {
 			if(temp_hoststatus->checks_enabled == FALSE)
 				hosts_pending_disabled++;
 			hosts_pending++;
-			}
+		}
 
 		/* get health stats */
 		if(temp_hoststatus->status == SD_HOST_UP)
@@ -637,12 +641,11 @@ void analyze_status_data(void) {
 
 			total_host_latency += temp_hoststatus->latency;
 			total_host_execution_time += temp_hoststatus->execution_time;
-			}
-		else
+		} else
 			total_passive_host_checks++;
 
 		total_hosts++;
-		}
+	}
 
 
 	/* calculate service health */
@@ -682,13 +685,14 @@ void analyze_status_data(void) {
 		average_host_execution_time = ((double)total_host_execution_time / (double)total_active_host_checks);
 
 	return;
-	}
+}
 
 
 
 
 /* determine what hosts are causing network outages */
-void find_hosts_causing_outages(void) {
+void find_hosts_causing_outages(void)
+{
 	hoststatus *temp_hoststatus;
 	hostoutage *temp_hostoutage;
 	host *temp_host;
@@ -712,8 +716,8 @@ void find_hosts_causing_outages(void) {
 			/* if the route to this host is not blocked, it is a causing an outage */
 			if(is_route_to_host_blocked(temp_host) == FALSE)
 				add_hostoutage(temp_host);
-			}
 		}
+	}
 
 
 	/* check all hosts that are causing problems and calculate the extent of the problem */
@@ -726,17 +730,18 @@ void find_hosts_causing_outages(void) {
 			total_blocking_outages++;
 		else
 			total_nonblocking_outages++;
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 
 
 /* adds a host outage entry */
-void add_hostoutage(host *hst) {
+void add_hostoutage(host *hst)
+{
 	hostoutage *new_hostoutage;
 
 	/* allocate memory for a new structure */
@@ -753,28 +758,30 @@ void add_hostoutage(host *hst) {
 	hostoutage_list = new_hostoutage;
 
 	return;
-	}
+}
 
 
 
 
 /* frees all memory allocated to the host outage list */
-void free_hostoutage_list(void) {
+void free_hostoutage_list(void)
+{
 	hostoutage *this_hostoutage;
 	hostoutage *next_hostoutage;
 
 	for(this_hostoutage = hostoutage_list; this_hostoutage != NULL; this_hostoutage = next_hostoutage) {
 		next_hostoutage = this_hostoutage->next;
 		free(this_hostoutage);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* calculates network outage effect of a particular host being down or unreachable */
-void calculate_outage_effect_of_host(host *hst, int *affected_hosts) {
+void calculate_outage_effect_of_host(host *hst, int *affected_hosts)
+{
 	int total_child_hosts_affected = 0;
 	int temp_child_hosts_affected = 0;
 	host *temp_host;
@@ -792,17 +799,18 @@ void calculate_outage_effect_of_host(host *hst, int *affected_hosts) {
 
 		/* keep a running total of outage effects */
 		total_child_hosts_affected += temp_child_hosts_affected;
-		}
+	}
 
 	*affected_hosts = total_child_hosts_affected + 1;
 
 	return;
-	}
+}
 
 
 
 /* tests whether or not a host is "blocked" by upstream parents (host is already assumed to be down or unreachable) */
-int is_route_to_host_blocked(host *hst) {
+int is_route_to_host_blocked(host *hst)
+{
 	hostsmember *temp_hostsmember;
 	hoststatus *temp_hoststatus;
 
@@ -822,17 +830,18 @@ int is_route_to_host_blocked(host *hst) {
 		/* at least one parent it up (or pending), so this host is not blocked */
 		if(temp_hoststatus->status == SD_HOST_UP || temp_hoststatus->status == HOST_PENDING)
 			return FALSE;
-		}
-
-	return TRUE;
 	}
 
+	return TRUE;
+}
 
 
 
 
 
-void display_tac_overview(void) {
+
+void display_tac_overview(void)
+{
 	char host_health_image[16];
 	char service_health_image[16];
 
@@ -1419,8 +1428,7 @@ void display_tac_overview(void) {
 
 		printf("</table>\n");
 		printf("</td>\n");
-		}
-	else
+	} else
 		printf("<Td valign=center width=100%% class='featureDisabledFlapDetection'>N/A</td>\n");
 	printf("</tr>\n");
 	printf("</table>\n");
@@ -1450,8 +1458,7 @@ void display_tac_overview(void) {
 
 		printf("</table>\n");
 		printf("</td>\n");
-		}
-	else
+	} else
 		printf("<Td valign=center width=100%% class='featureDisabledNotifications'>N/A</td>\n");
 	printf("</tr>\n");
 	printf("</table>\n");
@@ -1482,8 +1489,7 @@ void display_tac_overview(void) {
 
 		printf("</table>\n");
 		printf("</td>\n");
-		}
-	else
+	} else
 		printf("<Td valign=center width=100%% class='featureDisabledHandlers'>N/A</td>\n");
 	printf("</tr>\n");
 	printf("</table>\n");
@@ -1514,8 +1520,7 @@ void display_tac_overview(void) {
 
 		printf("</table>\n");
 		printf("</td>\n");
-		}
-	else
+	} else
 		printf("<Td valign=center width=100%% class='featureDisabledActiveChecks'>N/A</td>\n");
 	printf("</tr>\n");
 	printf("</table>\n");
@@ -1547,8 +1552,7 @@ void display_tac_overview(void) {
 
 		printf("</table>\n");
 		printf("</td>\n");
-		}
-	else
+	} else
 		printf("<Td valign=center width=100%% class='featureDisabledPassiveChecks'>N/A</td>\n");
 	printf("</tr>\n");
 	printf("</table>\n");
@@ -1562,4 +1566,4 @@ void display_tac_overview(void) {
 
 
 	return;
-	}
+}

--- a/cgi/trends.c
+++ b/cgi/trends.c
@@ -108,7 +108,7 @@ typedef struct archived_state_struct {
 	int     state_type;
 	char    *state_info;
 	struct archived_state_struct *next;
-	} archived_state;
+} archived_state;
 
 
 archived_state *as_list = NULL;
@@ -239,7 +239,8 @@ int problem_found;
 
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result = OK;
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char image_template[MAX_INPUT_BUFFER];
@@ -270,9 +271,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			cgi_config_file_error(get_cgi_config_location());
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 	/* read the main configuration file */
 	result = read_main_config_file(main_config_file);
@@ -281,9 +282,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			main_config_file_error(main_config_file);
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 
 	/* initialize time period to last 24 hours */
@@ -293,22 +294,22 @@ int main(int argc, char **argv) {
 
 	/* default number of backtracked archives */
 	switch(log_rotation_method) {
-		case LOG_ROTATION_MONTHLY:
-			backtrack_archives = 1;
-			break;
-		case LOG_ROTATION_WEEKLY:
-			backtrack_archives = 2;
-			break;
-		case LOG_ROTATION_DAILY:
-			backtrack_archives = 4;
-			break;
-		case LOG_ROTATION_HOURLY:
-			backtrack_archives = 8;
-			break;
-		default:
-			backtrack_archives = 2;
-			break;
-		}
+	case LOG_ROTATION_MONTHLY:
+		backtrack_archives = 1;
+		break;
+	case LOG_ROTATION_WEEKLY:
+		backtrack_archives = 2;
+		break;
+	case LOG_ROTATION_DAILY:
+		backtrack_archives = 4;
+		break;
+	case LOG_ROTATION_HOURLY:
+		backtrack_archives = 8;
+		break;
+	default:
+		backtrack_archives = 2;
+		break;
+	}
 
 	/* get the arguments passed in the URL */
 	process_cgivars();
@@ -322,9 +323,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			object_data_error();
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 	/* read all status data */
 	result = read_all_status_data(main_config_file, READ_ALL_STATUS_DATA);
@@ -333,9 +334,9 @@ int main(int argc, char **argv) {
 			document_header(FALSE);
 			status_data_error();
 			document_footer();
-			}
-		return ERROR;
 		}
+		return ERROR;
+	}
 
 	document_header(TRUE);
 
@@ -347,14 +348,14 @@ int main(int argc, char **argv) {
 		t3 = t2;
 		t2 = t1;
 		t1 = t3;
-		}
+	}
 
 	/* don't let user create reports in the future */
 	if(t2 > current_time) {
 		t2 = current_time;
 		if(t1 > t2)
 			t1 = t2 - (60 * 60 * 24);
-		}
+	}
 
 	if(mode == CREATE_HTML && display_header == TRUE) {
 		time_t old_t1 = t1, old_t2 = t2;
@@ -390,53 +391,51 @@ int main(int argc, char **argv) {
 						problem_t1 = temp_as->time_stamp;
 						problem_found = TRUE;
 						break;
-						}
 					}
+				}
 				if(problem_found == TRUE) {
 					for(; temp_as != NULL; temp_as = temp_as->next) {
 						if(temp_as->entry_type == AS_HOST_UP && temp_as->time_stamp > problem_t1) {
 							problem_t2 = temp_as->time_stamp;
 							break;
-							}
 						}
 					}
 				}
-			else {
+			} else {
 				for(temp_as = as_list; temp_as != NULL; temp_as = temp_as->next) {
 					if((temp_as->entry_type == AS_SVC_UNKNOWN || temp_as->entry_type == AS_SVC_CRITICAL || temp_as->entry_type == AS_SVC_WARNING) && temp_as->time_stamp > t1) {
 						problem_t1 = temp_as->time_stamp;
 						problem_found = TRUE;
 						break;
-						}
 					}
+				}
 				if(problem_found == TRUE) {
 					for(; temp_as != NULL; temp_as = temp_as->next) {
 						if(temp_as->entry_type == AS_SVC_OK && temp_as->time_stamp > problem_t1) {
 							problem_t2 = temp_as->time_stamp;
 							break;
-							}
 						}
 					}
 				}
+			}
 			if(problem_found == TRUE) {
 				time_t margin;
 
 				if(problem_t2 == 0) {
 					margin = 12 * 60 * 60;
 					problem_t2 = problem_t1;
-					}
-				else
+				} else
 					margin = (problem_t2 - problem_t1) / 2;
 
 				t1 = problem_t1 - margin;
 				t2 = problem_t2 + margin;
-				}
 			}
+		}
 
 		if(timeperiod_type == TIMEPERIOD_NEXTPROBLEM && problem_found == FALSE) {
 			t1 = old_t1;
 			t2 = old_t2;
-			}
+		}
 
 		if(display_type != DISPLAY_NO_TRENDS && input_type == GET_INPUT_NONE) {
 
@@ -451,8 +450,7 @@ int main(int argc, char **argv) {
 				printf("<a href='%s?host=%s'>View Status Detail For This Host</a><BR>\n", STATUS_CGI, url_encode(host_name));
 				printf("<a href='%s?host=%s'>View Alert History For This Host</a><BR>\n", HISTORY_CGI, url_encode(host_name));
 				printf("<a href='%s?host=%s'>View Notifications For This Host</a><BR>\n", NOTIFICATIONS_CGI, url_encode(host_name));
-				}
-			else {
+			} else {
 				printf("<a href='%s?host=%s&t1=%lu&t2=%lu&includesoftstates=%s&assumestateretention=%s&assumeinitialstates=%s&assumestatesduringnotrunning=%s&initialassumedservicestate=%d&backtrack=%d'>View Trends For This Host</a><BR>\n", TRENDS_CGI, url_encode(host_name), t1, t2, (include_soft_states == TRUE) ? "yes" : "no", (assume_state_retention == TRUE) ? "yes" : "no", (assume_initial_states == TRUE) ? "yes" : "no", (assume_states_during_notrunning == TRUE) ? "yes" : "no", initial_assumed_service_state, backtrack_archives);
 				printf("<a href='%s?host=%s", AVAIL_CGI, url_encode(host_name));
 				printf("&service=%s&t1=%lu&t2=%lu&assumestateretention=%s&includesoftstates=%s&assumeinitialstates=%s&assumestatesduringnotrunning=%s&initialassumedservicestate=%d&backtrack=%d&show_log_entries'>View Availability Report For This Service</a><BR>\n", url_encode(svc_description), t1, t2, (include_soft_states == TRUE) ? "yes" : "no", (assume_state_retention == TRUE) ? "yes" : "no", (assume_initial_states == TRUE) ? "yes" : "no", (assume_states_during_notrunning == TRUE) ? "yes" : "no", initial_assumed_service_state, backtrack_archives);
@@ -462,11 +460,11 @@ int main(int argc, char **argv) {
 				printf("service=%s'>View Alert History For This Service</A><BR>\n", url_encode(svc_description));
 				printf("<A HREF='%s?host=%s&", NOTIFICATIONS_CGI, url_encode(host_name));
 				printf("service=%s'>View Notifications For This Service</A><BR>\n", url_encode(svc_description));
-				}
+			}
 
 			printf("</TD></TR>\n");
 			printf("</TABLE>\n");
-			}
+		}
 
 		printf("</td>\n");
 
@@ -494,7 +492,7 @@ int main(int argc, char **argv) {
 
 			get_time_breakdown((time_t)(t2 - t1), &days, &hours, &minutes, &seconds);
 			printf("<div align=center class='reportDuration'>Duration: %dd %dh %dm %ds</div>\n", days, hours, minutes, seconds);
-			}
+		}
 
 		printf("</td>\n");
 
@@ -531,8 +529,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Host Up\n", AS_HOST_UP, (initial_assumed_host_state == AS_HOST_UP) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host Down\n", AS_HOST_DOWN, (initial_assumed_host_state == AS_HOST_DOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Host Unreachable\n", AS_HOST_UNREACHABLE, (initial_assumed_host_state == AS_HOST_UNREACHABLE) ? "SELECTED" : "");
-				}
-			else {
+			} else {
 				printf("<input type='hidden' name='initialassumedhoststate' value='%d'>", initial_assumed_host_state);
 				printf("<select name='initialassumedservicestate'>\n");
 				printf("<option value=%d %s>Unspecified\n", AS_NO_DATA, (initial_assumed_service_state == AS_NO_DATA) ? "SELECTED" : "");
@@ -541,7 +538,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d %s>Service Warning\n", AS_SVC_WARNING, (initial_assumed_service_state == AS_SVC_WARNING) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service Unknown\n", AS_SVC_UNKNOWN, (initial_assumed_service_state == AS_SVC_UNKNOWN) ? "SELECTED" : "");
 				printf("<option value=%d %s>Service Critical\n", AS_SVC_CRITICAL, (initial_assumed_service_state == AS_SVC_CRITICAL) ? "SELECTED" : "");
-				}
+			}
 			printf("</select>\n");
 			printf("</td><td CLASS='optBoxItem' valign=top align=left>\n");
 			printf("<input type='text' name='backtrack' size='2' maxlength='2' value='%d'>\n", backtrack_archives);
@@ -583,7 +580,7 @@ int main(int argc, char **argv) {
 			printf("</td><td CLASS='optBoxItem' valign=top align=left>\n");
 			printf("<input type='submit' value='Update'>\n");
 			printf("</td></tr>\n");
-			}
+		}
 
 		/* display context-sensitive help */
 		printf("<tr><td></td><td align=right valign=bottom>\n");
@@ -592,8 +589,7 @@ int main(int argc, char **argv) {
 				display_context_help(CONTEXTHELP_TRENDS_HOST);
 			else
 				display_context_help(CONTEXTHELP_TRENDS_SERVICE);
-			}
-		else if(display_type == DISPLAY_NO_TRENDS || input_type != GET_INPUT_NONE) {
+		} else if(display_type == DISPLAY_NO_TRENDS || input_type != GET_INPUT_NONE) {
 			if(input_type == GET_INPUT_NONE)
 				display_context_help(CONTEXTHELP_TRENDS_MENU1);
 			else if(input_type == GET_INPUT_TARGET_TYPE)
@@ -604,7 +600,7 @@ int main(int argc, char **argv) {
 				display_context_help(CONTEXTHELP_TRENDS_MENU3);
 			else if(input_type == GET_INPUT_OPTIONS)
 				display_context_help(CONTEXTHELP_TRENDS_MENU4);
-			}
+		}
 		printf("</td></tr>\n");
 
 		printf("</table>\n");
@@ -615,7 +611,7 @@ int main(int argc, char **argv) {
 		/* end of top table */
 		printf("</tr>\n");
 		printf("</table>\n");
-		}
+	}
 
 
 #ifndef DEBUG
@@ -625,12 +621,11 @@ int main(int argc, char **argv) {
 		temp_host = find_host(host_name);
 		if(temp_host == NULL || is_authorized_for_host(temp_host, &current_authdata) == FALSE)
 			is_authorized = FALSE;
-		}
-	else if(display_type == DISPLAY_SERVICE_TRENDS) {
+	} else if(display_type == DISPLAY_SERVICE_TRENDS) {
 		temp_service = find_service(host_name, svc_description);
 		if(temp_service == NULL || is_authorized_for_service(temp_service, &current_authdata) == FALSE)
 			is_authorized = FALSE;
-		}
+	}
 	if(is_authorized == FALSE) {
 
 		if(mode == CREATE_HTML)
@@ -639,7 +634,7 @@ int main(int argc, char **argv) {
 		document_footer();
 		free_memory();
 		return ERROR;
-		}
+	}
 #endif
 
 
@@ -649,17 +644,16 @@ int main(int argc, char **argv) {
 		document_footer();
 		free_memory();
 		return ERROR;
-		}
+	}
 	/* set drawing parameters, etc */
 
 	if(small_image == TRUE) {
 		image_height = 20;
 		image_width = 500;
-		}
-	else {
+	} else {
 		image_height = 300;
 		image_width = 900;
-		}
+	}
 
 	if(display_type == DISPLAY_HOST_TRENDS) {
 
@@ -668,29 +662,26 @@ int main(int argc, char **argv) {
 			drawing_height = SMALL_HOST_DRAWING_HEIGHT;
 			drawing_x_offset = SMALL_HOST_DRAWING_X_OFFSET;
 			drawing_y_offset = SMALL_HOST_DRAWING_Y_OFFSET;
-			}
-		else {
+		} else {
 			drawing_width = HOST_DRAWING_WIDTH;
 			drawing_height = HOST_DRAWING_HEIGHT;
 			drawing_x_offset = HOST_DRAWING_X_OFFSET;
 			drawing_y_offset = HOST_DRAWING_Y_OFFSET;
-			}
 		}
-	else if(display_type == DISPLAY_SERVICE_TRENDS) {
+	} else if(display_type == DISPLAY_SERVICE_TRENDS) {
 
 		if(small_image == TRUE) {
 			drawing_width = SMALL_SVC_DRAWING_WIDTH;
 			drawing_height = SMALL_SVC_DRAWING_HEIGHT;
 			drawing_x_offset = SMALL_SVC_DRAWING_X_OFFSET;
 			drawing_y_offset = SMALL_SVC_DRAWING_Y_OFFSET;
-			}
-		else {
+		} else {
 			drawing_width = SVC_DRAWING_WIDTH;
 			drawing_height = SVC_DRAWING_HEIGHT;
 			drawing_x_offset = SVC_DRAWING_X_OFFSET;
 			drawing_y_offset = SVC_DRAWING_Y_OFFSET;
-			}
 		}
+	}
 
 	/* last known state should always be initially set to indeterminate! */
 	last_known_state = AS_NO_DATA;
@@ -706,8 +697,8 @@ int main(int argc, char **argv) {
 				printf("Error: Could not allocate memory for image\n");
 #endif
 				return ERROR;
-				}
 			}
+		}
 
 		else {
 
@@ -723,7 +714,7 @@ int main(int argc, char **argv) {
 			if(image_file != NULL) {
 				trends_image = gdImageCreateFromPng(image_file);
 				fclose(image_file);
-				}
+			}
 			if(trends_image == NULL)
 				trends_image = gdImageCreate(image_width, image_height);
 			if(trends_image == NULL) {
@@ -731,8 +722,8 @@ int main(int argc, char **argv) {
 				printf("Error: Could not allocate memory for image\n");
 #endif
 				return ERROR;
-				}
 			}
+		}
 
 		/* allocate colors used for drawing */
 		color_white = gdImageColorAllocate(trends_image, 255, 255, 255);
@@ -781,8 +772,8 @@ int main(int argc, char **argv) {
 			temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 			string_width = gdFontSmall->w * strlen(temp_buffer);
 			gdImageStringUp(trends_image, gdFontSmall, drawing_x_offset - (string_height / 2), drawing_y_offset + drawing_height + string_width + 5, (unsigned char *)temp_buffer, color_black);
-			}
 		}
+	}
 
 	if(display_type != DISPLAY_NO_TRENDS && input_type == GET_INPUT_NONE) {
 
@@ -794,7 +785,7 @@ int main(int argc, char **argv) {
 
 			/* graph archived state trend data */
 			graph_all_trend_data();
-			}
+		}
 
 		/* print URL to image */
 		if(mode == CREATE_HTML) {
@@ -816,7 +807,7 @@ int main(int argc, char **argv) {
 			printf("&zoom=%d", zoom_factor);
 			printf("' BORDER=0 name='trendsimage' useMap='#trendsmap' width=%d>\n", image_width);
 			printf("</DIV>\n");
-			}
+		}
 
 		if(mode == CREATE_IMAGE || (mode == CREATE_HTML && use_map == TRUE)) {
 
@@ -828,7 +819,7 @@ int main(int argc, char **argv) {
 
 			/* draw state time breakdowns */
 			draw_time_breakdowns();
-			}
+		}
 
 		if(mode == CREATE_IMAGE) {
 
@@ -846,13 +837,13 @@ int main(int argc, char **argv) {
 			else {
 				gdImagePng(trends_image, image_file);
 				fclose(image_file);
-				}
+			}
 #endif
 
 			/* free memory allocated to image */
 			gdImageDestroy(trends_image);
-			}
 		}
+	}
 
 
 	/* show user a selection of hosts and services to choose from... */
@@ -878,7 +869,7 @@ int main(int argc, char **argv) {
 			for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
 				if(is_authorized_for_host(temp_host, &current_authdata) == TRUE)
 					printf("<option value='%s'>%s\n", escape_string(temp_host->name), temp_host->name);
-				}
+			}
 
 			printf("</select>\n");
 			printf("</td></tr>\n");
@@ -891,7 +882,7 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
+		}
 
 		/* ask the user for what service they want a report for */
 		else if(input_type == GET_INPUT_SERVICE_TARGET) {
@@ -908,8 +899,8 @@ int main(int argc, char **argv) {
 						first_service = temp_service->host_name;
 					printf(" \"%s\"", temp_service->host_name);
 					found = TRUE;
-					}
 				}
+			}
 
 			printf(" ]\n");
 			printf("return hostnames[hostindex];\n");
@@ -935,7 +926,7 @@ int main(int argc, char **argv) {
 			for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
 				if(is_authorized_for_service(temp_service, &current_authdata) == TRUE)
 					printf("<option value='%s'>%s;%s\n", escape_string(temp_service->description), temp_service->host_name, temp_service->description);
-				}
+			}
 
 			printf("</select>\n");
 			printf("</td></tr>\n");
@@ -948,7 +939,7 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
+		}
 
 		/* ask the user for report range and options */
 		else if(input_type == GET_INPUT_OPTIONS) {
@@ -1086,8 +1077,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d>Host Up\n", AS_HOST_UP);
 				printf("<option value=%d>Host Down\n", AS_HOST_DOWN);
 				printf("<option value=%d>Host Unreachable\n", AS_HOST_UNREACHABLE);
-				}
-			else {
+			} else {
 				printf("<select name='initialassumedservicestate'>\n");
 				printf("<option value=%d>Unspecified\n", AS_NO_DATA);
 				printf("<option value=%d>Current State\n", AS_CURRENT_STATE);
@@ -1095,7 +1085,7 @@ int main(int argc, char **argv) {
 				printf("<option value=%d>Service Warning\n", AS_SVC_WARNING);
 				printf("<option value=%d>Service Unknown\n", AS_SVC_UNKNOWN);
 				printf("<option value=%d>Service Critical\n", AS_SVC_CRITICAL);
-				}
+			}
 			printf("</select>\n");
 			printf("</td></tr>\n");
 
@@ -1119,7 +1109,7 @@ int main(int argc, char **argv) {
 			printf("Note: Choosing the 'suppress image map' option will make the report run approximately twice as fast as it would otherwise, but it will prevent you from being able to zoom in on specific time periods.\n");
 			printf("</DIV></P>\n");
 			*/
-			}
+		}
 
 		/* as the user whether they want a graph for a host or service */
 		else {
@@ -1148,9 +1138,9 @@ int main(int argc, char **argv) {
 			printf("</form>\n");
 
 			printf("</DIV></P>\n");
-			}
-
 		}
+
+	}
 
 	document_footer();
 
@@ -1161,11 +1151,12 @@ int main(int argc, char **argv) {
 	free_memory();
 
 	return OK;
-	}
+}
 
 
 
-void document_header(int use_stylesheet) {
+void document_header(int use_stylesheet)
+{
 	char date_time[MAX_DATETIME_LENGTH];
 	time_t current_time;
 	time_t expire_time;
@@ -1197,7 +1188,7 @@ void document_header(int use_stylesheet) {
 		if(use_stylesheet == TRUE) {
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, COMMON_CSS);
 			printf("<LINK REL='stylesheet' TYPE='text/css' HREF='%s%s'>\n", url_stylesheets_path, TRENDS_CSS);
-			}
+		}
 
 		/* write JavaScript code for popup window */
 		if(display_type != DISPLAY_NO_TRENDS)
@@ -1211,7 +1202,7 @@ void document_header(int use_stylesheet) {
 		include_ssi_files(TRENDS_CGI, SSI_HEADER);
 
 		printf("<div id=\"popup\" style=\"position:absolute; z-index:1; visibility: hidden\"></div>\n");
-		}
+	}
 
 	else {
 		printf("Cache-Control: no-store\r\n");
@@ -1226,14 +1217,15 @@ void document_header(int use_stylesheet) {
 		printf("Expires: %s\r\n", date_time);
 
 		printf("Content-Type: image/png\r\n\r\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
 
-void document_footer(void) {
+
+void document_footer(void)
+{
 
 	if(embedded == TRUE)
 		return;
@@ -1245,14 +1237,15 @@ void document_footer(void) {
 
 		printf("</body>\n");
 		printf("</html>\n");
-		}
-
-	return;
 	}
 
+	return;
+}
 
 
-int process_cgivars(void) {
+
+int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -1264,7 +1257,7 @@ int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
+		}
 
 		/* we found the host argument */
 		else if(!strcmp(variables[x], "host")) {
@@ -1272,14 +1265,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((host_name = (char *)strdup(variables[x])) == NULL)
 				host_name = "";
 			strip_html_brackets(host_name);
 
 			display_type = DISPLAY_HOST_TRENDS;
-			}
+		}
 
 		/* we found the node width argument */
 		else if(!strcmp(variables[x], "service")) {
@@ -1287,14 +1280,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if((svc_description = (char *)strdup(variables[x])) == NULL)
 				svc_description = "";
 			strip_html_brackets(svc_description);
 
 			display_type = DISPLAY_SERVICE_TRENDS;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t1")) {
@@ -1302,11 +1295,11 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t1 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
-			}
+		}
 
 		/* we found first time argument */
 		else if(!strcmp(variables[x], "t2")) {
@@ -1314,16 +1307,16 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			t2 = (time_t)strtoul(variables[x], NULL, 10);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
-			}
+		}
 
 		/* we found the image creation option */
 		else if(!strcmp(variables[x], "createimage")) {
 			mode = CREATE_IMAGE;
-			}
+		}
 
 		/* we found the assume initial states option */
 		else if(!strcmp(variables[x], "assumeinitialstates")) {
@@ -1331,13 +1324,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_initial_states = TRUE;
 			else
 				assume_initial_states = FALSE;
-			}
+		}
 
 		/* we found the initial assumed host state option */
 		else if(!strcmp(variables[x], "initialassumedhoststate")) {
@@ -1345,10 +1338,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			initial_assumed_host_state = atoi(variables[x]);
-			}
+		}
 
 		/* we found the initial assumed service state option */
 		else if(!strcmp(variables[x], "initialassumedservicestate")) {
@@ -1356,10 +1349,10 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			initial_assumed_service_state = atoi(variables[x]);
-			}
+		}
 
 		/* we found the assume state during program not running option */
 		else if(!strcmp(variables[x], "assumestatesduringnotrunning")) {
@@ -1367,13 +1360,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_states_during_notrunning = TRUE;
 			else
 				assume_states_during_notrunning = FALSE;
-			}
+		}
 
 		/* we found the assume state retention option */
 		else if(!strcmp(variables[x], "assumestateretention")) {
@@ -1381,13 +1374,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				assume_state_retention = TRUE;
 			else
 				assume_state_retention = FALSE;
-			}
+		}
 
 		/* we found the include soft states option */
 		else if(!strcmp(variables[x], "includesoftstates")) {
@@ -1395,13 +1388,13 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "yes"))
 				include_soft_states = TRUE;
 			else
 				include_soft_states = FALSE;
-			}
+		}
 
 		/* we found the zoom factor argument */
 		else if(!strcmp(variables[x], "zoom")) {
@@ -1409,12 +1402,12 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			zoom_factor = atoi(variables[x]);
 			if(zoom_factor == 0)
 				zoom_factor = 1;
-			}
+		}
 
 		/* we found the backtrack archives argument */
 		else if(!strcmp(variables[x], "backtrack")) {
@@ -1422,14 +1415,14 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			backtrack_archives = atoi(variables[x]);
 			if(backtrack_archives < 0)
 				backtrack_archives = 0;
 			if(backtrack_archives > MAX_ARCHIVE_BACKTRACKS)
 				backtrack_archives = MAX_ARCHIVE_BACKTRACKS;
-			}
+		}
 
 		/* we found the standard timeperiod argument */
 		else if(!strcmp(variables[x], "timeperiod")) {
@@ -1437,7 +1430,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "today"))
 				timeperiod_type = TIMEPERIOD_TODAY;
@@ -1473,7 +1466,7 @@ int process_cgivars(void) {
 				continue;
 
 			convert_timeperiod_to_times(timeperiod_type);
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smon")) {
@@ -1481,7 +1474,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1489,7 +1482,7 @@ int process_cgivars(void) {
 			start_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "sday")) {
@@ -1497,7 +1490,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1505,7 +1498,7 @@ int process_cgivars(void) {
 			start_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "syear")) {
@@ -1513,7 +1506,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1521,7 +1514,7 @@ int process_cgivars(void) {
 			start_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "smin")) {
@@ -1529,7 +1522,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1537,7 +1530,7 @@ int process_cgivars(void) {
 			start_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ssec")) {
@@ -1545,7 +1538,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1553,7 +1546,7 @@ int process_cgivars(void) {
 			start_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "shour")) {
@@ -1561,7 +1554,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1569,7 +1562,7 @@ int process_cgivars(void) {
 			start_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 
 		/* we found time argument */
@@ -1578,7 +1571,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1586,7 +1579,7 @@ int process_cgivars(void) {
 			end_month = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eday")) {
@@ -1594,7 +1587,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1602,7 +1595,7 @@ int process_cgivars(void) {
 			end_day = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "eyear")) {
@@ -1610,7 +1603,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1618,7 +1611,7 @@ int process_cgivars(void) {
 			end_year = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "emin")) {
@@ -1626,7 +1619,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1634,7 +1627,7 @@ int process_cgivars(void) {
 			end_minute = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "esec")) {
@@ -1642,7 +1635,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1650,7 +1643,7 @@ int process_cgivars(void) {
 			end_second = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found time argument */
 		else if(!strcmp(variables[x], "ehour")) {
@@ -1658,7 +1651,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(timeperiod_type != TIMEPERIOD_CUSTOM)
 				continue;
@@ -1666,7 +1659,7 @@ int process_cgivars(void) {
 			end_hour = atoi(variables[x]);
 			timeperiod_type = TIMEPERIOD_CUSTOM;
 			compute_time_from_parts = TRUE;
-			}
+		}
 
 		/* we found the embed option */
 		else if(!strcmp(variables[x], "embedded"))
@@ -1684,7 +1677,7 @@ int process_cgivars(void) {
 		else if(!strcmp(variables[x], "nomap")) {
 			display_popups = FALSE;
 			use_map = FALSE;
-			}
+		}
 
 		/* we found the input option */
 		else if(!strcmp(variables[x], "input")) {
@@ -1692,7 +1685,7 @@ int process_cgivars(void) {
 			if(variables[x] == NULL) {
 				error = TRUE;
 				break;
-				}
+			}
 
 			if(!strcmp(variables[x], "gethost"))
 				input_type = GET_INPUT_HOST_TARGET;
@@ -1702,24 +1695,25 @@ int process_cgivars(void) {
 				input_type = GET_INPUT_OPTIONS;
 			else
 				input_type = GET_INPUT_TARGET_TYPE;
-			}
+		}
 
 		/* we found the small image option */
 		else if(!strcmp(variables[x], "smallimage"))
 			small_image = TRUE;
 
-		}
+	}
 
 	/* free memory allocated to the CGI variables */
 	free_cgivars(variables);
 
 	return error;
-	}
+}
 
 
 
 /* top level routine for graphic all trend data */
-void graph_all_trend_data(void) {
+void graph_all_trend_data(void)
+{
 	archived_state *temp_as;
 	archived_state *last_as;
 	time_t a;
@@ -1772,9 +1766,8 @@ void graph_all_trend_data(void) {
 
 				/* add a dummy archived state item, so something can get graphed */
 				add_archived_state(last_known_state, AS_HARD_STATE, t1, "Current Host State Assumed (Faked Log Entry)");
-				}
 			}
-		else {
+		} else {
 			if(svcstatus != NULL) {
 
 				if(svcstatus->status == SERVICE_OK)
@@ -1788,9 +1781,9 @@ void graph_all_trend_data(void) {
 
 				/* add a dummy archived state item, so something can get graphed */
 				add_archived_state(last_known_state, AS_HARD_STATE, t1, "Current Service State Assumed (Faked Log Entry)");
-				}
 			}
 		}
+	}
 
 
 	/******************************************/
@@ -1808,54 +1801,52 @@ void graph_all_trend_data(void) {
 				initial_assumed_state = initial_assumed_service_state;
 			if(initial_assumed_service_state == AS_CURRENT_STATE && svcstatus == NULL)
 				error = TRUE;
-			}
-		else {
+		} else {
 			if(initial_assumed_host_state != AS_HOST_UP && initial_assumed_host_state != AS_HOST_DOWN && initial_assumed_host_state != AS_HOST_UNREACHABLE && initial_assumed_host_state != AS_CURRENT_STATE)
 				error = TRUE;
 			else
 				initial_assumed_state = initial_assumed_host_state;
 			if(initial_assumed_host_state == AS_CURRENT_STATE && hststatus == NULL)
 				error = TRUE;
-			}
+		}
 
 		/* get the current state if applicable */
 		if(((display_type == DISPLAY_HOST_TRENDS && initial_assumed_host_state == AS_CURRENT_STATE) || (display_type == DISPLAY_SERVICE_TRENDS && initial_assumed_service_state == AS_CURRENT_STATE)) && error == FALSE) {
 			if(display_type == DISPLAY_HOST_TRENDS) {
 				switch(hststatus->status) {
-					case SD_HOST_DOWN:
-						initial_assumed_state = AS_HOST_DOWN;
-						break;
-					case SD_HOST_UNREACHABLE:
-						initial_assumed_state = AS_HOST_UNREACHABLE;
-						break;
-					case SD_HOST_UP:
-						initial_assumed_state = AS_HOST_UP;
-						break;
-					default:
-						error = TRUE;
-						break;
-					}
+				case SD_HOST_DOWN:
+					initial_assumed_state = AS_HOST_DOWN;
+					break;
+				case SD_HOST_UNREACHABLE:
+					initial_assumed_state = AS_HOST_UNREACHABLE;
+					break;
+				case SD_HOST_UP:
+					initial_assumed_state = AS_HOST_UP;
+					break;
+				default:
+					error = TRUE;
+					break;
 				}
-			else {
+			} else {
 				switch(svcstatus->status) {
-					case SERVICE_OK:
-						initial_assumed_state = AS_SVC_OK;
-						break;
-					case SERVICE_WARNING:
-						initial_assumed_state = AS_SVC_WARNING;
-						break;
-					case SERVICE_UNKNOWN:
-						initial_assumed_state = AS_SVC_UNKNOWN;
-						break;
-					case SERVICE_CRITICAL:
-						initial_assumed_state = AS_SVC_CRITICAL;
-						break;
-					default:
-						error = TRUE;
-						break;
-					}
+				case SERVICE_OK:
+					initial_assumed_state = AS_SVC_OK;
+					break;
+				case SERVICE_WARNING:
+					initial_assumed_state = AS_SVC_WARNING;
+					break;
+				case SERVICE_UNKNOWN:
+					initial_assumed_state = AS_SVC_UNKNOWN;
+					break;
+				case SERVICE_CRITICAL:
+					initial_assumed_state = AS_SVC_CRITICAL;
+					break;
+				default:
+					error = TRUE;
+					break;
 				}
 			}
+		}
 
 		if(error == FALSE) {
 
@@ -1871,8 +1862,8 @@ void graph_all_trend_data(void) {
 				add_archived_state(initial_assumed_state, AS_HARD_STATE, initial_assumed_time, "First Host State Assumed (Faked Log Entry)");
 			else
 				add_archived_state(initial_assumed_state, AS_HARD_STATE, initial_assumed_time, "First Service State Assumed (Faked Log Entry)");
-			}
 		}
+	}
 
 
 
@@ -1886,8 +1877,8 @@ void graph_all_trend_data(void) {
 		if(temp_as->entry_type != AS_NO_DATA && temp_as->entry_type != AS_PROGRAM_START && temp_as->entry_type != AS_PROGRAM_END) {
 			have_some_real_data = TRUE;
 			break;
-			}
 		}
+	}
 	if(have_some_real_data == FALSE)
 		return;
 
@@ -1920,7 +1911,7 @@ void graph_all_trend_data(void) {
 #ifdef DEBUG
 			printf("SETTING LAST KNOWN STATE=%d<br>\n", last_known_state);
 #endif
-			}
+		}
 
 		/* skip this entry if it occurs before the starting point of the graph */
 		if(temp_as->time_stamp <= t1) {
@@ -1929,7 +1920,7 @@ void graph_all_trend_data(void) {
 #endif
 			last_as = temp_as;
 			continue;
-			}
+		}
 
 		/* graph this span if we're not on the first item */
 		if(last_as != NULL) {
@@ -1956,13 +1947,13 @@ void graph_all_trend_data(void) {
 				if(a < earliest_time) {
 					earliest_time = a;
 					earliest_state = last_as->entry_type;
-					}
+				}
 
 				/* save this time if its the latest we've graphed */
 				if(b > latest_time) {
 					latest_time = b;
 					latest_state = last_as->entry_type;
-					}
+				}
 
 				/* compute availability times for this chunk */
 				graph_trend_data(last_as->entry_type, temp_as->entry_type, last_as->time_stamp, a, b, last_as->state_info);
@@ -1971,14 +1962,14 @@ void graph_all_trend_data(void) {
 				if(b >= t2) {
 					last_as = temp_as;
 					break;
-					}
 				}
 			}
+		}
 
 
 		/* keep track of the last item */
 		last_as = temp_as;
-		}
+	}
 
 
 #ifdef DEBUG
@@ -2011,8 +2002,8 @@ void graph_all_trend_data(void) {
 
 			/* compute availability times for last state */
 			graph_trend_data(last_as->entry_type, current_state, a, a, b, last_as->state_info);
-			}
 		}
+	}
 
 
 
@@ -2021,12 +2012,13 @@ void graph_all_trend_data(void) {
 		printf("</MAP>\n");
 
 	return;
-	}
+}
 
 
 
 /* graphs trend data */
-void graph_trend_data(int first_state, int last_state, time_t real_start_time, time_t start_time, time_t end_time, char *state_info) {
+void graph_trend_data(int first_state, int last_state, time_t real_start_time, time_t start_time, time_t end_time, char *state_info)
+{
 	int start_state;
 	int start_pixel = 0;
 	int end_pixel = 0;
@@ -2052,13 +2044,13 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 	if(first_state == AS_PROGRAM_START && (last_state == AS_PROGRAM_END || last_state == AS_PROGRAM_START)) {
 		if(assume_initial_states == FALSE)
 			return;
-		}
+	}
 	if(first_state == AS_PROGRAM_END) {
 		if(assume_states_during_notrunning == TRUE)
 			first_state = last_known_state;
 		else
 			return;
-		}
+	}
 
 	/* special case if first entry was program start */
 	if(first_state == AS_PROGRAM_START) {
@@ -2074,8 +2066,7 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 #ifdef DEBUG
 				printf("\tWe are assuming state retention (%d)...\n", start_state);
 #endif
-				}
-			else {
+			} else {
 #ifdef DEBUG
 				printf("\tWe are NOT assuming state retention...\n");
 #endif
@@ -2083,19 +2074,17 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 					start_state = AS_HOST_UP;
 				else
 					start_state = AS_SVC_OK;
-				}
 			}
-		else {
+		} else {
 #ifdef DEBUG
 			printf("We ARE NOT assuming initial states!\n");
 #endif
 			return;
-			}
 		}
-	else {
+	} else {
 		start_state = first_state;
 		last_known_state = first_state;
-		}
+	}
 
 #ifdef DEBUG
 	printf("Graphing state %d\n", start_state);
@@ -2116,13 +2105,13 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 	else {
 		start_pixel_ratio = ((double)(start_time - t1)) / ((double)(t2 - t1));
 		start_pixel = (int)(start_pixel_ratio * (drawing_width - 1));
-		}
+	}
 	if(end_time == t1)
 		end_pixel = 0;
 	else {
 		end_pixel_ratio = ((double)(end_time - t1)) / ((double)(t2 - t1));
 		end_pixel = (int)(end_pixel_ratio * (drawing_width - 1));
-		}
+	}
 
 #ifdef DEBUG
 	printf("\tPixel %d to %d\n\n", start_pixel, end_pixel);
@@ -2134,44 +2123,44 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 
 		/* figure out the color to use for drawing */
 		switch(start_state) {
-			case AS_HOST_UP:
-				color_to_use = color_green;
-				height = 60;
-				break;
-			case AS_HOST_DOWN:
-				color_to_use = color_red;
-				height = 40;
-				break;
-			case AS_HOST_UNREACHABLE:
-				color_to_use = color_darkred;
-				height = 20;
-				break;
-			case AS_SVC_OK:
-				color_to_use = color_green;
-				height = 80;
-				break;
-			case AS_SVC_WARNING:
-				color_to_use = color_yellow;
-				height = 60;
-				break;
-			case AS_SVC_UNKNOWN:
-				color_to_use = color_orange;
-				height = 40;
-				break;
-			case AS_SVC_CRITICAL:
-				color_to_use = color_red;
-				height = 20;
-				break;
-			default:
-				color_to_use = color_black;
-				height = 0;
-				break;
-			}
+		case AS_HOST_UP:
+			color_to_use = color_green;
+			height = 60;
+			break;
+		case AS_HOST_DOWN:
+			color_to_use = color_red;
+			height = 40;
+			break;
+		case AS_HOST_UNREACHABLE:
+			color_to_use = color_darkred;
+			height = 20;
+			break;
+		case AS_SVC_OK:
+			color_to_use = color_green;
+			height = 80;
+			break;
+		case AS_SVC_WARNING:
+			color_to_use = color_yellow;
+			height = 60;
+			break;
+		case AS_SVC_UNKNOWN:
+			color_to_use = color_orange;
+			height = 40;
+			break;
+		case AS_SVC_CRITICAL:
+			color_to_use = color_red;
+			height = 20;
+			break;
+		default:
+			color_to_use = color_black;
+			height = 0;
+			break;
+		}
 
 		/* draw a rectangle */
 		if(start_state != AS_NO_DATA)
 			gdImageFilledRectangle(trends_image, start_pixel + drawing_x_offset, drawing_height - height + drawing_y_offset, end_pixel + drawing_x_offset, drawing_height + drawing_y_offset, color_to_use);
-		}
+	}
 
 	/* else we're creating the HTML, so write map area code... */
 	else {
@@ -2179,39 +2168,39 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 
 		/* figure out the the state string to use */
 		switch(start_state) {
-			case AS_HOST_UP:
-				strcpy(state_string, "UP");
-				height = 60;
-				break;
-			case AS_HOST_DOWN:
-				strcpy(state_string, "DOWN");
-				height = 40;
-				break;
-			case AS_HOST_UNREACHABLE:
-				strcpy(state_string, "UNREACHABLE");
-				height = 20;
-				break;
-			case AS_SVC_OK:
-				strcpy(state_string, "OK");
-				height = 80;
-				break;
-			case AS_SVC_WARNING:
-				strcpy(state_string, "WARNING");
-				height = 60;
-				break;
-			case AS_SVC_UNKNOWN:
-				strcpy(state_string, "UNKNOWN");
-				height = 40;
-				break;
-			case AS_SVC_CRITICAL:
-				strcpy(state_string, "CRITICAL");
-				height = 20;
-				break;
-			default:
-				strcpy(state_string, "?");
-				height = 5;
-				break;
-			}
+		case AS_HOST_UP:
+			strcpy(state_string, "UP");
+			height = 60;
+			break;
+		case AS_HOST_DOWN:
+			strcpy(state_string, "DOWN");
+			height = 40;
+			break;
+		case AS_HOST_UNREACHABLE:
+			strcpy(state_string, "UNREACHABLE");
+			height = 20;
+			break;
+		case AS_SVC_OK:
+			strcpy(state_string, "OK");
+			height = 80;
+			break;
+		case AS_SVC_WARNING:
+			strcpy(state_string, "WARNING");
+			height = 60;
+			break;
+		case AS_SVC_UNKNOWN:
+			strcpy(state_string, "UNKNOWN");
+			height = 40;
+			break;
+		case AS_SVC_CRITICAL:
+			strcpy(state_string, "CRITICAL");
+			height = 20;
+			break;
+		default:
+			strcpy(state_string, "?");
+			height = 5;
+			break;
+		}
 
 		/* get the center of this time range */
 		center_time = start_time + ((end_time - start_time) / 2);
@@ -2220,11 +2209,10 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 		if(zoom_factor > 0) {
 			next_start_time = center_time - (((t2 - t1) / 2) / zoom_factor);
 			next_end_time = center_time + (((t2 - t1) / 2) / zoom_factor);
-			}
-		else {
+		} else {
 			next_start_time = center_time + (((t2 - t1) / 2) * zoom_factor);
 			next_end_time = center_time - (((t2 - t1) / 2) * zoom_factor);
-			}
+		}
 
 		printf("<AREA shape='rect' ");
 
@@ -2267,47 +2255,48 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 			temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
 			printf("%s", temp_buffer);
 			printf("\",event)' onMouseOut='hidePopup()'");
-			}
+		}
 
 		printf(">\n");
 
-		}
+	}
 
 
 	/* calculate time in this state */
 	switch(start_state) {
-		case AS_HOST_UP:
-			time_up += (unsigned long)(end_time - start_time);
-			break;
-		case AS_HOST_DOWN:
-			time_down += (unsigned long)(end_time - start_time);
-			break;
-		case AS_HOST_UNREACHABLE:
-			time_unreachable += (unsigned long)(end_time - start_time);
-			break;
-		case AS_SVC_OK:
-			time_ok += (unsigned long)(end_time - start_time);
-			break;
-		case AS_SVC_WARNING:
-			time_warning += (unsigned long)(end_time - start_time);
-			break;
-		case AS_SVC_UNKNOWN:
-			time_unknown += (unsigned long)(end_time - start_time);
-			break;
-		case AS_SVC_CRITICAL:
-			time_critical += (unsigned long)(end_time - start_time);
-			break;
-		default:
-			break;
-		}
+	case AS_HOST_UP:
+		time_up += (unsigned long)(end_time - start_time);
+		break;
+	case AS_HOST_DOWN:
+		time_down += (unsigned long)(end_time - start_time);
+		break;
+	case AS_HOST_UNREACHABLE:
+		time_unreachable += (unsigned long)(end_time - start_time);
+		break;
+	case AS_SVC_OK:
+		time_ok += (unsigned long)(end_time - start_time);
+		break;
+	case AS_SVC_WARNING:
+		time_warning += (unsigned long)(end_time - start_time);
+		break;
+	case AS_SVC_UNKNOWN:
+		time_unknown += (unsigned long)(end_time - start_time);
+		break;
+	case AS_SVC_CRITICAL:
+		time_critical += (unsigned long)(end_time - start_time);
+		break;
+	default:
+		break;
+	}
 
 	return;
-	}
+}
 
 
 
 /* convert current host state to archived state value */
-int convert_host_state_to_archived_state(int current_status) {
+int convert_host_state_to_archived_state(int current_status)
+{
 
 	if(current_status == SD_HOST_UP)
 		return AS_HOST_UP;
@@ -2317,11 +2306,12 @@ int convert_host_state_to_archived_state(int current_status) {
 		return AS_HOST_UNREACHABLE;
 
 	return AS_NO_DATA;
-	}
+}
 
 
 /* convert current service state to archived state value */
-int convert_service_state_to_archived_state(int current_status) {
+int convert_service_state_to_archived_state(int current_status)
+{
 
 	if(current_status == SERVICE_OK)
 		return AS_SVC_OK;
@@ -2333,12 +2323,13 @@ int convert_service_state_to_archived_state(int current_status) {
 		return AS_SVC_CRITICAL;
 
 	return AS_NO_DATA;
-	}
+}
 
 
 
 /* adds an archived state entry */
-void add_archived_state(int entry_type, int state_type, time_t time_stamp, char *state_info) {
+void add_archived_state(int entry_type, int state_type, time_t time_stamp, char *state_info)
+{
 	archived_state *last_as = NULL;
 	archived_state *temp_as = NULL;
 	archived_state *new_as = NULL;
@@ -2357,8 +2348,7 @@ void add_archived_state(int entry_type, int state_type, time_t time_stamp, char 
 		new_as->state_info = (char *)malloc(strlen(state_info) + 1);
 		if(new_as->state_info != NULL)
 			strcpy(new_as->state_info, state_info);
-		}
-	else new_as->state_info = NULL;
+	} else new_as->state_info = NULL;
 
 	new_as->entry_type = entry_type;
 	new_as->processed_state = entry_type;
@@ -2375,25 +2365,24 @@ void add_archived_state(int entry_type, int state_type, time_t time_stamp, char 
 			else
 				last_as->next = new_as;
 			break;
-			}
-		else
+		} else
 			last_as = temp_as;
-		}
+	}
 	if(as_list == NULL) {
 		new_as->next = NULL;
 		as_list = new_as;
-		}
-	else if(temp_as == NULL) {
+	} else if(temp_as == NULL) {
 		new_as->next = NULL;
 		last_as->next = new_as;
-		}
+	}
 
 	return;
-	}
+}
 
 
 /* frees memory allocated to the archived state list */
-void free_archived_state_list(void) {
+void free_archived_state_list(void)
+{
 	archived_state *this_as = NULL;
 	archived_state *next_as = NULL;
 
@@ -2403,16 +2392,17 @@ void free_archived_state_list(void) {
 			free(this_as->state_info);
 		free(this_as);
 		this_as = next_as;
-		}
+	}
 
 	as_list = NULL;
 
 	return;
-	}
+}
 
 
 /* reads log files for archived state data */
-void read_archived_state_data(void) {
+void read_archived_state_data(void)
+{
 	char filename[MAX_FILENAME_LENGTH];
 	int newest_archive = 0;
 	int oldest_archive = 0;
@@ -2450,15 +2440,16 @@ void read_archived_state_data(void) {
 
 		/* scan the log file for archived state data */
 		scan_log_file_for_archived_state_data(filename);
-		}
+	}
 
 	return;
-	}
+}
 
 
 
 /* grabs archives state data from a log file */
-void scan_log_file_for_archived_state_data(char *filename) {
+void scan_log_file_for_archived_state_data(char *filename)
+{
 	char *input = NULL;
 	char *input2 = NULL;
 	char entry_host_name[MAX_INPUT_BUFFER];
@@ -2473,14 +2464,14 @@ void scan_log_file_for_archived_state_data(char *filename) {
 	if(mode == CREATE_HTML) {
 		printf(" ");
 		fflush(NULL);
-		}
+	}
 
 	if((thefile = mmap_fopen(filename)) == NULL) {
 #ifdef DEBUG
 		printf("Could not open file '%s' for reading.\n", filename);
 #endif
 		return;
-		}
+	}
 
 #ifdef DEBUG
 	printf("Scanning log file '%s' for archived state data...\n", filename);
@@ -2540,7 +2531,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					if(include_soft_states == FALSE)
 						continue;
 					state_type = AS_SOFT_STATE;
-					}
+				}
 				if(strstr(input, ";HARD;"))
 					state_type = AS_HARD_STATE;
 
@@ -2558,8 +2549,8 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					add_archived_state(AS_HOST_UP, state_type, time_stamp, plugin_output);
 				else
 					add_archived_state(AS_NO_DATA, AS_NO_DATA, time_stamp, plugin_output);
-				}
 			}
+		}
 		if(display_type == DISPLAY_SERVICE_TRENDS) {
 			if(strstr(input, "SERVICE ALERT:") || strstr(input, "INITIAL SERVICE STATE:") || strstr(input, "CURRENT SERVICE STATE:")) {
 
@@ -2590,7 +2581,7 @@ void scan_log_file_for_archived_state_data(char *filename) {
 					if(include_soft_states == FALSE)
 						continue;
 					state_type = AS_SOFT_STATE;
-					}
+				}
 				if(strstr(input, ";HARD;"))
 					state_type = AS_HARD_STATE;
 
@@ -2611,10 +2602,10 @@ void scan_log_file_for_archived_state_data(char *filename) {
 				else
 					add_archived_state(AS_NO_DATA, AS_NO_DATA, time_stamp, plugin_output);
 
-				}
 			}
-
 		}
+
+	}
 
 	/* free memory and close the file */
 	free(input);
@@ -2622,12 +2613,13 @@ void scan_log_file_for_archived_state_data(char *filename) {
 	mmap_fclose(thefile);
 
 	return;
-	}
+}
 
 
 
 /* write JavaScript code and layer for popup window */
-void write_popup_code(void) {
+void write_popup_code(void)
+{
 	char *border_color = "#000000";
 	char *background_color = "#ffffcc";
 	int border = 1;
@@ -2704,13 +2696,14 @@ void write_popup_code(void) {
 	printf("</SCRIPT>\n");
 
 	return;
-	}
+}
 
 
 
 
 /* write timestamps */
-void draw_timestamps(void) {
+void draw_timestamps(void)
+{
 	int last_timestamp = 0;
 	archived_state *temp_as;
 	double start_pixel_ratio;
@@ -2735,18 +2728,19 @@ void draw_timestamps(void) {
 		if((start_pixel > last_timestamp + MIN_TIMESTAMP_SPACING) && (start_pixel < drawing_width - 1 - MIN_TIMESTAMP_SPACING)) {
 			draw_timestamp(start_pixel, temp_as->time_stamp);
 			last_timestamp = start_pixel;
-			}
 		}
+	}
 
 	/* draw last timestamp */
 	draw_timestamp(drawing_width - 1, t2);
 
 	return;
-	}
+}
 
 
 /* write timestamp below graph */
-void draw_timestamp(int ts_pixel, time_t ts_time) {
+void draw_timestamp(int ts_pixel, time_t ts_time)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	int string_height;
 	int string_width;
@@ -2766,12 +2760,13 @@ void draw_timestamp(int ts_pixel, time_t ts_time) {
 		draw_dashed_line(ts_pixel + drawing_x_offset, drawing_y_offset, ts_pixel + drawing_x_offset, drawing_y_offset + drawing_height, color_black);
 
 	return;
-	}
+}
 
 
 
 /* draw total state times */
-void draw_time_breakdowns(void) {
+void draw_time_breakdowns(void)
+{
 	char temp_buffer[MAX_INPUT_BUFFER];
 	unsigned long total_time = 0L;
 	unsigned long total_state_time;
@@ -2813,8 +2808,7 @@ void draw_time_breakdowns(void) {
 		get_time_breakdown_string(total_time, time_indeterminate, "Indeterminate", &temp_buffer[0], sizeof(temp_buffer));
 		gdImageString(trends_image, gdFontSmall, drawing_x_offset + drawing_width + 20, drawing_y_offset + 65, (unsigned char *)temp_buffer, color_black);
 		gdImageString(trends_image, gdFontSmall, drawing_x_offset - 10 - (gdFontSmall->w * 13), drawing_y_offset + 65, (unsigned char *)"Indeterminate", color_black);
-		}
-	else {
+	} else {
 		get_time_breakdown_string(total_time, time_ok, "Ok", &temp_buffer[0], sizeof(temp_buffer));
 		gdImageString(trends_image, gdFontSmall, drawing_x_offset + drawing_width + 20, drawing_y_offset + 5, (unsigned char *)temp_buffer, color_darkgreen);
 		gdImageString(trends_image, gdFontSmall, drawing_x_offset - 10 - (gdFontSmall->w * 2), drawing_y_offset + 5, (unsigned char *)"Ok", color_darkgreen);
@@ -2834,13 +2828,14 @@ void draw_time_breakdowns(void) {
 		get_time_breakdown_string(total_time, time_indeterminate, "Indeterminate", &temp_buffer[0], sizeof(temp_buffer));
 		gdImageString(trends_image, gdFontSmall, drawing_x_offset + drawing_width + 20, drawing_y_offset + 85, (unsigned char *)temp_buffer, color_black);
 		gdImageString(trends_image, gdFontSmall, drawing_x_offset - 10 - (gdFontSmall->w * 13), drawing_y_offset + 85, (unsigned char *)"Indeterminate", color_black);
-		}
-
-	return;
 	}
 
+	return;
+}
 
-void get_time_breakdown_string(unsigned long total_time, unsigned long state_time, char *state_string, char *buffer, int buffer_length) {
+
+void get_time_breakdown_string(unsigned long total_time, unsigned long state_time, char *state_string, char *buffer, int buffer_length)
+{
 	int days;
 	int hours;
 	int minutes;
@@ -2856,10 +2851,11 @@ void get_time_breakdown_string(unsigned long total_time, unsigned long state_tim
 	buffer[buffer_length - 1] = '\x0';
 
 	return;
-	}
+}
 
 
-void convert_timeperiod_to_times(int type) {
+void convert_timeperiod_to_times(int type)
+{
 	time_t current_time;
 	struct tm *t;
 
@@ -2874,79 +2870,79 @@ void convert_timeperiod_to_times(int type) {
 	t->tm_isdst = -1;
 
 	switch(type) {
-		case TIMEPERIOD_LAST24HOURS:
-			t1 = current_time - (60 * 60 * 24);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_TODAY:
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_YESTERDAY:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24));
-			t2 = (time_t)mktime(t);
-			break;
-		case TIMEPERIOD_THISWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTWEEK:
-			t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
-			t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
-			break;
-		case TIMEPERIOD_THISMONTH:
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTMONTH:
-			t->tm_mday = 1;
-			t2 = mktime(t);
-			if(t->tm_mon == 0) {
-				t->tm_mon = 11;
-				t->tm_year--;
-				}
-			else
-				t->tm_mon--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_THISQUARTER:
-			break;
-		case TIMEPERIOD_LASTQUARTER:
-			break;
-		case TIMEPERIOD_THISYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t1 = mktime(t);
-			t2 = current_time;
-			break;
-		case TIMEPERIOD_LASTYEAR:
-			t->tm_mon = 0;
-			t->tm_mday = 1;
-			t2 = mktime(t);
+	case TIMEPERIOD_LAST24HOURS:
+		t1 = current_time - (60 * 60 * 24);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_TODAY:
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_YESTERDAY:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24));
+		t2 = (time_t)mktime(t);
+		break;
+	case TIMEPERIOD_THISWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTWEEK:
+		t1 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday) - (60 * 60 * 24 * 7));
+		t2 = (time_t)(mktime(t) - (60 * 60 * 24 * t->tm_wday));
+		break;
+	case TIMEPERIOD_THISMONTH:
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTMONTH:
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		if(t->tm_mon == 0) {
+			t->tm_mon = 11;
 			t->tm_year--;
-			t1 = mktime(t);
-			break;
-		case TIMEPERIOD_NEXTPROBLEM:
-			/* Time period will be defined later */
-			break;
-		case TIMEPERIOD_LAST7DAYS:
-			t2 = current_time;
-			t1 = current_time - (7 * 24 * 60 * 60);
-			break;
-		case TIMEPERIOD_LAST31DAYS:
-			t2 = current_time;
-			t1 = current_time - (31 * 24 * 60 * 60);
-			break;
-		default:
-			break;
-		}
-
-	return;
+		} else
+			t->tm_mon--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_THISQUARTER:
+		break;
+	case TIMEPERIOD_LASTQUARTER:
+		break;
+	case TIMEPERIOD_THISYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t1 = mktime(t);
+		t2 = current_time;
+		break;
+	case TIMEPERIOD_LASTYEAR:
+		t->tm_mon = 0;
+		t->tm_mday = 1;
+		t2 = mktime(t);
+		t->tm_year--;
+		t1 = mktime(t);
+		break;
+	case TIMEPERIOD_NEXTPROBLEM:
+		/* Time period will be defined later */
+		break;
+	case TIMEPERIOD_LAST7DAYS:
+		t2 = current_time;
+		t1 = current_time - (7 * 24 * 60 * 60);
+		break;
+	case TIMEPERIOD_LAST31DAYS:
+		t2 = current_time;
+		t1 = current_time - (31 * 24 * 60 * 60);
+		break;
+	default:
+		break;
 	}
 
+	return;
+}
 
-void compute_report_times(void) {
+
+void compute_report_times(void)
+{
 	time_t current_time;
 	struct tm *st;
 	struct tm *et;
@@ -2977,12 +2973,13 @@ void compute_report_times(void) {
 	et->tm_isdst = -1;
 
 	t2 = mktime(et);
-	}
+}
 
 
 
 /* draws a dashed line */
-void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
+void draw_dashed_line(int x1, int y1, int x2, int y2, int color)
+{
 	int styleDashed[12];
 
 	styleDashed[0] = color;
@@ -3005,11 +3002,12 @@ void draw_dashed_line(int x1, int y1, int x2, int y2, int color) {
 	gdImageLine(trends_image, x1, y1, x2, y2, gdStyled);
 
 	return;
-	}
+}
 
 
 /* draws horizontal grid lines */
-void draw_horizontal_grid_lines(void) {
+void draw_horizontal_grid_lines(void)
+{
 
 	if(mode == CREATE_HTML)
 		return;
@@ -3024,4 +3022,4 @@ void draw_horizontal_grid_lines(void) {
 		draw_dashed_line(drawing_x_offset, drawing_y_offset + 70, drawing_x_offset + drawing_width, drawing_y_offset + 70, color_black);
 
 	return;
-	}
+}

--- a/common/comments.c
+++ b/common/comments.c
@@ -51,9 +51,10 @@ comment     **comment_hashlist = NULL;
 
 
 /* initializes comment data */
-int initialize_comment_data(void) {
+int initialize_comment_data(void)
+{
 	return xcddefault_initialize_comment_data();
-	}
+}
 
 
 /******************************************************************/
@@ -62,7 +63,8 @@ int initialize_comment_data(void) {
 
 
 /* adds a new host or service comment */
-int add_new_comment(int type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id) {
+int add_new_comment(int type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id)
+{
 	int result;
 	unsigned long new_comment_id = 0L;
 
@@ -80,11 +82,12 @@ int add_new_comment(int type, int entry_type, char *host_name, char *svc_descrip
 		*comment_id = new_comment_id;
 
 	return result;
-	}
+}
 
 
 /* adds a new host comment */
-int add_new_host_comment(int entry_type, char *host_name, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id) {
+int add_new_host_comment(int entry_type, char *host_name, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id)
+{
 	int result;
 	unsigned long new_comment_id = 0L;
 
@@ -100,11 +103,12 @@ int add_new_host_comment(int entry_type, char *host_name, time_t entry_time, cha
 #endif
 
 	return result;
-	}
+}
 
 
 /* adds a new service comment */
-int add_new_service_comment(int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id) {
+int add_new_service_comment(int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id)
+{
 	int result;
 	unsigned long new_comment_id = 0L;
 
@@ -120,7 +124,7 @@ int add_new_service_comment(int entry_type, char *host_name, char *svc_descripti
 #endif
 
 	return result;
-	}
+}
 
 
 
@@ -130,7 +134,8 @@ int add_new_service_comment(int entry_type, char *host_name, char *svc_descripti
 
 
 /* deletes a host or service comment */
-int delete_comment(int type, unsigned long comment_id) {
+int delete_comment(int type, unsigned long comment_id)
+{
 	comment *this_comment = NULL;
 	comment *last_comment = NULL;
 	comment *next_comment = NULL;
@@ -147,7 +152,7 @@ int delete_comment(int type, unsigned long comment_id) {
 			break;
 
 		last_comment = this_comment;
-		}
+	}
 
 	if(this_comment == NULL)
 		return ERROR;
@@ -170,11 +175,11 @@ int delete_comment(int type, unsigned long comment_id) {
 					comment_hashlist[hashslot] = this_hash->nexthash;
 				else
 					comment_hashlist[hashslot] = NULL;
-				}
-			break;
 			}
-			last_hash = this_hash;
+			break;
 		}
+		last_hash = this_hash;
+	}
 
 	/* then removed from linked list */
 	if(comment_list == this_comment)
@@ -190,34 +195,37 @@ int delete_comment(int type, unsigned long comment_id) {
 	my_free(this_comment);
 
 	return OK;
-	}
+}
 
 
 /* deletes a host comment */
-int delete_host_comment(unsigned long comment_id) {
+int delete_host_comment(unsigned long comment_id)
+{
 	int result = OK;
 
 	/* delete the comment from memory */
 	result = delete_comment(HOST_COMMENT, comment_id);
 
 	return result;
-	}
+}
 
 
 
 /* deletes a service comment */
-int delete_service_comment(unsigned long comment_id) {
+int delete_service_comment(unsigned long comment_id)
+{
 	int result = OK;
 
 	/* delete the comment from memory */
 	result = delete_comment(SERVICE_COMMENT, comment_id);
 
 	return result;
-	}
+}
 
 
 /* deletes all comments for a particular host or service */
-int delete_all_comments(int type, char *host_name, char *svc_description) {
+int delete_all_comments(int type, char *host_name, char *svc_description)
+{
 	int result = OK;
 
 	if(type == HOST_COMMENT)
@@ -226,11 +234,12 @@ int delete_all_comments(int type, char *host_name, char *svc_description) {
 		result = delete_all_service_comments(host_name, svc_description);
 
 	return result;
-	}
+}
 
 
 /* deletes all comments for a particular host */
-int delete_all_host_comments(char *host_name) {
+int delete_all_host_comments(char *host_name)
+{
 	int result = OK;
 	comment *temp_comment = NULL;
 	comment *next_comment = NULL;
@@ -243,14 +252,15 @@ int delete_all_host_comments(char *host_name) {
 		next_comment = get_next_comment_by_host(host_name, temp_comment);
 		if(temp_comment->comment_type == HOST_COMMENT)
 			delete_comment(HOST_COMMENT, temp_comment->comment_id);
-		}
+	}
 
 	return result;
-	}
+}
 
 
 /* deletes all non-persistent acknowledgement comments for a particular host */
-int delete_host_acknowledgement_comments(host *hst) {
+int delete_host_acknowledgement_comments(host *hst)
+{
 	int result = OK;
 	comment *temp_comment = NULL;
 	comment *next_comment = NULL;
@@ -264,16 +274,17 @@ int delete_host_acknowledgement_comments(host *hst) {
 		next_comment = get_next_comment_by_host(hst->name, temp_comment);
 		if(temp_comment->comment_type == HOST_COMMENT && temp_comment->entry_type == ACKNOWLEDGEMENT_COMMENT && temp_comment->persistent == FALSE) {
 			delete_comment(HOST_COMMENT, temp_comment->comment_id);
-			}
-		temp_comment = next_comment;
 		}
+		temp_comment = next_comment;
+	}
 
 	return result;
-	}
+}
 
 
 /* deletes all comments for a particular service */
-int delete_all_service_comments(char *host_name, char *svc_description) {
+int delete_all_service_comments(char *host_name, char *svc_description)
+{
 	int result = OK;
 	comment *temp_comment = NULL;
 	comment *next_comment = NULL;
@@ -286,14 +297,15 @@ int delete_all_service_comments(char *host_name, char *svc_description) {
 		next_comment = temp_comment->next;
 		if(temp_comment->comment_type == SERVICE_COMMENT && !strcmp(temp_comment->host_name, host_name) && !strcmp(temp_comment->service_description, svc_description))
 			delete_comment(SERVICE_COMMENT, temp_comment->comment_id);
-		}
+	}
 
 	return result;
-	}
+}
 
 
 /* deletes all non-persistent acknowledgement comments for a particular service */
-int delete_service_acknowledgement_comments(service *svc) {
+int delete_service_acknowledgement_comments(service *svc)
+{
 	int result = OK;
 	comment *temp_comment = NULL;
 	comment *next_comment = NULL;
@@ -306,14 +318,15 @@ int delete_service_acknowledgement_comments(service *svc) {
 		next_comment = temp_comment->next;
 		if(temp_comment->comment_type == SERVICE_COMMENT && !strcmp(temp_comment->host_name, svc->host_name) && !strcmp(temp_comment->service_description, svc->description)  && temp_comment->entry_type == ACKNOWLEDGEMENT_COMMENT && temp_comment->persistent == FALSE)
 			delete_comment(SERVICE_COMMENT, temp_comment->comment_id);
-		}
+	}
 
 	return result;
-	}
+}
 
 
 /* checks for an expired comment (and removes it) */
-int check_for_expired_comment(unsigned long comment_id) {
+int check_for_expired_comment(unsigned long comment_id)
+{
 	comment *temp_comment = NULL;
 
 	/* check all comments */
@@ -323,11 +336,11 @@ int check_for_expired_comment(unsigned long comment_id) {
 		if(temp_comment->comment_id == comment_id && temp_comment->expires == TRUE && temp_comment->expire_time < time(NULL)) {
 			delete_comment(temp_comment->comment_type, comment_id);
 			break;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 #endif
@@ -341,7 +354,8 @@ int check_for_expired_comment(unsigned long comment_id) {
 /******************************************************************/
 
 /* adds comment to hash list in memory */
-int add_comment_to_hashlist(comment *new_comment) {
+int add_comment_to_hashlist(comment *new_comment)
+{
 	comment *temp_comment = NULL;
 	comment *lastpointer = NULL;
 	int hashslot = 0;
@@ -356,7 +370,7 @@ int add_comment_to_hashlist(comment *new_comment) {
 
 		for(i = 0; i < COMMENT_HASHSLOTS; i++)
 			comment_hashlist[i] = NULL;
-		}
+	}
 
 	if(!new_comment)
 		return 0;
@@ -367,7 +381,7 @@ int add_comment_to_hashlist(comment *new_comment) {
 		if(compare_hashdata(temp_comment->host_name, NULL, new_comment->host_name, NULL) >= 0)
 			break;
 		lastpointer = temp_comment;
-		}
+	}
 
 	/* multiples are allowed */
 	if(lastpointer)
@@ -377,7 +391,7 @@ int add_comment_to_hashlist(comment *new_comment) {
 	new_comment->nexthash = temp_comment;
 
 	return 1;
-	}
+}
 
 
 
@@ -387,29 +401,32 @@ int add_comment_to_hashlist(comment *new_comment) {
 
 
 /* adds a host comment to the list in memory */
-int add_host_comment(int entry_type, char *host_name, time_t entry_time, char *author, char *comment_data, unsigned long comment_id, int persistent, int expires, time_t expire_time, int source) {
+int add_host_comment(int entry_type, char *host_name, time_t entry_time, char *author, char *comment_data, unsigned long comment_id, int persistent, int expires, time_t expire_time, int source)
+{
 	int result = OK;
 
 	result = add_comment(HOST_COMMENT, entry_type, host_name, NULL, entry_time, author, comment_data, comment_id, persistent, expires, expire_time, source);
 
 	return result;
-	}
+}
 
 
 
 /* adds a service comment to the list in memory */
-int add_service_comment(int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, unsigned long comment_id, int persistent, int expires, time_t expire_time, int source) {
+int add_service_comment(int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, unsigned long comment_id, int persistent, int expires, time_t expire_time, int source)
+{
 	int result = OK;
 
 	result = add_comment(SERVICE_COMMENT, entry_type, host_name, svc_description, entry_time, author, comment_data, comment_id, persistent, expires, expire_time, source);
 
 	return result;
-	}
+}
 
 
 
 /* adds a comment to the list in memory */
-int add_comment(int comment_type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, unsigned long comment_id, int persistent, int expires, time_t expire_time, int source) {
+int add_comment(int comment_type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, unsigned long comment_id, int persistent, int expires, time_t expire_time, int source)
+{
 	comment *new_comment = NULL;
 	comment *last_comment = NULL;
 	comment *temp_comment = NULL;
@@ -429,7 +446,7 @@ int add_comment(int comment_type, int entry_type, char *host_name, char *svc_des
 	if(comment_type == SERVICE_COMMENT) {
 		if((new_comment->service_description = (char *)strdup(svc_description)) == NULL)
 			result = ERROR;
-		}
+	}
 	if((new_comment->author = (char *)strdup(author)) == NULL)
 		result = ERROR;
 	if((new_comment->comment_data = (char *)strdup(comment_data)) == NULL)
@@ -448,7 +465,7 @@ int add_comment(int comment_type, int entry_type, char *host_name, char *svc_des
 	if(result == OK) {
 		if(!add_comment_to_hashlist(new_comment))
 			result = ERROR;
-		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
@@ -458,13 +475,12 @@ int add_comment(int comment_type, int entry_type, char *host_name, char *svc_des
 		my_free(new_comment->host_name);
 		my_free(new_comment);
 		return ERROR;
-		}
+	}
 
 	if(defer_comment_sorting) {
 		new_comment->next = comment_list;
 		comment_list = new_comment;
-		}
-	else {
+	} else {
 		/* add new comment to comment list, sorted by comment id */
 		last_comment = comment_list;
 		for(temp_comment = comment_list; temp_comment != NULL; temp_comment = temp_comment->next) {
@@ -475,19 +491,17 @@ int add_comment(int comment_type, int entry_type, char *host_name, char *svc_des
 				else
 					last_comment->next = new_comment;
 				break;
-				}
-			else
+			} else
 				last_comment = temp_comment;
-			}
+		}
 		if(comment_list == NULL) {
 			new_comment->next = NULL;
 			comment_list = new_comment;
-			}
-		else if(temp_comment == NULL) {
+		} else if(temp_comment == NULL) {
 			new_comment->next = NULL;
 			last_comment->next = new_comment;
-			}
 		}
+	}
 
 #ifdef NSCORE
 #ifdef USE_EVENT_BROKER
@@ -497,15 +511,17 @@ int add_comment(int comment_type, int entry_type, char *host_name, char *svc_des
 #endif
 
 	return OK;
-	}
+}
 
-static int comment_compar(const void *p1, const void *p2) {
+static int comment_compar(const void *p1, const void *p2)
+{
 	comment *c1 = *(comment **)p1;
 	comment *c2 = *(comment **)p2;
 	return c1->comment_id - c2->comment_id;
-	}
+}
 
-int sort_comments(void) {
+int sort_comments(void)
+{
 	comment **array, *temp_comment;
 	unsigned long i = 0, unsorted_comments = 0;
 
@@ -517,7 +533,7 @@ int sort_comments(void) {
 	while(temp_comment != NULL) {
 		temp_comment = temp_comment->next;
 		unsorted_comments++;
-		}
+	}
 
 	if(!unsorted_comments)
 		return OK;
@@ -527,25 +543,26 @@ int sort_comments(void) {
 	while(comment_list) {
 		array[i++] = comment_list;
 		comment_list = comment_list->next;
-		}
+	}
 
 	qsort((void *)array, i, sizeof(*array), comment_compar);
 	comment_list = temp_comment = array[0];
 	for(i = 1; i < unsorted_comments; i++) {
 		temp_comment->next = array[i];
 		temp_comment = temp_comment->next;
-		}
+	}
 	temp_comment->next = NULL;
 	my_free(array);
 	return OK;
-	}
+}
 
 /******************************************************************/
 /********************* CLEANUP FUNCTIONS **************************/
 /******************************************************************/
 
 /* frees memory allocated for the comment data */
-void free_comment_data(void) {
+void free_comment_data(void)
+{
 	comment *this_comment = NULL;
 	comment *next_comment = NULL;
 
@@ -557,7 +574,7 @@ void free_comment_data(void) {
 		my_free(this_comment->author);
 		my_free(this_comment->comment_data);
 		my_free(this_comment);
-		}
+	}
 
 	/* free hash list and reset list pointer */
 	my_free(comment_hashlist);
@@ -565,7 +582,7 @@ void free_comment_data(void) {
 	comment_list = NULL;
 
 	return;
-	}
+}
 
 
 
@@ -575,7 +592,8 @@ void free_comment_data(void) {
 /******************************************************************/
 
 /* get the number of comments associated with a particular host */
-int number_of_host_comments(char *host_name) {
+int number_of_host_comments(char *host_name)
+{
 	comment *temp_comment = NULL;
 	int total_comments = 0;
 
@@ -585,14 +603,15 @@ int number_of_host_comments(char *host_name) {
 	for(temp_comment = get_first_comment_by_host(host_name); temp_comment != NULL; temp_comment = get_next_comment_by_host(host_name, temp_comment)) {
 		if(temp_comment->comment_type == HOST_COMMENT)
 			total_comments++;
-		}
+	}
 
 	return total_comments;
-	}
+}
 
 
 /* get the number of comments associated with a particular service */
-int number_of_service_comments(char *host_name, char *svc_description) {
+int number_of_service_comments(char *host_name, char *svc_description)
+{
 	comment *temp_comment = NULL;
 	int total_comments = 0;
 
@@ -602,10 +621,10 @@ int number_of_service_comments(char *host_name, char *svc_description) {
 	for(temp_comment = get_first_comment_by_host(host_name); temp_comment != NULL; temp_comment = get_next_comment_by_host(host_name, temp_comment)) {
 		if(temp_comment->comment_type == SERVICE_COMMENT && !strcmp(temp_comment->service_description, svc_description))
 			total_comments++;
-		}
+	}
 
 	return total_comments;
-	}
+}
 
 
 
@@ -613,13 +632,15 @@ int number_of_service_comments(char *host_name, char *svc_description) {
 /********************* TRAVERSAL FUNCTIONS ************************/
 /******************************************************************/
 
-comment *get_first_comment_by_host(char *host_name) {
+comment *get_first_comment_by_host(char *host_name)
+{
 
 	return get_next_comment_by_host(host_name, NULL);
-	}
+}
 
 
-comment *get_next_comment_by_host(char *host_name, comment *start) {
+comment *get_next_comment_by_host(char *host_name, comment *start)
+{
 	comment *temp_comment = NULL;
 
 	if(host_name == NULL || comment_hashlist == NULL)
@@ -636,7 +657,7 @@ comment *get_next_comment_by_host(char *host_name, comment *start) {
 		return temp_comment;
 
 	return NULL;
-	}
+}
 
 
 
@@ -645,27 +666,30 @@ comment *get_next_comment_by_host(char *host_name, comment *start) {
 /******************************************************************/
 
 /* find a service comment by id */
-comment *find_service_comment(unsigned long comment_id) {
+comment *find_service_comment(unsigned long comment_id)
+{
 
 	return find_comment(comment_id, SERVICE_COMMENT);
-	}
+}
 
 
 /* find a host comment by id */
-comment *find_host_comment(unsigned long comment_id) {
+comment *find_host_comment(unsigned long comment_id)
+{
 
 	return find_comment(comment_id, HOST_COMMENT);
-	}
+}
 
 
 /* find a comment by id */
-comment *find_comment(unsigned long comment_id, int comment_type) {
+comment *find_comment(unsigned long comment_id, int comment_type)
+{
 	comment *temp_comment = NULL;
 
 	for(temp_comment = comment_list; temp_comment != NULL; temp_comment = temp_comment->next) {
 		if(temp_comment->comment_id == comment_id && temp_comment->comment_type == comment_type)
 			return temp_comment;
-		}
+	}
 
 	return NULL;
-	}
+}

--- a/common/downtime.c
+++ b/common/downtime.c
@@ -52,17 +52,24 @@ static const char *dt_strerror(int err)
 		return strerror(err);
 
 	switch(err) {
-	 case DT_ENULL: return "NULL pointer";
-	 case DT_EHOST: return "No hostname, or host not found";
-	 case DT_ESERVICE: return "No service_description, or service not found";
-	 case DT_ETYPE: return "Invalid downtime type, or type/data mismatch";
-	 case DT_ETRIGGER: return "Triggering downtime not found";
-	 case DT_ETIME: return "Bad time spec";
+	case DT_ENULL:
+		return "NULL pointer";
+	case DT_EHOST:
+		return "No hostname, or host not found";
+	case DT_ESERVICE:
+		return "No service_description, or service not found";
+	case DT_ETYPE:
+		return "Invalid downtime type, or type/data mismatch";
+	case DT_ETRIGGER:
+		return "Triggering downtime not found";
+	case DT_ETIME:
+		return "Bad time spec";
 	}
 	return "Unknown error";
 }
 
-static int downtime_compar(const void *p1, const void *p2) {
+static int downtime_compar(const void *p1, const void *p2)
+{
 	scheduled_downtime *d1 = *(scheduled_downtime **)p1;
 	scheduled_downtime *d2 = *(scheduled_downtime **)p2;
 
@@ -94,12 +101,12 @@ static int downtime_compar(const void *p1, const void *p2) {
 
 	if(d1->start_time == d2->start_time) {
 		if(( d1->triggered_by == 0 && d2->triggered_by != 0) ||
-				( d1->triggered_by != 0 && d2->triggered_by == 0)) {
+		   ( d1->triggered_by != 0 && d2->triggered_by == 0)) {
 			return d1->triggered_by == 0 ? -1 : 1;
-			}
 		}
-	return (d1->start_time < d2->start_time) ? -1 : (d1->start_time - d2->start_time);
 	}
+	return (d1->start_time < d2->start_time) ? -1 : (d1->start_time - d2->start_time);
+}
 
 static int downtime_add(scheduled_downtime *dt)
 {
@@ -112,9 +119,9 @@ static int downtime_add(scheduled_downtime *dt)
 		return DT_ENULL;
 
 	log_debug_info(DEBUGL_DOWNTIME, 0, "downtime_add(): id=%lu; type=%s; host=%s; service=%s\n",
-				   dt->downtime_id,
-				   dt->type == HOST_DOWNTIME ? "host" : "service",
-				   dt->host_name, dt->service_description);
+	               dt->downtime_id,
+	               dt->type == HOST_DOWNTIME ? "host" : "service",
+	               dt->host_name, dt->service_description);
 	/*
 	 * check for errors.
 	 * host_name must always be set
@@ -160,15 +167,13 @@ static int downtime_add(scheduled_downtime *dt)
 	}
 
 	if(defer_downtime_sorting || !scheduled_downtime_list ||
-	   downtime_compar(&dt, &scheduled_downtime_list) < 0)
-	{
+	   downtime_compar(&dt, &scheduled_downtime_list) < 0) {
 		if (scheduled_downtime_list) {
 			scheduled_downtime_list->prev = dt;
 		}
 		dt->next = scheduled_downtime_list;
 		scheduled_downtime_list = dt;
-		}
-	else {
+	} else {
 		scheduled_downtime *cur;
 
 		/* add new downtime to downtime list, sorted by start time */
@@ -179,7 +184,7 @@ static int downtime_add(scheduled_downtime *dt)
 				cur->prev->next = dt;
 				cur->prev = dt;
 				break;
-				}
+			}
 			if (!cur->next) {
 				dt->next = NULL;
 				cur->next = dt;
@@ -209,20 +214,22 @@ static void downtime_remove(scheduled_downtime *dt)
 
 
 /* initializes scheduled downtime data */
-int initialize_downtime_data(void) {
+int initialize_downtime_data(void)
+{
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "initialize_downtime_data()\n");
 	dt_fanout = fanout_create(16384);
 	next_downtime_id = 1;
 	return dt_fanout ? OK : ERROR;
-	}
+}
 
 
 /* cleans up scheduled downtime data */
-int cleanup_downtime_data(void) {
+int cleanup_downtime_data(void)
+{
 	/* free memory allocated to downtime data */
 	free_downtime_data();
 	return OK;
-	}
+}
 
 
 #ifdef NSCORE
@@ -232,7 +239,8 @@ int cleanup_downtime_data(void) {
 /******************************************************************/
 
 /* schedules a host or service downtime */
-int schedule_downtime(int type, char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *new_downtime_id) {
+int schedule_downtime(int type, char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *new_downtime_id)
+{
 	unsigned long downtime_id = 0L;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "schedule_downtime()\n");
@@ -240,9 +248,9 @@ int schedule_downtime(int type, char *host_name, char *service_description, time
 	/* don't add old or invalid downtimes */
 	if(start_time >= end_time || end_time <= time(NULL)) {
 		log_debug_info(DEBUGL_DOWNTIME, 1, "Invalid start (%lu) or end (%lu) times\n",
-				start_time, end_time);
+		               start_time, end_time);
 		return ERROR;
-		}
+	}
 
 	/* add a new downtime entry */
 	add_new_downtime(type, host_name, service_description, entry_time, author, comment_data, start_time, end_time, fixed, triggered_by, duration, &downtime_id, FALSE, FALSE);
@@ -255,11 +263,12 @@ int schedule_downtime(int type, char *host_name, char *service_description, time
 		*new_downtime_id = downtime_id;
 
 	return OK;
-	}
+}
 
 
 /* unschedules a host or service downtime */
-int unschedule_downtime(int type, unsigned long downtime_id) {
+int unschedule_downtime(int type, unsigned long downtime_id)
+{
 	scheduled_downtime *temp_downtime = NULL;
 	scheduled_downtime *next_downtime = NULL;
 	host *hst = NULL;
@@ -278,11 +287,10 @@ int unschedule_downtime(int type, unsigned long downtime_id) {
 	if(temp_downtime->type == HOST_DOWNTIME) {
 		if((hst = find_host(temp_downtime->host_name)) == NULL)
 			return ERROR;
-		}
-	else {
+	} else {
 		if((svc = find_service(temp_downtime->host_name, temp_downtime->service_description)) == NULL)
 			return ERROR;
-		}
+	}
 
 	/* decrement pending flex downtime if necessary ... */
 	if(temp_downtime->fixed == FALSE && temp_downtime->incremented_pending_downtime == TRUE) {
@@ -290,7 +298,7 @@ int unschedule_downtime(int type, unsigned long downtime_id) {
 			hst->pending_flex_downtime--;
 		else
 			svc->pending_flex_downtime--;
-		}
+	}
 
 	log_debug_info(DEBUGL_DOWNTIME, 0, "Cancelling %s downtime (id=%lu)\n",
 	               temp_downtime->type == HOST_DOWNTIME ? "host" : "service",
@@ -318,8 +326,8 @@ int unschedule_downtime(int type, unsigned long downtime_id) {
 
 				/* send a notification */
 				host_notification(hst, NOTIFICATION_DOWNTIMECANCELLED, NULL, NULL, NOTIFICATION_OPTION_NONE);
-				}
 			}
+		}
 
 		else {
 
@@ -334,19 +342,19 @@ int unschedule_downtime(int type, unsigned long downtime_id) {
 
 				/* send a notification */
 				service_notification(svc, NOTIFICATION_DOWNTIMECANCELLED, NULL, NULL, NOTIFICATION_OPTION_NONE);
-				}
 			}
 		}
+	}
 
 	/* remove scheduled entries from event queue */
 	if (temp_downtime->start_event) {
 		remove_event(nagios_squeue, temp_downtime->start_event);
 		my_free(temp_downtime->start_event);
-		}
+	}
 	if (temp_downtime->stop_event) {
 		remove_event(nagios_squeue, temp_downtime->stop_event);
 		my_free(temp_downtime->stop_event);
-		}
+	}
 
 	/* delete downtime entry */
 	if(temp_downtime->type == HOST_DOWNTIME)
@@ -367,20 +375,21 @@ int unschedule_downtime(int type, unsigned long downtime_id) {
 			if(temp_downtime->triggered_by == downtime_id) {
 				unschedule_downtime(ANY_DOWNTIME, temp_downtime->downtime_id);
 				break;
-				}
 			}
+		}
 
 		if(temp_downtime == NULL)
 			break;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers scheduled downtime (schedules it, adds comments, etc.) */
-int register_downtime(int type, unsigned long downtime_id) {
+int register_downtime(int type, unsigned long downtime_id)
+{
 	char *temp_buffer = NULL;
 	char start_time_string[MAX_DATETIME_LENGTH] = "";
 	char flex_start_string[MAX_DATETIME_LENGTH] = "";
@@ -396,33 +405,32 @@ int register_downtime(int type, unsigned long downtime_id) {
 	int was_in_effect = FALSE;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "register_downtime( %d, %lu)\n", type,
-			downtime_id);
+	               downtime_id);
 
 	/* find the downtime entry in memory */
 	temp_downtime = find_downtime(type, downtime_id);
 	if(temp_downtime == NULL) {
 		log_debug_info(DEBUGL_DOWNTIME, 0, "Cannot find downtime ID: %lu\n", downtime_id);
 		return ERROR;
-		}
+	}
 
 	/* find the host or service associated with this downtime */
 	if(temp_downtime->type == HOST_DOWNTIME) {
 		if((hst = find_host(temp_downtime->host_name)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1,
-					"Cannot find host (%s) for downtime ID: %lu\n",
-					temp_downtime->host_name, downtime_id);
+			               "Cannot find host (%s) for downtime ID: %lu\n",
+			               temp_downtime->host_name, downtime_id);
 			return ERROR;
-			}
 		}
-	else {
+	} else {
 		if((svc = find_service(temp_downtime->host_name, temp_downtime->service_description)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1,
-					"Cannot find service (%s) for host (%s) for downtime ID: %lu\n",
-					temp_downtime->service_description, temp_downtime->host_name,
-					downtime_id);
+			               "Cannot find service (%s) for host (%s) for downtime ID: %lu\n",
+			               temp_downtime->service_description, temp_downtime->host_name,
+			               downtime_id);
 			return ERROR;
-			}
 		}
+	}
 
 	/* create the comment */
 	get_datetime_string(&(temp_downtime->start_time), start_time_string, MAX_DATETIME_LENGTH, SHORT_DATE_TIME);
@@ -445,17 +453,16 @@ int register_downtime(int type, unsigned long downtime_id) {
 	if(temp_downtime->type == HOST_DOWNTIME) {
 		log_debug_info(DEBUGL_DOWNTIME, 0, " Type:        Host Downtime\n");
 		log_debug_info(DEBUGL_DOWNTIME, 0, " Host:        %s\n", hst->name);
-		}
-	else {
+	} else {
 		log_debug_info(DEBUGL_DOWNTIME, 0, " Type:        Service Downtime\n");
 		log_debug_info(DEBUGL_DOWNTIME, 0, " Host:        %s\n", svc->host_name);
 		log_debug_info(DEBUGL_DOWNTIME, 0, " Service:     %s\n", svc->description);
-		}
+	}
 	log_debug_info(DEBUGL_DOWNTIME, 0, " Fixed/Flex:  %s\n", (temp_downtime->fixed == TRUE) ? "Fixed" : "Flexible");
 	log_debug_info(DEBUGL_DOWNTIME, 0, " Start:       %s\n", start_time_string);
 	if( temp_downtime->flex_downtime_start) {
 		log_debug_info(DEBUGL_DOWNTIME, 0, " Flex Start:  %s\n", flex_start_string);
-		}
+	}
 	log_debug_info(DEBUGL_DOWNTIME, 0, " End:         %s\n", end_time_string);
 	log_debug_info(DEBUGL_DOWNTIME, 0, " Duration:    %dh %dm %ds\n", hours, minutes, seconds);
 	log_debug_info(DEBUGL_DOWNTIME, 0, " Downtime ID: %lu\n", temp_downtime->downtime_id);
@@ -472,8 +479,8 @@ int register_downtime(int type, unsigned long downtime_id) {
 
 	/* only non-triggered downtime is scheduled... */
 	if((temp_downtime->triggered_by == 0) && ((TRUE == temp_downtime->fixed) ||
-			((FALSE == temp_downtime->fixed) &&
-			(TRUE == temp_downtime->is_in_effect)))) {
+	        ((FALSE == temp_downtime->fixed) &&
+	         (TRUE == temp_downtime->is_in_effect)))) {
 		/* If this is a fixed downtime, schedule the event to start it. If this
 			is a flexible downtime, normally we wait for one of the
 			check_pending_flex_*_downtime() functions to start it, but if the
@@ -490,16 +497,16 @@ int register_downtime(int type, unsigned long downtime_id) {
 				handle it correctly */
 			was_in_effect = temp_downtime->is_in_effect;
 			temp_downtime->is_in_effect = FALSE;
-			}
 		}
+	}
 
-	/* If the downtime is triggered and was in effect, mark it as not in 
+	/* If the downtime is triggered and was in effect, mark it as not in
 		effect so it gets scheduled correctly */
-	if((temp_downtime->triggered_by != 0) && 
-			(TRUE == temp_downtime->is_in_effect)) {
+	if((temp_downtime->triggered_by != 0) &&
+	   (TRUE == temp_downtime->is_in_effect)) {
 		was_in_effect = temp_downtime->is_in_effect;
 		temp_downtime->is_in_effect = FALSE;
-		}
+	}
 
 	if((FALSE == temp_downtime->fixed) && (FALSE == was_in_effect)) {
 		/* increment pending flex downtime counter */
@@ -514,7 +521,7 @@ int register_downtime(int type, unsigned long downtime_id) {
 			a downtime event that is in effect */
 		log_debug_info(DEBUGL_DOWNTIME, 1, "Scheduling downtime expire event in case flexible downtime is never triggered\n");
 		temp_downtime->stop_event = schedule_new_event(EVENT_EXPIRE_DOWNTIME, TRUE, (temp_downtime->end_time + 1), FALSE, 0, NULL, FALSE, NULL, NULL, 0);
-		}
+	}
 
 #ifdef PROBABLY_NOT_NEEDED
 	/*** FLEXIBLE DOWNTIME SANITY CHECK - ADDED 02/17/2008 ****/
@@ -526,16 +533,17 @@ int register_downtime(int type, unsigned long downtime_id) {
 			check_pending_flex_host_downtime(hst);
 		else
 			check_pending_flex_service_downtime(svc);
-		}
+	}
 #endif
 
 	return OK;
-	}
+}
 
 
 
 /* handles scheduled downtime (id passed from timed event queue) */
-int handle_scheduled_downtime_by_id(unsigned long downtime_id) {
+int handle_scheduled_downtime_by_id(unsigned long downtime_id)
+{
 	scheduled_downtime *temp_downtime = NULL;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "handle_scheduled_downtime_by_id()\n");
@@ -543,9 +551,9 @@ int handle_scheduled_downtime_by_id(unsigned long downtime_id) {
 	/* find the downtime entry */
 	if((temp_downtime = find_downtime(ANY_DOWNTIME, downtime_id)) == NULL) {
 		log_debug_info(DEBUGL_DOWNTIME, 1, "Unable to find downtime id: %lu\n",
-				downtime_id);
+		               downtime_id);
 		return ERROR;
-		}
+	}
 
 	/* NULL out this event's start time since the calling function,
 		handle_timed_event(), will free the event, this will prevent
@@ -556,12 +564,13 @@ int handle_scheduled_downtime_by_id(unsigned long downtime_id) {
 
 	/* handle the downtime */
 	return handle_scheduled_downtime(temp_downtime);
-	}
+}
 
 
 
 /* handles scheduled host or service downtime */
-int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
+int handle_scheduled_downtime(scheduled_downtime *temp_downtime)
+{
 	scheduled_downtime *this_downtime = NULL;
 	host *hst = NULL;
 	service *svc = NULL;
@@ -582,14 +591,13 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 		if((hst = find_host(temp_downtime->host_name)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1, "Unable to find host (%s) for downtime\n", temp_downtime->host_name);
 			return ERROR;
-			}
 		}
-	else {
+	} else {
 		if((svc = find_service(temp_downtime->host_name, temp_downtime->service_description)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1, "Unable to find service (%s) host (%s) for downtime\n", temp_downtime->service_description, temp_downtime->host_name);
 			return ERROR;
-			}
 		}
+	}
 
 	/* have we come to the end of the scheduled downtime? */
 	if(temp_downtime->is_in_effect == TRUE) {
@@ -615,7 +623,7 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 
 			/* send a notification */
 			host_notification(hst, NOTIFICATION_DOWNTIMEEND, temp_downtime->author, temp_downtime->comment, NOTIFICATION_OPTION_NONE);
-			}
+		}
 
 		else if(temp_downtime->type == SERVICE_DOWNTIME && svc->scheduled_downtime_depth == 0) {
 
@@ -626,7 +634,7 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 
 			/* send a notification */
 			service_notification(svc, NOTIFICATION_DOWNTIMEEND, temp_downtime->author, temp_downtime->comment, NOTIFICATION_OPTION_NONE);
-			}
+		}
 
 
 		/* update the status data */
@@ -640,12 +648,11 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 			if(temp_downtime->type == HOST_DOWNTIME) {
 				if(hst->pending_flex_downtime > 0)
 					hst->pending_flex_downtime--;
-				}
-			else {
+			} else {
 				if(svc->pending_flex_downtime > 0)
 					svc->pending_flex_downtime--;
-				}
 			}
+		}
 
 		/* handle (stop) downtime that is triggered by this one */
 		while(1) {
@@ -655,19 +662,19 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 				if(this_downtime->triggered_by == temp_downtime->downtime_id) {
 					handle_scheduled_downtime(this_downtime);
 					break;
-					}
 				}
+			}
 
 			if(this_downtime == NULL)
 				break;
-			}
+		}
 
 		/* delete downtime entry */
 		if(temp_downtime->type == HOST_DOWNTIME)
 			delete_host_downtime(temp_downtime->downtime_id);
 		else
 			delete_service_downtime(temp_downtime->downtime_id);
-		}
+	}
 
 	/* else we are just starting the scheduled downtime */
 	else {
@@ -688,8 +695,8 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 			if( FALSE == temp_downtime->start_notification_sent) {
 				host_notification(hst, NOTIFICATION_DOWNTIMESTART, temp_downtime->author, temp_downtime->comment, NOTIFICATION_OPTION_NONE);
 				temp_downtime->start_notification_sent = TRUE;
-				}
 			}
+		}
 
 		else if(temp_downtime->type == SERVICE_DOWNTIME && svc->scheduled_downtime_depth == 0) {
 
@@ -702,8 +709,8 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 			if( FALSE == temp_downtime->start_notification_sent) {
 				service_notification(svc, NOTIFICATION_DOWNTIMESTART, temp_downtime->author, temp_downtime->comment, NOTIFICATION_OPTION_NONE);
 				temp_downtime->start_notification_sent = TRUE;
-				}
 			}
+		}
 
 		/* increment the downtime depth variable */
 		if(temp_downtime->type == HOST_DOWNTIME)
@@ -723,30 +730,30 @@ int handle_scheduled_downtime(scheduled_downtime *temp_downtime) {
 		/* schedule an event to end the downtime */
 		if(temp_downtime->fixed == FALSE) {
 			event_time = (time_t)((unsigned long)temp_downtime->flex_downtime_start
-					+ temp_downtime->duration);
-			}
-		else {
+			                      + temp_downtime->duration);
+		} else {
 			event_time = temp_downtime->end_time;
-			}
+		}
 		if((new_downtime_id = (unsigned long *)malloc(sizeof(unsigned long *)))) {
 			*new_downtime_id = temp_downtime->downtime_id;
 			schedule_new_event(EVENT_SCHEDULED_DOWNTIME, TRUE, event_time, FALSE, 0, NULL, FALSE, (void *)new_downtime_id, NULL, 0);
-			}
+		}
 
 		/* handle (start) downtime that is triggered by this one */
 		for(this_downtime = scheduled_downtime_list; this_downtime != NULL; this_downtime = this_downtime->next) {
 			if(this_downtime->triggered_by == temp_downtime->downtime_id)
 				handle_scheduled_downtime(this_downtime);
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* checks for flexible (non-fixed) host downtime that should start now */
-int check_pending_flex_host_downtime(host *hst) {
+int check_pending_flex_host_downtime(host *hst)
+{
 	scheduled_downtime *temp_downtime = NULL;
 	time_t current_time = 0L;
 	unsigned long * new_downtime_id = NULL;
@@ -790,17 +797,18 @@ int check_pending_flex_host_downtime(host *hst) {
 				if((new_downtime_id = (unsigned long *)malloc(sizeof(unsigned long *)))) {
 					*new_downtime_id = temp_downtime->downtime_id;
 					temp_downtime->start_event = schedule_new_event(EVENT_SCHEDULED_DOWNTIME, TRUE, temp_downtime->flex_downtime_start, FALSE, 0, NULL, FALSE, (void *)new_downtime_id, NULL, 0);
-					}
 				}
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* checks for flexible (non-fixed) service downtime that should start now */
-int check_pending_flex_service_downtime(service *svc) {
+int check_pending_flex_service_downtime(service *svc)
+{
 	scheduled_downtime *temp_downtime = NULL;
 	time_t current_time = 0L;
 	unsigned long * new_downtime_id = NULL;
@@ -845,17 +853,18 @@ int check_pending_flex_service_downtime(service *svc) {
 				if((new_downtime_id = (unsigned long *)malloc(sizeof(unsigned long *)))) {
 					*new_downtime_id = temp_downtime->downtime_id;
 					temp_downtime->start_event = schedule_new_event(EVENT_SCHEDULED_DOWNTIME, TRUE, temp_downtime->flex_downtime_start, FALSE, 0, NULL, FALSE, (void *)new_downtime_id, NULL, 0);
-					}
 				}
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* checks for (and removes) expired downtime entries */
-int check_for_expired_downtime(void) {
+int check_for_expired_downtime(void)
+{
 	scheduled_downtime *temp_downtime = NULL;
 	scheduled_downtime *next_downtime = NULL;
 	time_t current_time = 0L;
@@ -880,31 +889,30 @@ int check_for_expired_downtime(void) {
 			/* find the host or service associated with this downtime */
 			if(temp_downtime->type == HOST_DOWNTIME) {
 				if((hst = find_host(temp_downtime->host_name)) == NULL) {
-					log_debug_info(DEBUGL_DOWNTIME, 1, 
-							"Unable to find host (%s) for downtime\n", 
-							temp_downtime->host_name);
+					log_debug_info(DEBUGL_DOWNTIME, 1,
+					               "Unable to find host (%s) for downtime\n",
+					               temp_downtime->host_name);
 					return ERROR;
-					}
-
-					/* send a notification */
-					host_notification(hst, NOTIFICATION_DOWNTIMEEND, 
-							temp_downtime->author, temp_downtime->comment, 
-							NOTIFICATION_OPTION_NONE);
 				}
-			else {
-				if((svc = find_service(temp_downtime->host_name, 
-							temp_downtime->service_description)) == NULL) {
-					log_debug_info(DEBUGL_DOWNTIME, 1, 
-							"Unable to find service (%s) host (%s) for downtime\n", 
-							temp_downtime->service_description, 
-							temp_downtime->host_name);
-					return ERROR;
-					}
 
 				/* send a notification */
-				service_notification(svc, NOTIFICATION_DOWNTIMEEND, 
-							temp_downtime->author, temp_downtime->comment, 
-							NOTIFICATION_OPTION_NONE);
+				host_notification(hst, NOTIFICATION_DOWNTIMEEND,
+				                  temp_downtime->author, temp_downtime->comment,
+				                  NOTIFICATION_OPTION_NONE);
+			} else {
+				if((svc = find_service(temp_downtime->host_name,
+				                       temp_downtime->service_description)) == NULL) {
+					log_debug_info(DEBUGL_DOWNTIME, 1,
+					               "Unable to find service (%s) host (%s) for downtime\n",
+					               temp_downtime->service_description,
+					               temp_downtime->host_name);
+					return ERROR;
+				}
+
+				/* send a notification */
+				service_notification(svc, NOTIFICATION_DOWNTIMEEND,
+				                     temp_downtime->author, temp_downtime->comment,
+				                     NOTIFICATION_OPTION_NONE);
 			}
 
 			/* delete the downtime entry */
@@ -912,11 +920,11 @@ int check_for_expired_downtime(void) {
 				delete_host_downtime(temp_downtime->downtime_id);
 			else
 				delete_service_downtime(temp_downtime->downtime_id);
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -926,7 +934,8 @@ int check_for_expired_downtime(void) {
 
 
 /* save a host or service downtime */
-int add_new_downtime(int type, char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *downtime_id, int is_in_effect, int start_notification_sent){
+int add_new_downtime(int type, char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *downtime_id, int is_in_effect, int start_notification_sent)
+{
 	int result = OK;
 
 	if(type == HOST_DOWNTIME)
@@ -935,21 +944,23 @@ int add_new_downtime(int type, char *host_name, char *service_description, time_
 		return add_new_service_downtime(host_name, service_description, entry_time, author, comment_data, start_time, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
 
 	return result;
-	}
+}
 
-static unsigned long get_next_downtime_id(void) {
+static unsigned long get_next_downtime_id(void)
+{
 	unsigned long new_dt_id;
 	for (;;) {
 		new_dt_id = next_downtime_id++;
 		if (!find_downtime(ANY_DOWNTIME, next_downtime_id)) {
 			return new_dt_id;
-			}
 		}
-	return 0;
 	}
+	return 0;
+}
 
 /* saves a host downtime entry */
-int add_new_host_downtime(char *host_name, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *downtime_id, int is_in_effect, int start_notification_sent){
+int add_new_host_downtime(char *host_name, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *downtime_id, int is_in_effect, int start_notification_sent)
+{
 	int result = OK;
 	unsigned long new_downtime_id = 0L;
 
@@ -970,11 +981,12 @@ int add_new_host_downtime(char *host_name, time_t entry_time, char *author, char
 #endif
 
 	return result;
-	}
+}
 
 
 /* saves a service downtime entry */
-int add_new_service_downtime(char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *downtime_id, int is_in_effect, int start_notification_sent){
+int add_new_service_downtime(char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *downtime_id, int is_in_effect, int start_notification_sent)
+{
 	int result = OK;
 	unsigned long new_downtime_id = 0L;
 
@@ -982,11 +994,11 @@ int add_new_service_downtime(char *host_name, char *service_description, time_t 
 
 	if(host_name == NULL || service_description == NULL) {
 		log_debug_info(DEBUGL_DOWNTIME, 1,
-				"Host name (%s) or service description (%s) is null\n",
-				((NULL == host_name) ? "null" : host_name),
-				((NULL == service_description) ? "null" : service_description));
+		               "Host name (%s) or service description (%s) is null\n",
+		               ((NULL == host_name) ? "null" : host_name),
+		               ((NULL == service_description) ? "null" : service_description));
 		return ERROR;
-		}
+	}
 
 	new_downtime_id = get_next_downtime_id();
 	result = add_service_downtime(host_name, service_description, entry_time, author, comment_data, start_time, 0, end_time, fixed, triggered_by, duration, new_downtime_id, is_in_effect, start_notification_sent);
@@ -1001,7 +1013,7 @@ int add_new_service_downtime(char *host_name, char *service_description, time_t 
 #endif
 
 	return result;
-	}
+}
 
 
 
@@ -1011,7 +1023,8 @@ int add_new_service_downtime(char *host_name, char *service_description, time_t 
 
 
 /* deletes a scheduled host or service downtime entry from the list in memory */
-int delete_downtime(int type, unsigned long downtime_id) {
+int delete_downtime(int type, unsigned long downtime_id)
+{
 	scheduled_downtime *this_downtime = NULL;
 
 	/* find the downtime we should remove */
@@ -1039,17 +1052,19 @@ int delete_downtime(int type, unsigned long downtime_id) {
 	my_free(this_downtime->comment);
 	my_free(this_downtime);
 	return OK;
-	}
+}
 
 
-int delete_host_downtime(unsigned long downtime_id) {
+int delete_host_downtime(unsigned long downtime_id)
+{
 	return delete_downtime(HOST_DOWNTIME, downtime_id);
-	}
+}
 
 
-int delete_service_downtime(unsigned long downtime_id) {
+int delete_service_downtime(unsigned long downtime_id)
+{
 	return delete_downtime(SERVICE_DOWNTIME, downtime_id);
-	}
+}
 
 /*
  * Deletes all host and service downtimes on a host by hostname,
@@ -1057,7 +1072,8 @@ int delete_service_downtime(unsigned long downtime_id) {
  * All char* must be set or NULL - "" will silently fail to match
  * Returns number deleted
  */
-int delete_downtime_by_hostname_service_description_start_time_comment(char *hostname, char *service_description, time_t start_time, char *cmnt) {
+int delete_downtime_by_hostname_service_description_start_time_comment(char *hostname, char *service_description, time_t start_time, char *cmnt)
+{
 	scheduled_downtime *temp_downtime;
 	scheduled_downtime *next_downtime;
 	void *downtime_cpy;
@@ -1072,7 +1088,7 @@ int delete_downtime_by_hostname_service_description_start_time_comment(char *hos
 		next_downtime = temp_downtime->next;
 		if(start_time != 0 && temp_downtime->start_time != start_time) {
 			continue;
-			}
+		}
 		if(cmnt != NULL && strcmp(temp_downtime->comment, cmnt) != 0)
 			continue;
 		if(temp_downtime->type == HOST_DOWNTIME) {
@@ -1081,30 +1097,29 @@ int delete_downtime_by_hostname_service_description_start_time_comment(char *hos
 				continue;
 			if(hostname != NULL && strcmp(temp_downtime->host_name, hostname) != 0)
 				continue;
-			}
-		else if(temp_downtime->type == SERVICE_DOWNTIME) {
+		} else if(temp_downtime->type == SERVICE_DOWNTIME) {
 			if(hostname != NULL && strcmp(temp_downtime->host_name, hostname) != 0)
 				continue;
 			if(service_description != NULL && strcmp(temp_downtime->service_description, service_description) != 0)
 				continue;
-			}
+		}
 
 		downtime_cpy = malloc(sizeof(scheduled_downtime));
 		memcpy(downtime_cpy, temp_downtime, sizeof(scheduled_downtime));
 		prepend_object_to_objectlist(&matches, downtime_cpy);
 		deleted++;
-		}
+	}
 
 	for(tmp_match = matches; tmp_match != NULL; tmp_match = tmp_match->next) {
 		temp_downtime = (scheduled_downtime *)tmp_match->object_ptr;
 		unschedule_downtime(temp_downtime->type, temp_downtime->downtime_id);
 		my_free(temp_downtime);
-		}
+	}
 
 	free_objectlist(&matches);
 
 	return deleted;
-	}
+}
 
 #endif
 
@@ -1117,19 +1132,22 @@ int delete_downtime_by_hostname_service_description_start_time_comment(char *hos
 /******************************************************************/
 
 /* adds a host downtime entry to the list in memory */
-int add_host_downtime(char *host_name, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t flex_downtime_start, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, int is_in_effect, int start_notification_sent){
+int add_host_downtime(char *host_name, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t flex_downtime_start, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, int is_in_effect, int start_notification_sent)
+{
 	return add_downtime(HOST_DOWNTIME, host_name, NULL, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
-	}
+}
 
 
 /* adds a service downtime entry to the list in memory */
-int add_service_downtime(char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t flex_downtime_start, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, int is_in_effect, int start_notification_sent){
+int add_service_downtime(char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t flex_downtime_start, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, int is_in_effect, int start_notification_sent)
+{
 	return add_downtime(SERVICE_DOWNTIME, host_name, svc_description, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
-	}
+}
 
 
 /* adds a host or service downtime entry to the list in memory */
-int add_downtime(int downtime_type, char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t flex_downtime_start, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, int is_in_effect, int start_notification_sent){
+int add_downtime(int downtime_type, char *host_name, char *svc_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t flex_downtime_start, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long downtime_id, int is_in_effect, int start_notification_sent)
+{
 	scheduled_downtime *new_downtime = NULL;
 	int result = OK;
 
@@ -1138,46 +1156,46 @@ int add_downtime(int downtime_type, char *host_name, char *svc_description, time
 	/* we don't have enough info */
 	if(host_name == NULL || (downtime_type == SERVICE_DOWNTIME && svc_description == NULL)) {
 		log_debug_info(DEBUGL_DOWNTIME, 1,
-				"Host name (%s) or service description (%s) is null\n",
-				((NULL == host_name) ? "null" : host_name),
-				((NULL == svc_description) ? "null" : svc_description));
+		               "Host name (%s) or service description (%s) is null\n",
+		               ((NULL == host_name) ? "null" : host_name),
+		               ((NULL == svc_description) ? "null" : svc_description));
 		return ERROR;
-		}
+	}
 
 	/* allocate memory for the downtime */
 	if((new_downtime = (scheduled_downtime *)calloc(1, sizeof(scheduled_downtime))) == NULL) {
 		log_debug_info(DEBUGL_DOWNTIME, 1,
-				"Unable to allocate memory for new downtime\n");
+		               "Unable to allocate memory for new downtime\n");
 		return ERROR;
-		}
+	}
 
 	/* duplicate vars */
 	if((new_downtime->host_name = (char *)strdup(host_name)) == NULL) {
 		log_debug_info(DEBUGL_DOWNTIME, 1,
-				"Unable to allocate memory for new downtime's host name\n");
+		               "Unable to allocate memory for new downtime's host name\n");
 		result = ERROR;
-		}
+	}
 	if(downtime_type == SERVICE_DOWNTIME) {
 		if((new_downtime->service_description = (char *)strdup(svc_description)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1,
-					"Unable to allocate memory for new downtime's service description\n");
+			               "Unable to allocate memory for new downtime's service description\n");
 			result = ERROR;
-			}
 		}
+	}
 	if(author) {
 		if((new_downtime->author = (char *)strdup(author)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1,
-					"Unable to allocate memory for new downtime's author\n");
+			               "Unable to allocate memory for new downtime's author\n");
 			result = ERROR;
-			}
 		}
+	}
 	if(comment_data) {
 		if((new_downtime->comment = (char *)strdup(comment_data)) == NULL) {
 			log_debug_info(DEBUGL_DOWNTIME, 1,
-					"Unable to allocate memory for new downtime's comment\n");
+			               "Unable to allocate memory for new downtime's comment\n");
 			result = ERROR;
-			}
 		}
+	}
 
 	new_downtime->type = downtime_type;
 	new_downtime->entry_time = entry_time;
@@ -1199,8 +1217,7 @@ int add_downtime(int downtime_type, char *host_name, char *svc_description, time
 		if (new_downtime->type == SERVICE_DOWNTIME) {
 			log_debug_info(DEBUGL_DOWNTIME, 0, "Failed to add downtime for service '%s' on host '%s': %s\n",
 			               new_downtime->service_description, new_downtime->host_name, dt_strerror(result));
-		}
-		else {
+		} else {
 			log_debug_info(DEBUGL_DOWNTIME, 0, "Failed to add downtime for host '%s': %s\n", new_downtime->host_name, dt_strerror(result));
 		}
 		result = ERROR;
@@ -1214,7 +1231,7 @@ int add_downtime(int downtime_type, char *host_name, char *svc_description, time
 		my_free(new_downtime->host_name);
 		my_free(new_downtime);
 		return ERROR;
-		}
+	}
 
 #ifdef NSCORE
 #ifdef USE_EVENT_BROKER
@@ -1224,9 +1241,10 @@ int add_downtime(int downtime_type, char *host_name, char *svc_description, time
 #endif
 
 	return OK;
-	}
+}
 
-int sort_downtime(void) {
+int sort_downtime(void)
+{
 	scheduled_downtime **array, *temp_downtime;
 	unsigned long i = 0, unsorted_downtimes = 0;
 
@@ -1240,7 +1258,7 @@ int sort_downtime(void) {
 	while(temp_downtime != NULL) {
 		temp_downtime = temp_downtime->next;
 		unsorted_downtimes++;
-		}
+	}
 
 	if(!unsorted_downtimes)
 		return OK;
@@ -1250,7 +1268,7 @@ int sort_downtime(void) {
 	while(scheduled_downtime_list) {
 		array[i++] = scheduled_downtime_list;
 		scheduled_downtime_list = scheduled_downtime_list->next;
-		}
+	}
 
 	qsort((void *)array, i, sizeof(*array), downtime_compar);
 	scheduled_downtime_list = temp_downtime = array[0];
@@ -1259,11 +1277,11 @@ int sort_downtime(void) {
 		temp_downtime->next = array[i];
 		temp_downtime = temp_downtime->next;
 		temp_downtime->prev = array[i-1];
-		}
+	}
 	temp_downtime->next = NULL;
 	my_free(array);
 	return OK;
-	}
+}
 
 
 
@@ -1272,7 +1290,8 @@ int sort_downtime(void) {
 /******************************************************************/
 
 /* finds a specific downtime entry */
-scheduled_downtime *find_downtime(int type, unsigned long downtime_id) {
+scheduled_downtime *find_downtime(int type, unsigned long downtime_id)
+{
 	scheduled_downtime *dt = NULL;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "find_downtime()\n");
@@ -1281,21 +1300,23 @@ scheduled_downtime *find_downtime(int type, unsigned long downtime_id) {
 	if (dt && (type == ANY_DOWNTIME || type == dt->type))
 		return dt;
 	return NULL;
-	}
+}
 
 
 /* finds a specific host downtime entry */
-scheduled_downtime *find_host_downtime(unsigned long downtime_id) {
+scheduled_downtime *find_host_downtime(unsigned long downtime_id)
+{
 
 	return find_downtime(HOST_DOWNTIME, downtime_id);
-	}
+}
 
 
 /* finds a specific service downtime entry */
-scheduled_downtime *find_service_downtime(unsigned long downtime_id) {
+scheduled_downtime *find_service_downtime(unsigned long downtime_id)
+{
 
 	return find_downtime(SERVICE_DOWNTIME, downtime_id);
-	}
+}
 
 
 
@@ -1304,7 +1325,8 @@ scheduled_downtime *find_service_downtime(unsigned long downtime_id) {
 /******************************************************************/
 
 /* frees memory allocated for the scheduled downtime data */
-void free_downtime_data(void) {
+void free_downtime_data(void)
+{
 	scheduled_downtime *this_downtime = NULL;
 	scheduled_downtime *next_downtime = NULL;
 
@@ -1318,10 +1340,10 @@ void free_downtime_data(void) {
 		my_free(this_downtime->author);
 		my_free(this_downtime->comment);
 		my_free(this_downtime);
-		}
+	}
 
 	/* reset list pointer */
 	scheduled_downtime_list = NULL;
 
 	return;
-	}
+}

--- a/common/macros.c
+++ b/common/macros.c
@@ -62,9 +62,10 @@ static char **macro_x = NULL;
 static nagios_macros global_macros;
 
 
-nagios_macros *get_global_macros(void) {
+nagios_macros *get_global_macros(void)
+{
 	return &global_macros;
-	}
+}
 
 /******************************************************************/
 /************************ MACRO FUNCTIONS *************************/
@@ -75,7 +76,8 @@ nagios_macros *get_global_macros(void) {
  * over all keys. O(log(n)) complexity and a vast improvement over
  * the previous linear scan
  */
-static const struct macro_key_code *find_macro_key(const char *name) {
+static const struct macro_key_code *find_macro_key(const char *name)
+{
 	unsigned int high, low = 0;
 	int value;
 	struct macro_key_code *key;
@@ -87,21 +89,22 @@ static const struct macro_key_code *find_macro_key(const char *name) {
 		value = strcmp(name, key->name);
 		if (value == 0) {
 			return key;
-			}
+		}
 		if (value > 0)
 			low = mid + 1;
 		else
 			high = mid;
-		}
-	return NULL;
 	}
+	return NULL;
+}
 
 
 /*
  * replace macros in notification commands with their values,
  * the thread-safe version
  */
-int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffer, int options) {
+int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffer, int options)
+{
 	char *temp_buffer = NULL;
 	char *save_buffer = NULL;
 	char *buf_ptr = NULL;
@@ -140,7 +143,7 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 		if((delim_ptr = strchr(buf_ptr, '$'))) {
 			delim_ptr[0] = '\x0';
 			buf_ptr = (char *)delim_ptr + 1;
-			}
+		}
 		/* no delimiter found - we already have the last of the buffer */
 		else
 			buf_ptr = NULL;
@@ -158,7 +161,7 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 
 			log_debug_info(DEBUGL_MACROS, 2, "  Not currently in macro.  Running output (%lu): '%s'\n", (unsigned long)strlen(*output_buffer), *output_buffer);
 			in_macro = TRUE;
-			}
+		}
 
 		/* looks like we're in a macro, so process it... */
 		else {
@@ -172,7 +175,7 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 				log_debug_info(DEBUGL_MACROS, 0, " WARNING: An error occurred processing macro '%s'!\n", temp_buffer);
 				if(free_macro == TRUE)
 					my_free(selected_macro);
-				}
+			}
 
 			if (result == OK)
 				; /* do nothing special if things worked out ok */
@@ -181,7 +184,7 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 				log_debug_info(DEBUGL_MACROS, 2, "  Escaped $.  Running output (%lu): '%s'\n", (unsigned long)strlen(*output_buffer), *output_buffer);
 				*output_buffer = (char *)realloc(*output_buffer, strlen(*output_buffer) + 2);
 				strcat(*output_buffer, "$");
-				}
+			}
 
 			/* a non-macro, just some user-defined string between two $s */
 			else {
@@ -192,7 +195,7 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 				strcat(*output_buffer, "$");
 				strcat(*output_buffer, temp_buffer);
 				strcat(*output_buffer, "$");
-				}
+			}
 
 			/* insert macro */
 			if(selected_macro != NULL) {
@@ -204,9 +207,9 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 					selected_macro = get_url_encoded_string(selected_macro);
 					if(free_macro == TRUE) {
 						my_free(original_macro);
-						}
-					free_macro = TRUE;
 					}
+					free_macro = TRUE;
+				}
 
 				/* some macros should sometimes be cleaned */
 				if(macro_options & options & (STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS)) {
@@ -220,8 +223,8 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 							my_free(cleaned_macro);
 
 						log_debug_info(DEBUGL_MACROS, 2, "  Cleaned macro.  Running output (%lu): '%s'\n", (unsigned long)strlen(*output_buffer), *output_buffer);
-						}
 					}
+				}
 
 				/* others are not cleaned */
 				else {
@@ -231,19 +234,19 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 						strcat(*output_buffer, selected_macro);
 
 						log_debug_info(DEBUGL_MACROS, 2, "  Uncleaned macro.  Running output (%lu): '%s'\n", (unsigned long)strlen(*output_buffer), *output_buffer);
-						}
 					}
+				}
 
 				/* free memory if necessary (if we URL encoded the macro or we were told to do so by grab_macro_value()) */
 				if(free_macro == TRUE)
 					my_free(selected_macro);
 
 				log_debug_info(DEBUGL_MACROS, 2, "  Just finished macro.  Running output (%lu): '%s'\n", (unsigned long)strlen(*output_buffer), *output_buffer);
-				}
+			}
 
 			in_macro = FALSE;
-			}
 		}
+	}
 
 	/* free copy of input buffer */
 	my_free(save_buffer);
@@ -252,18 +255,20 @@ int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffe
 	log_debug_info(DEBUGL_MACROS, 1, "**** END MACRO PROCESSING *************\n");
 
 	return OK;
-	}
+}
 
-int process_macros(char *input_buffer, char **output_buffer, int options) {
+int process_macros(char *input_buffer, char **output_buffer, int options)
+{
 	return process_macros_r(&global_macros, input_buffer, output_buffer, options);
-	}
+}
 
 /******************************************************************/
 /********************** MACRO GRAB FUNCTIONS **********************/
 /******************************************************************/
 
 /* grab macros that are specific to a particular host */
-int grab_host_macros_r(nagios_macros *mac, host *hst) {
+int grab_host_macros_r(nagios_macros *mac, host *hst)
+{
 	/* clear host-related macros */
 	clear_host_macros_r(mac);
 	clear_hostgroup_macros_r(mac);
@@ -280,15 +285,17 @@ int grab_host_macros_r(nagios_macros *mac, host *hst) {
 		mac->hostgroup_ptr = (hostgroup *)hst->hostgroups_ptr->object_ptr;
 
 	return OK;
-	}
+}
 
-int grab_host_macros(host *hst) {
+int grab_host_macros(host *hst)
+{
 	return grab_host_macros_r(&global_macros, hst);
-	}
+}
 
 
 /* grab hostgroup macros */
-int grab_hostgroup_macros_r(nagios_macros *mac, hostgroup *hg) {
+int grab_hostgroup_macros_r(nagios_macros *mac, hostgroup *hg)
+{
 	/* clear hostgroup macros */
 	clear_hostgroup_macros_r(mac);
 
@@ -299,15 +306,17 @@ int grab_hostgroup_macros_r(nagios_macros *mac, hostgroup *hg) {
 		return ERROR;
 
 	return OK;
-	}
+}
 
-int grab_hostgroup_macros(hostgroup *hg) {
+int grab_hostgroup_macros(hostgroup *hg)
+{
 	return grab_hostgroup_macros_r(&global_macros, hg);
-	}
+}
 
 
 /* grab macros that are specific to a particular service */
-int grab_service_macros_r(nagios_macros *mac, service *svc) {
+int grab_service_macros_r(nagios_macros *mac, service *svc)
+{
 
 	/* clear service-related macros */
 	clear_service_macros_r(mac);
@@ -325,15 +334,17 @@ int grab_service_macros_r(nagios_macros *mac, service *svc) {
 		mac->servicegroup_ptr = (servicegroup *)svc->servicegroups_ptr->object_ptr;
 
 	return OK;
-	}
+}
 
-int grab_service_macros(service *svc) {
+int grab_service_macros(service *svc)
+{
 	return grab_service_macros_r(&global_macros, svc);
-	}
+}
 
 
 /* grab macros that are specific to a particular servicegroup */
-int grab_servicegroup_macros_r(nagios_macros *mac, servicegroup *sg) {
+int grab_servicegroup_macros_r(nagios_macros *mac, servicegroup *sg)
+{
 	/* clear servicegroup macros */
 	clear_servicegroup_macros_r(mac);
 
@@ -344,15 +355,17 @@ int grab_servicegroup_macros_r(nagios_macros *mac, servicegroup *sg) {
 		return ERROR;
 
 	return OK;
-	}
+}
 
-int grab_servicegroup_macros(servicegroup *sg) {
+int grab_servicegroup_macros(servicegroup *sg)
+{
 	return grab_servicegroup_macros_r(&global_macros, sg);
-	}
+}
 
 
 /* grab macros that are specific to a particular contact */
-int grab_contact_macros_r(nagios_macros *mac, contact *cntct) {
+int grab_contact_macros_r(nagios_macros *mac, contact *cntct)
+{
 	/* clear contact-related macros */
 	clear_contact_macros_r(mac);
 	clear_contactgroup_macros_r(mac);
@@ -369,11 +382,12 @@ int grab_contact_macros_r(nagios_macros *mac, contact *cntct) {
 		mac->contactgroup_ptr = (contactgroup *)cntct->contactgroups_ptr->object_ptr;
 
 	return OK;
-	}
+}
 
-int grab_contact_macros(contact *cntct) {
+int grab_contact_macros(contact *cntct)
+{
 	return grab_contact_macros_r(&global_macros, cntct);
-	}
+}
 
 
 /******************************************************************/
@@ -381,7 +395,8 @@ int grab_contact_macros(contact *cntct) {
 /******************************************************************/
 
 /* this is the big one */
-int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, int *clean_options, int *free_macro) {
+int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, int *clean_options, int *free_macro)
+{
 	char *buf = NULL;
 	char *ptr = NULL;
 	char *macro_name = NULL;
@@ -423,12 +438,12 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 
 		if(x <= 0 || x > MAX_COMMAND_ARGUMENTS) {
 			return ERROR;
-			}
+		}
 
 		/* use a pre-computed macro value */
 		*output = mac->argv[x - 1];
 		return OK;
-		}
+	}
 
 	if(strstr(macro_buffer, "USER") == macro_buffer) {
 
@@ -437,19 +452,19 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 
 		if(x <= 0 || x > MAX_USER_MACROS) {
 			return ERROR;
-			}
+		}
 
 		/* use a pre-computed macro value */
 		*output = macro_user[x - 1];
 		return OK;
-		}
+	}
 
 	/* most frequently used "x" macro gets a shortcut */
 	if(mac->host_ptr && !strcmp(macro_buffer, "HOSTADDRESS")) {
 		if(mac->host_ptr->address)
 			*output = mac->host_ptr->address;
 		return OK;
-		}
+	}
 
 	/* work with a copy of the original buffer */
 	if((buf = (char *)strdup(macro_buffer)) == NULL)
@@ -475,8 +490,8 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 
 			/* save second argument - service description or delimiter */
 			arg[1] = ptr;
-			}
 		}
+	}
 
 	if ((mkey = find_macro_key(macro_name))) {
 		log_debug_info(DEBUGL_MACROS, 2, "  macros[%d] (%s) match.\n", mkey->code, macro_x_names[mkey->code]);
@@ -488,8 +503,8 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 
 		if(clean_options) {
 			*clean_options = mkey->options;
-			}
 		}
+	}
 	/***** CONTACT ADDRESS MACROS *****/
 	/* NOTE: the code below should be broken out into a separate function */
 	else if(strstr(macro_name, "CONTACTADDRESS") == macro_name) {
@@ -504,12 +519,12 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 			if((temp_contact = mac->contact_ptr) == NULL) {
 				my_free(buf);
 				return ERROR;
-				}
+			}
 
 			/* get the macro value by reference, so no need to free() */
 			*free_macro = FALSE;
 			result = grab_contact_address_macro(x, temp_contact, output);
-			}
+		}
 
 		/* on-demand macro */
 		else {
@@ -542,10 +557,10 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 							continue;
 						strcat(*output, arg[1]);
 						strcat(*output, temp_buffer);
-						}
-					my_free(temp_buffer);
 					}
+					my_free(temp_buffer);
 				}
+			}
 
 			/* else on-demand contact macro */
 			else {
@@ -554,39 +569,41 @@ int grab_macro_value_r(nagios_macros *mac, char *macro_buffer, char **output, in
 				if((temp_contact = find_contact(arg[0])) == NULL) {
 					my_free(buf);
 					return ERROR;
-					}
+				}
 
 				/* get the macro value */
 				result = grab_contact_address_macro(x, temp_contact, output);
-				}
 			}
 		}
+	}
 
 	/***** CUSTOM VARIABLE MACROS *****/
 	else if(macro_name[0] == '_') {
 
 		/* get the macro value */
 		result = grab_custom_macro_value_r(mac, macro_name, arg[0], arg[1], output);
-		}
+	}
 
 	/* no macro matched... */
 	else {
 		log_debug_info(DEBUGL_MACROS, 0, " WARNING: Could not find a macro matching '%s'!\n", macro_name);
 		result = ERROR;
-		}
+	}
 
 	/* free memory */
 	my_free(buf);
 
 	return result;
-	}
+}
 
-int grab_macro_value(char *macro_buffer, char **output, int *clean_options, int *free_macro) {
+int grab_macro_value(char *macro_buffer, char **output, int *clean_options, int *free_macro)
+{
 	return grab_macro_value_r(&global_macros, macro_buffer, output, clean_options, free_macro);
-	}
+}
 
 
-int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, char *arg2, char **output, int *free_macro) {
+int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, char *arg2, char **output, int *free_macro)
+{
 	host *temp_host = NULL;
 	hostgroup *temp_hostgroup = NULL;
 	hostsmember *temp_hostsmember = NULL;
@@ -631,327 +648,235 @@ int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, char *ar
 	/* handle the macro */
 	switch(macro_type) {
 
-			/***************/
-			/* HOST MACROS */
-			/***************/
-		case MACRO_HOSTGROUPNAMES:
-			*free_macro = TRUE;
-		case MACRO_HOSTNAME:
-		case MACRO_HOSTALIAS:
-		case MACRO_HOSTADDRESS:
-		case MACRO_LASTHOSTCHECK:
-		case MACRO_LASTHOSTSTATECHANGE:
-		case MACRO_HOSTOUTPUT:
-		case MACRO_HOSTPERFDATA:
-		case MACRO_HOSTSTATE:
-		case MACRO_HOSTSTATEID:
-		case MACRO_HOSTATTEMPT:
-		case MACRO_HOSTEXECUTIONTIME:
-		case MACRO_HOSTLATENCY:
-		case MACRO_HOSTDURATION:
-		case MACRO_HOSTDURATIONSEC:
-		case MACRO_HOSTDOWNTIME:
-		case MACRO_HOSTSTATETYPE:
-		case MACRO_HOSTPERCENTCHANGE:
-		case MACRO_HOSTACKAUTHOR:
-		case MACRO_HOSTACKCOMMENT:
-		case MACRO_LASTHOSTUP:
-		case MACRO_LASTHOSTDOWN:
-		case MACRO_LASTHOSTUNREACHABLE:
-		case MACRO_HOSTCHECKCOMMAND:
-		case MACRO_HOSTDISPLAYNAME:
-		case MACRO_HOSTACTIONURL:
-		case MACRO_HOSTNOTESURL:
-		case MACRO_HOSTNOTES:
-		case MACRO_HOSTCHECKTYPE:
-		case MACRO_LONGHOSTOUTPUT:
-		case MACRO_HOSTNOTIFICATIONNUMBER:
-		case MACRO_HOSTNOTIFICATIONID:
-		case MACRO_HOSTEVENTID:
-		case MACRO_LASTHOSTEVENTID:
-		case MACRO_HOSTACKAUTHORNAME:
-		case MACRO_HOSTACKAUTHORALIAS:
-		case MACRO_MAXHOSTATTEMPTS:
-		case MACRO_TOTALHOSTSERVICES:
-		case MACRO_TOTALHOSTSERVICESOK:
-		case MACRO_TOTALHOSTSERVICESWARNING:
-		case MACRO_TOTALHOSTSERVICESUNKNOWN:
-		case MACRO_TOTALHOSTSERVICESCRITICAL:
-		case MACRO_HOSTPROBLEMID:
-		case MACRO_LASTHOSTPROBLEMID:
-		case MACRO_LASTHOSTSTATE:
-		case MACRO_LASTHOSTSTATEID:
-		case MACRO_HOSTIMPORTANCE:
-		case MACRO_HOSTANDSERVICESIMPORTANCE:
+	/***************/
+	/* HOST MACROS */
+	/***************/
+	case MACRO_HOSTGROUPNAMES:
+		*free_macro = TRUE;
+	case MACRO_HOSTNAME:
+	case MACRO_HOSTALIAS:
+	case MACRO_HOSTADDRESS:
+	case MACRO_LASTHOSTCHECK:
+	case MACRO_LASTHOSTSTATECHANGE:
+	case MACRO_HOSTOUTPUT:
+	case MACRO_HOSTPERFDATA:
+	case MACRO_HOSTSTATE:
+	case MACRO_HOSTSTATEID:
+	case MACRO_HOSTATTEMPT:
+	case MACRO_HOSTEXECUTIONTIME:
+	case MACRO_HOSTLATENCY:
+	case MACRO_HOSTDURATION:
+	case MACRO_HOSTDURATIONSEC:
+	case MACRO_HOSTDOWNTIME:
+	case MACRO_HOSTSTATETYPE:
+	case MACRO_HOSTPERCENTCHANGE:
+	case MACRO_HOSTACKAUTHOR:
+	case MACRO_HOSTACKCOMMENT:
+	case MACRO_LASTHOSTUP:
+	case MACRO_LASTHOSTDOWN:
+	case MACRO_LASTHOSTUNREACHABLE:
+	case MACRO_HOSTCHECKCOMMAND:
+	case MACRO_HOSTDISPLAYNAME:
+	case MACRO_HOSTACTIONURL:
+	case MACRO_HOSTNOTESURL:
+	case MACRO_HOSTNOTES:
+	case MACRO_HOSTCHECKTYPE:
+	case MACRO_LONGHOSTOUTPUT:
+	case MACRO_HOSTNOTIFICATIONNUMBER:
+	case MACRO_HOSTNOTIFICATIONID:
+	case MACRO_HOSTEVENTID:
+	case MACRO_LASTHOSTEVENTID:
+	case MACRO_HOSTACKAUTHORNAME:
+	case MACRO_HOSTACKAUTHORALIAS:
+	case MACRO_MAXHOSTATTEMPTS:
+	case MACRO_TOTALHOSTSERVICES:
+	case MACRO_TOTALHOSTSERVICESOK:
+	case MACRO_TOTALHOSTSERVICESWARNING:
+	case MACRO_TOTALHOSTSERVICESUNKNOWN:
+	case MACRO_TOTALHOSTSERVICESCRITICAL:
+	case MACRO_HOSTPROBLEMID:
+	case MACRO_LASTHOSTPROBLEMID:
+	case MACRO_LASTHOSTSTATE:
+	case MACRO_LASTHOSTSTATEID:
+	case MACRO_HOSTIMPORTANCE:
+	case MACRO_HOSTANDSERVICESIMPORTANCE:
 
-			/* a standard host macro */
-			if(arg2 == NULL) {
+		/* a standard host macro */
+		if(arg2 == NULL) {
 
-				/* find the host for on-demand macros */
-				if(arg1) {
-					if((temp_host = find_host(arg1)) == NULL)
-						return ERROR;
-					}
-
-				/* else use saved host pointer */
-				else if((temp_host = mac->host_ptr) == NULL)
+			/* find the host for on-demand macros */
+			if(arg1) {
+				if((temp_host = find_host(arg1)) == NULL)
 					return ERROR;
+			}
 
-				/* get the host macro value */
-				result = grab_standard_host_macro_r(mac, macro_type, temp_host, output, free_macro);
-				}
+			/* else use saved host pointer */
+			else if((temp_host = mac->host_ptr) == NULL)
+				return ERROR;
 
-			/* a host macro with a hostgroup name and delimiter */
-			else {
+			/* get the host macro value */
+			result = grab_standard_host_macro_r(mac, macro_type, temp_host, output, free_macro);
+		}
 
-				if((temp_hostgroup = find_hostgroup(arg1)) == NULL)
-					return ERROR;
+		/* a host macro with a hostgroup name and delimiter */
+		else {
 
-				delimiter_len = strlen(arg2);
+			if((temp_hostgroup = find_hostgroup(arg1)) == NULL)
+				return ERROR;
 
-				/* concatenate macro values for all hostgroup members */
-				for(temp_hostsmember = temp_hostgroup->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
+			delimiter_len = strlen(arg2);
 
-					if((temp_host = temp_hostsmember->host_ptr) == NULL)
+			/* concatenate macro values for all hostgroup members */
+			for(temp_hostsmember = temp_hostgroup->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
+
+				if((temp_host = temp_hostsmember->host_ptr) == NULL)
+					continue;
+
+				/* get the macro value for this host */
+				grab_standard_host_macro_r(mac, macro_type, temp_host, &temp_buffer, &free_sub_macro);
+
+				if(temp_buffer == NULL)
+					continue;
+
+				/* add macro value to already running macro */
+				if(*output == NULL)
+					*output = (char *)strdup(temp_buffer);
+				else {
+					if((*output = (char *)realloc(*output, strlen(*output) + strlen(temp_buffer) + delimiter_len + 1)) == NULL)
 						continue;
-
-					/* get the macro value for this host */
-					grab_standard_host_macro_r(mac, macro_type, temp_host, &temp_buffer, &free_sub_macro);
-
-					if(temp_buffer == NULL)
-						continue;
-
-					/* add macro value to already running macro */
-					if(*output == NULL)
-						*output = (char *)strdup(temp_buffer);
-					else {
-						if((*output = (char *)realloc(*output, strlen(*output) + strlen(temp_buffer) + delimiter_len + 1)) == NULL)
-							continue;
-						strcat(*output, arg2);
-						strcat(*output, temp_buffer);
-						}
-					if(free_sub_macro == TRUE)
-						my_free(temp_buffer);
-					}
+					strcat(*output, arg2);
+					strcat(*output, temp_buffer);
 				}
-			break;
+				if(free_sub_macro == TRUE)
+					my_free(temp_buffer);
+			}
+		}
+		break;
 
-			/********************/
-			/* HOSTGROUP MACROS */
-			/********************/
-		case MACRO_HOSTGROUPMEMBERS:
-			*free_macro = TRUE;
-		case MACRO_HOSTGROUPNAME:
-		case MACRO_HOSTGROUPALIAS:
-		case MACRO_HOSTGROUPNOTES:
-		case MACRO_HOSTGROUPNOTESURL:
-		case MACRO_HOSTGROUPACTIONURL:
+	/********************/
+	/* HOSTGROUP MACROS */
+	/********************/
+	case MACRO_HOSTGROUPMEMBERS:
+		*free_macro = TRUE;
+	case MACRO_HOSTGROUPNAME:
+	case MACRO_HOSTGROUPALIAS:
+	case MACRO_HOSTGROUPNOTES:
+	case MACRO_HOSTGROUPNOTESURL:
+	case MACRO_HOSTGROUPACTIONURL:
 
-			/* a standard hostgroup macro */
-			/* use the saved hostgroup pointer */
-			if(arg1 == NULL) {
-				if((temp_hostgroup = mac->hostgroup_ptr) == NULL)
+		/* a standard hostgroup macro */
+		/* use the saved hostgroup pointer */
+		if(arg1 == NULL) {
+			if((temp_hostgroup = mac->hostgroup_ptr) == NULL)
+				return ERROR;
+		}
+
+		/* else find the hostgroup for on-demand macros */
+		else {
+			if((temp_hostgroup = find_hostgroup(arg1)) == NULL)
+				return ERROR;
+		}
+
+		/* get the hostgroup macro value */
+		result = grab_standard_hostgroup_macro_r(mac, macro_type, temp_hostgroup, output);
+		break;
+
+	/******************/
+	/* SERVICE MACROS */
+	/******************/
+	case MACRO_SERVICEGROUPNAMES:
+		*free_macro = TRUE;
+	case MACRO_SERVICEDESC:
+	case MACRO_SERVICESTATE:
+	case MACRO_SERVICESTATEID:
+	case MACRO_SERVICEATTEMPT:
+	case MACRO_LASTSERVICECHECK:
+	case MACRO_LASTSERVICESTATECHANGE:
+	case MACRO_SERVICEOUTPUT:
+	case MACRO_SERVICEPERFDATA:
+	case MACRO_SERVICEEXECUTIONTIME:
+	case MACRO_SERVICELATENCY:
+	case MACRO_SERVICEDURATION:
+	case MACRO_SERVICEDURATIONSEC:
+	case MACRO_SERVICEDOWNTIME:
+	case MACRO_SERVICESTATETYPE:
+	case MACRO_SERVICEPERCENTCHANGE:
+	case MACRO_SERVICEACKAUTHOR:
+	case MACRO_SERVICEACKCOMMENT:
+	case MACRO_LASTSERVICEOK:
+	case MACRO_LASTSERVICEWARNING:
+	case MACRO_LASTSERVICEUNKNOWN:
+	case MACRO_LASTSERVICECRITICAL:
+	case MACRO_SERVICECHECKCOMMAND:
+	case MACRO_SERVICEDISPLAYNAME:
+	case MACRO_SERVICEACTIONURL:
+	case MACRO_SERVICENOTESURL:
+	case MACRO_SERVICENOTES:
+	case MACRO_SERVICECHECKTYPE:
+	case MACRO_LONGSERVICEOUTPUT:
+	case MACRO_SERVICENOTIFICATIONNUMBER:
+	case MACRO_SERVICENOTIFICATIONID:
+	case MACRO_SERVICEEVENTID:
+	case MACRO_LASTSERVICEEVENTID:
+	case MACRO_SERVICEACKAUTHORNAME:
+	case MACRO_SERVICEACKAUTHORALIAS:
+	case MACRO_MAXSERVICEATTEMPTS:
+	case MACRO_SERVICEISVOLATILE:
+	case MACRO_SERVICEPROBLEMID:
+	case MACRO_LASTSERVICEPROBLEMID:
+	case MACRO_LASTSERVICESTATE:
+	case MACRO_LASTSERVICESTATEID:
+	case MACRO_SERVICEIMPORTANCE:
+
+		/* use saved service pointer */
+		if(arg1 == NULL && arg2 == NULL) {
+
+			if((temp_service = mac->service_ptr) == NULL)
+				return ERROR;
+
+			result = grab_standard_service_macro_r(mac, macro_type, temp_service, output, free_macro);
+		}
+
+		/* else and ondemand macro... */
+		else {
+
+			/* if first arg is blank, it means use the current host name */
+			if(arg1 == NULL || arg1[0] == '\x0') {
+
+				if(mac->host_ptr == NULL)
 					return ERROR;
-				}
 
-			/* else find the hostgroup for on-demand macros */
-			else {
-				if((temp_hostgroup = find_hostgroup(arg1)) == NULL)
-					return ERROR;
-				}
-
-			/* get the hostgroup macro value */
-			result = grab_standard_hostgroup_macro_r(mac, macro_type, temp_hostgroup, output);
-			break;
-
-			/******************/
-			/* SERVICE MACROS */
-			/******************/
-		case MACRO_SERVICEGROUPNAMES:
-			*free_macro = TRUE;
-		case MACRO_SERVICEDESC:
-		case MACRO_SERVICESTATE:
-		case MACRO_SERVICESTATEID:
-		case MACRO_SERVICEATTEMPT:
-		case MACRO_LASTSERVICECHECK:
-		case MACRO_LASTSERVICESTATECHANGE:
-		case MACRO_SERVICEOUTPUT:
-		case MACRO_SERVICEPERFDATA:
-		case MACRO_SERVICEEXECUTIONTIME:
-		case MACRO_SERVICELATENCY:
-		case MACRO_SERVICEDURATION:
-		case MACRO_SERVICEDURATIONSEC:
-		case MACRO_SERVICEDOWNTIME:
-		case MACRO_SERVICESTATETYPE:
-		case MACRO_SERVICEPERCENTCHANGE:
-		case MACRO_SERVICEACKAUTHOR:
-		case MACRO_SERVICEACKCOMMENT:
-		case MACRO_LASTSERVICEOK:
-		case MACRO_LASTSERVICEWARNING:
-		case MACRO_LASTSERVICEUNKNOWN:
-		case MACRO_LASTSERVICECRITICAL:
-		case MACRO_SERVICECHECKCOMMAND:
-		case MACRO_SERVICEDISPLAYNAME:
-		case MACRO_SERVICEACTIONURL:
-		case MACRO_SERVICENOTESURL:
-		case MACRO_SERVICENOTES:
-		case MACRO_SERVICECHECKTYPE:
-		case MACRO_LONGSERVICEOUTPUT:
-		case MACRO_SERVICENOTIFICATIONNUMBER:
-		case MACRO_SERVICENOTIFICATIONID:
-		case MACRO_SERVICEEVENTID:
-		case MACRO_LASTSERVICEEVENTID:
-		case MACRO_SERVICEACKAUTHORNAME:
-		case MACRO_SERVICEACKAUTHORALIAS:
-		case MACRO_MAXSERVICEATTEMPTS:
-		case MACRO_SERVICEISVOLATILE:
-		case MACRO_SERVICEPROBLEMID:
-		case MACRO_LASTSERVICEPROBLEMID:
-		case MACRO_LASTSERVICESTATE:
-		case MACRO_LASTSERVICESTATEID:
-		case MACRO_SERVICEIMPORTANCE:
-
-			/* use saved service pointer */
-			if(arg1 == NULL && arg2 == NULL) {
-
-				if((temp_service = mac->service_ptr) == NULL)
-					return ERROR;
-
-				result = grab_standard_service_macro_r(mac, macro_type, temp_service, output, free_macro);
-				}
-
-			/* else and ondemand macro... */
-			else {
-
-				/* if first arg is blank, it means use the current host name */
-				if(arg1 == NULL || arg1[0] == '\x0') {
-
-					if(mac->host_ptr == NULL)
-						return ERROR;
-
-					if((temp_service = find_service(mac->host_ptr->name, arg2))) {
-
-						/* get the service macro value */
-						result = grab_standard_service_macro_r(mac, macro_type, temp_service, output, free_macro);
-						}
-					}
-
-				/* on-demand macro with both host and service name */
-				else if((temp_service = find_service(arg1, arg2))) {
+				if((temp_service = find_service(mac->host_ptr->name, arg2))) {
 
 					/* get the service macro value */
 					result = grab_standard_service_macro_r(mac, macro_type, temp_service, output, free_macro);
-					}
-
-				/* else we have a service macro with a servicegroup name and a delimiter... */
-				else if(arg1 && arg2) {
-
-					if((temp_servicegroup = find_servicegroup(arg1)) == NULL)
-						return ERROR;
-
-					delimiter_len = strlen(arg2);
-					*free_macro = TRUE;
-
-					/* concatenate macro values for all servicegroup members */
-					for(temp_servicesmember = temp_servicegroup->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
-
-						if((temp_service = temp_servicesmember->service_ptr) == NULL)
-							continue;
-
-						/* get the macro value for this service */
-						grab_standard_service_macro_r(mac, macro_type, temp_service, &temp_buffer, &free_sub_macro);
-
-						if(temp_buffer == NULL)
-							continue;
-
-						/* add macro value to already running macro */
-						if(*output == NULL)
-							*output = (char *)strdup(temp_buffer);
-						else {
-							if((*output = (char *)realloc(*output, strlen(*output) + strlen(temp_buffer) + delimiter_len + 1)) == NULL)
-								continue;
-							strcat(*output, arg2);
-							strcat(*output, temp_buffer);
-							}
-						if(free_sub_macro == TRUE)
-							my_free(temp_buffer);
-						}
-					}
-				else
-					return ERROR;
 				}
-			break;
+			}
 
-			/***********************/
-			/* SERVICEGROUP MACROS */
-			/***********************/
-		case MACRO_SERVICEGROUPMEMBERS:
-		case MACRO_SERVICEGROUPNOTES:
-		case MACRO_SERVICEGROUPNOTESURL:
-		case MACRO_SERVICEGROUPACTIONURL:
-			*free_macro = TRUE;
-		case MACRO_SERVICEGROUPNAME:
-		case MACRO_SERVICEGROUPALIAS:
-			/* a standard servicegroup macro */
-			/* use the saved servicegroup pointer */
-			if(arg1 == NULL) {
-				if((temp_servicegroup = mac->servicegroup_ptr) == NULL)
-					return ERROR;
-				}
+			/* on-demand macro with both host and service name */
+			else if((temp_service = find_service(arg1, arg2))) {
 
-			/* else find the servicegroup for on-demand macros */
-			else {
+				/* get the service macro value */
+				result = grab_standard_service_macro_r(mac, macro_type, temp_service, output, free_macro);
+			}
+
+			/* else we have a service macro with a servicegroup name and a delimiter... */
+			else if(arg1 && arg2) {
+
 				if((temp_servicegroup = find_servicegroup(arg1)) == NULL)
-					return ERROR;
-				}
-
-			/* get the servicegroup macro value */
-			result = grab_standard_servicegroup_macro_r(mac, macro_type, temp_servicegroup, output);
-			break;
-
-			/******************/
-			/* CONTACT MACROS */
-			/******************/
-		case MACRO_CONTACTGROUPNAMES:
-			*free_macro = TRUE;
-		case MACRO_CONTACTNAME:
-		case MACRO_CONTACTALIAS:
-		case MACRO_CONTACTEMAIL:
-		case MACRO_CONTACTPAGER:
-			/* a standard contact macro */
-			if(arg2 == NULL) {
-
-				/* find the contact for on-demand macros */
-				if(arg1) {
-					if((temp_contact = find_contact(arg1)) == NULL)
-						return ERROR;
-					}
-
-				/* else use saved contact pointer */
-				else if((temp_contact = mac->contact_ptr) == NULL)
-					return ERROR;
-
-				/* get the contact macro value */
-				result = grab_standard_contact_macro_r(mac, macro_type, temp_contact, output);
-				}
-
-			/* a contact macro with a contactgroup name and delimiter */
-			else {
-
-				if((temp_contactgroup = find_contactgroup(arg1)) == NULL)
 					return ERROR;
 
 				delimiter_len = strlen(arg2);
 				*free_macro = TRUE;
 
-				/* concatenate macro values for all contactgroup members */
-				for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
+				/* concatenate macro values for all servicegroup members */
+				for(temp_servicesmember = temp_servicegroup->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
 
-					if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
+					if((temp_service = temp_servicesmember->service_ptr) == NULL)
 						continue;
 
-					/* get the macro value for this contact */
-					grab_standard_contact_macro_r(mac, macro_type, temp_contact, &temp_buffer);
+					/* get the macro value for this service */
+					grab_standard_service_macro_r(mac, macro_type, temp_service, &temp_buffer, &free_sub_macro);
 
 					if(temp_buffer == NULL)
 						continue;
@@ -964,262 +889,352 @@ int grab_macrox_value_r(nagios_macros *mac, int macro_type, char *arg1, char *ar
 							continue;
 						strcat(*output, arg2);
 						strcat(*output, temp_buffer);
-						}
-					my_free(temp_buffer);
 					}
+					if(free_sub_macro == TRUE)
+						my_free(temp_buffer);
 				}
-			break;
+			} else
+				return ERROR;
+		}
+		break;
 
-			/***********************/
-			/* CONTACTGROUP MACROS */
-			/***********************/
-		case MACRO_CONTACTGROUPMEMBERS:
-			*free_macro = TRUE;
-		case MACRO_CONTACTGROUPNAME:
-		case MACRO_CONTACTGROUPALIAS:
-			/* a standard contactgroup macro */
-			/* use the saved contactgroup pointer */
-			if(arg1 == NULL) {
-				if((temp_contactgroup = mac->contactgroup_ptr) == NULL)
-					return ERROR;
-				}
-
-			/* else find the contactgroup for on-demand macros */
-			else {
-				if((temp_contactgroup = find_contactgroup(arg1)) == NULL)
-					return ERROR;
-				}
-
-			/* get the contactgroup macro value */
-			result = grab_standard_contactgroup_macro(macro_type, temp_contactgroup, output);
-			break;
-
-			/***********************/
-			/* NOTIFICATION MACROS */
-			/***********************/
-		case MACRO_NOTIFICATIONTYPE:
-		case MACRO_NOTIFICATIONNUMBER:
-		case MACRO_NOTIFICATIONRECIPIENTS:
-		case MACRO_NOTIFICATIONISESCALATED:
-		case MACRO_NOTIFICATIONAUTHOR:
-		case MACRO_NOTIFICATIONAUTHORNAME:
-		case MACRO_NOTIFICATIONAUTHORALIAS:
-		case MACRO_NOTIFICATIONCOMMENT:
-
-			/* notification macros have already been pre-computed */
-			*output = mac->x[macro_type];
-			*free_macro = FALSE;
-			break;
-
-			/********************/
-			/* DATE/TIME MACROS */
-			/********************/
-		case MACRO_LONGDATETIME:
-		case MACRO_SHORTDATETIME:
-		case MACRO_DATE:
-		case MACRO_TIME:
-			*free_macro = TRUE;
-		case MACRO_TIMET:
-		case MACRO_ISVALIDTIME:
-		case MACRO_NEXTVALIDTIME:
-
-			/* calculate macros */
-			result = grab_datetime_macro_r(mac, macro_type, arg1, arg2, output);
-			break;
-
-			/*****************/
-			/* STATIC MACROS */
-			/*****************/
-		case MACRO_ADMINEMAIL:
-		case MACRO_ADMINPAGER:
-		case MACRO_MAINCONFIGFILE:
-		case MACRO_STATUSDATAFILE:
-		case MACRO_RETENTIONDATAFILE:
-		case MACRO_OBJECTCACHEFILE:
-		case MACRO_TEMPFILE:
-		case MACRO_LOGFILE:
-		case MACRO_RESOURCEFILE:
-		case MACRO_COMMANDFILE:
-		case MACRO_HOSTPERFDATAFILE:
-		case MACRO_SERVICEPERFDATAFILE:
-		case MACRO_PROCESSSTARTTIME:
-		case MACRO_TEMPPATH:
-		case MACRO_EVENTSTARTTIME:
-
-			/* no need to do any more work - these are already precomputed for us */
-			*output = global_macros.x[macro_type];
-			*free_macro = FALSE;
-			break;
-
-			/******************/
-			/* SUMMARY MACROS */
-			/******************/
-		case MACRO_TOTALHOSTSUP:
-		case MACRO_TOTALHOSTSDOWN:
-		case MACRO_TOTALHOSTSUNREACHABLE:
-		case MACRO_TOTALHOSTSDOWNUNHANDLED:
-		case MACRO_TOTALHOSTSUNREACHABLEUNHANDLED:
-		case MACRO_TOTALHOSTPROBLEMS:
-		case MACRO_TOTALHOSTPROBLEMSUNHANDLED:
-		case MACRO_TOTALSERVICESOK:
-		case MACRO_TOTALSERVICESWARNING:
-		case MACRO_TOTALSERVICESCRITICAL:
-		case MACRO_TOTALSERVICESUNKNOWN:
-		case MACRO_TOTALSERVICESWARNINGUNHANDLED:
-		case MACRO_TOTALSERVICESCRITICALUNHANDLED:
-		case MACRO_TOTALSERVICESUNKNOWNUNHANDLED:
-		case MACRO_TOTALSERVICEPROBLEMS:
-		case MACRO_TOTALSERVICEPROBLEMSUNHANDLED:
-
-#ifdef NSCORE
-			/* generate summary macros if needed */
-			if(mac->x[MACRO_TOTALHOSTSUP] == NULL) {
-
-				/* get host totals */
-				for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
-
-					/* filter totals based on contact if necessary */
-					if(mac->contact_ptr != NULL)
-						authorized = is_contact_for_host(temp_host, mac->contact_ptr);
-
-					if(authorized == TRUE) {
-						problem = TRUE;
-
-						if(temp_host->current_state == HOST_UP && temp_host->has_been_checked == TRUE)
-							hosts_up++;
-						else if(temp_host->current_state == HOST_DOWN) {
-							if(temp_host->scheduled_downtime_depth > 0)
-								problem = FALSE;
-							if(temp_host->problem_has_been_acknowledged == TRUE)
-								problem = FALSE;
-							if(temp_host->checks_enabled == FALSE)
-								problem = FALSE;
-							if(problem == TRUE)
-								hosts_down_unhandled++;
-							hosts_down++;
-							}
-						else if(temp_host->current_state == HOST_UNREACHABLE) {
-							if(temp_host->scheduled_downtime_depth > 0)
-								problem = FALSE;
-							if(temp_host->problem_has_been_acknowledged == TRUE)
-								problem = FALSE;
-							if(temp_host->checks_enabled == FALSE)
-								problem = FALSE;
-							if(problem == TRUE)
-								hosts_down_unhandled++;
-							hosts_unreachable++;
-							}
-						}
-					}
-
-				host_problems = hosts_down + hosts_unreachable;
-				host_problems_unhandled = hosts_down_unhandled + hosts_unreachable_unhandled;
-
-				/* get service totals */
-				for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
-
-					/* filter totals based on contact if necessary */
-					if(mac->contact_ptr != NULL)
-						authorized = is_contact_for_service(temp_service, mac->contact_ptr);
-
-					if(authorized == TRUE) {
-						problem = TRUE;
-
-						if(temp_service->current_state == STATE_OK && temp_service->has_been_checked == TRUE)
-							services_ok++;
-						else if(temp_service->current_state == STATE_WARNING) {
-							temp_host = find_host(temp_service->host_name);
-							if(temp_host != NULL && (temp_host->current_state == HOST_DOWN || temp_host->current_state == HOST_UNREACHABLE))
-								problem = FALSE;
-							if(temp_service->scheduled_downtime_depth > 0)
-								problem = FALSE;
-							if(temp_service->problem_has_been_acknowledged == TRUE)
-								problem = FALSE;
-							if(temp_service->checks_enabled == FALSE)
-								problem = FALSE;
-							if(problem == TRUE)
-								services_warning_unhandled++;
-							services_warning++;
-							}
-						else if(temp_service->current_state == STATE_UNKNOWN) {
-							temp_host = find_host(temp_service->host_name);
-							if(temp_host != NULL && (temp_host->current_state == HOST_DOWN || temp_host->current_state == HOST_UNREACHABLE))
-								problem = FALSE;
-							if(temp_service->scheduled_downtime_depth > 0)
-								problem = FALSE;
-							if(temp_service->problem_has_been_acknowledged == TRUE)
-								problem = FALSE;
-							if(temp_service->checks_enabled == FALSE)
-								problem = FALSE;
-							if(problem == TRUE)
-								services_unknown_unhandled++;
-							services_unknown++;
-							}
-						else if(temp_service->current_state == STATE_CRITICAL) {
-							temp_host = find_host(temp_service->host_name);
-							if(temp_host != NULL && (temp_host->current_state == HOST_DOWN || temp_host->current_state == HOST_UNREACHABLE))
-								problem = FALSE;
-							if(temp_service->scheduled_downtime_depth > 0)
-								problem = FALSE;
-							if(temp_service->problem_has_been_acknowledged == TRUE)
-								problem = FALSE;
-							if(temp_service->checks_enabled == FALSE)
-								problem = FALSE;
-							if(problem == TRUE)
-								services_critical_unhandled++;
-							services_critical++;
-							}
-						}
-					}
-
-				service_problems = services_warning + services_critical + services_unknown;
-				service_problems_unhandled = services_warning_unhandled + services_critical_unhandled + services_unknown_unhandled;
-
-				/* these macros are time-intensive to compute, and will likely be used together, so save them all for future use */
-				for(x = MACRO_TOTALHOSTSUP; x <= MACRO_TOTALSERVICEPROBLEMSUNHANDLED; x++)
-					my_free(mac->x[x]);
-				asprintf(&mac->x[MACRO_TOTALHOSTSUP], "%d", hosts_up);
-				asprintf(&mac->x[MACRO_TOTALHOSTSDOWN], "%d", hosts_down);
-				asprintf(&mac->x[MACRO_TOTALHOSTSUNREACHABLE], "%d", hosts_unreachable);
-				asprintf(&mac->x[MACRO_TOTALHOSTSDOWNUNHANDLED], "%d", hosts_down_unhandled);
-				asprintf(&mac->x[MACRO_TOTALHOSTSUNREACHABLEUNHANDLED], "%d", hosts_unreachable_unhandled);
-				asprintf(&mac->x[MACRO_TOTALHOSTPROBLEMS], "%d", host_problems);
-				asprintf(&mac->x[MACRO_TOTALHOSTPROBLEMSUNHANDLED], "%d", host_problems_unhandled);
-				asprintf(&mac->x[MACRO_TOTALSERVICESOK], "%d", services_ok);
-				asprintf(&mac->x[MACRO_TOTALSERVICESWARNING], "%d", services_warning);
-				asprintf(&mac->x[MACRO_TOTALSERVICESCRITICAL], "%d", services_critical);
-				asprintf(&mac->x[MACRO_TOTALSERVICESUNKNOWN], "%d", services_unknown);
-				asprintf(&mac->x[MACRO_TOTALSERVICESWARNINGUNHANDLED], "%d", services_warning_unhandled);
-				asprintf(&mac->x[MACRO_TOTALSERVICESCRITICALUNHANDLED], "%d", services_critical_unhandled);
-				asprintf(&mac->x[MACRO_TOTALSERVICESUNKNOWNUNHANDLED], "%d", services_unknown_unhandled);
-				asprintf(&mac->x[MACRO_TOTALSERVICEPROBLEMS], "%d", service_problems);
-				asprintf(&mac->x[MACRO_TOTALSERVICEPROBLEMSUNHANDLED], "%d", service_problems_unhandled);
-				}
-
-			/* return only the macro the user requested */
-			*output = mac->x[macro_type];
-
-			/* tell caller to NOT free memory when done */
-			*free_macro = FALSE;
-#endif
-			break;
-
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
-			break;
+	/***********************/
+	/* SERVICEGROUP MACROS */
+	/***********************/
+	case MACRO_SERVICEGROUPMEMBERS:
+	case MACRO_SERVICEGROUPNOTES:
+	case MACRO_SERVICEGROUPNOTESURL:
+	case MACRO_SERVICEGROUPACTIONURL:
+		*free_macro = TRUE;
+	case MACRO_SERVICEGROUPNAME:
+	case MACRO_SERVICEGROUPALIAS:
+		/* a standard servicegroup macro */
+		/* use the saved servicegroup pointer */
+		if(arg1 == NULL) {
+			if((temp_servicegroup = mac->servicegroup_ptr) == NULL)
+				return ERROR;
 		}
 
-	return result;
+		/* else find the servicegroup for on-demand macros */
+		else {
+			if((temp_servicegroup = find_servicegroup(arg1)) == NULL)
+				return ERROR;
+		}
+
+		/* get the servicegroup macro value */
+		result = grab_standard_servicegroup_macro_r(mac, macro_type, temp_servicegroup, output);
+		break;
+
+	/******************/
+	/* CONTACT MACROS */
+	/******************/
+	case MACRO_CONTACTGROUPNAMES:
+		*free_macro = TRUE;
+	case MACRO_CONTACTNAME:
+	case MACRO_CONTACTALIAS:
+	case MACRO_CONTACTEMAIL:
+	case MACRO_CONTACTPAGER:
+		/* a standard contact macro */
+		if(arg2 == NULL) {
+
+			/* find the contact for on-demand macros */
+			if(arg1) {
+				if((temp_contact = find_contact(arg1)) == NULL)
+					return ERROR;
+			}
+
+			/* else use saved contact pointer */
+			else if((temp_contact = mac->contact_ptr) == NULL)
+				return ERROR;
+
+			/* get the contact macro value */
+			result = grab_standard_contact_macro_r(mac, macro_type, temp_contact, output);
+		}
+
+		/* a contact macro with a contactgroup name and delimiter */
+		else {
+
+			if((temp_contactgroup = find_contactgroup(arg1)) == NULL)
+				return ERROR;
+
+			delimiter_len = strlen(arg2);
+			*free_macro = TRUE;
+
+			/* concatenate macro values for all contactgroup members */
+			for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
+
+				if((temp_contact = temp_contactsmember->contact_ptr) == NULL)
+					continue;
+
+				/* get the macro value for this contact */
+				grab_standard_contact_macro_r(mac, macro_type, temp_contact, &temp_buffer);
+
+				if(temp_buffer == NULL)
+					continue;
+
+				/* add macro value to already running macro */
+				if(*output == NULL)
+					*output = (char *)strdup(temp_buffer);
+				else {
+					if((*output = (char *)realloc(*output, strlen(*output) + strlen(temp_buffer) + delimiter_len + 1)) == NULL)
+						continue;
+					strcat(*output, arg2);
+					strcat(*output, temp_buffer);
+				}
+				my_free(temp_buffer);
+			}
+		}
+		break;
+
+	/***********************/
+	/* CONTACTGROUP MACROS */
+	/***********************/
+	case MACRO_CONTACTGROUPMEMBERS:
+		*free_macro = TRUE;
+	case MACRO_CONTACTGROUPNAME:
+	case MACRO_CONTACTGROUPALIAS:
+		/* a standard contactgroup macro */
+		/* use the saved contactgroup pointer */
+		if(arg1 == NULL) {
+			if((temp_contactgroup = mac->contactgroup_ptr) == NULL)
+				return ERROR;
+		}
+
+		/* else find the contactgroup for on-demand macros */
+		else {
+			if((temp_contactgroup = find_contactgroup(arg1)) == NULL)
+				return ERROR;
+		}
+
+		/* get the contactgroup macro value */
+		result = grab_standard_contactgroup_macro(macro_type, temp_contactgroup, output);
+		break;
+
+	/***********************/
+	/* NOTIFICATION MACROS */
+	/***********************/
+	case MACRO_NOTIFICATIONTYPE:
+	case MACRO_NOTIFICATIONNUMBER:
+	case MACRO_NOTIFICATIONRECIPIENTS:
+	case MACRO_NOTIFICATIONISESCALATED:
+	case MACRO_NOTIFICATIONAUTHOR:
+	case MACRO_NOTIFICATIONAUTHORNAME:
+	case MACRO_NOTIFICATIONAUTHORALIAS:
+	case MACRO_NOTIFICATIONCOMMENT:
+
+		/* notification macros have already been pre-computed */
+		*output = mac->x[macro_type];
+		*free_macro = FALSE;
+		break;
+
+	/********************/
+	/* DATE/TIME MACROS */
+	/********************/
+	case MACRO_LONGDATETIME:
+	case MACRO_SHORTDATETIME:
+	case MACRO_DATE:
+	case MACRO_TIME:
+		*free_macro = TRUE;
+	case MACRO_TIMET:
+	case MACRO_ISVALIDTIME:
+	case MACRO_NEXTVALIDTIME:
+
+		/* calculate macros */
+		result = grab_datetime_macro_r(mac, macro_type, arg1, arg2, output);
+		break;
+
+	/*****************/
+	/* STATIC MACROS */
+	/*****************/
+	case MACRO_ADMINEMAIL:
+	case MACRO_ADMINPAGER:
+	case MACRO_MAINCONFIGFILE:
+	case MACRO_STATUSDATAFILE:
+	case MACRO_RETENTIONDATAFILE:
+	case MACRO_OBJECTCACHEFILE:
+	case MACRO_TEMPFILE:
+	case MACRO_LOGFILE:
+	case MACRO_RESOURCEFILE:
+	case MACRO_COMMANDFILE:
+	case MACRO_HOSTPERFDATAFILE:
+	case MACRO_SERVICEPERFDATAFILE:
+	case MACRO_PROCESSSTARTTIME:
+	case MACRO_TEMPPATH:
+	case MACRO_EVENTSTARTTIME:
+
+		/* no need to do any more work - these are already precomputed for us */
+		*output = global_macros.x[macro_type];
+		*free_macro = FALSE;
+		break;
+
+	/******************/
+	/* SUMMARY MACROS */
+	/******************/
+	case MACRO_TOTALHOSTSUP:
+	case MACRO_TOTALHOSTSDOWN:
+	case MACRO_TOTALHOSTSUNREACHABLE:
+	case MACRO_TOTALHOSTSDOWNUNHANDLED:
+	case MACRO_TOTALHOSTSUNREACHABLEUNHANDLED:
+	case MACRO_TOTALHOSTPROBLEMS:
+	case MACRO_TOTALHOSTPROBLEMSUNHANDLED:
+	case MACRO_TOTALSERVICESOK:
+	case MACRO_TOTALSERVICESWARNING:
+	case MACRO_TOTALSERVICESCRITICAL:
+	case MACRO_TOTALSERVICESUNKNOWN:
+	case MACRO_TOTALSERVICESWARNINGUNHANDLED:
+	case MACRO_TOTALSERVICESCRITICALUNHANDLED:
+	case MACRO_TOTALSERVICESUNKNOWNUNHANDLED:
+	case MACRO_TOTALSERVICEPROBLEMS:
+	case MACRO_TOTALSERVICEPROBLEMSUNHANDLED:
+
+#ifdef NSCORE
+		/* generate summary macros if needed */
+		if(mac->x[MACRO_TOTALHOSTSUP] == NULL) {
+
+			/* get host totals */
+			for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next) {
+
+				/* filter totals based on contact if necessary */
+				if(mac->contact_ptr != NULL)
+					authorized = is_contact_for_host(temp_host, mac->contact_ptr);
+
+				if(authorized == TRUE) {
+					problem = TRUE;
+
+					if(temp_host->current_state == HOST_UP && temp_host->has_been_checked == TRUE)
+						hosts_up++;
+					else if(temp_host->current_state == HOST_DOWN) {
+						if(temp_host->scheduled_downtime_depth > 0)
+							problem = FALSE;
+						if(temp_host->problem_has_been_acknowledged == TRUE)
+							problem = FALSE;
+						if(temp_host->checks_enabled == FALSE)
+							problem = FALSE;
+						if(problem == TRUE)
+							hosts_down_unhandled++;
+						hosts_down++;
+					} else if(temp_host->current_state == HOST_UNREACHABLE) {
+						if(temp_host->scheduled_downtime_depth > 0)
+							problem = FALSE;
+						if(temp_host->problem_has_been_acknowledged == TRUE)
+							problem = FALSE;
+						if(temp_host->checks_enabled == FALSE)
+							problem = FALSE;
+						if(problem == TRUE)
+							hosts_down_unhandled++;
+						hosts_unreachable++;
+					}
+				}
+			}
+
+			host_problems = hosts_down + hosts_unreachable;
+			host_problems_unhandled = hosts_down_unhandled + hosts_unreachable_unhandled;
+
+			/* get service totals */
+			for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
+
+				/* filter totals based on contact if necessary */
+				if(mac->contact_ptr != NULL)
+					authorized = is_contact_for_service(temp_service, mac->contact_ptr);
+
+				if(authorized == TRUE) {
+					problem = TRUE;
+
+					if(temp_service->current_state == STATE_OK && temp_service->has_been_checked == TRUE)
+						services_ok++;
+					else if(temp_service->current_state == STATE_WARNING) {
+						temp_host = find_host(temp_service->host_name);
+						if(temp_host != NULL && (temp_host->current_state == HOST_DOWN || temp_host->current_state == HOST_UNREACHABLE))
+							problem = FALSE;
+						if(temp_service->scheduled_downtime_depth > 0)
+							problem = FALSE;
+						if(temp_service->problem_has_been_acknowledged == TRUE)
+							problem = FALSE;
+						if(temp_service->checks_enabled == FALSE)
+							problem = FALSE;
+						if(problem == TRUE)
+							services_warning_unhandled++;
+						services_warning++;
+					} else if(temp_service->current_state == STATE_UNKNOWN) {
+						temp_host = find_host(temp_service->host_name);
+						if(temp_host != NULL && (temp_host->current_state == HOST_DOWN || temp_host->current_state == HOST_UNREACHABLE))
+							problem = FALSE;
+						if(temp_service->scheduled_downtime_depth > 0)
+							problem = FALSE;
+						if(temp_service->problem_has_been_acknowledged == TRUE)
+							problem = FALSE;
+						if(temp_service->checks_enabled == FALSE)
+							problem = FALSE;
+						if(problem == TRUE)
+							services_unknown_unhandled++;
+						services_unknown++;
+					} else if(temp_service->current_state == STATE_CRITICAL) {
+						temp_host = find_host(temp_service->host_name);
+						if(temp_host != NULL && (temp_host->current_state == HOST_DOWN || temp_host->current_state == HOST_UNREACHABLE))
+							problem = FALSE;
+						if(temp_service->scheduled_downtime_depth > 0)
+							problem = FALSE;
+						if(temp_service->problem_has_been_acknowledged == TRUE)
+							problem = FALSE;
+						if(temp_service->checks_enabled == FALSE)
+							problem = FALSE;
+						if(problem == TRUE)
+							services_critical_unhandled++;
+						services_critical++;
+					}
+				}
+			}
+
+			service_problems = services_warning + services_critical + services_unknown;
+			service_problems_unhandled = services_warning_unhandled + services_critical_unhandled + services_unknown_unhandled;
+
+			/* these macros are time-intensive to compute, and will likely be used together, so save them all for future use */
+			for(x = MACRO_TOTALHOSTSUP; x <= MACRO_TOTALSERVICEPROBLEMSUNHANDLED; x++)
+				my_free(mac->x[x]);
+			asprintf(&mac->x[MACRO_TOTALHOSTSUP], "%d", hosts_up);
+			asprintf(&mac->x[MACRO_TOTALHOSTSDOWN], "%d", hosts_down);
+			asprintf(&mac->x[MACRO_TOTALHOSTSUNREACHABLE], "%d", hosts_unreachable);
+			asprintf(&mac->x[MACRO_TOTALHOSTSDOWNUNHANDLED], "%d", hosts_down_unhandled);
+			asprintf(&mac->x[MACRO_TOTALHOSTSUNREACHABLEUNHANDLED], "%d", hosts_unreachable_unhandled);
+			asprintf(&mac->x[MACRO_TOTALHOSTPROBLEMS], "%d", host_problems);
+			asprintf(&mac->x[MACRO_TOTALHOSTPROBLEMSUNHANDLED], "%d", host_problems_unhandled);
+			asprintf(&mac->x[MACRO_TOTALSERVICESOK], "%d", services_ok);
+			asprintf(&mac->x[MACRO_TOTALSERVICESWARNING], "%d", services_warning);
+			asprintf(&mac->x[MACRO_TOTALSERVICESCRITICAL], "%d", services_critical);
+			asprintf(&mac->x[MACRO_TOTALSERVICESUNKNOWN], "%d", services_unknown);
+			asprintf(&mac->x[MACRO_TOTALSERVICESWARNINGUNHANDLED], "%d", services_warning_unhandled);
+			asprintf(&mac->x[MACRO_TOTALSERVICESCRITICALUNHANDLED], "%d", services_critical_unhandled);
+			asprintf(&mac->x[MACRO_TOTALSERVICESUNKNOWNUNHANDLED], "%d", services_unknown_unhandled);
+			asprintf(&mac->x[MACRO_TOTALSERVICEPROBLEMS], "%d", service_problems);
+			asprintf(&mac->x[MACRO_TOTALSERVICEPROBLEMSUNHANDLED], "%d", service_problems_unhandled);
+		}
+
+		/* return only the macro the user requested */
+		*output = mac->x[macro_type];
+
+		/* tell caller to NOT free memory when done */
+		*free_macro = FALSE;
+#endif
+		break;
+
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+		break;
 	}
 
-int grab_macrox_value(int macro_type, char *arg1, char *arg2, char **output, int *free_macro) {
+	return result;
+}
+
+int grab_macrox_value(int macro_type, char *arg1, char *arg2, char **output, int *free_macro)
+{
 	return grab_macrox_value_r(&global_macros, macro_type, arg1, arg2, output, free_macro);
-	}
+}
 
 
 /* calculates the value of a custom macro */
-int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, char *arg2, char **output) {
+int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, char *arg2, char **output)
+{
 	host *temp_host = NULL;
 	hostgroup *temp_hostgroup = NULL;
 	hostsmember *temp_hostsmember = NULL;
@@ -1246,7 +1261,7 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 			if(arg1) {
 				if((temp_host = find_host(arg1)) == NULL)
 					return ERROR;
-				}
+			}
 
 			/* else use saved host pointer */
 			else if((temp_host = mac->host_ptr) == NULL)
@@ -1254,7 +1269,7 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 
 			/* get the host macro value */
 			result = grab_custom_object_macro_r(mac, macro_name + 5, temp_host->custom_variables, output);
-			}
+		}
 
 		/* a host macro with a hostgroup name and delimiter */
 		else {
@@ -1283,11 +1298,11 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 						continue;
 					strcat(*output, arg2);
 					strcat(*output, temp_buffer);
-					}
-				my_free(temp_buffer);
 				}
+				my_free(temp_buffer);
 			}
 		}
+	}
 
 	/***** CUSTOM SERVICE MACRO *****/
 	else if(strstr(macro_name, "_SERVICE") == macro_name) {
@@ -1300,7 +1315,7 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 
 			/* get the service macro value */
 			result = grab_custom_object_macro_r(mac, macro_name + 8, temp_service->custom_variables, output);
-			}
+		}
 
 		/* else and ondemand macro... */
 		else {
@@ -1312,7 +1327,7 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 
 				/* get the service macro value */
 				result = grab_custom_object_macro_r(mac, macro_name + 8, temp_service->custom_variables, output);
-				}
+			}
 
 			/* else we have a service macro with a servicegroup name and a delimiter... */
 			else {
@@ -1342,12 +1357,12 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 							continue;
 						strcat(*output, arg2);
 						strcat(*output, temp_buffer);
-						}
-					my_free(temp_buffer);
 					}
+					my_free(temp_buffer);
 				}
 			}
 		}
+	}
 
 	/***** CUSTOM CONTACT VARIABLE *****/
 	else if(strstr(macro_name, "_CONTACT") == macro_name) {
@@ -1359,7 +1374,7 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 			if(arg1) {
 				if((temp_contact = find_contact(arg1)) == NULL)
 					return ERROR;
-				}
+			}
 
 			/* else use saved contact pointer */
 			else if((temp_contact = mac->contact_ptr) == NULL)
@@ -1367,7 +1382,7 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 
 			/* get the contact macro value */
 			result = grab_custom_object_macro_r(mac, macro_name + 8, temp_contact->custom_variables, output);
-			}
+		}
 
 		/* a contact macro with a contactgroup name and delimiter */
 		else {
@@ -1397,25 +1412,27 @@ int grab_custom_macro_value_r(nagios_macros *mac, char *macro_name, char *arg1, 
 						continue;
 					strcat(*output, arg2);
 					strcat(*output, temp_buffer);
-					}
-				my_free(temp_buffer);
 				}
+				my_free(temp_buffer);
 			}
 		}
+	}
 
 	else
 		return ERROR;
 
 	return result;
-	}
+}
 
-int grab_custom_macro_value(char *macro_name, char *arg1, char *arg2, char **output) {
+int grab_custom_macro_value(char *macro_name, char *arg1, char *arg2, char **output)
+{
 	return grab_custom_macro_value_r(&global_macros, macro_name, arg1, arg2, output);
-	}
+}
 
 
 /* calculates a date/time macro */
-int grab_datetime_macro_r(nagios_macros *mac, int macro_type, char *arg1, char *arg2, char **output) {
+int grab_datetime_macro_r(nagios_macros *mac, int macro_type, char *arg1, char *arg2, char **output)
+{
 	time_t current_time = 0L;
 	timeperiod *temp_timeperiod = NULL;
 #ifdef NSCORE
@@ -1432,89 +1449,91 @@ int grab_datetime_macro_r(nagios_macros *mac, int macro_type, char *arg1, char *
 	/* parse args, do prep work */
 	switch(macro_type) {
 
-		case MACRO_ISVALIDTIME:
-		case MACRO_NEXTVALIDTIME:
+	case MACRO_ISVALIDTIME:
+	case MACRO_NEXTVALIDTIME:
 
-			/* find the timeperiod */
-			if((temp_timeperiod = find_timeperiod(arg1)) == NULL)
-				return ERROR;
+		/* find the timeperiod */
+		if((temp_timeperiod = find_timeperiod(arg1)) == NULL)
+			return ERROR;
 
-			/* what timestamp should we use? */
+		/* what timestamp should we use? */
 #ifdef NSCORE
-			if(arg2)
-				test_time = (time_t)strtoul(arg2, NULL, 0);
-			else
-				test_time = current_time;
+		if(arg2)
+			test_time = (time_t)strtoul(arg2, NULL, 0);
+		else
+			test_time = current_time;
 #endif
-			break;
+		break;
 
-		default:
-			break;
-		}
+	default:
+		break;
+	}
 
 	/* calculate the value */
 	switch(macro_type) {
 
-		case MACRO_LONGDATETIME:
-			if(*output == NULL)
-				*output = (char *)malloc(MAX_DATETIME_LENGTH);
-			if(*output)
-				get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, LONG_DATE_TIME);
-			break;
+	case MACRO_LONGDATETIME:
+		if(*output == NULL)
+			*output = (char *)malloc(MAX_DATETIME_LENGTH);
+		if(*output)
+			get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, LONG_DATE_TIME);
+		break;
 
-		case MACRO_SHORTDATETIME:
-			if(*output == NULL)
-				*output = (char *)malloc(MAX_DATETIME_LENGTH);
-			if(*output)
-				get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, SHORT_DATE_TIME);
-			break;
+	case MACRO_SHORTDATETIME:
+		if(*output == NULL)
+			*output = (char *)malloc(MAX_DATETIME_LENGTH);
+		if(*output)
+			get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, SHORT_DATE_TIME);
+		break;
 
-		case MACRO_DATE:
-			if(*output == NULL)
-				*output = (char *)malloc(MAX_DATETIME_LENGTH);
-			if(*output)
-				get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, SHORT_DATE);
-			break;
+	case MACRO_DATE:
+		if(*output == NULL)
+			*output = (char *)malloc(MAX_DATETIME_LENGTH);
+		if(*output)
+			get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, SHORT_DATE);
+		break;
 
-		case MACRO_TIME:
-			if(*output == NULL)
-				*output = (char *)malloc(MAX_DATETIME_LENGTH);
-			if(*output)
-				get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, SHORT_TIME);
-			break;
+	case MACRO_TIME:
+		if(*output == NULL)
+			*output = (char *)malloc(MAX_DATETIME_LENGTH);
+		if(*output)
+			get_datetime_string(&current_time, *output, MAX_DATETIME_LENGTH, SHORT_TIME);
+		break;
 
-		case MACRO_TIMET:
-			*output = (char *)mkstr("%lu", (unsigned long)current_time);
-			break;
+	case MACRO_TIMET:
+		*output = (char *)mkstr("%lu", (unsigned long)current_time);
+		break;
 
 #ifdef NSCORE
-		case MACRO_ISVALIDTIME:
-			*output = (char *)mkstr("%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
-			break;
+	case MACRO_ISVALIDTIME:
+		*output = (char *)mkstr("%d", (check_time_against_period(test_time, temp_timeperiod) == OK) ? 1 : 0);
+		break;
 
-		case MACRO_NEXTVALIDTIME:
-			get_next_valid_time(test_time, &next_valid_time, temp_timeperiod);
-			if(next_valid_time == test_time && check_time_against_period(test_time, temp_timeperiod) == ERROR)
-				next_valid_time = (time_t)0L;
-			*output = (char *)mkstr("%lu", (unsigned long)next_valid_time);
-			break;
+	case MACRO_NEXTVALIDTIME:
+		get_next_valid_time(test_time, &next_valid_time, temp_timeperiod);
+		if(next_valid_time == test_time && check_time_against_period(test_time, temp_timeperiod) == ERROR)
+			next_valid_time = (time_t)0L;
+		*output = (char *)mkstr("%lu", (unsigned long)next_valid_time);
+		break;
 #endif
 
-		default:
-			return ERROR;
-			break;
-		}
+	default:
+		return ERROR;
+		break;
+	}
 
 	return OK;
-	}
+}
 
-int grab_datetime_macro(int macro_type, char *arg1, char *arg2, char **output) {
+int grab_datetime_macro(int macro_type, char *arg1, char *arg2, char **output)
+{
 	return grab_datetime_macro_r(&global_macros, macro_type, arg1, arg2, output);
-	}
+}
 
 
 /* calculates a host macro */
-int grab_standard_host_macro_r(nagios_macros *mac, int macro_type, host *temp_host, char **output, int *free_macro) {
+int grab_standard_host_macro_r(nagios_macros *mac, int macro_type, host *temp_host, char **output, int *free_macro)
+{
 	char *temp_buffer = NULL;
 #ifdef NSCORE
 	hostgroup *temp_hostgroup = NULL;
@@ -1542,260 +1561,262 @@ int grab_standard_host_macro_r(nagios_macros *mac, int macro_type, host *temp_ho
 	/* get the macro */
 	switch(macro_type) {
 
-		case MACRO_HOSTNAME:
-			*output = temp_host->name;
-			break;
-		case MACRO_HOSTDISPLAYNAME:
-			if(temp_host->display_name)
-				*output = temp_host->display_name;
-			break;
-		case MACRO_HOSTALIAS:
-			*output = temp_host->alias;
-			break;
-		case MACRO_HOSTADDRESS:
-			*output = temp_host->address;
-			break;
+	case MACRO_HOSTNAME:
+		*output = temp_host->name;
+		break;
+	case MACRO_HOSTDISPLAYNAME:
+		if(temp_host->display_name)
+			*output = temp_host->display_name;
+		break;
+	case MACRO_HOSTALIAS:
+		*output = temp_host->alias;
+		break;
+	case MACRO_HOSTADDRESS:
+		*output = temp_host->address;
+		break;
 #ifdef NSCORE
-		case MACRO_HOSTSTATE:
-			*output = (char *)host_state_name(temp_host->current_state);
-			break;
-		case MACRO_HOSTSTATEID:
-			*output = (char *)mkstr("%d", temp_host->current_state);
-			break;
-		case MACRO_LASTHOSTSTATE:
-			*output = (char *)host_state_name(temp_host->last_state);
-			break;
-		case MACRO_LASTHOSTSTATEID:
-			*output = (char *)mkstr("%d", temp_host->last_state);
-			break;
-		case MACRO_HOSTCHECKTYPE:
-			*output = (char *)check_type_name(temp_host->check_type);
-			break;
-		case MACRO_HOSTSTATETYPE:
-			*output = (char *)state_type_name(temp_host->state_type);
-			break;
-		case MACRO_HOSTOUTPUT:
-			if(temp_host->plugin_output)
-				*output = temp_host->plugin_output;
-			break;
-		case MACRO_LONGHOSTOUTPUT:
-			if(temp_host->long_plugin_output)
-				*output = temp_host->long_plugin_output;
-			break;
-		case MACRO_HOSTPERFDATA:
-			if(temp_host->perf_data)
-				*output = temp_host->perf_data;
-			break;
+	case MACRO_HOSTSTATE:
+		*output = (char *)host_state_name(temp_host->current_state);
+		break;
+	case MACRO_HOSTSTATEID:
+		*output = (char *)mkstr("%d", temp_host->current_state);
+		break;
+	case MACRO_LASTHOSTSTATE:
+		*output = (char *)host_state_name(temp_host->last_state);
+		break;
+	case MACRO_LASTHOSTSTATEID:
+		*output = (char *)mkstr("%d", temp_host->last_state);
+		break;
+	case MACRO_HOSTCHECKTYPE:
+		*output = (char *)check_type_name(temp_host->check_type);
+		break;
+	case MACRO_HOSTSTATETYPE:
+		*output = (char *)state_type_name(temp_host->state_type);
+		break;
+	case MACRO_HOSTOUTPUT:
+		if(temp_host->plugin_output)
+			*output = temp_host->plugin_output;
+		break;
+	case MACRO_LONGHOSTOUTPUT:
+		if(temp_host->long_plugin_output)
+			*output = temp_host->long_plugin_output;
+		break;
+	case MACRO_HOSTPERFDATA:
+		if(temp_host->perf_data)
+			*output = temp_host->perf_data;
+		break;
 #endif
-		case MACRO_HOSTCHECKCOMMAND:
-			if(temp_host->check_command)
-				*output = temp_host->check_command;
-			break;
+	case MACRO_HOSTCHECKCOMMAND:
+		if(temp_host->check_command)
+			*output = temp_host->check_command;
+		break;
 #ifdef NSCORE
-		case MACRO_HOSTATTEMPT:
-			*output = (char *)mkstr("%d", temp_host->current_attempt);
-			break;
-		case MACRO_MAXHOSTATTEMPTS:
-			*output = (char *)mkstr("%d", temp_host->max_attempts);
-			break;
-		case MACRO_HOSTDOWNTIME:
-			*output = (char *)mkstr("%d", temp_host->scheduled_downtime_depth);
-			break;
-		case MACRO_HOSTPERCENTCHANGE:
-			*output = (char *)mkstr("%.2f", temp_host->percent_state_change);
-			break;
-		case MACRO_HOSTDURATIONSEC:
-		case MACRO_HOSTDURATION:
-			time(&current_time);
-			duration = (unsigned long)(current_time - temp_host->last_state_change);
+	case MACRO_HOSTATTEMPT:
+		*output = (char *)mkstr("%d", temp_host->current_attempt);
+		break;
+	case MACRO_MAXHOSTATTEMPTS:
+		*output = (char *)mkstr("%d", temp_host->max_attempts);
+		break;
+	case MACRO_HOSTDOWNTIME:
+		*output = (char *)mkstr("%d", temp_host->scheduled_downtime_depth);
+		break;
+	case MACRO_HOSTPERCENTCHANGE:
+		*output = (char *)mkstr("%.2f", temp_host->percent_state_change);
+		break;
+	case MACRO_HOSTDURATIONSEC:
+	case MACRO_HOSTDURATION:
+		time(&current_time);
+		duration = (unsigned long)(current_time - temp_host->last_state_change);
 
-			if(macro_type == MACRO_HOSTDURATIONSEC)
-				*output = (char *)mkstr("%lu", duration);
-			else {
+		if(macro_type == MACRO_HOSTDURATIONSEC)
+			*output = (char *)mkstr("%lu", duration);
+		else {
 
-				days = duration / 86400;
-				duration -= (days * 86400);
-				hours = duration / 3600;
-				duration -= (hours * 3600);
-				minutes = duration / 60;
-				duration -= (minutes * 60);
-				seconds = duration;
-				*output = (char *)mkstr("%dd %dh %dm %ds", days, hours, minutes, seconds);
-				}
-			break;
-		case MACRO_HOSTEXECUTIONTIME:
-			*output = (char *)mkstr("%.3f", temp_host->execution_time);
-			break;
-		case MACRO_HOSTLATENCY:
-			*output = (char *)mkstr("%.3f", temp_host->latency);
-			break;
-		case MACRO_LASTHOSTCHECK:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_check);
-			break;
-		case MACRO_LASTHOSTSTATECHANGE:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_state_change);
-			break;
-		case MACRO_LASTHOSTUP:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_time_up);
-			break;
-		case MACRO_LASTHOSTDOWN:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_time_down);
-			break;
-		case MACRO_LASTHOSTUNREACHABLE:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_time_unreachable);
-			break;
-		case MACRO_HOSTNOTIFICATIONNUMBER:
-			*output = (char *)mkstr("%d", temp_host->current_notification_number);
-			break;
-		case MACRO_HOSTNOTIFICATIONID:
-			*output = (char *)mkstr("%lu", temp_host->current_notification_id);
-			break;
-		case MACRO_HOSTEVENTID:
-			*output = (char *)mkstr("%lu", temp_host->current_event_id);
-			break;
-		case MACRO_LASTHOSTEVENTID:
-			*output = (char *)mkstr("%lu", temp_host->last_event_id);
-			break;
-		case MACRO_HOSTPROBLEMID:
-			*output = (char *)mkstr("%lu", temp_host->current_problem_id);
-			break;
-		case MACRO_LASTHOSTPROBLEMID:
-			*output = (char *)mkstr("%lu", temp_host->last_problem_id);
-			break;
+			days = duration / 86400;
+			duration -= (days * 86400);
+			hours = duration / 3600;
+			duration -= (hours * 3600);
+			minutes = duration / 60;
+			duration -= (minutes * 60);
+			seconds = duration;
+			*output = (char *)mkstr("%dd %dh %dm %ds", days, hours, minutes, seconds);
+		}
+		break;
+	case MACRO_HOSTEXECUTIONTIME:
+		*output = (char *)mkstr("%.3f", temp_host->execution_time);
+		break;
+	case MACRO_HOSTLATENCY:
+		*output = (char *)mkstr("%.3f", temp_host->latency);
+		break;
+	case MACRO_LASTHOSTCHECK:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_check);
+		break;
+	case MACRO_LASTHOSTSTATECHANGE:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_state_change);
+		break;
+	case MACRO_LASTHOSTUP:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_time_up);
+		break;
+	case MACRO_LASTHOSTDOWN:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_time_down);
+		break;
+	case MACRO_LASTHOSTUNREACHABLE:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_host->last_time_unreachable);
+		break;
+	case MACRO_HOSTNOTIFICATIONNUMBER:
+		*output = (char *)mkstr("%d", temp_host->current_notification_number);
+		break;
+	case MACRO_HOSTNOTIFICATIONID:
+		*output = (char *)mkstr("%lu", temp_host->current_notification_id);
+		break;
+	case MACRO_HOSTEVENTID:
+		*output = (char *)mkstr("%lu", temp_host->current_event_id);
+		break;
+	case MACRO_LASTHOSTEVENTID:
+		*output = (char *)mkstr("%lu", temp_host->last_event_id);
+		break;
+	case MACRO_HOSTPROBLEMID:
+		*output = (char *)mkstr("%lu", temp_host->current_problem_id);
+		break;
+	case MACRO_LASTHOSTPROBLEMID:
+		*output = (char *)mkstr("%lu", temp_host->last_problem_id);
+		break;
 #endif
-		case MACRO_HOSTACTIONURL:
-			if(temp_host->action_url)
-				*output = temp_host->action_url;
-			break;
-		case MACRO_HOSTNOTESURL:
-			if(temp_host->notes_url)
-				*output = temp_host->notes_url;
-			break;
-		case MACRO_HOSTNOTES:
-			if(temp_host->notes)
-				*output = temp_host->notes;
-			break;
+	case MACRO_HOSTACTIONURL:
+		if(temp_host->action_url)
+			*output = temp_host->action_url;
+		break;
+	case MACRO_HOSTNOTESURL:
+		if(temp_host->notes_url)
+			*output = temp_host->notes_url;
+		break;
+	case MACRO_HOSTNOTES:
+		if(temp_host->notes)
+			*output = temp_host->notes;
+		break;
 #ifdef NSCORE
-		case MACRO_HOSTGROUPNAMES:
-			/* find all hostgroups this host is associated with */
-			for(temp_objectlist = temp_host->hostgroups_ptr; temp_objectlist != NULL; temp_objectlist = temp_objectlist->next) {
+	case MACRO_HOSTGROUPNAMES:
+		/* find all hostgroups this host is associated with */
+		for(temp_objectlist = temp_host->hostgroups_ptr; temp_objectlist != NULL; temp_objectlist = temp_objectlist->next) {
 
-				if((temp_hostgroup = (hostgroup *)temp_objectlist->object_ptr) == NULL)
+			if((temp_hostgroup = (hostgroup *)temp_objectlist->object_ptr) == NULL)
+				continue;
+
+			asprintf(&buf1, "%s%s%s", (buf2) ? buf2 : "", (buf2) ? "," : "", temp_hostgroup->group_name);
+			my_free(buf2);
+			buf2 = buf1;
+		}
+		if(buf2) {
+			*output = (char *)strdup(buf2);
+			my_free(buf2);
+		}
+		break;
+	case MACRO_TOTALHOSTSERVICES:
+	case MACRO_TOTALHOSTSERVICESOK:
+	case MACRO_TOTALHOSTSERVICESWARNING:
+	case MACRO_TOTALHOSTSERVICESUNKNOWN:
+	case MACRO_TOTALHOSTSERVICESCRITICAL:
+
+		/* generate host service summary macros (if they haven't already been computed) */
+		if(mac->x[MACRO_TOTALHOSTSERVICES] == NULL) {
+
+			for(temp_servicesmember = temp_host->services; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
+				if((temp_service = temp_servicesmember->service_ptr) == NULL)
 					continue;
 
-				asprintf(&buf1, "%s%s%s", (buf2) ? buf2 : "", (buf2) ? "," : "", temp_hostgroup->group_name);
-				my_free(buf2);
-				buf2 = buf1;
+				total_host_services++;
+
+				switch(temp_service->current_state) {
+				case STATE_OK:
+					total_host_services_ok++;
+					break;
+				case STATE_WARNING:
+					total_host_services_warning++;
+					break;
+				case STATE_UNKNOWN:
+					total_host_services_unknown++;
+					break;
+				case STATE_CRITICAL:
+					total_host_services_critical++;
+					break;
+				default:
+					break;
 				}
-			if(buf2) {
-				*output = (char *)strdup(buf2);
-				my_free(buf2);
-				}
-			break;
-		case MACRO_TOTALHOSTSERVICES:
-		case MACRO_TOTALHOSTSERVICESOK:
-		case MACRO_TOTALHOSTSERVICESWARNING:
-		case MACRO_TOTALHOSTSERVICESUNKNOWN:
-		case MACRO_TOTALHOSTSERVICESCRITICAL:
+			}
 
-			/* generate host service summary macros (if they haven't already been computed) */
-			if(mac->x[MACRO_TOTALHOSTSERVICES] == NULL) {
+			/* these macros are time-intensive to compute, and will likely be used together, so save them all for future use */
+			mac->x[MACRO_TOTALHOSTSERVICES] =
+			    (char *)mkstr("%d", total_host_services);
+			mac->x[MACRO_TOTALHOSTSERVICESOK] =
+			    (char *)mkstr("%d", total_host_services_ok);
+			mac->x[MACRO_TOTALHOSTSERVICESWARNING] =
+			    (char *)mkstr("%d", total_host_services_warning);
+			mac->x[MACRO_TOTALHOSTSERVICESUNKNOWN] =
+			    (char *)mkstr("%d", total_host_services_unknown);
+			mac->x[MACRO_TOTALHOSTSERVICESCRITICAL] =
+			    (char *)mkstr("%d", total_host_services_critical);
+		}
 
-				for(temp_servicesmember = temp_host->services; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
-					if((temp_service = temp_servicesmember->service_ptr) == NULL)
-						continue;
-
-					total_host_services++;
-
-					switch(temp_service->current_state) {
-						case STATE_OK:
-							total_host_services_ok++;
-							break;
-						case STATE_WARNING:
-							total_host_services_warning++;
-							break;
-						case STATE_UNKNOWN:
-							total_host_services_unknown++;
-							break;
-						case STATE_CRITICAL:
-							total_host_services_critical++;
-							break;
-						default:
-							break;
-						}
-					}
-
-				/* these macros are time-intensive to compute, and will likely be used together, so save them all for future use */
-				mac->x[MACRO_TOTALHOSTSERVICES] = 
-						(char *)mkstr("%d", total_host_services);
-				mac->x[MACRO_TOTALHOSTSERVICESOK] = 
-						(char *)mkstr("%d", total_host_services_ok);
-				mac->x[MACRO_TOTALHOSTSERVICESWARNING] = 
-						(char *)mkstr("%d", total_host_services_warning);
-				mac->x[MACRO_TOTALHOSTSERVICESUNKNOWN] = 
-						(char *)mkstr("%d", total_host_services_unknown);
-				mac->x[MACRO_TOTALHOSTSERVICESCRITICAL] = 
-						(char *)mkstr("%d", total_host_services_critical);
-				}
-
-			/* return only the macro the user requested */
-			*output = mac->x[macro_type];
-			break;
-		case MACRO_HOSTIMPORTANCE:
-			*output = (char *)mkstr("%u", temp_host->hourly_value);
-			break;
-		case MACRO_HOSTANDSERVICESIMPORTANCE:
-			*output = (char *)mkstr("%u", temp_host->hourly_value +
-					host_services_value(temp_host));
-			break;
+		/* return only the macro the user requested */
+		*output = mac->x[macro_type];
+		break;
+	case MACRO_HOSTIMPORTANCE:
+		*output = (char *)mkstr("%u", temp_host->hourly_value);
+		break;
+	case MACRO_HOSTANDSERVICESIMPORTANCE:
+		*output = (char *)mkstr("%u", temp_host->hourly_value +
+		                        host_services_value(temp_host));
+		break;
 #endif
 
-			/***************/
-			/* MISC MACROS */
-			/***************/
-		case MACRO_HOSTACKAUTHOR:
-		case MACRO_HOSTACKAUTHORNAME:
-		case MACRO_HOSTACKAUTHORALIAS:
-		case MACRO_HOSTACKCOMMENT:
-			/* no need to do any more work - these are already precomputed elsewhere */
-			/* NOTE: these macros won't work as on-demand macros */
-			*output = mac->x[macro_type];
-			break;
+	/***************/
+	/* MISC MACROS */
+	/***************/
+	case MACRO_HOSTACKAUTHOR:
+	case MACRO_HOSTACKAUTHORNAME:
+	case MACRO_HOSTACKAUTHORALIAS:
+	case MACRO_HOSTACKCOMMENT:
+		/* no need to do any more work - these are already precomputed elsewhere */
+		/* NOTE: these macros won't work as on-demand macros */
+		*output = mac->x[macro_type];
+		break;
 
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED HOST MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
-			break;
-		}
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED HOST MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+		break;
+	}
 
 	/* post-processing */
 	/* notes, notes URL and action URL macros may themselves contain macros, so process them... */
 	switch(macro_type) {
-		case MACRO_HOSTACTIONURL:
-		case MACRO_HOSTNOTESURL:
-			*free_macro = TRUE;
-			process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
-			*output = temp_buffer;
-			break;
-		case MACRO_HOSTNOTES:
-			*free_macro = TRUE;
-			process_macros_r(mac, *output, &temp_buffer, 0);
-			*output = temp_buffer;
-			break;
-		default:
-			break;
-		}
+	case MACRO_HOSTACTIONURL:
+	case MACRO_HOSTNOTESURL:
+		*free_macro = TRUE;
+		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
+		*output = temp_buffer;
+		break;
+	case MACRO_HOSTNOTES:
+		*free_macro = TRUE;
+		process_macros_r(mac, *output, &temp_buffer, 0);
+		*output = temp_buffer;
+		break;
+	default:
+		break;
+	}
 
 	return OK;
-	}
+}
 
-int grab_standard_host_macro(int macro_type, host *temp_host, char **output, int *free_macro) {
+int grab_standard_host_macro(int macro_type, host *temp_host, char **output, int *free_macro)
+{
 	return grab_standard_host_macro_r(&global_macros, macro_type, temp_host, output, free_macro);
-	}
+}
 
 
 /* computes a hostgroup macro */
-int grab_standard_hostgroup_macro_r(nagios_macros *mac, int macro_type, hostgroup *temp_hostgroup, char **output) {
+int grab_standard_hostgroup_macro_r(nagios_macros *mac, int macro_type, hostgroup *temp_hostgroup, char **output)
+{
 	hostsmember *temp_hostsmember = NULL;
 	char *temp_buffer = NULL;
 	unsigned int	temp_len = 0;
@@ -1806,97 +1827,96 @@ int grab_standard_hostgroup_macro_r(nagios_macros *mac, int macro_type, hostgrou
 
 	/* get the macro value */
 	switch(macro_type) {
-		case MACRO_HOSTGROUPNAME:
-			*output = temp_hostgroup->group_name;
-			break;
-		case MACRO_HOSTGROUPALIAS:
-			if(temp_hostgroup->alias)
-				*output = temp_hostgroup->alias;
-			break;
-		case MACRO_HOSTGROUPMEMBERS:
-			/* make the calculations for total string length */
-			for(temp_hostsmember = temp_hostgroup->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
-				if(temp_hostsmember->host_name == NULL)
-					continue;
-				if(temp_len == 0) {
-					temp_len += strlen(temp_hostsmember->host_name) + 1;
-					}
-				else {
-					temp_len += strlen(temp_hostsmember->host_name) + 2;
-					}
-				}
-			if(!temp_len) {
-				/* empty group, so return the nul string */
-				*output = calloc(1, 1);
-				return OK;
-				}
-
-			/* allocate or reallocate the memory buffer */
-			if(*output == NULL) {
-				*output = (char *)malloc(temp_len);
-				}
-			else {
-				init_len = strlen(*output);
-				temp_len += init_len;
-				*output = (char *)realloc(*output, temp_len);
-				}
-			/* now fill in the string with the member names */
-			for(temp_hostsmember = temp_hostgroup->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
-				if(temp_hostsmember->host_name == NULL)
-					continue;
-				temp_buffer = *output + init_len;
-				if(init_len == 0) {  /* If our buffer didn't contain anything, we just need to write "%s,%s" */
-					init_len += sprintf(temp_buffer, "%s", temp_hostsmember->host_name);
-					}
-				else {
-					init_len += sprintf(temp_buffer, ",%s", temp_hostsmember->host_name);
-					}
-				}
-			break;
-		case MACRO_HOSTGROUPACTIONURL:
-			if(temp_hostgroup->action_url)
-				*output = temp_hostgroup->action_url;
-			break;
-		case MACRO_HOSTGROUPNOTESURL:
-			if(temp_hostgroup->notes_url)
-				*output = temp_hostgroup->notes_url;
-			break;
-		case MACRO_HOSTGROUPNOTES:
-			if(temp_hostgroup->notes)
-				*output = temp_hostgroup->notes;
-			break;
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED HOSTGROUP MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
-			break;
+	case MACRO_HOSTGROUPNAME:
+		*output = temp_hostgroup->group_name;
+		break;
+	case MACRO_HOSTGROUPALIAS:
+		if(temp_hostgroup->alias)
+			*output = temp_hostgroup->alias;
+		break;
+	case MACRO_HOSTGROUPMEMBERS:
+		/* make the calculations for total string length */
+		for(temp_hostsmember = temp_hostgroup->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
+			if(temp_hostsmember->host_name == NULL)
+				continue;
+			if(temp_len == 0) {
+				temp_len += strlen(temp_hostsmember->host_name) + 1;
+			} else {
+				temp_len += strlen(temp_hostsmember->host_name) + 2;
+			}
 		}
+		if(!temp_len) {
+			/* empty group, so return the nul string */
+			*output = calloc(1, 1);
+			return OK;
+		}
+
+		/* allocate or reallocate the memory buffer */
+		if(*output == NULL) {
+			*output = (char *)malloc(temp_len);
+		} else {
+			init_len = strlen(*output);
+			temp_len += init_len;
+			*output = (char *)realloc(*output, temp_len);
+		}
+		/* now fill in the string with the member names */
+		for(temp_hostsmember = temp_hostgroup->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
+			if(temp_hostsmember->host_name == NULL)
+				continue;
+			temp_buffer = *output + init_len;
+			if(init_len == 0) {  /* If our buffer didn't contain anything, we just need to write "%s,%s" */
+				init_len += sprintf(temp_buffer, "%s", temp_hostsmember->host_name);
+			} else {
+				init_len += sprintf(temp_buffer, ",%s", temp_hostsmember->host_name);
+			}
+		}
+		break;
+	case MACRO_HOSTGROUPACTIONURL:
+		if(temp_hostgroup->action_url)
+			*output = temp_hostgroup->action_url;
+		break;
+	case MACRO_HOSTGROUPNOTESURL:
+		if(temp_hostgroup->notes_url)
+			*output = temp_hostgroup->notes_url;
+		break;
+	case MACRO_HOSTGROUPNOTES:
+		if(temp_hostgroup->notes)
+			*output = temp_hostgroup->notes;
+		break;
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED HOSTGROUP MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+		break;
+	}
 
 	/* post-processing */
 	/* notes, notes URL and action URL macros may themselves contain macros, so process them... */
 	switch(macro_type) {
-		case MACRO_HOSTGROUPACTIONURL:
-		case MACRO_HOSTGROUPNOTESURL:
-			process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
-			*output = temp_buffer;
-			break;
-		case MACRO_HOSTGROUPNOTES:
-			process_macros_r(mac, *output, &temp_buffer, 0);
-			*output = temp_buffer;
-			break;
-		default:
-			break;
-		}
+	case MACRO_HOSTGROUPACTIONURL:
+	case MACRO_HOSTGROUPNOTESURL:
+		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
+		*output = temp_buffer;
+		break;
+	case MACRO_HOSTGROUPNOTES:
+		process_macros_r(mac, *output, &temp_buffer, 0);
+		*output = temp_buffer;
+		break;
+	default:
+		break;
+	}
 
 	return OK;
-	}
+}
 
-int grab_standard_hostgroup_macro(int macro_type, hostgroup *temp_hostgroup, char **output) {
+int grab_standard_hostgroup_macro(int macro_type, hostgroup *temp_hostgroup, char **output)
+{
 	return grab_standard_hostgroup_macro_r(&global_macros, macro_type, temp_hostgroup, output);
-	}
+}
 
 
 /* computes a service macro */
-int grab_standard_service_macro_r(nagios_macros *mac, int macro_type, service *temp_service, char **output, int *free_macro) {
+int grab_standard_service_macro_r(nagios_macros *mac, int macro_type, service *temp_service, char **output, int *free_macro)
+{
 	char *temp_buffer = NULL;
 #ifdef NSCORE
 	servicegroup *temp_servicegroup = NULL;
@@ -1916,212 +1936,214 @@ int grab_standard_service_macro_r(nagios_macros *mac, int macro_type, service *t
 
 	/* get the macro value */
 	switch(macro_type) {
-		case MACRO_SERVICEDESC:
-			*output = temp_service->description;
-			break;
-		case MACRO_SERVICEDISPLAYNAME:
-			if(temp_service->display_name)
-				*output = temp_service->display_name;
-			break;
+	case MACRO_SERVICEDESC:
+		*output = temp_service->description;
+		break;
+	case MACRO_SERVICEDISPLAYNAME:
+		if(temp_service->display_name)
+			*output = temp_service->display_name;
+		break;
 #ifdef NSCORE
-		case MACRO_SERVICEOUTPUT:
-			if(temp_service->plugin_output)
-				*output = temp_service->plugin_output;
-			break;
-		case MACRO_LONGSERVICEOUTPUT:
-			if(temp_service->long_plugin_output)
-				*output = temp_service->long_plugin_output;
-			break;
-		case MACRO_SERVICEPERFDATA:
-			if(temp_service->perf_data)
-				*output = temp_service->perf_data;
-			break;
+	case MACRO_SERVICEOUTPUT:
+		if(temp_service->plugin_output)
+			*output = temp_service->plugin_output;
+		break;
+	case MACRO_LONGSERVICEOUTPUT:
+		if(temp_service->long_plugin_output)
+			*output = temp_service->long_plugin_output;
+		break;
+	case MACRO_SERVICEPERFDATA:
+		if(temp_service->perf_data)
+			*output = temp_service->perf_data;
+		break;
 #endif
-		case MACRO_SERVICECHECKCOMMAND:
-			if(temp_service->check_command)
-				*output = temp_service->check_command;
-			break;
+	case MACRO_SERVICECHECKCOMMAND:
+		if(temp_service->check_command)
+			*output = temp_service->check_command;
+		break;
 #ifdef NSCORE
-		case MACRO_SERVICECHECKTYPE:
-			*output = (char *)check_type_name(temp_service->check_type);
-			break;
-		case MACRO_SERVICESTATETYPE:
-			*output = (char *)state_type_name(temp_service->state_type);
-			break;
-		case MACRO_SERVICESTATE:
-			*output = (char *)service_state_name(temp_service->current_state);
-			break;
-		case MACRO_SERVICESTATEID:
-			*output = (char *)mkstr("%d", temp_service->current_state);
-			break;
-		case MACRO_LASTSERVICESTATE:
-			*output = (char *)service_state_name(temp_service->last_state);
-			break;
-		case MACRO_LASTSERVICESTATEID:
-			*output = (char *)mkstr("%d", temp_service->last_state);
-			break;
+	case MACRO_SERVICECHECKTYPE:
+		*output = (char *)check_type_name(temp_service->check_type);
+		break;
+	case MACRO_SERVICESTATETYPE:
+		*output = (char *)state_type_name(temp_service->state_type);
+		break;
+	case MACRO_SERVICESTATE:
+		*output = (char *)service_state_name(temp_service->current_state);
+		break;
+	case MACRO_SERVICESTATEID:
+		*output = (char *)mkstr("%d", temp_service->current_state);
+		break;
+	case MACRO_LASTSERVICESTATE:
+		*output = (char *)service_state_name(temp_service->last_state);
+		break;
+	case MACRO_LASTSERVICESTATEID:
+		*output = (char *)mkstr("%d", temp_service->last_state);
+		break;
 #endif
-		case MACRO_SERVICEISVOLATILE:
-			*output = (char *)mkstr("%d", temp_service->is_volatile);
-			break;
+	case MACRO_SERVICEISVOLATILE:
+		*output = (char *)mkstr("%d", temp_service->is_volatile);
+		break;
 #ifdef NSCORE
-		case MACRO_SERVICEATTEMPT:
-			*output = (char *)mkstr("%d", temp_service->current_attempt);
-			break;
-		case MACRO_MAXSERVICEATTEMPTS:
-			*output = (char *)mkstr("%d", temp_service->max_attempts);
-			break;
-		case MACRO_SERVICEEXECUTIONTIME:
-			*output = (char *)mkstr("%.3f", temp_service->execution_time);
-			break;
-		case MACRO_SERVICELATENCY:
-			*output = (char *)mkstr("%.3f", temp_service->latency);
-			break;
-		case MACRO_LASTSERVICECHECK:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_check);
-			break;
-		case MACRO_LASTSERVICESTATECHANGE:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_state_change);
-			break;
-		case MACRO_LASTSERVICEOK:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_ok);
-			break;
-		case MACRO_LASTSERVICEWARNING:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_warning);
-			break;
-		case MACRO_LASTSERVICEUNKNOWN:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_unknown);
-			break;
-		case MACRO_LASTSERVICECRITICAL:
-			*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_critical);
-			break;
-		case MACRO_SERVICEDOWNTIME:
-			*output = (char *)mkstr("%d", temp_service->scheduled_downtime_depth);
-			break;
-		case MACRO_SERVICEPERCENTCHANGE:
-			*output = (char *)mkstr("%.2f", temp_service->percent_state_change);
-			break;
-		case MACRO_SERVICEDURATIONSEC:
-		case MACRO_SERVICEDURATION:
+	case MACRO_SERVICEATTEMPT:
+		*output = (char *)mkstr("%d", temp_service->current_attempt);
+		break;
+	case MACRO_MAXSERVICEATTEMPTS:
+		*output = (char *)mkstr("%d", temp_service->max_attempts);
+		break;
+	case MACRO_SERVICEEXECUTIONTIME:
+		*output = (char *)mkstr("%.3f", temp_service->execution_time);
+		break;
+	case MACRO_SERVICELATENCY:
+		*output = (char *)mkstr("%.3f", temp_service->latency);
+		break;
+	case MACRO_LASTSERVICECHECK:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_check);
+		break;
+	case MACRO_LASTSERVICESTATECHANGE:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_state_change);
+		break;
+	case MACRO_LASTSERVICEOK:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_ok);
+		break;
+	case MACRO_LASTSERVICEWARNING:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_warning);
+		break;
+	case MACRO_LASTSERVICEUNKNOWN:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_unknown);
+		break;
+	case MACRO_LASTSERVICECRITICAL:
+		*output = (char *)mkstr("%lu", (unsigned long)temp_service->last_time_critical);
+		break;
+	case MACRO_SERVICEDOWNTIME:
+		*output = (char *)mkstr("%d", temp_service->scheduled_downtime_depth);
+		break;
+	case MACRO_SERVICEPERCENTCHANGE:
+		*output = (char *)mkstr("%.2f", temp_service->percent_state_change);
+		break;
+	case MACRO_SERVICEDURATIONSEC:
+	case MACRO_SERVICEDURATION:
 
-			time(&current_time);
-			duration = (unsigned long)(current_time - temp_service->last_state_change);
+		time(&current_time);
+		duration = (unsigned long)(current_time - temp_service->last_state_change);
 
-			/* get the state duration in seconds */
-			if(macro_type == MACRO_SERVICEDURATIONSEC)
-				*output = (char *)mkstr("%lu", duration);
+		/* get the state duration in seconds */
+		if(macro_type == MACRO_SERVICEDURATIONSEC)
+			*output = (char *)mkstr("%lu", duration);
 
-			/* get the state duration */
-			else {
-				days = duration / 86400;
-				duration -= (days * 86400);
-				hours = duration / 3600;
-				duration -= (hours * 3600);
-				minutes = duration / 60;
-				duration -= (minutes * 60);
-				seconds = duration;
-				*output = (char *)mkstr("%dd %dh %dm %ds", days, hours, minutes, seconds);
-				}
-			break;
-		case MACRO_SERVICENOTIFICATIONNUMBER:
-			*output = (char *)mkstr("%d", temp_service->current_notification_number);
-			break;
-		case MACRO_SERVICENOTIFICATIONID:
-			*output = (char *)mkstr("%lu", temp_service->current_notification_id);
-			break;
-		case MACRO_SERVICEEVENTID:
-			*output = (char *)mkstr("%lu", temp_service->current_event_id);
-			break;
-		case MACRO_LASTSERVICEEVENTID:
-			*output = (char *)mkstr("%lu", temp_service->last_event_id);
-			break;
-		case MACRO_SERVICEPROBLEMID:
-			*output = (char *)mkstr("%lu", temp_service->current_problem_id);
-			break;
-		case MACRO_LASTSERVICEPROBLEMID:
-			*output = (char *)mkstr("%lu", temp_service->last_problem_id);
-			break;
-#endif
-		case MACRO_SERVICEACTIONURL:
-			if(temp_service->action_url)
-				*output = temp_service->action_url;
-			break;
-		case MACRO_SERVICENOTESURL:
-			if(temp_service->notes_url)
-				*output = temp_service->notes_url;
-			break;
-		case MACRO_SERVICENOTES:
-			if(temp_service->notes)
-				*output = temp_service->notes;
-			break;
-
-#ifdef NSCORE
-		case MACRO_SERVICEGROUPNAMES:
-			/* find all servicegroups this service is associated with */
-			for(temp_objectlist = temp_service->servicegroups_ptr; temp_objectlist != NULL; temp_objectlist = temp_objectlist->next) {
-
-				if((temp_servicegroup = (servicegroup *)temp_objectlist->object_ptr) == NULL)
-					continue;
-
-				asprintf(&buf1, "%s%s%s", (buf2) ? buf2 : "", (buf2) ? "," : "", temp_servicegroup->group_name);
-				my_free(buf2);
-				buf2 = buf1;
-				}
-			if(buf2) {
-				*output = (char *)strdup(buf2);
-				my_free(buf2);
-				}
-			break;
-		case MACRO_SERVICEIMPORTANCE:
-			*output = (char *)mkstr("%u", temp_service->hourly_value);
-			break;
-#endif
-
-			/***************/
-			/* MISC MACROS */
-			/***************/
-		case MACRO_SERVICEACKAUTHOR:
-		case MACRO_SERVICEACKAUTHORNAME:
-		case MACRO_SERVICEACKAUTHORALIAS:
-		case MACRO_SERVICEACKCOMMENT:
-			/* no need to do any more work - these are already precomputed elsewhere */
-			/* NOTE: these macros won't work as on-demand macros */
-			*output = mac->x[macro_type];
-			*free_macro = FALSE;
-			break;
-
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED SERVICE MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
-			break;
+		/* get the state duration */
+		else {
+			days = duration / 86400;
+			duration -= (days * 86400);
+			hours = duration / 3600;
+			duration -= (hours * 3600);
+			minutes = duration / 60;
+			duration -= (minutes * 60);
+			seconds = duration;
+			*output = (char *)mkstr("%dd %dh %dm %ds", days, hours, minutes, seconds);
 		}
+		break;
+	case MACRO_SERVICENOTIFICATIONNUMBER:
+		*output = (char *)mkstr("%d", temp_service->current_notification_number);
+		break;
+	case MACRO_SERVICENOTIFICATIONID:
+		*output = (char *)mkstr("%lu", temp_service->current_notification_id);
+		break;
+	case MACRO_SERVICEEVENTID:
+		*output = (char *)mkstr("%lu", temp_service->current_event_id);
+		break;
+	case MACRO_LASTSERVICEEVENTID:
+		*output = (char *)mkstr("%lu", temp_service->last_event_id);
+		break;
+	case MACRO_SERVICEPROBLEMID:
+		*output = (char *)mkstr("%lu", temp_service->current_problem_id);
+		break;
+	case MACRO_LASTSERVICEPROBLEMID:
+		*output = (char *)mkstr("%lu", temp_service->last_problem_id);
+		break;
+#endif
+	case MACRO_SERVICEACTIONURL:
+		if(temp_service->action_url)
+			*output = temp_service->action_url;
+		break;
+	case MACRO_SERVICENOTESURL:
+		if(temp_service->notes_url)
+			*output = temp_service->notes_url;
+		break;
+	case MACRO_SERVICENOTES:
+		if(temp_service->notes)
+			*output = temp_service->notes;
+		break;
+
+#ifdef NSCORE
+	case MACRO_SERVICEGROUPNAMES:
+		/* find all servicegroups this service is associated with */
+		for(temp_objectlist = temp_service->servicegroups_ptr; temp_objectlist != NULL; temp_objectlist = temp_objectlist->next) {
+
+			if((temp_servicegroup = (servicegroup *)temp_objectlist->object_ptr) == NULL)
+				continue;
+
+			asprintf(&buf1, "%s%s%s", (buf2) ? buf2 : "", (buf2) ? "," : "", temp_servicegroup->group_name);
+			my_free(buf2);
+			buf2 = buf1;
+		}
+		if(buf2) {
+			*output = (char *)strdup(buf2);
+			my_free(buf2);
+		}
+		break;
+	case MACRO_SERVICEIMPORTANCE:
+		*output = (char *)mkstr("%u", temp_service->hourly_value);
+		break;
+#endif
+
+	/***************/
+	/* MISC MACROS */
+	/***************/
+	case MACRO_SERVICEACKAUTHOR:
+	case MACRO_SERVICEACKAUTHORNAME:
+	case MACRO_SERVICEACKAUTHORALIAS:
+	case MACRO_SERVICEACKCOMMENT:
+		/* no need to do any more work - these are already precomputed elsewhere */
+		/* NOTE: these macros won't work as on-demand macros */
+		*output = mac->x[macro_type];
+		*free_macro = FALSE;
+		break;
+
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED SERVICE MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+		break;
+	}
 
 	/* post-processing */
 	/* notes, notes URL and action URL macros may themselves contain macros, so process them... */
 	switch(macro_type) {
-		case MACRO_SERVICEACTIONURL:
-		case MACRO_SERVICENOTESURL:
-			process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
-			*output = temp_buffer;
-			break;
-		case MACRO_SERVICENOTES:
-			process_macros_r(mac, *output, &temp_buffer, 0);
-			*output = temp_buffer;
-			break;
-		default:
-			break;
-		}
+	case MACRO_SERVICEACTIONURL:
+	case MACRO_SERVICENOTESURL:
+		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
+		*output = temp_buffer;
+		break;
+	case MACRO_SERVICENOTES:
+		process_macros_r(mac, *output, &temp_buffer, 0);
+		*output = temp_buffer;
+		break;
+	default:
+		break;
+	}
 
 	return OK;
-	}
+}
 
-int grab_standard_service_macro(int macro_type, service *temp_service, char **output, int *free_macro) {
+int grab_standard_service_macro(int macro_type, service *temp_service, char **output, int *free_macro)
+{
 	return grab_standard_service_macro_r(&global_macros, macro_type, temp_service, output, free_macro);
-	}
+}
 
 
 /* computes a servicegroup macro */
-int grab_standard_servicegroup_macro_r(nagios_macros *mac, int macro_type, servicegroup *temp_servicegroup, char **output) {
+int grab_standard_servicegroup_macro_r(nagios_macros *mac, int macro_type, servicegroup *temp_servicegroup, char **output)
+{
 	servicesmember *temp_servicesmember = NULL;
 	char *temp_buffer = NULL;
 	unsigned int	temp_len = 0;
@@ -2132,95 +2154,94 @@ int grab_standard_servicegroup_macro_r(nagios_macros *mac, int macro_type, servi
 
 	/* get the macro value */
 	switch(macro_type) {
-		case MACRO_SERVICEGROUPNAME:
-			*output = temp_servicegroup->group_name;
-			break;
-		case MACRO_SERVICEGROUPALIAS:
-			if(temp_servicegroup->alias)
-				*output = temp_servicegroup->alias;
-			break;
-		case MACRO_SERVICEGROUPMEMBERS:
-			/* make the calculations for total string length */
-			for(temp_servicesmember = temp_servicegroup->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
-				if(temp_servicesmember->host_name == NULL || temp_servicesmember->service_description == NULL)
-					continue;
-				if(temp_len == 0) {
-					temp_len += strlen(temp_servicesmember->host_name) + strlen(temp_servicesmember->service_description) + 2;
-					}
-				else {
-					temp_len += strlen(temp_servicesmember->host_name) + strlen(temp_servicesmember->service_description) + 3;
-					}
-				}
-			if(!temp_len) {
-				/* empty group, so return the nul string */
-				*output = calloc(1, 1);
-				return OK;
-				}
-			/* allocate or reallocate the memory buffer */
-			if(*output == NULL) {
-				*output = (char *)malloc(temp_len);
-				}
-			else {
-				init_len = strlen(*output);
-				temp_len += init_len;
-				*output = (char *)realloc(*output, temp_len);
-				}
-			/* now fill in the string with the group members */
-			for(temp_servicesmember = temp_servicegroup->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
-				if(temp_servicesmember->host_name == NULL || temp_servicesmember->service_description == NULL)
-					continue;
-				temp_buffer = *output + init_len;
-				if(init_len == 0) {  /* If our buffer didn't contain anything, we just need to write "%s,%s" */
-					init_len += sprintf(temp_buffer, "%s,%s", temp_servicesmember->host_name, temp_servicesmember->service_description);
-					}
-				else {   /* Now we need to write ",%s,%s" */
-					init_len += sprintf(temp_buffer, ",%s,%s", temp_servicesmember->host_name, temp_servicesmember->service_description);
-					}
-				}
-			break;
-		case MACRO_SERVICEGROUPACTIONURL:
-			if(temp_servicegroup->action_url)
-				*output = temp_servicegroup->action_url;
-			break;
-		case MACRO_SERVICEGROUPNOTESURL:
-			if(temp_servicegroup->notes_url)
-				*output = temp_servicegroup->notes_url;
-			break;
-		case MACRO_SERVICEGROUPNOTES:
-			if(temp_servicegroup->notes)
-				*output = temp_servicegroup->notes;
-			break;
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED SERVICEGROUP MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
+	case MACRO_SERVICEGROUPNAME:
+		*output = temp_servicegroup->group_name;
+		break;
+	case MACRO_SERVICEGROUPALIAS:
+		if(temp_servicegroup->alias)
+			*output = temp_servicegroup->alias;
+		break;
+	case MACRO_SERVICEGROUPMEMBERS:
+		/* make the calculations for total string length */
+		for(temp_servicesmember = temp_servicegroup->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
+			if(temp_servicesmember->host_name == NULL || temp_servicesmember->service_description == NULL)
+				continue;
+			if(temp_len == 0) {
+				temp_len += strlen(temp_servicesmember->host_name) + strlen(temp_servicesmember->service_description) + 2;
+			} else {
+				temp_len += strlen(temp_servicesmember->host_name) + strlen(temp_servicesmember->service_description) + 3;
+			}
 		}
+		if(!temp_len) {
+			/* empty group, so return the nul string */
+			*output = calloc(1, 1);
+			return OK;
+		}
+		/* allocate or reallocate the memory buffer */
+		if(*output == NULL) {
+			*output = (char *)malloc(temp_len);
+		} else {
+			init_len = strlen(*output);
+			temp_len += init_len;
+			*output = (char *)realloc(*output, temp_len);
+		}
+		/* now fill in the string with the group members */
+		for(temp_servicesmember = temp_servicegroup->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
+			if(temp_servicesmember->host_name == NULL || temp_servicesmember->service_description == NULL)
+				continue;
+			temp_buffer = *output + init_len;
+			if(init_len == 0) {  /* If our buffer didn't contain anything, we just need to write "%s,%s" */
+				init_len += sprintf(temp_buffer, "%s,%s", temp_servicesmember->host_name, temp_servicesmember->service_description);
+			} else { /* Now we need to write ",%s,%s" */
+				init_len += sprintf(temp_buffer, ",%s,%s", temp_servicesmember->host_name, temp_servicesmember->service_description);
+			}
+		}
+		break;
+	case MACRO_SERVICEGROUPACTIONURL:
+		if(temp_servicegroup->action_url)
+			*output = temp_servicegroup->action_url;
+		break;
+	case MACRO_SERVICEGROUPNOTESURL:
+		if(temp_servicegroup->notes_url)
+			*output = temp_servicegroup->notes_url;
+		break;
+	case MACRO_SERVICEGROUPNOTES:
+		if(temp_servicegroup->notes)
+			*output = temp_servicegroup->notes;
+		break;
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED SERVICEGROUP MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+	}
 
 	/* post-processing */
 	/* notes, notes URL and action URL macros may themselves contain macros, so process them... */
 	switch(macro_type) {
-		case MACRO_SERVICEGROUPACTIONURL:
-		case MACRO_SERVICEGROUPNOTESURL:
-			process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
-			*output = temp_buffer;
-			break;
-		case MACRO_SERVICEGROUPNOTES:
-			process_macros_r(mac, *output, &temp_buffer, 0);
-			*output = temp_buffer;
-			break;
-		default:
-			break;
-		}
+	case MACRO_SERVICEGROUPACTIONURL:
+	case MACRO_SERVICEGROUPNOTESURL:
+		process_macros_r(mac, *output, &temp_buffer, URL_ENCODE_MACRO_CHARS);
+		*output = temp_buffer;
+		break;
+	case MACRO_SERVICEGROUPNOTES:
+		process_macros_r(mac, *output, &temp_buffer, 0);
+		*output = temp_buffer;
+		break;
+	default:
+		break;
+	}
 
 	return OK;
-	}
+}
 
-int grab_standard_servicegroup_macro(int macro_type, servicegroup *temp_servicegroup, char **output) {
+int grab_standard_servicegroup_macro(int macro_type, servicegroup *temp_servicegroup, char **output)
+{
 	return grab_standard_servicegroup_macro_r(&global_macros, macro_type, temp_servicegroup, output);
-	}
+}
 
 
 /* computes a contact macro */
-int grab_standard_contact_macro_r(nagios_macros *mac, int macro_type, contact *temp_contact, char **output) {
+int grab_standard_contact_macro_r(nagios_macros *mac, int macro_type, contact *temp_contact, char **output)
+{
 #ifdef NSCORE
 	contactgroup *temp_contactgroup = NULL;
 	objectlist *temp_objectlist = NULL;
@@ -2233,54 +2254,56 @@ int grab_standard_contact_macro_r(nagios_macros *mac, int macro_type, contact *t
 
 	/* get the macro value */
 	switch(macro_type) {
-		case MACRO_CONTACTNAME:
-			*output = temp_contact->name;
-			break;
-		case MACRO_CONTACTALIAS:
-			*output = temp_contact->alias;
-			break;
-		case MACRO_CONTACTEMAIL:
-			if(temp_contact->email)
-				*output = temp_contact->email;
-			break;
-		case MACRO_CONTACTPAGER:
-			if(temp_contact->pager)
-				*output = temp_contact->pager;
-			break;
+	case MACRO_CONTACTNAME:
+		*output = temp_contact->name;
+		break;
+	case MACRO_CONTACTALIAS:
+		*output = temp_contact->alias;
+		break;
+	case MACRO_CONTACTEMAIL:
+		if(temp_contact->email)
+			*output = temp_contact->email;
+		break;
+	case MACRO_CONTACTPAGER:
+		if(temp_contact->pager)
+			*output = temp_contact->pager;
+		break;
 #ifdef NSCORE
-		case MACRO_CONTACTGROUPNAMES:
-			/* get the contactgroup names */
-			/* find all contactgroups this contact is a member of */
-			for(temp_objectlist = temp_contact->contactgroups_ptr; temp_objectlist != NULL; temp_objectlist = temp_objectlist->next) {
+	case MACRO_CONTACTGROUPNAMES:
+		/* get the contactgroup names */
+		/* find all contactgroups this contact is a member of */
+		for(temp_objectlist = temp_contact->contactgroups_ptr; temp_objectlist != NULL; temp_objectlist = temp_objectlist->next) {
 
-				if((temp_contactgroup = (contactgroup *)temp_objectlist->object_ptr) == NULL)
-					continue;
+			if((temp_contactgroup = (contactgroup *)temp_objectlist->object_ptr) == NULL)
+				continue;
 
-				asprintf(&buf1, "%s%s%s", (buf2) ? buf2 : "", (buf2) ? "," : "", temp_contactgroup->group_name);
-				my_free(buf2);
-				buf2 = buf1;
-				}
-			if(buf2) {
-				*output = (char *)strdup(buf2);
-				my_free(buf2);
-				}
-			break;
-#endif
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED CONTACT MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
+			asprintf(&buf1, "%s%s%s", (buf2) ? buf2 : "", (buf2) ? "," : "", temp_contactgroup->group_name);
+			my_free(buf2);
+			buf2 = buf1;
 		}
+		if(buf2) {
+			*output = (char *)strdup(buf2);
+			my_free(buf2);
+		}
+		break;
+#endif
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED CONTACT MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+	}
 
 	return OK;
-	}
+}
 
-int grab_standard_contact_macro(int macro_type, contact *temp_contact, char **output) {
+int grab_standard_contact_macro(int macro_type, contact *temp_contact, char **output)
+{
 	return grab_standard_contact_macro_r(&global_macros, macro_type, temp_contact, output);
-	}
+}
 
 
 /* computes a contact address macro */
-int grab_contact_address_macro(int macro_num, contact *temp_contact, char **output) {
+int grab_contact_address_macro(int macro_num, contact *temp_contact, char **output)
+{
 	if(macro_num < 0 || macro_num >= MAX_CONTACT_ADDRESSES)
 		return ERROR;
 
@@ -2292,12 +2315,13 @@ int grab_contact_address_macro(int macro_num, contact *temp_contact, char **outp
 		*output = temp_contact->address[macro_num];
 
 	return OK;
-	}
+}
 
 
 
 /* computes a contactgroup macro */
-int grab_standard_contactgroup_macro(int macro_type, contactgroup *temp_contactgroup, char **output) {
+int grab_standard_contactgroup_macro(int macro_type, contactgroup *temp_contactgroup, char **output)
+{
 	contactsmember *temp_contactsmember = NULL;
 
 	if(temp_contactgroup == NULL || output == NULL)
@@ -2305,37 +2329,38 @@ int grab_standard_contactgroup_macro(int macro_type, contactgroup *temp_contactg
 
 	/* get the macro value */
 	switch(macro_type) {
-		case MACRO_CONTACTGROUPNAME:
-			*output = temp_contactgroup->group_name;
-			break;
-		case MACRO_CONTACTGROUPALIAS:
-			if(temp_contactgroup->alias)
-				*output = temp_contactgroup->alias;
-			break;
-		case MACRO_CONTACTGROUPMEMBERS:
-			/* get the member list */
-			for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
-				if(temp_contactsmember->contact_name == NULL)
-					continue;
-				if(*output == NULL)
-					*output = (char *)strdup(temp_contactsmember->contact_name);
-				else if((*output = (char *)realloc(*output, strlen(*output) + strlen(temp_contactsmember->contact_name) + 2))) {
-					strcat(*output, ",");
-					strcat(*output, temp_contactsmember->contact_name);
-					}
-				}
-			break;
-		default:
-			log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED CONTACTGROUP MACRO #%d! THIS IS A BUG!\n", macro_type);
-			return ERROR;
+	case MACRO_CONTACTGROUPNAME:
+		*output = temp_contactgroup->group_name;
+		break;
+	case MACRO_CONTACTGROUPALIAS:
+		if(temp_contactgroup->alias)
+			*output = temp_contactgroup->alias;
+		break;
+	case MACRO_CONTACTGROUPMEMBERS:
+		/* get the member list */
+		for(temp_contactsmember = temp_contactgroup->members; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
+			if(temp_contactsmember->contact_name == NULL)
+				continue;
+			if(*output == NULL)
+				*output = (char *)strdup(temp_contactsmember->contact_name);
+			else if((*output = (char *)realloc(*output, strlen(*output) + strlen(temp_contactsmember->contact_name) + 2))) {
+				strcat(*output, ",");
+				strcat(*output, temp_contactsmember->contact_name);
+			}
 		}
+		break;
+	default:
+		log_debug_info(DEBUGL_MACROS, 0, "UNHANDLED CONTACTGROUP MACRO #%d! THIS IS A BUG!\n", macro_type);
+		return ERROR;
+	}
 
 	return OK;
-	}
+}
 
 
 /* computes a custom object macro */
-int grab_custom_object_macro_r(nagios_macros *mac, char *macro_name, customvariablesmember *vars, char **output) {
+int grab_custom_object_macro_r(nagios_macros *mac, char *macro_name, customvariablesmember *vars, char **output)
+{
 	customvariablesmember *temp_customvariablesmember = NULL;
 	int result = ERROR;
 
@@ -2353,15 +2378,16 @@ int grab_custom_object_macro_r(nagios_macros *mac, char *macro_name, customvaria
 				*output = temp_customvariablesmember->variable_value;
 			result = OK;
 			break;
-			}
 		}
+	}
 
 	return result;
-	}
+}
 
-int grab_custom_object_macro(char *macro_name, customvariablesmember *vars, char **output) {
+int grab_custom_object_macro(char *macro_name, customvariablesmember *vars, char **output)
+{
 	return grab_custom_object_macro_r(&global_macros, macro_name, vars, output);
-	}
+}
 
 
 /******************************************************************/
@@ -2369,7 +2395,8 @@ int grab_custom_object_macro(char *macro_name, customvariablesmember *vars, char
 /******************************************************************/
 
 /* cleans illegal characters in macros before output */
-char *clean_macro_chars(char *macro, int options) {
+char *clean_macro_chars(char *macro, int options)
+{
 	register int x = 0;
 	register int y = 0;
 	register int ch = 0;
@@ -2390,18 +2417,19 @@ char *clean_macro_chars(char *macro, int options) {
 			/* illegal chars are skipped */
 			if(!illegal_output_char_map[ch])
 				ret[y++] = ret[x];
-			}
-
-		ret[y++] = '\x0';
 		}
 
-	return ret;
+		ret[y++] = '\x0';
 	}
+
+	return ret;
+}
 
 
 
 /* encodes a string in proper URL format */
-char *get_url_encoded_string(char *input) {
+char *get_url_encoded_string(char *input)
+{
 	/* From RFC 3986:
 	segment       = *pchar
 
@@ -2451,8 +2479,7 @@ char *get_url_encoded_string(char *input) {
 		   (char)input[x] == '.' ||
 		   (char)input[x] == '-' ||
 		   (char)input[x] == '_' ||
-		   (char)input[x] == '~')
-		{
+		   (char)input[x] == '~') {
 			encoded_url_string[y++] = input[x];
 		}
 
@@ -2460,14 +2487,14 @@ char *get_url_encoded_string(char *input) {
 		else {
 			sprintf(&encoded_url_string[y], "%%%02X", (unsigned int)(input[x] & 0xFF));
 			y += 3;
-			}
 		}
+	}
 
 	/* terminate encoded string */
 	encoded_url_string[y] = '\x0';
 
 	return encoded_url_string;
-	}
+}
 
 
 static int macro_key_cmp(const void *a_, const void *b_)
@@ -2484,7 +2511,8 @@ static int macro_key_cmp(const void *a_, const void *b_)
 /******************************************************************/
 
 /* initializes global macros */
-int init_macros(void) {
+int init_macros(void)
+{
 	int x;
 	init_macrox_names();
 
@@ -2534,14 +2562,15 @@ int init_macros(void) {
 
 	qsort(macro_keys, x, sizeof(struct macro_key_code), macro_key_cmp);
 	return OK;
-	}
+}
 
 /*
  * initializes the names of macros, using this nifty little macro
  * which ensures we never add any typos to the list
  */
 #define add_macrox_name(name) macro_x_names[MACRO_##name] = strdup(#name)
-int init_macrox_names(void) {
+int init_macrox_names(void)
+{
 	register int x = 0;
 
 	/* initialize macro names */
@@ -2707,7 +2736,7 @@ int init_macrox_names(void) {
 	add_macrox_name(HOSTANDSERVICESIMPORTANCE);
 
 	return OK;
-	}
+}
 
 
 /******************************************************************/
@@ -2715,7 +2744,8 @@ int init_macrox_names(void) {
 /******************************************************************/
 
 /* free memory associated with the macrox names */
-int free_macrox_names(void) {
+int free_macrox_names(void)
+{
 	register int x = 0;
 
 	/* free each macro name */
@@ -2723,12 +2753,13 @@ int free_macrox_names(void) {
 		my_free(macro_x_names[x]);
 
 	return OK;
-	}
+}
 
 
 
 /* clear argv macros - used in commands */
-int clear_argv_macros_r(nagios_macros *mac) {
+int clear_argv_macros_r(nagios_macros *mac)
+{
 	register int x = 0;
 
 	/* command argument macros */
@@ -2736,11 +2767,12 @@ int clear_argv_macros_r(nagios_macros *mac) {
 		my_free(mac->argv[x]);
 
 	return OK;
-	}
+}
 
-int clear_argv_macros(void) {
+int clear_argv_macros(void)
+{
 	return clear_argv_macros_r(&global_macros);
-	}
+}
 
 /*
  * copies non-volatile macros from global macro_x to **dest, which
@@ -2748,7 +2780,8 @@ int clear_argv_macros(void) {
  * We use a shortlived macro to save up on typing
  */
 #define cp_macro(name) dest[MACRO_##name] = global_macros.x[MACRO_##name]
-void copy_constant_macros(char **dest) {
+void copy_constant_macros(char **dest)
+{
 	cp_macro(ADMINEMAIL);
 	cp_macro(ADMINPAGER);
 	cp_macro(MAINCONFIGFILE);
@@ -2764,26 +2797,28 @@ void copy_constant_macros(char **dest) {
 	cp_macro(PROCESSSTARTTIME);
 	cp_macro(TEMPPATH);
 	cp_macro(EVENTSTARTTIME);
-	}
+}
 #undef cp_macro
 
-static void clear_custom_vars(customvariablesmember **vars) {
+static void clear_custom_vars(customvariablesmember **vars)
+{
 	customvariablesmember *this_customvariablesmember = NULL;
 	customvariablesmember *next_customvariablesmember = NULL;
 
 	for(this_customvariablesmember = *vars;
-			this_customvariablesmember != NULL;
-			this_customvariablesmember = next_customvariablesmember) {
+	    this_customvariablesmember != NULL;
+	    this_customvariablesmember = next_customvariablesmember) {
 		next_customvariablesmember = this_customvariablesmember->next;
 		my_free(this_customvariablesmember->variable_name);
 		my_free(this_customvariablesmember->variable_value);
 		my_free(this_customvariablesmember);
-		}
-	*vars = NULL;
 	}
+	*vars = NULL;
+}
 
 /* clear all macros that are not "constant" (i.e. they change throughout the course of monitoring) */
-int clear_volatile_macros_r(nagios_macros *mac) {
+int clear_volatile_macros_r(nagios_macros *mac)
+{
 	register int x = 0;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "clear_volatile_macros_r()\n");
@@ -2808,26 +2843,29 @@ int clear_volatile_macros_r(nagios_macros *mac) {
 	clear_argv_macros_r(mac);
 
 	return OK;
-	}
+}
 
 
-int clear_volatile_macros(void) {
+int clear_volatile_macros(void)
+{
 	return clear_volatile_macros_r(&global_macros);
-	}
+}
 
 
 /* clear datetime macros */
-int clear_datetime_macros_r(nagios_macros *mac) {
+int clear_datetime_macros_r(nagios_macros *mac)
+{
 	my_free(mac->x[MACRO_LONGDATETIME]);
 	my_free(mac->x[MACRO_SHORTDATETIME]);
 	my_free(mac->x[MACRO_DATE]);
 	my_free(mac->x[MACRO_TIME]);
 
 	return OK;
-	}
+}
 
 /* clear service macros */
-int clear_service_macros_r(nagios_macros *mac) {
+int clear_service_macros_r(nagios_macros *mac)
+{
 
 	/* these are recursive but persistent. what to do? */
 	my_free(mac->x[MACRO_SERVICEACTIONURL]);
@@ -2843,14 +2881,16 @@ int clear_service_macros_r(nagios_macros *mac) {
 	mac->service_ptr = NULL;
 
 	return OK;
-	}
+}
 
-int clear_service_macros(void) {
+int clear_service_macros(void)
+{
 	return clear_service_macros_r(&global_macros);
-	}
+}
 
 /* clear host macros */
-int clear_host_macros_r(nagios_macros *mac) {
+int clear_host_macros_r(nagios_macros *mac)
+{
 
 	/* these are recursive but persistent. what to do? */
 	my_free(mac->x[MACRO_HOSTACTIONURL]);
@@ -2867,15 +2907,17 @@ int clear_host_macros_r(nagios_macros *mac) {
 	mac->host_ptr = NULL;
 
 	return OK;
-	}
+}
 
-int clear_host_macros(void) {
+int clear_host_macros(void)
+{
 	return clear_host_macros_r(&global_macros);
-	}
+}
 
 
 /* clear hostgroup macros */
-int clear_hostgroup_macros_r(nagios_macros *mac) {
+int clear_hostgroup_macros_r(nagios_macros *mac)
+{
 
 	/* recursive but persistent. what to do? */
 	my_free(mac->x[MACRO_HOSTGROUPACTIONURL]);
@@ -2889,15 +2931,17 @@ int clear_hostgroup_macros_r(nagios_macros *mac) {
 	mac->hostgroup_ptr = NULL;
 
 	return OK;
-	}
+}
 
-int clear_hostgroup_macros(void) {
+int clear_hostgroup_macros(void)
+{
 	return clear_hostgroup_macros_r(&global_macros);
-	}
+}
 
 
 /* clear servicegroup macros */
-int clear_servicegroup_macros_r(nagios_macros *mac) {
+int clear_servicegroup_macros_r(nagios_macros *mac)
+{
 	/* recursive but persistent. what to do? */
 	my_free(mac->x[MACRO_SERVICEGROUPACTIONURL]);
 	my_free(mac->x[MACRO_SERVICEGROUPNOTESURL]);
@@ -2910,15 +2954,17 @@ int clear_servicegroup_macros_r(nagios_macros *mac) {
 	mac->servicegroup_ptr = NULL;
 
 	return OK;
-	}
+}
 
-int clear_servicegroup_macros(void) {
+int clear_servicegroup_macros(void)
+{
 	return clear_servicegroup_macros_r(&global_macros);
-	}
+}
 
 
 /* clear contact macros */
-int clear_contact_macros_r(nagios_macros *mac) {
+int clear_contact_macros_r(nagios_macros *mac)
+{
 
 	/* generated */
 	my_free(mac->x[MACRO_CONTACTGROUPNAMES]);
@@ -2930,15 +2976,17 @@ int clear_contact_macros_r(nagios_macros *mac) {
 	mac->contact_ptr = NULL;
 
 	return OK;
-	}
+}
 
-int clear_contact_macros(void) {
+int clear_contact_macros(void)
+{
 	return clear_contact_macros_r(&global_macros);
-	}
+}
 
 
 /* clear contactgroup macros */
-int clear_contactgroup_macros_r(nagios_macros *mac) {
+int clear_contactgroup_macros_r(nagios_macros *mac)
+{
 	/* generated */
 	my_free(mac->x[MACRO_CONTACTGROUPMEMBERS]);
 
@@ -2946,25 +2994,28 @@ int clear_contactgroup_macros_r(nagios_macros *mac) {
 	mac->contactgroup_ptr = NULL;
 
 	return OK;
-	}
+}
 
-int clear_contactgroup_macros(void) {
+int clear_contactgroup_macros(void)
+{
 	return clear_contactgroup_macros_r(&global_macros);
-	}
+}
 
 /* clear summary macros */
-int clear_summary_macros_r(nagios_macros *mac) {
+int clear_summary_macros_r(nagios_macros *mac)
+{
 	register int x;
 
 	for(x = MACRO_TOTALHOSTSUP; x <= MACRO_TOTALSERVICEPROBLEMSUNHANDLED; x++)
 		my_free(mac->x[x]);
 
 	return OK;
-	}
+}
 
-int clear_summary_macros(void) {
+int clear_summary_macros(void)
+{
 	return clear_summary_macros_r(&global_macros);
-	}
+}
 
 
 /******************************************************************/
@@ -2974,7 +3025,8 @@ int clear_summary_macros(void) {
 #ifdef NSCORE
 
 /* sets or unsets all macro environment variables */
-int set_all_macro_environment_vars_r(nagios_macros *mac, int set) {
+int set_all_macro_environment_vars_r(nagios_macros *mac, int set)
+{
 	if(enable_environment_macros == FALSE)
 		return ERROR;
 
@@ -2984,15 +3036,17 @@ int set_all_macro_environment_vars_r(nagios_macros *mac, int set) {
 	set_contact_address_environment_vars_r(mac, set);
 
 	return OK;
-	}
+}
 
-int set_all_macro_environment_vars(int set) {
+int set_all_macro_environment_vars(int set)
+{
 	return set_all_macro_environment_vars_r(&global_macros, set);
-	}
+}
 
 
 /* sets or unsets macrox environment variables */
-int set_macrox_environment_vars_r(nagios_macros *mac, int set) {
+int set_macrox_environment_vars_r(nagios_macros *mac, int set)
+{
 	register int x = 0;
 	int free_macro = FALSE;
 
@@ -3013,7 +3067,7 @@ int set_macrox_environment_vars_r(nagios_macros *mac, int set) {
 			/* summary macros are CPU intensive to compute */
 			if(x >= MACRO_TOTALHOSTSUP && x <= MACRO_TOTALSERVICEPROBLEMSUNHANDLED)
 				continue;
-			}
+		}
 
 		/* generate the macro value if it hasn't already been done */
 		/* THIS IS EXPENSIVE */
@@ -3021,22 +3075,24 @@ int set_macrox_environment_vars_r(nagios_macros *mac, int set) {
 
 			if(mac->x[x] == NULL)
 				grab_macrox_value_r(mac, x, NULL, NULL, &mac->x[x], &free_macro);
-			}
+		}
 
 		/* set the value */
 		set_macro_environment_var(macro_x_names[x], mac->x[x], set);
-		}
+	}
 
 	return OK;
-	}
+}
 
-int set_macrox_environment_vars(int set) {
+int set_macrox_environment_vars(int set)
+{
 	return set_macrox_environment_vars_r(&global_macros, set);
-	}
+}
 
 
 /* sets or unsets argv macro environment variables */
-int set_argv_macro_environment_vars_r(nagios_macros *mac, int set) {
+int set_argv_macro_environment_vars_r(nagios_macros *mac, int set)
+{
 	char *macro_name = NULL;
 	register int x = 0;
 
@@ -3045,18 +3101,20 @@ int set_argv_macro_environment_vars_r(nagios_macros *mac, int set) {
 		asprintf(&macro_name, "ARG%d", x + 1);
 		set_macro_environment_var(macro_name, mac->argv[x], set);
 		my_free(macro_name);
-		}
+	}
 
 	return OK;
-	}
+}
 
-int set_argv_macro_environment_vars(int set) {
+int set_argv_macro_environment_vars(int set)
+{
 	return set_argv_macro_environment_vars_r(&global_macros, set);
-	}
+}
 
 
 /* sets or unsets custom host/service/contact macro environment variables */
-int set_custom_macro_environment_vars_r(nagios_macros *mac, int set) {
+int set_custom_macro_environment_vars_r(nagios_macros *mac, int set)
+{
 	customvariablesmember *temp_customvariablesmember = NULL;
 	host *temp_host = NULL;
 	service *temp_service = NULL;
@@ -3070,12 +3128,12 @@ int set_custom_macro_environment_vars_r(nagios_macros *mac, int set) {
 			asprintf(&customvarname, "_HOST%s", temp_customvariablesmember->variable_name);
 			add_custom_variable_to_object(&mac->custom_host_vars, customvarname, temp_customvariablesmember->variable_value);
 			my_free(customvarname);
-			}
 		}
+	}
 	/* set variables */
 	for(temp_customvariablesmember = mac->custom_host_vars; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 		set_macro_environment_var(temp_customvariablesmember->variable_name, clean_macro_chars(temp_customvariablesmember->variable_value, STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS), set);
-		}
+	}
 
 	/***** CUSTOM SERVICE VARIABLES *****/
 	/* generate variables and save them for later */
@@ -3084,8 +3142,8 @@ int set_custom_macro_environment_vars_r(nagios_macros *mac, int set) {
 			asprintf(&customvarname, "_SERVICE%s", temp_customvariablesmember->variable_name);
 			add_custom_variable_to_object(&mac->custom_service_vars, customvarname, temp_customvariablesmember->variable_value);
 			my_free(customvarname);
-			}
 		}
+	}
 	/* set variables */
 	for(temp_customvariablesmember = mac->custom_service_vars; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next)
 		set_macro_environment_var(temp_customvariablesmember->variable_name, clean_macro_chars(temp_customvariablesmember->variable_value, STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS), set);
@@ -3097,22 +3155,24 @@ int set_custom_macro_environment_vars_r(nagios_macros *mac, int set) {
 			asprintf(&customvarname, "_CONTACT%s", temp_customvariablesmember->variable_name);
 			add_custom_variable_to_object(&mac->custom_contact_vars, customvarname, temp_customvariablesmember->variable_value);
 			my_free(customvarname);
-			}
 		}
+	}
 	/* set variables */
 	for(temp_customvariablesmember = mac->custom_contact_vars; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next)
 		set_macro_environment_var(temp_customvariablesmember->variable_name, clean_macro_chars(temp_customvariablesmember->variable_value, STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS), set);
 
 	return OK;
-	}
+}
 
-int set_custom_macro_environment_vars(int set) {
+int set_custom_macro_environment_vars(int set)
+{
 	return set_custom_macro_environment_vars_r(&global_macros, set);
-	}
+}
 
 
 /* sets or unsets contact address environment variables */
-int set_contact_address_environment_vars_r(nagios_macros *mac, int set) {
+int set_contact_address_environment_vars_r(nagios_macros *mac, int set)
+{
 	char *varname = NULL;
 	register int x;
 
@@ -3124,18 +3184,20 @@ int set_contact_address_environment_vars_r(nagios_macros *mac, int set) {
 		asprintf(&varname, "CONTACTADDRESS%d", x);
 		set_macro_environment_var(varname, mac->contact_ptr->address[x], set);
 		my_free(varname);
-		}
+	}
 
 	return OK;
-	}
+}
 
-int set_contact_address_environment_vars(int set) {
+int set_contact_address_environment_vars(int set)
+{
 	return set_contact_address_environment_vars_r(&global_macros, set);
-	}
+}
 
 
 /* sets or unsets a macro environment variable */
-int set_macro_environment_var(char *name, char *value, int set) {
+int set_macro_environment_var(char *name, char *value, int set)
+{
 	char *env_macro_name = NULL;
 
 	/* we won't mess with null variable names */
@@ -3152,15 +3214,16 @@ int set_macro_environment_var(char *name, char *value, int set) {
 	my_free(env_macro_name);
 
 	return OK;
-	}
+}
 
 static int add_macrox_environment_vars_r(nagios_macros *, struct kvvec *);
 static int add_argv_macro_environment_vars_r(nagios_macros *, struct kvvec *);
 static int add_custom_macro_environment_vars_r(nagios_macros *, struct kvvec *);
 static int add_contact_address_environment_vars_r(nagios_macros *,
-		struct kvvec *);
+        struct kvvec *);
 
-struct kvvec * macros_to_kvv(nagios_macros *mac) {
+struct kvvec * macros_to_kvv(nagios_macros *mac)
+{
 
 	struct kvvec *kvvp;
 
@@ -3180,11 +3243,12 @@ struct kvvec * macros_to_kvv(nagios_macros *mac) {
 	add_contact_address_environment_vars_r(mac, kvvp);
 
 	return kvvp;
-	}
+}
 
 /* adds macrox environment variables */
 static int add_macrox_environment_vars_r(nagios_macros *mac,
-		struct kvvec *kvvp) {
+        struct kvvec *kvvp)
+{
 	register int x = 0;
 	int free_macro = FALSE;
 	char *envname;
@@ -3195,7 +3259,7 @@ static int add_macrox_environment_vars_r(nagios_macros *mac,
 	for(x = 0; x < MACRO_X_COUNT; x++) {
 
 		log_debug_info(DEBUGL_MACROS, 2, "Processing macro %d of %d\n", x,
-				MACRO_X_COUNT);
+		               MACRO_X_COUNT);
 		free_macro = FALSE;
 
 		/* large installations don't get all macros */
@@ -3205,39 +3269,40 @@ static int add_macrox_environment_vars_r(nagios_macros *mac,
 			 * environment on large installations
 			 */
 			if(x == MACRO_SERVICEGROUPMEMBERS ||
-					x == MACRO_HOSTGROUPMEMBERS) continue;
+			   x == MACRO_HOSTGROUPMEMBERS) continue;
 
 			/* summary macros are CPU intensive to compute */
 			if(x >= MACRO_TOTALHOSTSUP &&
-					x <= MACRO_TOTALSERVICEPROBLEMSUNHANDLED) continue;
-			}
+			   x <= MACRO_TOTALSERVICEPROBLEMSUNHANDLED) continue;
+		}
 
 		/* generate the macro value if it hasn't already been done */
 		/* THIS IS EXPENSIVE */
 		if(mac->x[x] == NULL) {
 			log_debug_info(DEBUGL_MACROS, 2, "Grabbing value for macro: %s\n",
-					macro_x_names[x]);
+			               macro_x_names[x]);
 
 			grab_macrox_value_r(mac, x, NULL, NULL, &mac->x[x], &free_macro);
-			}
+		}
 
 		/* add the value to the kvvec */
 		log_debug_info(DEBUGL_MACROS, 2, "Adding macro \"%s\" with value \"%s\" to kvvec\n",
-					macro_x_names[x], mac->x[x]);
-		/* Allocate memory for each environment variable name, but not the 
+		               macro_x_names[x], mac->x[x]);
+		/* Allocate memory for each environment variable name, but not the
 			values because when kvvec_destroy() is called, it is called with
 			KVVEC_FREE_KEYS */
 		asprintf(&envname, "%s%s", MACRO_ENV_VAR_PREFIX, macro_x_names[x]);
 		kvvec_addkv(kvvp, envname, mac->x[x]);
-		}
+	}
 
 	log_debug_info(DEBUGL_FUNCTIONS, 2, "add_macrox_environment_vars_r() end\n");
 	return OK;
-	}
+}
 
 /* adds argv macro environment variables */
 static int add_argv_macro_environment_vars_r(nagios_macros *mac,
-		struct kvvec *kvvp) {
+        struct kvvec *kvvp)
+{
 	char *macro_name = NULL;
 	register int x = 0;
 
@@ -3245,19 +3310,20 @@ static int add_argv_macro_environment_vars_r(nagios_macros *mac,
 
 	/* set each of the argv macro environment variables */
 	for(x = 0; x < MAX_COMMAND_ARGUMENTS; x++) {
-		/* Allocate memory for each environment variable name, but not the 
+		/* Allocate memory for each environment variable name, but not the
 			values because when kvvec_destroy() is called, it is called with
 			KVVEC_FREE_KEYS */
 		asprintf(&macro_name, "%sARG%d", MACRO_ENV_VAR_PREFIX, x + 1);
 		kvvec_addkv(kvvp, macro_name, mac->argv[x]);
-		}
+	}
 
 	return OK;
-	}
+}
 
 /* adds custom host/service/contact macro environment variables */
 static int add_custom_macro_environment_vars_r(nagios_macros *mac,
-		struct kvvec *kvvp) {
+        struct kvvec *kvvp)
+{
 
 	customvariablesmember *temp_customvariablesmember = NULL;
 	host *temp_host = NULL;
@@ -3273,103 +3339,104 @@ static int add_custom_macro_environment_vars_r(nagios_macros *mac,
 	temp_host = mac->host_ptr;
 	if(temp_host) {
 		for(temp_customvariablesmember = temp_host->custom_variables;
-				temp_customvariablesmember != NULL;
-				temp_customvariablesmember = temp_customvariablesmember->next) {
+		    temp_customvariablesmember != NULL;
+		    temp_customvariablesmember = temp_customvariablesmember->next) {
 			asprintf(&customvarname, "%s_HOST%s", MACRO_ENV_VAR_PREFIX,
-					temp_customvariablesmember->variable_name);
+			         temp_customvariablesmember->variable_name);
 			add_custom_variable_to_object(&mac->custom_host_vars, customvarname,
-					temp_customvariablesmember->variable_value);
+			                              temp_customvariablesmember->variable_value);
 			my_free(customvarname);
-			}
 		}
+	}
 	/* set variables */
 	for(temp_customvariablesmember = mac->custom_host_vars;
-			temp_customvariablesmember != NULL;
-			temp_customvariablesmember = temp_customvariablesmember->next) {
-		customvarvalue = 
-				clean_macro_chars(temp_customvariablesmember->variable_value,
-				STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
+	    temp_customvariablesmember != NULL;
+	    temp_customvariablesmember = temp_customvariablesmember->next) {
+		customvarvalue =
+		    clean_macro_chars(temp_customvariablesmember->variable_value,
+		                      STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
 		if(NULL != customvarvalue) {
 			my_free(temp_customvariablesmember->variable_value);
 			temp_customvariablesmember->variable_value = customvarvalue;
-			/* Allocate memory for each environment variable name, but not the 
+			/* Allocate memory for each environment variable name, but not the
 				values because when kvvec_destroy() is called, it is called with
 				KVVEC_FREE_KEYS */
 			kvvec_addkv(kvvp, strdup(temp_customvariablesmember->variable_name),
-					customvarvalue);
-			}
+			            customvarvalue);
 		}
+	}
 
 	/***** CUSTOM SERVICE VARIABLES *****/
 	/* generate variables and save them for later */
 	temp_service = mac->service_ptr;
 	if(temp_service) {
 		for(temp_customvariablesmember = temp_service->custom_variables;
-				temp_customvariablesmember != NULL;
-				temp_customvariablesmember = temp_customvariablesmember->next) {
+		    temp_customvariablesmember != NULL;
+		    temp_customvariablesmember = temp_customvariablesmember->next) {
 			asprintf(&customvarname, "%s_SERVICE%s", MACRO_ENV_VAR_PREFIX,
-					temp_customvariablesmember->variable_name);
+			         temp_customvariablesmember->variable_name);
 			add_custom_variable_to_object(&mac->custom_service_vars,
-					customvarname, temp_customvariablesmember->variable_value);
+			                              customvarname, temp_customvariablesmember->variable_value);
 			my_free(customvarname);
-			}
 		}
+	}
 	/* set variables */
 	for(temp_customvariablesmember = mac->custom_service_vars;
-			temp_customvariablesmember != NULL;
-			temp_customvariablesmember = temp_customvariablesmember->next) {
+	    temp_customvariablesmember != NULL;
+	    temp_customvariablesmember = temp_customvariablesmember->next) {
 		customvarvalue =
-				clean_macro_chars(temp_customvariablesmember->variable_value,
-				STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
+		    clean_macro_chars(temp_customvariablesmember->variable_value,
+		                      STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
 		if(NULL != customvarvalue) {
 			my_free(temp_customvariablesmember->variable_value);
 			temp_customvariablesmember->variable_value = customvarvalue;
-			/* Allocate memory for each environment variable name, but not the 
+			/* Allocate memory for each environment variable name, but not the
 				values because when kvvec_destroy() is called, it is called with
 				KVVEC_FREE_KEYS */
 			kvvec_addkv(kvvp, strdup(temp_customvariablesmember->variable_name),
-					customvarvalue);
-			}
+			            customvarvalue);
 		}
+	}
 
 	/***** CUSTOM CONTACT VARIABLES *****/
 	/* generate variables and save them for later */
 	temp_contact = mac->contact_ptr;
 	if(temp_contact) {
 		for(temp_customvariablesmember = temp_contact->custom_variables;
-				temp_customvariablesmember != NULL;
-				temp_customvariablesmember = temp_customvariablesmember->next) {
+		    temp_customvariablesmember != NULL;
+		    temp_customvariablesmember = temp_customvariablesmember->next) {
 			asprintf(&customvarname, "%s_CONTACT%s", MACRO_ENV_VAR_PREFIX,
-					temp_customvariablesmember->variable_name);
+			         temp_customvariablesmember->variable_name);
 			add_custom_variable_to_object(&mac->custom_contact_vars,
-					customvarname, temp_customvariablesmember->variable_value);
+			                              customvarname, temp_customvariablesmember->variable_value);
 			my_free(customvarname);
-			}
 		}
+	}
 	/* set variables */
 	for(temp_customvariablesmember = mac->custom_contact_vars;
-			temp_customvariablesmember != NULL;
-			temp_customvariablesmember = temp_customvariablesmember->next) {
-		customvarvalue = 
-				clean_macro_chars(temp_customvariablesmember->variable_value,
-				STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
+	    temp_customvariablesmember != NULL;
+	    temp_customvariablesmember = temp_customvariablesmember->next) {
+		customvarvalue =
+		    clean_macro_chars(temp_customvariablesmember->variable_value,
+		                      STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
 		if(NULL != customvarvalue) {
 			my_free(temp_customvariablesmember->variable_value);
 			temp_customvariablesmember->variable_value = customvarvalue;
-			/* Allocate memory for each environment variable name, but not the 
+			/* Allocate memory for each environment variable name, but not the
 				values because when kvvec_destroy() is called, it is called with
 				KVVEC_FREE_KEYS */
 			kvvec_addkv(kvvp, strdup(temp_customvariablesmember->variable_name),
-					customvarvalue);
-			}
+			            customvarvalue);
 		}
+	}
 
 	return OK;
-	}
+}
 
 /* add contact address environment variables */
 static int add_contact_address_environment_vars_r(nagios_macros *mac,
-		struct kvvec *kvvp) {
+        struct kvvec *kvvp)
+{
 
 	char *varname = NULL;
 	register int x;
@@ -3381,14 +3448,14 @@ static int add_contact_address_environment_vars_r(nagios_macros *mac,
 		return OK;
 
 	for(x = 0; x < MAX_CONTACT_ADDRESSES; x++) {
-		/* Allocate memory for each environment variable name, but not the 
+		/* Allocate memory for each environment variable name, but not the
 			values because when kvvec_destroy() is called, it is called with
 			KVVEC_FREE_KEYS */
 		asprintf(&varname, "%sCONTACTADDRESS%d", MACRO_ENV_VAR_PREFIX, x);
 		kvvec_addkv(kvvp, varname, mac->contact_ptr->address[x]);
-		}
+	}
 
 	return OK;
-	}
+}
 
 #endif

--- a/common/objects.c
+++ b/common/objects.c
@@ -109,7 +109,7 @@ static const char *opts2str(int opts, const struct flag_map *map, char ok_char)
 		flag_unset(opts, OPT_OK);
 		buf[pos++] = ok_char;
 		buf[pos++] = opts ? ',' : 0;
-		}
+	}
 
 	for (i = 0; map[i].name; i++) {
 		if(flag_isset(opts, map[i].opt)) {
@@ -125,48 +125,54 @@ static const char *opts2str(int opts, const struct flag_map *map, char ok_char)
 }
 #endif
 
-unsigned int host_services_value(host *h) {
+unsigned int host_services_value(host *h)
+{
 	servicesmember *sm;
 	unsigned int ret = 0;
 	for(sm = h->services; sm; sm = sm->next) {
 		ret += sm->service_ptr->hourly_value;
-		}
-	return ret;
 	}
+	return ret;
+}
 
 
 #ifndef NSCGI
 /* Host/Service dependencies are not visible in Nagios CGIs, so we exclude them */
-static int cmp_sdep(const void *a_, const void *b_) {
+static int cmp_sdep(const void *a_, const void *b_)
+{
 	const servicedependency *a = *(servicedependency **)a_;
 	const servicedependency *b = *(servicedependency **)b_;
 	int ret;
 	ret = a->master_service_ptr->id - b->master_service_ptr->id;
 	return ret ? ret : (int)(a->dependent_service_ptr->id - b->dependent_service_ptr->id);
-	}
+}
 
-static int cmp_hdep(const void *a_, const void *b_) {
+static int cmp_hdep(const void *a_, const void *b_)
+{
 	const hostdependency *a = *(const hostdependency **)a_;
 	const hostdependency *b = *(const hostdependency **)b_;
 	int ret;
 	ret = a->master_host_ptr->id - b->master_host_ptr->id;
 	return ret ? ret : (int)(a->dependent_host_ptr->id - b->dependent_host_ptr->id);
-	}
+}
 
-static int cmp_serviceesc(const void *a_, const void *b_) {
+static int cmp_serviceesc(const void *a_, const void *b_)
+{
 	const serviceescalation *a = *(const serviceescalation **)a_;
 	const serviceescalation *b = *(const serviceescalation **)b_;
 	return a->service_ptr->id - b->service_ptr->id;
-	}
+}
 
-static int cmp_hostesc(const void *a_, const void *b_) {
+static int cmp_hostesc(const void *a_, const void *b_)
+{
 	const hostescalation *a = *(const hostescalation **)a_;
 	const hostescalation *b = *(const hostescalation **)b_;
 	return a->host_ptr->id - b->host_ptr->id;
-	}
+}
 #endif
 
-static void post_process_object_config(void) {
+static void post_process_object_config(void)
+{
 	objectlist *list;
 	unsigned int i, slot;
 
@@ -227,9 +233,12 @@ static void post_process_object_config(void) {
 const char *service_state_name(int state)
 {
 	switch (state) {
-	case STATE_OK: return "OK";
-	case STATE_WARNING: return "WARNING";
-	case STATE_CRITICAL: return "CRITICAL";
+	case STATE_OK:
+		return "OK";
+	case STATE_WARNING:
+		return "WARNING";
+	case STATE_CRITICAL:
+		return "CRITICAL";
 	}
 
 	return "UNKNOWN";
@@ -238,9 +247,12 @@ const char *service_state_name(int state)
 const char *host_state_name(int state)
 {
 	switch (state) {
-	case HOST_UP: return "UP";
-	case HOST_DOWN: return "DOWN";
-	case HOST_UNREACHABLE: return "UNREACHABLE";
+	case HOST_UP:
+		return "UP";
+	case HOST_DOWN:
+		return "DOWN";
+	case HOST_UNREACHABLE:
+		return "UNREACHABLE";
 	}
 
 	return "(unknown)";
@@ -262,7 +274,8 @@ const char *check_type_name(int check_type)
 
 
 /* read all host configuration data from external source */
-int read_object_config_data(const char *main_config_file, int options) {
+int read_object_config_data(const char *main_config_file, int options)
+{
 	int result = OK;
 
 	/* reset object counts */
@@ -278,7 +291,7 @@ int read_object_config_data(const char *main_config_file, int options) {
 	timing_point("Done post-processing configuration\n");
 
 	return result;
-	}
+}
 
 
 
@@ -287,7 +300,8 @@ int read_object_config_data(const char *main_config_file, int options) {
 /******************************************************************/
 
 
-int skiplist_compare_text(const char *val1a, const char *val1b, const char *val2a, const char *val2b) {
+int skiplist_compare_text(const char *val1a, const char *val1b, const char *val2a, const char *val2b)
+{
 	int result = 0;
 
 	/* check first name */
@@ -310,20 +324,22 @@ int skiplist_compare_text(const char *val1a, const char *val1b, const char *val2
 			result = -1;
 		else
 			result = strcmp(val1b, val2b);
-		}
+	}
 
 	return result;
-	}
+}
 
 
-int get_host_count(void) {
+int get_host_count(void)
+{
 	return num_objects.hosts;
-	}
+}
 
 
-int get_service_count(void) {
+int get_service_count(void)
+{
 	return num_objects.services;
-	}
+}
 
 
 
@@ -338,12 +354,12 @@ static int create_object_table(const char *name, unsigned int elems, unsigned in
 	if (!elems) {
 		*ptr = NULL;
 		return OK;
-		}
+	}
 	ret = calloc(elems, size);
 	if (!ret) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to allocate %s table with %u elements\n", name, elems);
 		return ERROR;
-		}
+	}
 	*ptr = ret;
 	return OK;
 }
@@ -400,7 +416,8 @@ int create_object_tables(unsigned int *ocount)
 
 
 /* add a new timeperiod to the list in memory */
-timeperiod *add_timeperiod(char *name, char *alias) {
+timeperiod *add_timeperiod(char *name, char *alias)
+{
 	timeperiod *new_timeperiod = NULL;
 	int result = OK;
 
@@ -408,7 +425,7 @@ timeperiod *add_timeperiod(char *name, char *alias) {
 	if((name == NULL || !strcmp(name, "")) || (alias == NULL || !strcmp(alias, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Name or alias for timeperiod is NULL\n");
 		return NULL;
-		}
+	}
 
 	new_timeperiod = calloc(1, sizeof(*new_timeperiod));
 	if(!new_timeperiod)
@@ -422,38 +439,39 @@ timeperiod *add_timeperiod(char *name, char *alias) {
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[TIMEPERIOD_SKIPLIST], new_timeperiod->name, NULL, new_timeperiod);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Timeperiod '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add timeperiod '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Timeperiod '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add timeperiod '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		free(new_timeperiod);
 		return NULL;
-		}
+	}
 
 	new_timeperiod->id = num_objects.timeperiods++;
 	if(new_timeperiod->id)
 		timeperiod_ary[new_timeperiod->id - 1]->next = new_timeperiod;
 	timeperiod_ary[new_timeperiod->id] = new_timeperiod;
 	return new_timeperiod;
-	}
+}
 
 
 
 
 /* adds a new exclusion to a timeperiod */
-timeperiodexclusion *add_exclusion_to_timeperiod(timeperiod *period, char *name) {
+timeperiodexclusion *add_exclusion_to_timeperiod(timeperiod *period, char *name)
+{
 	timeperiodexclusion *new_timeperiodexclusion = NULL;
 
 	/* make sure we have enough data */
@@ -469,13 +487,14 @@ timeperiodexclusion *add_exclusion_to_timeperiod(timeperiod *period, char *name)
 	period->exclusions = new_timeperiodexclusion;
 
 	return new_timeperiodexclusion;
-	}
+}
 
 
 
 
 /* add a new timerange to a timeperiod */
-timerange *add_timerange_to_timeperiod(timeperiod *period, int day, unsigned long start_time, unsigned long end_time) {
+timerange *add_timerange_to_timeperiod(timeperiod *period, int day, unsigned long start_time, unsigned long end_time)
+{
 	timerange *prev = NULL, *tr, *new_timerange = NULL;
 
 	/* make sure we have the data we need */
@@ -485,15 +504,15 @@ timerange *add_timerange_to_timeperiod(timeperiod *period, int day, unsigned lon
 	if(day < 0 || day > 6) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Day %d is not valid for timeperiod '%s'\n", day, period->name);
 		return NULL;
-		}
+	}
 	if(start_time > 86400) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Start time %lu on day %d is not valid for timeperiod '%s'\n", start_time, day, period->name);
 		return NULL;
-		}
+	}
 	if(end_time > 86400) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: End time %lu on day %d is not value for timeperiod '%s'\n", end_time, day, period->name);
 		return NULL;
-		}
+	}
 
 	/* allocate memory for the new time range */
 	if((new_timerange = malloc(sizeof(timerange))) == NULL)
@@ -507,28 +526,29 @@ timerange *add_timerange_to_timeperiod(timeperiod *period, int day, unsigned lon
 		new_timerange->next = period->days[day];
 		period->days[day] = new_timerange;
 		return new_timerange;
-		}
+	}
 
 	for(tr = period->days[day]; tr; tr = tr->next) {
 		if(new_timerange->range_start < tr->range_start) {
 			new_timerange->next = tr;
 			prev->next = new_timerange;
 			break;
-			}
+		}
 		if(!tr->next) {
 			tr->next = new_timerange;
 			new_timerange->next = NULL;
 			break;
-			}
-		prev = tr;
 		}
+		prev = tr;
+	}
 
 	return new_timerange;
-	}
+}
 
 
 /* add a new exception to a timeperiod */
-daterange *add_exception_to_timeperiod(timeperiod *period, int type, int syear, int smon, int smday, int swday, int swday_offset, int eyear, int emon, int emday, int ewday, int ewday_offset, int skip_interval) {
+daterange *add_exception_to_timeperiod(timeperiod *period, int type, int syear, int smon, int smday, int swday, int swday_offset, int eyear, int emon, int emday, int ewday, int ewday_offset, int skip_interval)
+{
 	daterange *new_daterange = NULL;
 
 	/* make sure we have the data we need */
@@ -560,12 +580,13 @@ daterange *add_exception_to_timeperiod(timeperiod *period, int type, int syear, 
 	period->exceptions[type] = new_daterange;
 
 	return new_daterange;
-	}
+}
 
 
 
 /* add a new timerange to a daterange */
-timerange *add_timerange_to_daterange(daterange *drange, unsigned long start_time, unsigned long end_time) {
+timerange *add_timerange_to_daterange(daterange *drange, unsigned long start_time, unsigned long end_time)
+{
 	timerange *new_timerange = NULL;
 
 	/* make sure we have the data we need */
@@ -575,11 +596,11 @@ timerange *add_timerange_to_daterange(daterange *drange, unsigned long start_tim
 	if(start_time > 86400) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Start time %lu is not valid for timeperiod\n", start_time);
 		return NULL;
-		}
+	}
 	if(end_time > 86400) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: End time %lu is not value for timeperiod\n", end_time);
 		return NULL;
-		}
+	}
 
 	/* allocate memory for the new time range */
 	if((new_timerange = malloc(sizeof(timerange))) == NULL)
@@ -593,12 +614,13 @@ timerange *add_timerange_to_daterange(daterange *drange, unsigned long start_tim
 	drange->times = new_timerange;
 
 	return new_timerange;
-	}
+}
 
 
 
 /* add a new host definition */
-host *add_host(char *name, char *display_name, char *alias, char *address, char *check_period, int initial_state, double check_interval, double retry_interval, int max_attempts, int notification_options, double notification_interval, double first_notification_delay, char *notification_period, int notifications_enabled, char *check_command, int checks_enabled, int accept_passive_checks, char *event_handler, int event_handler_enabled, int flap_detection_enabled, double low_flap_threshold, double high_flap_threshold, int flap_detection_options, int stalking_options, int process_perfdata, int check_freshness, int freshness_threshold, char *notes, char *notes_url, char *action_url, char *icon_image, char *icon_image_alt, char *vrml_image, char *statusmap_image, int x_2d, int y_2d, int have_2d_coords, double x_3d, double y_3d, double z_3d, int have_3d_coords, int should_be_drawn, int retain_status_information, int retain_nonstatus_information, int obsess, unsigned int hourly_value) {
+host *add_host(char *name, char *display_name, char *alias, char *address, char *check_period, int initial_state, double check_interval, double retry_interval, int max_attempts, int notification_options, double notification_interval, double first_notification_delay, char *notification_period, int notifications_enabled, char *check_command, int checks_enabled, int accept_passive_checks, char *event_handler, int event_handler_enabled, int flap_detection_enabled, double low_flap_threshold, double high_flap_threshold, int flap_detection_options, int stalking_options, int process_perfdata, int check_freshness, int freshness_threshold, char *notes, char *notes_url, char *action_url, char *icon_image, char *icon_image_alt, char *vrml_image, char *statusmap_image, int x_2d, int y_2d, int have_2d_coords, double x_3d, double y_3d, double z_3d, int have_3d_coords, int should_be_drawn, int retain_status_information, int retain_nonstatus_information, int obsess, unsigned int hourly_value)
+{
 	host *new_host = NULL;
 	timeperiod *check_tp = NULL, *notify_tp = NULL;
 	int result = OK;
@@ -607,39 +629,39 @@ host *add_host(char *name, char *display_name, char *alias, char *address, char 
 	if(name == NULL || !strcmp(name, "")) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host name is NULL\n");
 		return NULL;
-		}
+	}
 
 	if(check_period && !(check_tp = find_timeperiod(check_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to locate check_period '%s' for host '%s'!\n",
-			  check_period, name);
+		      check_period, name);
 		return NULL;
 	}
 	if(notification_period && !(notify_tp = find_timeperiod(notification_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to locate notification_period '%s' for host '%s'!\n",
-			  notification_period, name);
+		      notification_period, name);
 		return NULL;
 	}
 	/* check values */
 	if(max_attempts <= 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid max_check_attempts value for host '%s'\n", name);
 		return NULL;
-		}
+	}
 	if(check_interval < 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid check_interval value for host '%s'\n", name);
 		return NULL;
-		}
+	}
 	if(notification_interval < 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification_interval value for host '%s'\n", name);
 		return NULL;
-		}
+	}
 	if(first_notification_delay < 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid first_notification_delay value for host '%s'\n", name);
 		return NULL;
-		}
+	}
 	if(freshness_threshold < 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid freshness_threshold value for host '%s'\n", name);
 		return NULL;
-		}
+	}
 
 	new_host = calloc(1, sizeof(*new_host));
 
@@ -709,36 +731,37 @@ host *add_host(char *name, char *display_name, char *alias, char *address, char 
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[HOST_SKIPLIST], new_host->name, NULL, new_host);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add host '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add host '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		my_free(new_host);
 		return NULL;
-		}
+	}
 
 	new_host->id = num_objects.hosts++;
 	host_ary[new_host->id] = new_host;
 	if(new_host->id)
 		host_ary[new_host->id - 1]->next = new_host;
 	return new_host;
-	}
+}
 
 
 
-hostsmember *add_parent_host_to_host(host *hst, char *host_name) {
+hostsmember *add_parent_host_to_host(host *hst, char *host_name)
+{
 	hostsmember *new_hostsmember = NULL;
 	int result = OK;
 
@@ -746,13 +769,13 @@ hostsmember *add_parent_host_to_host(host *hst, char *host_name) {
 	if(hst == NULL || host_name == NULL || !strcmp(host_name, "")) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host is NULL or parent host name is NULL\n");
 		return NULL;
-		}
+	}
 
 	/* a host cannot be a parent/child of itself */
 	if(!strcmp(host_name, hst->name)) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host '%s' cannot be a child/parent of itself\n", hst->name);
 		return NULL;
-		}
+	}
 
 	/* allocate memory */
 	if((new_hostsmember = (hostsmember *)calloc(1, sizeof(hostsmember))) == NULL)
@@ -767,16 +790,17 @@ hostsmember *add_parent_host_to_host(host *hst, char *host_name) {
 		my_free(new_hostsmember->host_name);
 		my_free(new_hostsmember);
 		return NULL;
-		}
+	}
 
 	/* add the parent host entry to the host definition */
 	new_hostsmember->next = hst->parent_hosts;
 	hst->parent_hosts = new_hostsmember;
 
 	return new_hostsmember;
-	}
+}
 
-servicesmember *add_parent_service_to_service(service *svc, char *host_name, char *description) {
+servicesmember *add_parent_service_to_service(service *svc, char *host_name, char *description)
+{
 	servicesmember *sm;
 
 	if(!svc || !host_name || !description || !*host_name || !*description)
@@ -790,14 +814,15 @@ servicesmember *add_parent_service_to_service(service *svc, char *host_name, cha
 		my_free(sm->host_name);
 		free(sm);
 		return NULL;
-		}
+	}
 
 	sm->next = svc->parents;
 	svc->parents = sm;
 	return sm;
-	}
+}
 
-hostsmember *add_child_link_to_host(host *hst, host *child_ptr) {
+hostsmember *add_child_link_to_host(host *hst, host *child_ptr)
+{
 	hostsmember *new_hostsmember = NULL;
 
 	/* make sure we have the data we need */
@@ -817,11 +842,12 @@ hostsmember *add_child_link_to_host(host *hst, host *child_ptr) {
 	hst->child_hosts = new_hostsmember;
 
 	return new_hostsmember;
-	}
+}
 
 
 
-servicesmember *add_service_link_to_host(host *hst, service *service_ptr) {
+servicesmember *add_service_link_to_host(host *hst, service *service_ptr)
+{
 	servicesmember *new_servicesmember = NULL;
 
 	/* make sure we have the data we need */
@@ -845,11 +871,12 @@ servicesmember *add_service_link_to_host(host *hst, service *service_ptr) {
 	hst->services = new_servicesmember;
 
 	return new_servicesmember;
-	}
+}
 
 
 
-servicesmember *add_child_link_to_service(service *svc, service *child_ptr) {
+servicesmember *add_child_link_to_service(service *svc, service *child_ptr)
+{
 	servicesmember *new_servicesmember = NULL;
 
 	/* make sure we have the data we need */
@@ -857,8 +884,8 @@ servicesmember *add_child_link_to_service(service *svc, service *child_ptr) {
 		return NULL;
 
 	/* allocate memory */
-	if((new_servicesmember = (servicesmember *)malloc(sizeof(servicesmember))) 
-			== NULL) return NULL;
+	if((new_servicesmember = (servicesmember *)malloc(sizeof(servicesmember)))
+	   == NULL) return NULL;
 
 	/* assign values */
 	new_servicesmember->host_name = child_ptr->host_name;
@@ -870,60 +897,65 @@ servicesmember *add_child_link_to_service(service *svc, service *child_ptr) {
 	svc->children = new_servicesmember;
 
 	return new_servicesmember;
-	}
+}
 
 
 
-static contactgroupsmember *add_contactgroup_to_object(contactgroupsmember **cg_list, const char *group_name) {
+static contactgroupsmember *add_contactgroup_to_object(contactgroupsmember **cg_list, const char *group_name)
+{
 	contactgroupsmember *cgm;
 	contactgroup *cg;
 
 	if(!group_name || !*group_name) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact name is NULL\n");
 		return NULL;
-		}
+	}
 	if(!(cg = find_contactgroup(group_name))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contactgroup '%s' is not defined anywhere\n", group_name);
 		return NULL;
-		}
+	}
 	if(!(cgm = malloc(sizeof(*cgm)))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for contactgroup\n");
 		return NULL;
-		}
+	}
 	cgm->group_name = cg->group_name;
 	cgm->group_ptr = cg;
 	cgm->next = *cg_list;
 	*cg_list = cgm;
 
 	return cgm;
-	}
+}
 
 
 /* add a new contactgroup to a host */
-contactgroupsmember *add_contactgroup_to_host(host *hst, char *group_name) {
+contactgroupsmember *add_contactgroup_to_host(host *hst, char *group_name)
+{
 	return add_contactgroup_to_object(&hst->contact_groups, group_name);
-	}
+}
 
 
 
 /* adds a contact to a host */
-contactsmember *add_contact_to_host(host *hst, char *contact_name) {
+contactsmember *add_contact_to_host(host *hst, char *contact_name)
+{
 
 	return add_contact_to_object(&hst->contacts, contact_name);
-	}
+}
 
 
 
 /* adds a custom variable to a host */
-customvariablesmember *add_custom_variable_to_host(host *hst, char *varname, char *varvalue) {
+customvariablesmember *add_custom_variable_to_host(host *hst, char *varname, char *varvalue)
+{
 
 	return add_custom_variable_to_object(&hst->custom_variables, varname, varvalue);
-	}
+}
 
 
 
 /* add a new host group to the list in memory */
-hostgroup *add_hostgroup(char *name, char *alias, char *notes, char *notes_url, char *action_url) {
+hostgroup *add_hostgroup(char *name, char *alias, char *notes, char *notes_url, char *action_url)
+{
 	hostgroup *new_hostgroup = NULL;
 	int result = OK;
 
@@ -931,7 +963,7 @@ hostgroup *add_hostgroup(char *name, char *alias, char *notes, char *notes_url, 
 	if(name == NULL || !strcmp(name, "")) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Hostgroup name is NULL\n");
 		return NULL;
-		}
+	}
 
 	new_hostgroup = calloc(1, sizeof(*new_hostgroup));
 
@@ -946,36 +978,37 @@ hostgroup *add_hostgroup(char *name, char *alias, char *notes, char *notes_url, 
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[HOSTGROUP_SKIPLIST], new_hostgroup->group_name, NULL, new_hostgroup);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Hostgroup '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add hostgroup '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Hostgroup '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add hostgroup '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		free(new_hostgroup);
 		return NULL;
-		}
+	}
 
 	new_hostgroup->id = num_objects.hostgroups++;
 	hostgroup_ary[new_hostgroup->id] = new_hostgroup;
 	if(new_hostgroup->id)
 		hostgroup_ary[new_hostgroup->id - 1]->next = new_hostgroup;
 	return new_hostgroup;
-	}
+}
 
 
 /* add a new host to a host group */
-hostsmember *add_host_to_hostgroup(hostgroup *temp_hostgroup, char *host_name) {
+hostsmember *add_host_to_hostgroup(hostgroup *temp_hostgroup, char *host_name)
+{
 	hostsmember *new_member = NULL;
 	hostsmember *last_member = NULL;
 	hostsmember *temp_member = NULL;
@@ -985,7 +1018,7 @@ hostsmember *add_host_to_hostgroup(hostgroup *temp_hostgroup, char *host_name) {
 	if(temp_hostgroup == NULL || (host_name == NULL || !strcmp(host_name, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Hostgroup or group member is NULL\n");
 		return NULL;
-		}
+	}
 	if (!(h = find_host(host_name))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to locate host '%s' for hostgroup '%s'\n", host_name, temp_hostgroup->group_name);
 		return NULL;
@@ -1008,7 +1041,7 @@ hostsmember *add_host_to_hostgroup(hostgroup *temp_hostgroup, char *host_name) {
 		new_member->next = temp_hostgroup->members;
 		temp_hostgroup->members = new_member;
 		return new_member;
-		}
+	}
 #endif
 	last_member = temp_hostgroup->members;
 	for(temp_member = temp_hostgroup->members; temp_member != NULL; temp_member = temp_member->next) {
@@ -1019,25 +1052,24 @@ hostsmember *add_host_to_hostgroup(hostgroup *temp_hostgroup, char *host_name) {
 			else
 				last_member->next = new_member;
 			break;
-			}
-		else
+		} else
 			last_member = temp_member;
-		}
+	}
 	if(temp_hostgroup->members == NULL) {
 		new_member->next = NULL;
 		temp_hostgroup->members = new_member;
-		}
-	else if(temp_member == NULL) {
+	} else if(temp_member == NULL) {
 		new_member->next = NULL;
 		last_member->next = new_member;
-		}
+	}
 
 	return new_member;
-	}
+}
 
 
 /* add a new service group to the list in memory */
-servicegroup *add_servicegroup(char *name, char *alias, char *notes, char *notes_url, char *action_url) {
+servicegroup *add_servicegroup(char *name, char *alias, char *notes, char *notes_url, char *action_url)
+{
 	servicegroup *new_servicegroup = NULL;
 	int result = OK;
 
@@ -1045,7 +1077,7 @@ servicegroup *add_servicegroup(char *name, char *alias, char *notes, char *notes
 	if(name == NULL || !strcmp(name, "")) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Servicegroup name is NULL\n");
 		return NULL;
-		}
+	}
 
 	new_servicegroup = calloc(1, sizeof(*new_servicegroup));
 
@@ -1060,36 +1092,37 @@ servicegroup *add_servicegroup(char *name, char *alias, char *notes, char *notes
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[SERVICEGROUP_SKIPLIST], new_servicegroup->group_name, NULL, new_servicegroup);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Servicegroup '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add servicegroup '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Servicegroup '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add servicegroup '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		my_free(new_servicegroup);
 		return NULL;
-		}
+	}
 
 	new_servicegroup->id = num_objects.servicegroups++;
 	servicegroup_ary[new_servicegroup->id] = new_servicegroup;
 	if(new_servicegroup->id)
 		servicegroup_ary[new_servicegroup->id - 1]->next = new_servicegroup;
 	return new_servicegroup;
-	}
+}
 
 
 /* add a new service to a service group */
-servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, char *host_name, char *svc_description) {
+servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, char *host_name, char *svc_description)
+{
 	servicesmember *new_member = NULL;
 	servicesmember *last_member = NULL;
 	servicesmember *temp_member = NULL;
@@ -1099,11 +1132,11 @@ servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, cha
 	if(temp_servicegroup == NULL || (host_name == NULL || !strcmp(host_name, "")) || (svc_description == NULL || !strcmp(svc_description, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Servicegroup or group member is NULL\n");
 		return NULL;
-		}
+	}
 	if (!(svc = find_service(host_name, svc_description))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to locate service '%s' on host '%s' for servicegroup '%s'\n", svc_description, host_name, temp_servicegroup->group_name);
 		return NULL;
-		}
+	}
 
 	/* allocate memory for a new member */
 	if((new_member = calloc(1, sizeof(servicesmember))) == NULL)
@@ -1127,7 +1160,7 @@ servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, cha
 		new_member->next = temp_servicegroup->members;
 		temp_servicegroup->members = new_member;
 		return new_member;
-		}
+	}
 #endif
 	last_member = temp_servicegroup->members;
 	for(temp_member = temp_servicegroup->members; temp_member != NULL; temp_member = temp_member->next) {
@@ -1139,7 +1172,7 @@ servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, cha
 			else
 				last_member->next = new_member;
 			break;
-			}
+		}
 
 		else if(strcmp(new_member->host_name, temp_member->host_name) == 0 && strcmp(new_member->service_description, temp_member->service_description) < 0) {
 			new_member->next = temp_member;
@@ -1148,26 +1181,26 @@ servicesmember *add_service_to_servicegroup(servicegroup *temp_servicegroup, cha
 			else
 				last_member->next = new_member;
 			break;
-			}
+		}
 
 		else
 			last_member = temp_member;
-		}
+	}
 	if(temp_servicegroup->members == NULL) {
 		new_member->next = NULL;
 		temp_servicegroup->members = new_member;
-		}
-	else if(temp_member == NULL) {
+	} else if(temp_member == NULL) {
 		new_member->next = NULL;
 		last_member->next = new_member;
-		}
+	}
 
 	return new_member;
-	}
+}
 
 
 /* add a new contact to the list in memory */
-contact *add_contact(char *name, char *alias, char *email, char *pager, char **addresses, char *svc_notification_period, char *host_notification_period, int service_notification_options, int host_notification_options, int host_notifications_enabled, int service_notifications_enabled, int can_submit_commands, int retain_status_information, int retain_nonstatus_information, unsigned int minimum_value) {
+contact *add_contact(char *name, char *alias, char *email, char *pager, char **addresses, char *svc_notification_period, char *host_notification_period, int service_notification_options, int host_notification_options, int host_notifications_enabled, int service_notifications_enabled, int can_submit_commands, int retain_status_information, int retain_nonstatus_information, unsigned int minimum_value)
+{
 	contact *new_contact = NULL;
 	timeperiod *htp = NULL, *stp = NULL;
 	int x = 0;
@@ -1177,17 +1210,17 @@ contact *add_contact(char *name, char *alias, char *email, char *pager, char **a
 	if(name == NULL || !*name) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact name is NULL\n");
 		return NULL;
-		}
+	}
 	if(svc_notification_period && !(stp = find_timeperiod(svc_notification_period))) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Service notification period '%s' specified for contact '%s' is not defined anywhere!\n",
-			  svc_notification_period, name);
+		      svc_notification_period, name);
 		return NULL;
-		}
+	}
 	if(host_notification_period && !(htp = find_timeperiod(host_notification_period))) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Host notification period '%s' specified for contact '%s' is not defined anywhere!\n",
-			  host_notification_period, name);
+		      host_notification_period, name);
 		return NULL;
-		}
+	}
 
 
 	new_contact = calloc(1, sizeof(*new_contact));
@@ -1205,7 +1238,7 @@ contact *add_contact(char *name, char *alias, char *email, char *pager, char **a
 	if(addresses) {
 		for(x = 0; x < MAX_CONTACT_ADDRESSES; x++)
 			new_contact->address[x] = addresses[x];
-		}
+	}
 
 	new_contact->minimum_value = minimum_value;
 	new_contact->service_notification_options = service_notification_options;
@@ -1220,37 +1253,38 @@ contact *add_contact(char *name, char *alias, char *email, char *pager, char **a
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[CONTACT_SKIPLIST], new_contact->name, NULL, new_contact);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contact '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contact '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		free(new_contact);
 		return NULL;
-		}
+	}
 
 	new_contact->id = num_objects.contacts++;
 	contact_ary[new_contact->id] = new_contact;
 	if(new_contact->id)
 		contact_ary[new_contact->id - 1]->next = new_contact;
 	return new_contact;
-	}
+}
 
 
 
 /* adds a host notification command to a contact definition */
-commandsmember *add_host_notification_command_to_contact(contact *cntct, char *command_name) {
+commandsmember *add_host_notification_command_to_contact(contact *cntct, char *command_name)
+{
 	commandsmember *new_commandsmember = NULL;
 	int result = OK;
 
@@ -1258,7 +1292,7 @@ commandsmember *add_host_notification_command_to_contact(contact *cntct, char *c
 	if(cntct == NULL || (command_name == NULL || !strcmp(command_name, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact or host notification command is NULL\n");
 		return NULL;
-		}
+	}
 
 	/* allocate memory */
 	if((new_commandsmember = calloc(1, sizeof(commandsmember))) == NULL)
@@ -1273,19 +1307,20 @@ commandsmember *add_host_notification_command_to_contact(contact *cntct, char *c
 		my_free(new_commandsmember->command);
 		my_free(new_commandsmember);
 		return NULL;
-		}
+	}
 
 	/* add the notification command */
 	new_commandsmember->next = cntct->host_notification_commands;
 	cntct->host_notification_commands = new_commandsmember;
 
 	return new_commandsmember;
-	}
+}
 
 
 
 /* adds a service notification command to a contact definition */
-commandsmember *add_service_notification_command_to_contact(contact *cntct, char *command_name) {
+commandsmember *add_service_notification_command_to_contact(contact *cntct, char *command_name)
+{
 	commandsmember *new_commandsmember = NULL;
 	int result = OK;
 
@@ -1293,7 +1328,7 @@ commandsmember *add_service_notification_command_to_contact(contact *cntct, char
 	if(cntct == NULL || (command_name == NULL || !strcmp(command_name, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact or service notification command is NULL\n");
 		return NULL;
-		}
+	}
 
 	/* allocate memory */
 	if((new_commandsmember = calloc(1, sizeof(commandsmember))) == NULL)
@@ -1308,27 +1343,29 @@ commandsmember *add_service_notification_command_to_contact(contact *cntct, char
 		my_free(new_commandsmember->command);
 		my_free(new_commandsmember);
 		return NULL;
-		}
+	}
 
 	/* add the notification command */
 	new_commandsmember->next = cntct->service_notification_commands;
 	cntct->service_notification_commands = new_commandsmember;
 
 	return new_commandsmember;
-	}
+}
 
 
 
 /* adds a custom variable to a contact */
-customvariablesmember *add_custom_variable_to_contact(contact *cntct, char *varname, char *varvalue) {
+customvariablesmember *add_custom_variable_to_contact(contact *cntct, char *varname, char *varvalue)
+{
 
 	return add_custom_variable_to_object(&cntct->custom_variables, varname, varvalue);
-	}
+}
 
 
 
 /* add a new contact group to the list in memory */
-contactgroup *add_contactgroup(char *name, char *alias) {
+contactgroup *add_contactgroup(char *name, char *alias)
+{
 	contactgroup *new_contactgroup = NULL;
 	int result = OK;
 
@@ -1336,7 +1373,7 @@ contactgroup *add_contactgroup(char *name, char *alias) {
 	if(name == NULL || !strcmp(name, "")) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contactgroup name is NULL\n");
 		return NULL;
-		}
+	}
 
 	new_contactgroup = calloc(1, sizeof(*new_contactgroup));
 	if(!new_contactgroup)
@@ -1350,37 +1387,38 @@ contactgroup *add_contactgroup(char *name, char *alias) {
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[CONTACTGROUP_SKIPLIST], new_contactgroup->group_name, NULL, new_contactgroup);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contactgroup '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contactgroup '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contactgroup '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contactgroup '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		free(new_contactgroup);
 		return NULL;
-		}
+	}
 
 	new_contactgroup->id = num_objects.contactgroups++;
 	contactgroup_ary[new_contactgroup->id] = new_contactgroup;
 	if(new_contactgroup->id)
 		contactgroup_ary[new_contactgroup->id - 1]->next = new_contactgroup;
 	return new_contactgroup;
-	}
+}
 
 
 
 /* add a new member to a contact group */
-contactsmember *add_contact_to_contactgroup(contactgroup *grp, char *contact_name) {
+contactsmember *add_contact_to_contactgroup(contactgroup *grp, char *contact_name)
+{
 	contactsmember *new_contactsmember = NULL;
 	struct contact *c;
 
@@ -1388,12 +1426,12 @@ contactsmember *add_contact_to_contactgroup(contactgroup *grp, char *contact_nam
 	if(grp == NULL || (contact_name == NULL || !strcmp(contact_name, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contactgroup or contact name is NULL\n");
 		return NULL;
-		}
+	}
 
 	if (!(c = find_contact(contact_name))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to locate contact '%s' for contactgroup '%s'\n", contact_name, grp->group_name);
 		return NULL;
-		}
+	}
 
 	/* allocate memory for a new member */
 	if((new_contactsmember = calloc(1, sizeof(contactsmember))) == NULL)
@@ -1410,12 +1448,13 @@ contactsmember *add_contact_to_contactgroup(contactgroup *grp, char *contact_nam
 	prepend_object_to_objectlist(&c->contactgroups_ptr, (void *)grp);
 
 	return new_contactsmember;
-	}
+}
 
 
 
 /* add a new service to the list in memory */
-service *add_service(char *host_name, char *description, char *display_name, char *check_period, int initial_state, int max_attempts, int parallelize, int accept_passive_checks, double check_interval, double retry_interval, double notification_interval, double first_notification_delay, char *notification_period, int notification_options, int notifications_enabled, int is_volatile, char *event_handler, int event_handler_enabled, char *check_command, int checks_enabled, int flap_detection_enabled, double low_flap_threshold, double high_flap_threshold, int flap_detection_options, int stalking_options, int process_perfdata, int check_freshness, int freshness_threshold, char *notes, char *notes_url, char *action_url, char *icon_image, char *icon_image_alt, int retain_status_information, int retain_nonstatus_information, int obsess, unsigned int hourly_value) {
+service *add_service(char *host_name, char *description, char *display_name, char *check_period, int initial_state, int max_attempts, int parallelize, int accept_passive_checks, double check_interval, double retry_interval, double notification_interval, double first_notification_delay, char *notification_period, int notification_options, int notifications_enabled, int is_volatile, char *event_handler, int event_handler_enabled, char *check_command, int checks_enabled, int flap_detection_enabled, double low_flap_threshold, double high_flap_threshold, int flap_detection_options, int stalking_options, int process_perfdata, int check_freshness, int freshness_threshold, char *notes, char *notes_url, char *action_url, char *icon_image, char *icon_image_alt, int retain_status_information, int retain_nonstatus_information, int obsess, unsigned int hourly_value)
+{
 	host *h;
 	timeperiod *cp = NULL, *np = NULL;
 	service *new_service = NULL;
@@ -1425,33 +1464,33 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 	if(host_name == NULL || description == NULL || !*description || check_command == NULL || !*check_command) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service description, host name, or check command is NULL\n");
 		return NULL;
-		}
+	}
 	if (!(h = find_host(host_name))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unable to locate host '%s' for service '%s'\n",
-			  host_name, description);
+		      host_name, description);
 		return NULL;
-		}
+	}
 	if(notification_period && !(np = find_timeperiod(notification_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: notification_period '%s' for service '%s' on host '%s' could not be found!\n",
-			  notification_period, description, host_name);
+		      notification_period, description, host_name);
 		return NULL;
-		}
+	}
 	if(check_period && !(cp = find_timeperiod(check_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: check_period '%s' for service '%s' on host '%s' not found!\n",
-			  check_period, description, host_name);
+		      check_period, description, host_name);
 		return NULL;
-		}
+	}
 
 	/* check values */
 	if(max_attempts <= 0 || check_interval < 0 || retry_interval <= 0 || notification_interval < 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid max_attempts, check_interval, retry_interval, or notification_interval value for service '%s' on host '%s'\n", description, host_name);
 		return NULL;
-		}
+	}
 
 	if(first_notification_delay < 0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid first_notification_delay value for service '%s' on host '%s'\n", description, host_name);
 		return NULL;
-		}
+	}
 
 	/* allocate memory */
 	new_service = calloc(1, sizeof(*new_service));
@@ -1470,36 +1509,35 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 	if(display_name) {
 		if((new_service->display_name = (char *)strdup(display_name)) == NULL)
 			result = ERROR;
-		}
-	else {
+	} else {
 		new_service->display_name = new_service->description;
-		}
+	}
 	if((new_service->check_command = (char *)strdup(check_command)) == NULL)
 		result = ERROR;
 	if(event_handler) {
 		if((new_service->event_handler = (char *)strdup(event_handler)) == NULL)
 			result = ERROR;
-		}
+	}
 	if(notes) {
 		if((new_service->notes = (char *)strdup(notes)) == NULL)
 			result = ERROR;
-		}
+	}
 	if(notes_url) {
 		if((new_service->notes_url = (char *)strdup(notes_url)) == NULL)
 			result = ERROR;
-		}
+	}
 	if(action_url) {
 		if((new_service->action_url = (char *)strdup(action_url)) == NULL)
 			result = ERROR;
-		}
+	}
 	if(icon_image) {
 		if((new_service->icon_image = (char *)strdup(icon_image)) == NULL)
 			result = ERROR;
-		}
+	}
 	if(icon_image_alt) {
 		if((new_service->icon_image_alt = (char *)strdup(icon_image_alt)) == NULL)
 			result = ERROR;
-		}
+	}
 
 	new_service->hourly_value = hourly_value;
 	new_service->check_interval = check_interval;
@@ -1541,19 +1579,19 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[SERVICE_SKIPLIST], new_service->host_name, new_service->description, new_service);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service '%s' on host '%s' has already been defined\n", description, host_name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add service '%s' on host '%s' to hash table\n", description, host_name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service '%s' on host '%s' has already been defined\n", description, host_name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add service '%s' on host '%s' to hash table\n", description, host_name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
@@ -1568,7 +1606,7 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 		if(display_name)
 			my_free(new_service->display_name);
 		return NULL;
-		}
+	}
 
 	add_service_link_to_host(h, new_service);
 
@@ -1577,35 +1615,39 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 	if(new_service->id)
 		service_ary[new_service->id - 1]->next = new_service;
 	return new_service;
-	}
+}
 
 
 
 /* adds a contact group to a service */
-contactgroupsmember *add_contactgroup_to_service(service *svc, char *group_name) {
+contactgroupsmember *add_contactgroup_to_service(service *svc, char *group_name)
+{
 	return add_contactgroup_to_object(&svc->contact_groups, group_name);
-	}
+}
 
 
 
 /* adds a contact to a service */
-contactsmember *add_contact_to_service(service *svc, char *contact_name) {
+contactsmember *add_contact_to_service(service *svc, char *contact_name)
+{
 
 	return add_contact_to_object(&svc->contacts, contact_name);
-	}
+}
 
 
 
 /* adds a custom variable to a service */
-customvariablesmember *add_custom_variable_to_service(service *svc, char *varname, char *varvalue) {
+customvariablesmember *add_custom_variable_to_service(service *svc, char *varname, char *varvalue)
+{
 
 	return add_custom_variable_to_object(&svc->custom_variables, varname, varvalue);
-	}
+}
 
 
 
 /* add a new command to the list in memory */
-command *add_command(char *name, char *value) {
+command *add_command(char *name, char *value)
+{
 	command *new_command = NULL;
 	int result = OK;
 
@@ -1613,7 +1655,7 @@ command *add_command(char *name, char *value) {
 	if((name == NULL || !strcmp(name, "")) || (value == NULL || !strcmp(value, ""))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Command name of command line is NULL\n");
 		return NULL;
-		}
+	}
 
 	/* allocate memory for the new command */
 	new_command = calloc(1, sizeof(*new_command));
@@ -1628,37 +1670,38 @@ command *add_command(char *name, char *value) {
 	if(result == OK) {
 		result = dkhash_insert(object_hash_tables[COMMAND_SKIPLIST], new_command->name, NULL, new_command);
 		switch(result) {
-			case DKHASH_EDUPE:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Command '%s' has already been defined\n", name);
-				result = ERROR;
-				break;
-			case DKHASH_OK:
-				result = OK;
-				break;
-			default:
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add command '%s' to hash table\n", name);
-				result = ERROR;
-				break;
-			}
+		case DKHASH_EDUPE:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Command '%s' has already been defined\n", name);
+			result = ERROR;
+			break;
+		case DKHASH_OK:
+			result = OK;
+			break;
+		default:
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add command '%s' to hash table\n", name);
+			result = ERROR;
+			break;
 		}
+	}
 
 	/* handle errors */
 	if(result == ERROR) {
 		my_free(new_command);
 		return NULL;
-		}
+	}
 
 	new_command->id = num_objects.commands++;
 	command_ary[new_command->id] = new_command;
 	if(new_command->id)
 		command_ary[new_command->id - 1]->next = new_command;
 	return new_command;
-	}
+}
 
 
 
 /* add a new service escalation to the list in memory */
-serviceescalation *add_serviceescalation(char *host_name, char *description, int first_notification, int last_notification, double notification_interval, char *escalation_period, int escalation_options) {
+serviceescalation *add_serviceescalation(char *host_name, char *description, int first_notification, int last_notification, double notification_interval, char *escalation_period, int escalation_options)
+{
 	serviceescalation *new_serviceescalation = NULL;
 	service *svc;
 	timeperiod *tp = NULL;
@@ -1667,17 +1710,17 @@ serviceescalation *add_serviceescalation(char *host_name, char *description, int
 	if(host_name == NULL || !*host_name || description == NULL || !*description) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service escalation host name or description is NULL\n");
 		return NULL;
-		}
+	}
 	if(!(svc = find_service(host_name, description))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service '%s' on host '%s' has an escalation but is not defined anywhere!\n",
-			  host_name, description);
+		      host_name, description);
 		return NULL;
-		}
+	}
 	if (escalation_period && !(tp = find_timeperiod(escalation_period))) {
 		logit(NSLOG_VERIFICATION_ERROR, TRUE, "Error: Escalation period '%s' specified in service escalation for service '%s' on host '%s' is not defined anywhere!\n",
-			  escalation_period, description, host_name);
+		      escalation_period, description, host_name);
 		return NULL ;
-		}
+	}
 
 	new_serviceescalation = calloc(1, sizeof(*new_serviceescalation));
 	if(!new_serviceescalation)
@@ -1685,9 +1728,9 @@ serviceescalation *add_serviceescalation(char *host_name, char *description, int
 
 	if(add_object_to_objectlist(&svc->escalation_list, new_serviceescalation) != OK) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Could not add escalation to service '%s' on host '%s'\n",
-			  svc->host_name, svc->description);
+		      svc->host_name, svc->description);
 		return NULL;
-		}
+	}
 
 	/* assign vars. object names are immutable, so no need to copy */
 	new_serviceescalation->host_name = svc->host_name;
@@ -1705,27 +1748,30 @@ serviceescalation *add_serviceescalation(char *host_name, char *description, int
 	new_serviceescalation->id = num_objects.serviceescalations++;
 	serviceescalation_ary[new_serviceescalation->id] = new_serviceescalation;
 	return new_serviceescalation;
-	}
+}
 
 
 
 /* adds a contact group to a service escalation */
-contactgroupsmember *add_contactgroup_to_serviceescalation(serviceescalation *se, char *group_name) {
+contactgroupsmember *add_contactgroup_to_serviceescalation(serviceescalation *se, char *group_name)
+{
 	return add_contactgroup_to_object(&se->contact_groups, group_name);
-	}
+}
 
 
 
 /* adds a contact to a service escalation */
-contactsmember *add_contact_to_serviceescalation(serviceescalation *se, char *contact_name) {
+contactsmember *add_contact_to_serviceescalation(serviceescalation *se, char *contact_name)
+{
 
 	return add_contact_to_object(&se->contacts, contact_name);
-	}
+}
 
 
 
 /* adds a service dependency definition */
-servicedependency *add_service_dependency(char *dependent_host_name, char *dependent_service_description, char *host_name, char *service_description, int dependency_type, int inherits_parent, int failure_options, char *dependency_period) {
+servicedependency *add_service_dependency(char *dependent_host_name, char *dependent_service_description, char *host_name, char *service_description, int dependency_type, int inherits_parent, int failure_options, char *dependency_period)
+{
 	servicedependency *new_servicedependency = NULL;
 	service *parent, *child;
 	timeperiod *tp = NULL;
@@ -1735,20 +1781,20 @@ servicedependency *add_service_dependency(char *dependent_host_name, char *depen
 	parent = find_service(host_name, service_description);
 	if(!parent) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Master service '%s' on host '%s' is not defined anywhere!\n",
-			  service_description, host_name);
+		      service_description, host_name);
 		return NULL;
-		}
+	}
 	child = find_service(dependent_host_name, dependent_service_description);
 	if(!child) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Dependent service '%s' on host '%s' is not defined anywhere!\n",
-			 dependent_service_description, dependent_host_name);
+		      dependent_service_description, dependent_host_name);
 		return NULL;
-		}
+	}
 	if (dependency_period && !(tp = find_timeperiod(dependency_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to locate timeperiod '%s' for dependency from service '%s' on host '%s' to service '%s' on host '%s'\n",
-			  dependency_period, dependent_service_description, dependent_host_name, service_description, host_name);
+		      dependency_period, dependent_service_description, dependent_host_name, service_description, host_name);
 		return NULL;
-		}
+	}
 
 	/* allocate memory for a new service dependency entry */
 	if((new_servicedependency = calloc(1, sizeof(*new_servicedependency))) == NULL)
@@ -1785,15 +1831,16 @@ servicedependency *add_service_dependency(char *dependent_host_name, char *depen
 		free(new_servicedependency);
 		/* hack to avoid caller bombing out */
 		return result == OBJECTLIST_DUPE ? (void *)1 : NULL;
-		}
+	}
 
 	num_objects.servicedependencies++;
 	return new_servicedependency;
-	}
+}
 
 
 /* adds a host dependency definition */
-hostdependency *add_host_dependency(char *dependent_host_name, char *host_name, int dependency_type, int inherits_parent, int failure_options, char *dependency_period) {
+hostdependency *add_host_dependency(char *dependent_host_name, char *host_name, int dependency_type, int inherits_parent, int failure_options, char *dependency_period)
+{
 	hostdependency *new_hostdependency = NULL;
 	host *parent, *child;
 	timeperiod *tp = NULL;
@@ -1803,18 +1850,18 @@ hostdependency *add_host_dependency(char *dependent_host_name, char *host_name, 
 	parent = find_host(host_name);
 	if (!parent) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Master host '%s' in hostdependency from '%s' to '%s' is not defined anywhere!\n",
-			  host_name, dependent_host_name, host_name);
+		      host_name, dependent_host_name, host_name);
 		return NULL;
-		}
+	}
 	child = find_host(dependent_host_name);
 	if (!child) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Dependent host '%s' in hostdependency from '%s' to '%s' is not defined anywhere!\n",
-			  dependent_host_name, dependent_host_name, host_name);
+		      dependent_host_name, dependent_host_name, host_name);
 		return NULL;
-		}
+	}
 	if (dependency_period && !(tp = find_timeperiod(dependency_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unable to locate dependency_period '%s' for %s->%s host dependency\n",
-			  dependency_period, parent->name, child->name);
+		      dependency_period, parent->name, child->name);
 		return NULL ;
 	}
 
@@ -1844,16 +1891,17 @@ hostdependency *add_host_dependency(char *dependent_host_name, char *host_name, 
 		free(new_hostdependency);
 		/* hack to avoid caller bombing out */
 		return result == OBJECTLIST_DUPE ? (void *)1 : NULL;
-		}
+	}
 
 	num_objects.hostdependencies++;
 	return new_hostdependency;
-	}
+}
 
 
 
 /* add a new host escalation to the list in memory */
-hostescalation *add_hostescalation(char *host_name, int first_notification, int last_notification, double notification_interval, char *escalation_period, int escalation_options) {
+hostescalation *add_hostescalation(char *host_name, int first_notification, int last_notification, double notification_interval, char *escalation_period, int escalation_options)
+{
 	hostescalation *new_hostescalation = NULL;
 	host *h;
 	timeperiod *tp = NULL;
@@ -1862,16 +1910,16 @@ hostescalation *add_hostescalation(char *host_name, int first_notification, int 
 	if(host_name == NULL || !*host_name) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host escalation host name is NULL\n");
 		return NULL;
-		}
+	}
 	if (!(h = find_host(host_name))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Host '%s' has an escalation, but is not defined anywhere!\n", host_name);
 		return NULL;
-		}
+	}
 	if (escalation_period && !(tp = find_timeperiod(escalation_period))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unable to locate timeperiod '%s' for hostescalation '%s'\n",
-			  escalation_period, host_name);
+		      escalation_period, host_name);
 		return NULL;
-		}
+	}
 
 	new_hostescalation = calloc(1, sizeof(*new_hostescalation));
 
@@ -1880,7 +1928,7 @@ hostescalation *add_hostescalation(char *host_name, int first_notification, int 
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add hostescalation to host '%s'\n", host_name);
 		free(new_hostescalation);
 		return NULL;
-		}
+	}
 
 	/* assign vars. Object names are immutable, so no need to copy */
 	new_hostescalation->host_name = h->name;
@@ -1895,27 +1943,30 @@ hostescalation *add_hostescalation(char *host_name, int first_notification, int 
 	new_hostescalation->id = num_objects.hostescalations++;
 	hostescalation_ary[new_hostescalation->id] = new_hostescalation;
 	return new_hostescalation;
-	}
+}
 
 
 
 /* adds a contact group to a host escalation */
-contactgroupsmember *add_contactgroup_to_hostescalation(hostescalation *he, char *group_name) {
+contactgroupsmember *add_contactgroup_to_hostescalation(hostescalation *he, char *group_name)
+{
 	return add_contactgroup_to_object(&he->contact_groups, group_name);
-	}
+}
 
 
 
 /* adds a contact to a host escalation */
-contactsmember *add_contact_to_hostescalation(hostescalation *he, char *contact_name) {
+contactsmember *add_contact_to_hostescalation(hostescalation *he, char *contact_name)
+{
 
 	return add_contact_to_object(&he->contacts, contact_name);
-	}
+}
 
 
 
 /* adds a contact to an object */
-contactsmember *add_contact_to_object(contactsmember **object_ptr, char *contactname) {
+contactsmember *add_contact_to_object(contactsmember **object_ptr, char *contactname)
+{
 	contactsmember *new_contactsmember = NULL;
 	contact *c;
 
@@ -1923,22 +1974,22 @@ contactsmember *add_contact_to_object(contactsmember **object_ptr, char *contact
 	if(object_ptr == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact object is NULL\n");
 		return NULL;
-		}
+	}
 
 	if(contactname == NULL || !*contactname) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact name is NULL\n");
 		return NULL;
-		}
+	}
 	if(!(c = find_contact(contactname))) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Contact '%s' is not defined anywhere!\n", contactname);
 		return NULL;
-		}
+	}
 
 	/* allocate memory for a new member */
 	if((new_contactsmember = malloc(sizeof(contactsmember))) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for contact\n");
 		return NULL;
-		}
+	}
 	new_contactsmember->contact_name = c->name;
 
 	/* set initial values */
@@ -1949,44 +2000,44 @@ contactsmember *add_contact_to_object(contactsmember **object_ptr, char *contact
 	*object_ptr = new_contactsmember;
 
 	return new_contactsmember;
-	}
+}
 
 
 
 /* adds a custom variable to an object */
-customvariablesmember *add_custom_variable_to_object(customvariablesmember **object_ptr, char *varname, char *varvalue) {
+customvariablesmember *add_custom_variable_to_object(customvariablesmember **object_ptr, char *varname, char *varvalue)
+{
 	customvariablesmember *new_customvariablesmember = NULL;
 
 	/* make sure we have the data we need */
 	if(object_ptr == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Custom variable object is NULL\n");
 		return NULL;
-		}
+	}
 
 	if(varname == NULL || !strcmp(varname, "")) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Custom variable name is NULL\n");
 		return NULL;
-		}
+	}
 
 	/* allocate memory for a new member */
 	if((new_customvariablesmember = malloc(sizeof(customvariablesmember))) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for custom variable\n");
 		return NULL;
-		}
+	}
 	if((new_customvariablesmember->variable_name = (char *)strdup(varname)) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for custom variable name\n");
 		my_free(new_customvariablesmember);
 		return NULL;
-		}
+	}
 	if(varvalue) {
 		if((new_customvariablesmember->variable_value = (char *)strdup(varvalue)) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not allocate memory for custom variable value\n");
 			my_free(new_customvariablesmember->variable_name);
 			my_free(new_customvariablesmember);
 			return NULL;
-			}
 		}
-	else
+	} else
 		new_customvariablesmember->variable_value = NULL;
 
 	/* set initial values */
@@ -1997,7 +2048,7 @@ customvariablesmember *add_custom_variable_to_object(customvariablesmember **obj
 	*object_ptr = new_customvariablesmember;
 
 	return new_customvariablesmember;
-	}
+}
 
 
 
@@ -2006,42 +2057,51 @@ customvariablesmember *add_custom_variable_to_object(customvariablesmember **obj
 /******************** OBJECT SEARCH FUNCTIONS *********************/
 /******************************************************************/
 
-timeperiod *find_timeperiod(const char *name) {
+timeperiod *find_timeperiod(const char *name)
+{
 	return dkhash_get(object_hash_tables[TIMEPERIOD_SKIPLIST], name, NULL);
-	}
+}
 
-host *find_host(const char *name) {
+host *find_host(const char *name)
+{
 	return dkhash_get(object_hash_tables[HOST_SKIPLIST], name, NULL);
-	}
+}
 
-hostgroup *find_hostgroup(const char *name) {
+hostgroup *find_hostgroup(const char *name)
+{
 	return dkhash_get(object_hash_tables[HOSTGROUP_SKIPLIST], name, NULL);
-	}
+}
 
-servicegroup *find_servicegroup(const char *name) {
+servicegroup *find_servicegroup(const char *name)
+{
 	return dkhash_get(object_hash_tables[SERVICEGROUP_SKIPLIST], name, NULL);
-	}
+}
 
-contact *find_contact(const char *name) {
+contact *find_contact(const char *name)
+{
 	return dkhash_get(object_hash_tables[CONTACT_SKIPLIST], name, NULL);
-	}
+}
 
-contactgroup *find_contactgroup(const char *name) {
+contactgroup *find_contactgroup(const char *name)
+{
 	return dkhash_get(object_hash_tables[CONTACTGROUP_SKIPLIST], name, NULL);
-	}
+}
 
-command *find_command(const char *name) {
+command *find_command(const char *name)
+{
 	return dkhash_get(object_hash_tables[COMMAND_SKIPLIST], name, NULL);
-	}
+}
 
-service *find_service(const char *host_name, const char *svc_desc) {
+service *find_service(const char *host_name, const char *svc_desc)
+{
 	return dkhash_get(object_hash_tables[SERVICE_SKIPLIST], host_name, svc_desc);
-	}
+}
 
 
 
 /* adds a object to a list of objects */
-int add_object_to_objectlist(objectlist **list, void *object_ptr) {
+int add_object_to_objectlist(objectlist **list, void *object_ptr)
+{
 	objectlist *temp_item = NULL;
 	objectlist *new_item = NULL;
 
@@ -2052,7 +2112,7 @@ int add_object_to_objectlist(objectlist **list, void *object_ptr) {
 	for(temp_item = *list; temp_item; temp_item = temp_item->next) {
 		if(temp_item->object_ptr == object_ptr)
 			break;
-		}
+	}
 	if(temp_item)
 		return OK;
 
@@ -2068,7 +2128,7 @@ int add_object_to_objectlist(objectlist **list, void *object_ptr) {
 	*list = new_item;
 
 	return OK;
-	}
+}
 
 
 /* useful when we don't care if the object is unique or not */
@@ -2083,22 +2143,24 @@ int prepend_object_to_objectlist(objectlist **list, void *object_ptr)
 	item->object_ptr = object_ptr;
 	*list = item;
 	return OK;
-	}
+}
 
 /* useful for adding dependencies to master objects */
-int prepend_unique_object_to_objectlist(objectlist **list, void *object_ptr, size_t size) {
+int prepend_unique_object_to_objectlist(objectlist **list, void *object_ptr, size_t size)
+{
 	objectlist *l;
 	if(list == NULL || object_ptr == NULL)
 		return ERROR;
 	for(l = *list; l; l = l->next) {
 		if(!memcmp(l->object_ptr, object_ptr, size))
 			return OBJECTLIST_DUPE;
-		}
+	}
 	return prepend_object_to_objectlist(list, object_ptr);
 }
 
 /* frees memory allocated to a temporary object list */
-int free_objectlist(objectlist **temp_list) {
+int free_objectlist(objectlist **temp_list)
+{
 	objectlist *this_objectlist = NULL;
 	objectlist *next_objectlist = NULL;
 
@@ -2109,12 +2171,12 @@ int free_objectlist(objectlist **temp_list) {
 	for(this_objectlist = *temp_list; this_objectlist != NULL; this_objectlist = next_objectlist) {
 		next_objectlist = this_objectlist->next;
 		my_free(this_objectlist);
-		}
+	}
 
 	*temp_list = NULL;
 
 	return OK;
-	}
+}
 
 
 
@@ -2123,7 +2185,8 @@ int free_objectlist(objectlist **temp_list) {
 /******************************************************************/
 
 /* determines whether or not a specific host is an immediate child of another host */
-int is_host_immediate_child_of_host(host *parent_host, host *child_host) {
+int is_host_immediate_child_of_host(host *parent_host, host *child_host)
+{
 	hostsmember *temp_hostsmember = NULL;
 
 	/* not enough data */
@@ -2134,7 +2197,7 @@ int is_host_immediate_child_of_host(host *parent_host, host *child_host) {
 	if(parent_host == NULL) {
 		if(child_host->parent_hosts == NULL)
 			return TRUE;
-		}
+	}
 
 	/* mid-level/bottom hosts */
 	else {
@@ -2142,21 +2205,22 @@ int is_host_immediate_child_of_host(host *parent_host, host *child_host) {
 		for(temp_hostsmember = child_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
 			if(temp_hostsmember->host_ptr == parent_host)
 				return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /* determines whether or not a specific host is an immediate parent of another host */
-int is_host_immediate_parent_of_host(host *child_host, host *parent_host) {
+int is_host_immediate_parent_of_host(host *child_host, host *parent_host)
+{
 
 	if(is_host_immediate_child_of_host(parent_host, child_host) == TRUE)
 		return TRUE;
 
 	return FALSE;
-	}
+}
 
 #ifdef NSCGI
 int hostsmember_elements(hostsmember *list)
@@ -2169,48 +2233,49 @@ int hostsmember_elements(hostsmember *list)
 
 /* returns a count of the immediate children for a given host */
 /* NOTE: This function is only used by the CGIS */
-int number_of_immediate_child_hosts(host *hst) {
+int number_of_immediate_child_hosts(host *hst)
+{
 	int children = 0;
 	host *temp_host = NULL;
 
 	if(hst == NULL) {
 		for(temp_host = host_list; temp_host != NULL;
-				temp_host = temp_host->next) {
+		    temp_host = temp_host->next) {
 			if(is_host_immediate_child_of_host(hst, temp_host) == TRUE)
 				children++;
-			}
+		}
 		return children;
-		}
-	else {
+	} else {
 		return hostsmember_elements(hst->child_hosts);
-		}
 	}
+}
 
 
 /* get the number of immediate parent hosts for a given host */
 /* NOTE: This function is only used by the CGIS */
-int number_of_immediate_parent_hosts(host *hst) {
+int number_of_immediate_parent_hosts(host *hst)
+{
 	int parents = 0;
 	host *temp_host = NULL;
 
 	if(hst == NULL) {
 		for(temp_host = host_list; temp_host != NULL;
-				temp_host = temp_host->next) {
+		    temp_host = temp_host->next) {
 			if(is_host_immediate_parent_of_host(hst, temp_host) == TRUE) {
 				parents++;
-				}
 			}
+		}
 		return parents;
-		}
-	else {
+	} else {
 		return hostsmember_elements(hst->parent_hosts);
-		}
 	}
+}
 #endif
 
 /*  tests whether a host is a member of a particular hostgroup */
 /* NOTE: This function is only used by the CGIS */
-int is_host_member_of_hostgroup(hostgroup *group, host *hst) {
+int is_host_member_of_hostgroup(hostgroup *group, host *hst)
+{
 	hostsmember *temp_hostsmember = NULL;
 
 	if(group == NULL || hst == NULL)
@@ -2219,15 +2284,16 @@ int is_host_member_of_hostgroup(hostgroup *group, host *hst) {
 	for(temp_hostsmember = group->members; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
 		if(temp_hostsmember->host_ptr == hst)
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /*  tests whether a host is a member of a particular servicegroup */
 /* NOTE: This function is only used by the CGIS */
-int is_host_member_of_servicegroup(servicegroup *group, host *hst) {
+int is_host_member_of_servicegroup(servicegroup *group, host *hst)
+{
 	servicesmember *temp_servicesmember = NULL;
 
 	if(group == NULL || hst == NULL)
@@ -2236,15 +2302,16 @@ int is_host_member_of_servicegroup(servicegroup *group, host *hst) {
 	for(temp_servicesmember = group->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
 		if(temp_servicesmember->service_ptr != NULL && temp_servicesmember->service_ptr->host_ptr == hst)
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /*  tests whether a service is a member of a particular servicegroup */
 /* NOTE: This function is only used by the CGIS */
-int is_service_member_of_servicegroup(servicegroup *group, service *svc) {
+int is_service_member_of_servicegroup(servicegroup *group, service *svc)
+{
 	servicesmember *temp_servicesmember = NULL;
 
 	if(group == NULL || svc == NULL)
@@ -2253,10 +2320,10 @@ int is_service_member_of_servicegroup(servicegroup *group, service *svc) {
 	for(temp_servicesmember = group->members; temp_servicesmember != NULL; temp_servicesmember = temp_servicesmember->next) {
 		if(temp_servicesmember->service_ptr == svc)
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 /*
@@ -2266,7 +2333,8 @@ int is_service_member_of_servicegroup(servicegroup *group, service *svc) {
  * The cgi's stopped using it quite long ago though, so we need only
  * compile it if we're building the core
  */
-int is_contact_member_of_contactgroup(contactgroup *group, contact *cntct) {
+int is_contact_member_of_contactgroup(contactgroup *group, contact *cntct)
+{
 	contactsmember *member;
 
 	if(!group || !cntct)
@@ -2276,63 +2344,66 @@ int is_contact_member_of_contactgroup(contactgroup *group, contact *cntct) {
 	for(member = group->members; member; member = member->next) {
 		if (member->contact_ptr == cntct)
 			return TRUE;
-		}
-
-	return FALSE;
 	}
 
+	return FALSE;
+}
+
 /*  tests whether a contact is a contact for a particular host */
-int is_contact_for_host(host *hst, contact *cntct) {
+int is_contact_for_host(host *hst, contact *cntct)
+{
 	contactsmember *temp_contactsmember = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 	contactgroup *temp_contactgroup = NULL;
 
 	if(hst == NULL || cntct == NULL) {
 		return FALSE;
-		}
+	}
 
 	/* search all individual contacts of this host */
 	for(temp_contactsmember = hst->contacts; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
 		if (temp_contactsmember->contact_ptr == cntct)
 			return TRUE;
-		}
+	}
 
 	/* search all contactgroups of this host */
 	for(temp_contactgroupsmember = hst->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		temp_contactgroup = temp_contactgroupsmember->group_ptr;
 		if(is_contact_member_of_contactgroup(temp_contactgroup, cntct))
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /*  tests whether a contactgroup is a contactgroup for a particular host */
-int is_contactgroup_for_host(host *hst, contactgroup *group) {
+int is_contactgroup_for_host(host *hst, contactgroup *group)
+{
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 
 	if(hst == NULL || group == NULL) {
 		return FALSE;
-		}
+	}
 
 	/* search all contactgroups of this host */
 	for(temp_contactgroupsmember = hst->contact_groups;
-			temp_contactgroupsmember != NULL;
-			temp_contactgroupsmember = temp_contactgroupsmember->next) {
+	    temp_contactgroupsmember != NULL;
+	    temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		if(temp_contactgroupsmember->group_ptr == group) {
 			return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /* tests whether a contact is an escalated contact for a particular host */
-int is_escalated_contact_for_host(host *hst, contact *cntct) {
+int is_escalated_contact_for_host(host *hst, contact *cntct)
+{
 	hostescalation *temp_hostescalation = NULL;
 	objectlist *list;
 
@@ -2342,16 +2413,17 @@ int is_escalated_contact_for_host(host *hst, contact *cntct) {
 
 		if(is_contact_for_host_escalation(temp_hostescalation, cntct) == TRUE) {
 			return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /* tests whether a contact is an contact for a particular host escalation */
-int is_contact_for_host_escalation(hostescalation *escalation, contact *cntct) {
+int is_contact_for_host_escalation(hostescalation *escalation, contact *cntct)
+{
 	contactsmember *temp_contactsmember = NULL;
 	hostescalation *temp_hostescalation = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
@@ -2359,52 +2431,54 @@ int is_contact_for_host_escalation(hostescalation *escalation, contact *cntct) {
 
 	/* search all contacts of this host escalation */
 	for(temp_contactsmember = temp_hostescalation->contacts;
-			temp_contactsmember != NULL;
-			temp_contactsmember = temp_contactsmember->next) {
+	    temp_contactsmember != NULL;
+	    temp_contactsmember = temp_contactsmember->next) {
 		if(temp_contactsmember->contact_ptr == cntct)
 			return TRUE;
-		}
+	}
 
 	/* search all contactgroups of this host escalation */
 	for(temp_contactgroupsmember = temp_hostescalation->contact_groups;
-			temp_contactgroupsmember != NULL;
-			temp_contactgroupsmember = temp_contactgroupsmember->next) {
+	    temp_contactgroupsmember != NULL;
+	    temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		temp_contactgroup = temp_contactgroupsmember->group_ptr;
 		if(is_contact_member_of_contactgroup(temp_contactgroup, cntct))
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /*  tests whether a contactgroup is a contactgroup for a particular
 	host escalation */
 int is_contactgroup_for_host_escalation(hostescalation *escalation,
-		contactgroup *group) {
+                                        contactgroup *group)
+{
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 
 	if(escalation == NULL || group == NULL) {
 		return FALSE;
-		}
+	}
 
 	/* search all contactgroups of this host escalation */
 	for(temp_contactgroupsmember = escalation->contact_groups;
-			temp_contactgroupsmember != NULL;
-			temp_contactgroupsmember = temp_contactgroupsmember->next) {
+	    temp_contactgroupsmember != NULL;
+	    temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		if(temp_contactgroupsmember->group_ptr == group) {
 			return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /*  tests whether a contact is a contact for a particular service */
-int is_contact_for_service(service *svc, contact *cntct) {
+int is_contact_for_service(service *svc, contact *cntct)
+{
 	contactsmember *temp_contactsmember = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 	contactgroup *temp_contactgroup = NULL;
@@ -2416,7 +2490,7 @@ int is_contact_for_service(service *svc, contact *cntct) {
 	for(temp_contactsmember = svc->contacts; temp_contactsmember != NULL; temp_contactsmember = temp_contactsmember->next) {
 		if(temp_contactsmember->contact_ptr == cntct)
 			return TRUE;
-		}
+	}
 
 	/* search all contactgroups of this service */
 	for(temp_contactgroupsmember = svc->contact_groups; temp_contactgroupsmember != NULL; temp_contactgroupsmember = temp_contactgroupsmember->next) {
@@ -2424,15 +2498,16 @@ int is_contact_for_service(service *svc, contact *cntct) {
 		if(is_contact_member_of_contactgroup(temp_contactgroup, cntct))
 			return TRUE;
 
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /*  tests whether a contactgroup is a contactgroup for a particular service */
-int is_contactgroup_for_service(service *svc, contactgroup *group) {
+int is_contactgroup_for_service(service *svc, contactgroup *group)
+{
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 
 	if(svc == NULL || group == NULL)
@@ -2440,20 +2515,21 @@ int is_contactgroup_for_service(service *svc, contactgroup *group) {
 
 	/* search all contactgroups of this service */
 	for(temp_contactgroupsmember = svc->contact_groups;
-			temp_contactgroupsmember != NULL;
-			temp_contactgroupsmember = temp_contactgroupsmember->next) {
+	    temp_contactgroupsmember != NULL;
+	    temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		if(temp_contactgroupsmember->group_ptr == group) {
 			return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /* tests whether a contact is an escalated contact for a particular service */
-int is_escalated_contact_for_service(service *svc, contact *cntct) {
+int is_escalated_contact_for_service(service *svc, contact *cntct)
+{
 	serviceescalation *temp_serviceescalation = NULL;
 	objectlist *list;
 
@@ -2462,66 +2538,68 @@ int is_escalated_contact_for_service(service *svc, contact *cntct) {
 		temp_serviceescalation = (serviceescalation *)list->object_ptr;
 
 		if(is_contact_for_service_escalation(temp_serviceescalation,
-				cntct) == TRUE) {
+		                                     cntct) == TRUE) {
 			return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /* tests whether a contact is an contact for a particular service escalation */
 int is_contact_for_service_escalation(serviceescalation *escalation,
-		contact *cntct) {
+                                      contact *cntct)
+{
 	contactsmember *temp_contactsmember = NULL;
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 	contactgroup *temp_contactgroup = NULL;
 
 	/* search all contacts of this service escalation */
 	for(temp_contactsmember = escalation->contacts;
-			temp_contactsmember != NULL;
-			temp_contactsmember = temp_contactsmember->next) {
+	    temp_contactsmember != NULL;
+	    temp_contactsmember = temp_contactsmember->next) {
 		if(temp_contactsmember->contact_ptr == cntct)
 			return TRUE;
-		}
+	}
 
 	/* search all contactgroups of this service escalation */
 	for(temp_contactgroupsmember =escalation->contact_groups;
-			temp_contactgroupsmember != NULL;
-			temp_contactgroupsmember = temp_contactgroupsmember->next) {
+	    temp_contactgroupsmember != NULL;
+	    temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		temp_contactgroup = temp_contactgroupsmember->group_ptr;
 		if(is_contact_member_of_contactgroup(temp_contactgroup, cntct))
 			return TRUE;
-		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
 /*  tests whether a contactgroup is a contactgroup for a particular
 	service escalation */
 int is_contactgroup_for_service_escalation(serviceescalation *escalation,
-		contactgroup *group) {
+        contactgroup *group)
+{
 	contactgroupsmember *temp_contactgroupsmember = NULL;
 
 	if(escalation == NULL || group == NULL) {
 		return FALSE;
-		}
+	}
 
 	/* search all contactgroups of this service escalation */
 	for(temp_contactgroupsmember = escalation->contact_groups;
-			temp_contactgroupsmember != NULL;
-			temp_contactgroupsmember = temp_contactgroupsmember->next) {
+	    temp_contactgroupsmember != NULL;
+	    temp_contactgroupsmember = temp_contactgroupsmember->next) {
 		if(temp_contactgroupsmember->group_ptr == group) {
 			return TRUE;
-			}
 		}
+	}
 
 	return FALSE;
-	}
+}
 
 
 
@@ -2531,7 +2609,8 @@ int is_contactgroup_for_service_escalation(serviceescalation *escalation,
 
 
 /* free all allocated memory for objects */
-int free_object_data(void) {
+int free_object_data(void)
+{
 	daterange *this_daterange = NULL;
 	daterange *next_daterange = NULL;
 	timerange *this_timerange = NULL;
@@ -2575,10 +2654,10 @@ int free_object_data(void) {
 				for(this_timerange = this_daterange->times; this_timerange != NULL; this_timerange = next_timerange) {
 					next_timerange = this_timerange->next;
 					my_free(this_timerange);
-					}
-				my_free(this_daterange);
 				}
+				my_free(this_daterange);
 			}
+		}
 
 		/* free the day time ranges contained in this timeperiod */
 		for(x = 0; x < 7; x++) {
@@ -2586,21 +2665,21 @@ int free_object_data(void) {
 			for(this_timerange = this_timeperiod->days[x]; this_timerange != NULL; this_timerange = next_timerange) {
 				next_timerange = this_timerange->next;
 				my_free(this_timerange);
-				}
 			}
+		}
 
 		/* free exclusions */
 		for(this_timeperiodexclusion = this_timeperiod->exclusions; this_timeperiodexclusion != NULL; this_timeperiodexclusion = next_timeperiodexclusion) {
 			next_timeperiodexclusion = this_timeperiodexclusion->next;
 			my_free(this_timeperiodexclusion->timeperiod_name);
 			my_free(this_timeperiodexclusion);
-			}
+		}
 
 		if (this_timeperiod->alias != this_timeperiod->name)
 			my_free(this_timeperiod->alias);
 		my_free(this_timeperiod->name);
 		my_free(this_timeperiod);
-		}
+	}
 
 	/* reset pointers */
 	my_free(timeperiod_ary);
@@ -2617,7 +2696,7 @@ int free_object_data(void) {
 			my_free(this_hostsmember->host_name);
 			my_free(this_hostsmember);
 			this_hostsmember = next_hostsmember;
-			}
+		}
 
 		/* free memory for child host links */
 		this_hostsmember = this_host->child_hosts;
@@ -2625,7 +2704,7 @@ int free_object_data(void) {
 			next_hostsmember = this_hostsmember->next;
 			my_free(this_hostsmember);
 			this_hostsmember = next_hostsmember;
-			}
+		}
 
 		/* free memory for service links */
 		this_servicesmember = this_host->services;
@@ -2633,7 +2712,7 @@ int free_object_data(void) {
 			next_servicesmember = this_servicesmember->next;
 			my_free(this_servicesmember);
 			this_servicesmember = next_servicesmember;
-			}
+		}
 
 		/* free memory for contact groups */
 		this_contactgroupsmember = this_host->contact_groups;
@@ -2641,7 +2720,7 @@ int free_object_data(void) {
 			next_contactgroupsmember = this_contactgroupsmember->next;
 			my_free(this_contactgroupsmember);
 			this_contactgroupsmember = next_contactgroupsmember;
-			}
+		}
 
 		/* free memory for contacts */
 		this_contactsmember = this_host->contacts;
@@ -2649,7 +2728,7 @@ int free_object_data(void) {
 			next_contactsmember = this_contactsmember->next;
 			my_free(this_contactsmember);
 			this_contactsmember = next_contactsmember;
-			}
+		}
 
 		/* free memory for custom variables */
 		this_customvariablesmember = this_host->custom_variables;
@@ -2659,7 +2738,7 @@ int free_object_data(void) {
 			my_free(this_customvariablesmember->variable_value);
 			my_free(this_customvariablesmember);
 			this_customvariablesmember = next_customvariablesmember;
-			}
+		}
 
 		if(this_host->display_name != this_host->name)
 			my_free(this_host->display_name);
@@ -2687,7 +2766,7 @@ int free_object_data(void) {
 		my_free(this_host->vrml_image);
 		my_free(this_host->statusmap_image);
 		my_free(this_host);
-		}
+	}
 
 	/* reset pointers */
 	my_free(host_ary);
@@ -2703,7 +2782,7 @@ int free_object_data(void) {
 			next_hostsmember = this_hostsmember->next;
 			my_free(this_hostsmember);
 			this_hostsmember = next_hostsmember;
-			}
+		}
 
 		if (this_hostgroup->alias != this_hostgroup->group_name)
 			my_free(this_hostgroup->alias);
@@ -2712,7 +2791,7 @@ int free_object_data(void) {
 		my_free(this_hostgroup->notes_url);
 		my_free(this_hostgroup->action_url);
 		my_free(this_hostgroup);
-		}
+	}
 
 	/* reset pointers */
 	my_free(hostgroup_ary);
@@ -2727,7 +2806,7 @@ int free_object_data(void) {
 			next_servicesmember = this_servicesmember->next;
 			my_free(this_servicesmember);
 			this_servicesmember = next_servicesmember;
-			}
+		}
 
 		if (this_servicegroup->alias != this_servicegroup->group_name)
 			my_free(this_servicegroup->alias);
@@ -2736,7 +2815,7 @@ int free_object_data(void) {
 		my_free(this_servicegroup->notes_url);
 		my_free(this_servicegroup->action_url);
 		my_free(this_servicegroup);
-		}
+	}
 
 	/* reset pointers */
 	my_free(servicegroup_ary);
@@ -2754,7 +2833,7 @@ int free_object_data(void) {
 				my_free(this_commandsmember->command);
 			my_free(this_commandsmember);
 			this_commandsmember = next_commandsmember;
-			}
+		}
 
 		/* free memory for the service notification commands */
 		this_commandsmember = this_contact->service_notification_commands;
@@ -2764,7 +2843,7 @@ int free_object_data(void) {
 				my_free(this_commandsmember->command);
 			my_free(this_commandsmember);
 			this_commandsmember = next_commandsmember;
-			}
+		}
 
 		/* free memory for custom variables */
 		this_customvariablesmember = this_contact->custom_variables;
@@ -2774,7 +2853,7 @@ int free_object_data(void) {
 			my_free(this_customvariablesmember->variable_value);
 			my_free(this_customvariablesmember);
 			this_customvariablesmember = next_customvariablesmember;
-			}
+		}
 
 		if (this_contact->alias != this_contact->name)
 			my_free(this_contact->alias);
@@ -2786,7 +2865,7 @@ int free_object_data(void) {
 
 		free_objectlist(&this_contact->contactgroups_ptr);
 		my_free(this_contact);
-		}
+	}
 
 	/* reset pointers */
 	my_free(contact_ary);
@@ -2802,13 +2881,13 @@ int free_object_data(void) {
 			next_contactsmember = this_contactsmember->next;
 			my_free(this_contactsmember);
 			this_contactsmember = next_contactsmember;
-			}
+		}
 
 		if (this_contactgroup->alias != this_contactgroup->group_name)
 			my_free(this_contactgroup->alias);
 		my_free(this_contactgroup->group_name);
 		my_free(this_contactgroup);
-		}
+	}
 
 	/* reset pointers */
 	my_free(contactgroup_ary);
@@ -2824,7 +2903,7 @@ int free_object_data(void) {
 			next_contactgroupsmember = this_contactgroupsmember->next;
 			my_free(this_contactgroupsmember);
 			this_contactgroupsmember = next_contactgroupsmember;
-			}
+		}
 
 		/* free memory for contacts */
 		this_contactsmember = this_service->contacts;
@@ -2832,7 +2911,7 @@ int free_object_data(void) {
 			next_contactsmember = this_contactsmember->next;
 			my_free(this_contactsmember);
 			this_contactsmember = next_contactsmember;
-			}
+		}
 
 		/* free memory for custom variables */
 		this_customvariablesmember = this_service->custom_variables;
@@ -2842,7 +2921,7 @@ int free_object_data(void) {
 			my_free(this_customvariablesmember->variable_value);
 			my_free(this_customvariablesmember);
 			this_customvariablesmember = next_customvariablesmember;
-			}
+		}
 
 		if(this_service->display_name != this_service->description)
 			my_free(this_service->display_name);
@@ -2868,7 +2947,7 @@ int free_object_data(void) {
 		my_free(this_service->icon_image);
 		my_free(this_service->icon_image_alt);
 		my_free(this_service);
-		}
+	}
 
 	/* reset pointers */
 	my_free(service_ary);
@@ -2880,7 +2959,7 @@ int free_object_data(void) {
 		my_free(this_command->name);
 		my_free(this_command->command_line);
 		my_free(this_command);
-		}
+	}
 
 	/* reset pointers */
 	my_free(command_ary);
@@ -2896,7 +2975,7 @@ int free_object_data(void) {
 			next_contactgroupsmember = this_contactgroupsmember->next;
 			my_free(this_contactgroupsmember);
 			this_contactgroupsmember = next_contactgroupsmember;
-			}
+		}
 
 		/* free memory for contacts */
 		this_contactsmember = this_serviceescalation->contacts;
@@ -2904,9 +2983,9 @@ int free_object_data(void) {
 			next_contactsmember = this_contactsmember->next;
 			my_free(this_contactsmember);
 			this_contactsmember = next_contactsmember;
-			}
-		my_free(this_serviceescalation);
 		}
+		my_free(this_serviceescalation);
+	}
 
 	/* reset pointers */
 	my_free(serviceescalation_ary);
@@ -2917,7 +2996,7 @@ int free_object_data(void) {
 		for(i = 0; i < num_objects.servicedependencies; i++)
 			my_free(servicedependency_ary[i]);
 		my_free(servicedependency_ary);
-		}
+	}
 
 
 	/**** free host dependency memory ****/
@@ -2925,7 +3004,7 @@ int free_object_data(void) {
 		for(i = 0; i < num_objects.hostdependencies; i++)
 			my_free(hostdependency_ary[i]);
 		my_free(hostdependency_ary);
-		}
+	}
 
 
 	/**** free host escalation memory ****/
@@ -2938,7 +3017,7 @@ int free_object_data(void) {
 			next_contactgroupsmember = this_contactgroupsmember->next;
 			my_free(this_contactgroupsmember);
 			this_contactgroupsmember = next_contactgroupsmember;
-			}
+		}
 
 		/* free memory for contacts */
 		this_contactsmember = this_hostescalation->contacts;
@@ -2946,9 +3025,9 @@ int free_object_data(void) {
 			next_contactsmember = this_contactsmember->next;
 			my_free(this_contactsmember);
 			this_contactsmember = next_contactsmember;
-			}
-		my_free(this_hostescalation);
 		}
+		my_free(this_hostescalation);
+	}
 
 	/* reset pointers */
 	my_free(hostescalation_ary);
@@ -2957,7 +3036,7 @@ int free_object_data(void) {
 	memset(&num_objects, 0, sizeof(num_objects));
 
 	return OK;
-	}
+}
 
 
 
@@ -3049,7 +3128,7 @@ void fcache_timeperiod(FILE *fp, timeperiod *temp_timeperiod)
 				continue;
 
 			switch(temp_daterange->type) {
-				case DATERANGE_CALENDAR_DATE:
+			case DATERANGE_CALENDAR_DATE:
 				fprintf(fp, "\t%d-%02d-%02d", temp_daterange->syear, temp_daterange->smon + 1, temp_daterange->smday);
 				if((temp_daterange->smday != temp_daterange->emday) || (temp_daterange->smon != temp_daterange->emon) || (temp_daterange->syear != temp_daterange->eyear))
 					fprintf(fp, " - %d-%02d-%02d", temp_daterange->eyear, temp_daterange->emon + 1, temp_daterange->emday);
@@ -3114,7 +3193,7 @@ void fcache_timeperiod(FILE *fp, timeperiod *temp_timeperiod)
 void fcache_command(FILE *fp, command *temp_command)
 {
 	fprintf(fp, "define command {\n\tcommand_name\t%s\n\tcommand_line\t%s\n\t}\n\n",
-		   temp_command->name, temp_command->command_line);
+	        temp_command->name, temp_command->command_line);
 }
 
 void fcache_contactgroup(FILE *fp, contactgroup *temp_contactgroup)
@@ -3422,8 +3501,8 @@ void fcache_hostdependency(FILE *fp, hostdependency *temp_hostdependency)
 		fprintf(fp, "\tdependency_period\t%s\n", temp_hostdependency->dependency_period);
 	fprintf(fp, "\tinherits_parent\t%d\n", temp_hostdependency->inherits_parent);
 	fprintf(fp, "\t%s_failure_options\t%s\n",
-			temp_hostdependency->dependency_type == NOTIFICATION_DEPENDENCY ? "notification" : "execution",
-			opts2str(temp_hostdependency->failure_options, host_flag_map, 'o'));
+	        temp_hostdependency->dependency_type == NOTIFICATION_DEPENDENCY ? "notification" : "execution",
+	        opts2str(temp_hostdependency->failure_options, host_flag_map, 'o'));
 	fprintf(fp, "\t}\n\n");
 }
 
@@ -3444,7 +3523,8 @@ void fcache_hostescalation(FILE *fp, hostescalation *temp_hostescalation)
 }
 
 /* writes cached object definitions for use by web interface */
-int fcache_objects(char *cache_file) {
+int fcache_objects(char *cache_file)
+{
 	FILE *fp = NULL;
 	time_t current_time = 0L;
 	unsigned int i;
@@ -3460,7 +3540,7 @@ int fcache_objects(char *cache_file) {
 	if(fp == NULL) {
 		logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Could not open object cache file '%s' for writing!\n", cache_file);
 		return ERROR;
-		}
+	}
 
 	/* write header to cache file */
 	fprintf(fp, "########################################\n");
@@ -3524,5 +3604,5 @@ int fcache_objects(char *cache_file) {
 	fclose(fp);
 
 	return OK;
-	}
+}
 #endif

--- a/common/shared.c
+++ b/common/shared.c
@@ -44,7 +44,8 @@ char *config_file_dir = NULL;
 
 
 /* silly debug-ish helper used to track down hotspots in config parsing */
-void timing_point(const char *fmt, ...) {
+void timing_point(const char *fmt, ...)
+{
 	static struct timeval last = {0, 0}, first = {0, 0};
 	struct timeval now;
 	va_list ap;
@@ -57,20 +58,20 @@ void timing_point(const char *fmt, ...) {
 		last.tv_sec = first.tv_sec;
 		last.tv_usec = first.tv_usec;
 		printf("[0.0000 (+0.0000)] ");
-		}
-	else {
+	} else {
 		gettimeofday(&now, NULL);
 		printf("[%.4f (+%.4f)] ", tv_delta_f(&first, &now), tv_delta_f(&last, &now));
 		last.tv_sec = now.tv_sec;
 		last.tv_usec = now.tv_usec;
-		}
+	}
 	va_start(ap, fmt);
 	vprintf(fmt, ap);
 	va_end(ap);
-	}
+}
 
 /* fix the problem with strtok() skipping empty options between tokens */
-char *my_strtok(char *buffer, const char *tokens) {
+char *my_strtok(char *buffer, const char *tokens)
+{
 	char *token_position = NULL;
 	char *sequence_head = NULL;
 	static char *my_strtok_buffer = NULL;
@@ -81,7 +82,7 @@ char *my_strtok(char *buffer, const char *tokens) {
 		if((my_strtok_buffer = (char *)strdup(buffer)) == NULL)
 			return NULL;
 		original_my_strtok_buffer = my_strtok_buffer;
-		}
+	}
 
 	sequence_head = my_strtok_buffer;
 
@@ -93,17 +94,18 @@ char *my_strtok(char *buffer, const char *tokens) {
 	if(token_position == NULL) {
 		my_strtok_buffer = strchr(my_strtok_buffer, '\x0');
 		return sequence_head;
-		}
+	}
 
 	token_position[0] = '\x0';
 	my_strtok_buffer = token_position + 1;
 
 	return sequence_head;
-	}
+}
 
 /* fixes compiler problems under Solaris, since strsep() isn't included */
 /* this code is taken from the glibc source */
-char *my_strsep(char **stringp, const char *delim) {
+char *my_strsep(char **stringp, const char *delim)
+{
 	char *begin, *end;
 
 	begin = *stringp;
@@ -123,27 +125,26 @@ char *my_strsep(char **stringp, const char *delim) {
 				end = begin;
 			else
 				end = strchr(begin + 1, ch);
-			}
 		}
-	else {
+	} else {
 		/* find the end of the token.  */
 		end = strpbrk(begin, delim);
-		}
+	}
 
 	if(end) {
 		/* terminate the token and set *STRINGP past NUL character.  */
 		*end++ = '\0';
 		*stringp = end;
-		}
-	else
+	} else
 		/* no more delimiters; this is the last token.  */
 		*stringp = NULL;
 
 	return begin;
-	}
+}
 
 /* open a file read-only via mmap() */
-mmapfile *mmap_fopen(const char *filename) {
+mmapfile *mmap_fopen(const char *filename)
+{
 	mmapfile *new_mmapfile = NULL;
 	int fd = 0;
 	void *mmap_buf = NULL;
@@ -162,14 +163,14 @@ mmapfile *mmap_fopen(const char *filename) {
 	if((fd = open(filename, mode)) == -1) {
 		my_free(new_mmapfile);
 		return NULL;
-		}
+	}
 
 	/* get file info */
 	if((fstat(fd, &statbuf)) == -1) {
 		close(fd);
 		my_free(new_mmapfile);
 		return NULL;
-		}
+	}
 
 	/* get file size */
 	file_size = (unsigned long)statbuf.st_size;
@@ -179,14 +180,13 @@ mmapfile *mmap_fopen(const char *filename) {
 
 		/* mmap() the file - allocate one extra byte for processing zero-byte files */
 		if((mmap_buf =
-		            (void *)mmap(0, file_size, PROT_READ, MAP_PRIVATE, fd,
-		                         0)) == MAP_FAILED) {
+		        (void *)mmap(0, file_size, PROT_READ, MAP_PRIVATE, fd,
+		                     0)) == MAP_FAILED) {
 			close(fd);
 			my_free(new_mmapfile);
 			return NULL;
-			}
 		}
-	else
+	} else
 		mmap_buf = NULL;
 
 	/* populate struct info for later use */
@@ -198,10 +198,11 @@ mmapfile *mmap_fopen(const char *filename) {
 	new_mmapfile->mmap_buf = mmap_buf;
 
 	return new_mmapfile;
-	}
+}
 
 /* close a file originally opened via mmap() */
-int mmap_fclose(mmapfile * temp_mmapfile) {
+int mmap_fclose(mmapfile * temp_mmapfile)
+{
 
 	if(temp_mmapfile == NULL)
 		return ERROR;
@@ -218,10 +219,11 @@ int mmap_fclose(mmapfile * temp_mmapfile) {
 	my_free(temp_mmapfile);
 
 	return OK;
-	}
+}
 
 /* gets one line of input from an mmap()'ed file */
-char *mmap_fgets(mmapfile * temp_mmapfile) {
+char *mmap_fgets(mmapfile * temp_mmapfile)
+{
 	char *buf = NULL;
 	unsigned long x = 0L;
 	int len = 0;
@@ -239,12 +241,12 @@ char *mmap_fgets(mmapfile * temp_mmapfile) {
 
 	/* find the end of the string (or buffer) */
 	for(x = temp_mmapfile->current_position; x < temp_mmapfile->file_size;
-	        x++) {
+	    x++) {
 		if(*((char *)(temp_mmapfile->mmap_buf) + x) == '\n') {
 			x++;
 			break;
-			}
 		}
+	}
 
 	/* calculate length of line we just read */
 	len = (int)(x - temp_mmapfile->current_position);
@@ -266,10 +268,11 @@ char *mmap_fgets(mmapfile * temp_mmapfile) {
 	temp_mmapfile->current_line++;
 
 	return buf;
-	}
+}
 
 /* gets one line of input from an mmap()'ed file (may be contained on more than one line in the source file) */
-char *mmap_fgets_multiline(mmapfile * temp_mmapfile) {
+char *mmap_fgets_multiline(mmapfile * temp_mmapfile)
+{
 	char *buf = NULL;
 	char *tempbuf = NULL;
 	char *stripped = NULL;
@@ -293,8 +296,7 @@ char *mmap_fgets_multiline(mmapfile * temp_mmapfile) {
 				break;
 			memcpy(buf, tempbuf, len);
 			buf[len] = '\x0';
-			}
-		else {
+		} else {
 			/* strip leading white space from continuation lines */
 			stripped = tempbuf;
 			while(*stripped == ' ' || *stripped == '\t')
@@ -302,12 +304,12 @@ char *mmap_fgets_multiline(mmapfile * temp_mmapfile) {
 			len = strlen(stripped);
 			len2 = strlen(buf);
 			if((buf =
-			            (char *)realloc(buf, len + len2 + 1)) == NULL)
+			        (char *)realloc(buf, len + len2 + 1)) == NULL)
 				break;
 			strcat(buf, stripped);
 			len += len2;
 			buf[len] = '\x0';
-			}
+		}
 
 		if(len == 0)
 			break;
@@ -326,7 +328,7 @@ char *mmap_fgets_multiline(mmapfile * temp_mmapfile) {
 			buf[end] = '\n';
 			buf[end + 1] = '\x0';
 			break;
-			}
+		}
 
 		/* one backslash found. continue reading the next line */
 		else if(end > 0 && buf[end] == '\\')
@@ -335,15 +337,16 @@ char *mmap_fgets_multiline(mmapfile * temp_mmapfile) {
 		/* no continuation marker was found, so break */
 		else
 			break;
-		}
+	}
 
 	my_free(tempbuf);
 
 	return buf;
-	}
+}
 
 /* strip newline, carriage return, and tab characters from beginning and end of a string */
-void strip(char *buffer) {
+void strip(char *buffer)
+{
 	register int x, z;
 	int len;
 
@@ -354,15 +357,15 @@ void strip(char *buffer) {
 	len = (int)strlen(buffer);
 	for(x = len - 1; x >= 0; x--) {
 		switch(buffer[x]) {
-			case ' ':
-			case '\n':
-			case '\r':
-			case '\t':
-				buffer[x] = '\x0';
-				continue;
-			}
-		break;
+		case ' ':
+		case '\n':
+		case '\r':
+		case '\t':
+			buffer[x] = '\x0';
+			continue;
 		}
+		break;
+	}
 
 	/* if we stripped all of it, just return */
 	if(!x)
@@ -375,14 +378,14 @@ void strip(char *buffer) {
 	/* NOTE: this is very expensive to do, so avoid it whenever possible */
 	for(x = 0;; x++) {
 		switch(buffer[x]) {
-			case ' ':
-			case '\n':
-			case '\r':
-			case '\t':
-				continue;
-			}
-		break;
+		case ' ':
+		case '\n':
+		case '\r':
+		case '\t':
+			continue;
 		}
+		break;
+	}
 
 	if(x > 0 && z > 0) {
 		/* new length of the string after we stripped the end */
@@ -392,14 +395,15 @@ void strip(char *buffer) {
 		for(z = x; z < len; z++)
 			buffer[z - x] = buffer[z];
 		buffer[len - x] = '\x0';
-		}
 	}
+}
 
 /**************************************************
  *************** HASH FUNCTIONS *******************
  **************************************************/
 /* dual hash function */
-int hashfunc(const char *name1, const char *name2, int hashslots) {
+int hashfunc(const char *name1, const char *name2, int hashslots)
+{
 	unsigned int i, result;
 
 	result = 0;
@@ -415,11 +419,12 @@ int hashfunc(const char *name1, const char *name2, int hashslots) {
 	result = result % hashslots;
 
 	return result;
-	}
+}
 
 /* dual hash data comparison */
 int compare_hashdata(const char *val1a, const char *val1b, const char *val2a,
-                     const char *val2b) {
+                     const char *val2b)
+{
 	int result = 0;
 
 	/* NOTE: If hash calculation changes, update the compare_strings() function! */
@@ -444,16 +449,17 @@ int compare_hashdata(const char *val1a, const char *val1b, const char *val2a,
 			result = -1;
 		else
 			result = strcmp(val1b, val2b);
-		}
+	}
 
 	return result;
-	}
+}
 /*
  * given a date/time in time_t format, produce a corresponding
  * date/time string, including timezone
  */
 void get_datetime_string(time_t * raw_time, char *buffer, int buffer_length,
-                         int type) {
+                         int type)
+{
 	time_t t;
 	struct tm *tm_ptr, tm_s;
 	int hour;
@@ -466,7 +472,7 @@ void get_datetime_string(time_t * raw_time, char *buffer, int buffer_length,
 	const char *months[12] = {
 		"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept",
 		"Oct", "Nov", "Dec"
-		};
+	};
 	const char *tzone = "";
 
 	if(raw_time == NULL)
@@ -516,7 +522,7 @@ void get_datetime_string(time_t * raw_time, char *buffer, int buffer_length,
 			snprintf(buffer, buffer_length,
 			         "%02d-%02d-%04d %02d:%02d:%02d", month, day,
 			         year, hour, minute, second);
-		}
+	}
 
 	/* short date */
 	else if(type == SHORT_DATE) {
@@ -530,7 +536,7 @@ void get_datetime_string(time_t * raw_time, char *buffer, int buffer_length,
 		else
 			snprintf(buffer, buffer_length, "%02d-%02d-%04d", month,
 			         day, year);
-		}
+	}
 
 	/* expiration date/time for HTTP headers */
 	else if(type == HTTP_DATE_TIME)
@@ -545,11 +551,12 @@ void get_datetime_string(time_t * raw_time, char *buffer, int buffer_length,
 		         second);
 
 	buffer[buffer_length - 1] = '\x0';
-	}
+}
 
 /* get days, hours, minutes, and seconds from a raw time_t format or total seconds */
 void get_time_breakdown(unsigned long raw_time, int *days, int *hours,
-                        int *minutes, int *seconds) {
+                        int *minutes, int *seconds)
+{
 	unsigned long temp_time;
 	int temp_days;
 	int temp_hours;
@@ -570,4 +577,4 @@ void get_time_breakdown(unsigned long raw_time, int *days, int *hours,
 	*hours = temp_hours;
 	*minutes = temp_minutes;
 	*seconds = temp_seconds;
-	}
+}

--- a/common/statusdata.c
+++ b/common/statusdata.c
@@ -57,13 +57,15 @@ extern int      use_pending_states;
 /******************************************************************/
 
 /* initializes status data at program start */
-int initialize_status_data(const char *cfgfile) {
+int initialize_status_data(const char *cfgfile)
+{
 	return xsddefault_initialize_status_data(cfgfile);
-	}
+}
 
 
 /* update all status data (aggregated dump) */
-int update_all_status_data(void) {
+int update_all_status_data(void)
+{
 	int result = OK;
 
 #ifdef USE_EVENT_BROKER
@@ -78,18 +80,20 @@ int update_all_status_data(void) {
 	broker_aggregated_status_data(NEBTYPE_AGGREGATEDSTATUS_ENDDUMP, NEBFLAG_NONE, NEBATTR_NONE, NULL);
 #endif
 	return result;
-	}
+}
 
 
 /* cleans up status data before program termination */
-int cleanup_status_data(int delete_status_data) {
+int cleanup_status_data(int delete_status_data)
+{
 	return xsddefault_cleanup_status_data(delete_status_data);
-	}
+}
 
 
 
 /* updates program status info */
-int update_program_status(int aggregated_dump) {
+int update_program_status(int aggregated_dump)
+{
 
 #ifdef USE_EVENT_BROKER
 	/* send data to event broker (non-aggregated dumps only) */
@@ -98,12 +102,13 @@ int update_program_status(int aggregated_dump) {
 #endif
 
 	return OK;
-	}
+}
 
 
 
 /* updates host status info */
-int update_host_status(host *hst, int aggregated_dump) {
+int update_host_status(host *hst, int aggregated_dump)
+{
 
 #ifdef USE_EVENT_BROKER
 	/* send data to event broker (non-aggregated dumps only) */
@@ -112,12 +117,13 @@ int update_host_status(host *hst, int aggregated_dump) {
 #endif
 
 	return OK;
-	}
+}
 
 
 
 /* updates service status info */
-int update_service_status(service *svc, int aggregated_dump) {
+int update_service_status(service *svc, int aggregated_dump)
+{
 
 #ifdef USE_EVENT_BROKER
 	/* send data to event broker (non-aggregated dumps only) */
@@ -126,12 +132,13 @@ int update_service_status(service *svc, int aggregated_dump) {
 #endif
 
 	return OK;
-	}
+}
 
 
 
 /* updates contact status info */
-int update_contact_status(contact *cntct, int aggregated_dump) {
+int update_contact_status(contact *cntct, int aggregated_dump)
+{
 
 #ifdef USE_EVENT_BROKER
 	/* send data to event broker (non-aggregated dumps only) */
@@ -140,7 +147,7 @@ int update_contact_status(contact *cntct, int aggregated_dump) {
 #endif
 
 	return OK;
-	}
+}
 #endif
 
 
@@ -155,9 +162,10 @@ int update_contact_status(contact *cntct, int aggregated_dump) {
 
 
 /* reads in all status data */
-int read_status_data(const char *cfgfile, int options) {
+int read_status_data(const char *cfgfile, int options)
+{
 	return xsddefault_read_status_data(cfgfile, options);
-	}
+}
 
 
 
@@ -166,7 +174,8 @@ int read_status_data(const char *cfgfile, int options) {
 /******************************************************************/
 
 /* adds hoststatus to hash list in memory */
-int add_hoststatus_to_hashlist(hoststatus *new_hoststatus) {
+int add_hoststatus_to_hashlist(hoststatus *new_hoststatus)
+{
 	hoststatus *temp_hoststatus = NULL;
 	hoststatus *lastpointer = NULL;
 	int hashslot = 0;
@@ -181,7 +190,7 @@ int add_hoststatus_to_hashlist(hoststatus *new_hoststatus) {
 
 		for(i = 0; i < HOSTSTATUS_HASHSLOTS; i++)
 			hoststatus_hashlist[i] = NULL;
-		}
+	}
 
 	if(!new_hoststatus)
 		return 0;
@@ -199,14 +208,15 @@ int add_hoststatus_to_hashlist(hoststatus *new_hoststatus) {
 		new_hoststatus->nexthash = temp_hoststatus;
 
 		return 1;
-		}
+	}
 
 	/* else already exists */
 	return 0;
-	}
+}
 
 
-int add_servicestatus_to_hashlist(servicestatus *new_servicestatus) {
+int add_servicestatus_to_hashlist(servicestatus *new_servicestatus)
+{
 	servicestatus *temp_servicestatus = NULL, *lastpointer = NULL;
 	int hashslot = 0;
 	int i = 0;
@@ -220,7 +230,7 @@ int add_servicestatus_to_hashlist(servicestatus *new_servicestatus) {
 
 		for(i = 0; i < SERVICESTATUS_HASHSLOTS; i++)
 			servicestatus_hashlist[i] = NULL;
-		}
+	}
 
 	if(!new_servicestatus)
 		return 0;
@@ -239,11 +249,11 @@ int add_servicestatus_to_hashlist(servicestatus *new_servicestatus) {
 
 
 		return 1;
-		}
+	}
 
 	/* else already exists */
 	return 0;
-	}
+}
 
 
 
@@ -253,7 +263,8 @@ int add_servicestatus_to_hashlist(servicestatus *new_servicestatus) {
 
 
 /* adds a host status entry to the list in memory */
-int add_host_status(hoststatus *new_hoststatus) {
+int add_host_status(hoststatus *new_hoststatus)
+{
 	char date_string[MAX_DATETIME_LENGTH];
 
 	/* make sure we have what we need */
@@ -265,19 +276,19 @@ int add_host_status(hoststatus *new_hoststatus) {
 	/* massage host status a bit */
 	if(new_hoststatus != NULL) {
 		switch(new_hoststatus->status) {
-			case 0:
-				new_hoststatus->status = SD_HOST_UP;
-				break;
-			case 1:
-				new_hoststatus->status = SD_HOST_DOWN;
-				break;
-			case 2:
-				new_hoststatus->status = SD_HOST_UNREACHABLE;
-				break;
-			default:
-				new_hoststatus->status = SD_HOST_UP;
-				break;
-			}
+		case 0:
+			new_hoststatus->status = SD_HOST_UP;
+			break;
+		case 1:
+			new_hoststatus->status = SD_HOST_DOWN;
+			break;
+		case 2:
+			new_hoststatus->status = SD_HOST_UNREACHABLE;
+			break;
+		default:
+			new_hoststatus->status = SD_HOST_UP;
+			break;
+		}
 		if(new_hoststatus->has_been_checked == FALSE) {
 			if(use_pending_states == TRUE)
 				new_hoststatus->status = HOST_PENDING;
@@ -285,19 +296,18 @@ int add_host_status(hoststatus *new_hoststatus) {
 			if(new_hoststatus->should_be_scheduled == TRUE) {
 				get_time_string(&new_hoststatus->next_check, date_string, sizeof(date_string), LONG_DATE_TIME);
 				asprintf(&new_hoststatus->plugin_output, "Host check scheduled for %s", date_string);
-				}
-			else {
+			} else {
 				/* passive-only hosts that have just been scheduled for a forced check */
 				if(new_hoststatus->checks_enabled == FALSE && new_hoststatus->next_check != (time_t)0L && (new_hoststatus->check_options & CHECK_OPTION_FORCE_EXECUTION)) {
 					get_time_string(&new_hoststatus->next_check, date_string, sizeof(date_string), LONG_DATE_TIME);
 					asprintf(&new_hoststatus->plugin_output, "Forced host check scheduled for %s", date_string);
-					}
+				}
 				/* passive-only hosts not scheduled to be checked */
 				else
 					new_hoststatus->plugin_output = (char *)strdup("Host is not scheduled to be checked...");
-				}
 			}
 		}
+	}
 
 	new_hoststatus->next = NULL;
 	new_hoststatus->nexthash = NULL;
@@ -310,18 +320,18 @@ int add_host_status(hoststatus *new_hoststatus) {
 	if(hoststatus_list == NULL) {
 		hoststatus_list = new_hoststatus;
 		hoststatus_list_tail = new_hoststatus;
-		}
-	else {
+	} else {
 		hoststatus_list_tail->next = new_hoststatus;
 		hoststatus_list_tail = new_hoststatus;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* adds a service status entry to the list in memory */
-int add_service_status(servicestatus *new_svcstatus) {
+int add_service_status(servicestatus *new_svcstatus)
+{
 	char date_string[MAX_DATETIME_LENGTH];
 
 	/* make sure we have what we need */
@@ -334,22 +344,22 @@ int add_service_status(servicestatus *new_svcstatus) {
 	/* massage service status a bit */
 	if(new_svcstatus != NULL) {
 		switch(new_svcstatus->status) {
-			case 0:
-				new_svcstatus->status = SERVICE_OK;
-				break;
-			case 1:
-				new_svcstatus->status = SERVICE_WARNING;
-				break;
-			case 2:
-				new_svcstatus->status = SERVICE_CRITICAL;
-				break;
-			case 3:
-				new_svcstatus->status = SERVICE_UNKNOWN;
-				break;
-			default:
-				new_svcstatus->status = SERVICE_OK;
-				break;
-			}
+		case 0:
+			new_svcstatus->status = SERVICE_OK;
+			break;
+		case 1:
+			new_svcstatus->status = SERVICE_WARNING;
+			break;
+		case 2:
+			new_svcstatus->status = SERVICE_CRITICAL;
+			break;
+		case 3:
+			new_svcstatus->status = SERVICE_UNKNOWN;
+			break;
+		default:
+			new_svcstatus->status = SERVICE_OK;
+			break;
+		}
 		if(new_svcstatus->has_been_checked == FALSE) {
 			if(use_pending_states == TRUE)
 				new_svcstatus->status = SERVICE_PENDING;
@@ -357,19 +367,18 @@ int add_service_status(servicestatus *new_svcstatus) {
 			if(new_svcstatus->should_be_scheduled == TRUE) {
 				get_time_string(&new_svcstatus->next_check, date_string, sizeof(date_string), LONG_DATE_TIME);
 				asprintf(&new_svcstatus->plugin_output, "Service check scheduled for %s", date_string);
-				}
-			else {
+			} else {
 				/* passive-only services that have just been scheduled for a forced check */
 				if(new_svcstatus->checks_enabled == FALSE && new_svcstatus->next_check != (time_t)0L && (new_svcstatus->check_options & CHECK_OPTION_FORCE_EXECUTION)) {
 					get_time_string(&new_svcstatus->next_check, date_string, sizeof(date_string), LONG_DATE_TIME);
 					asprintf(&new_svcstatus->plugin_output, "Forced service check scheduled for %s", date_string);
-					}
+				}
 				/* passive-only services not scheduled to be checked */
 				else
 					new_svcstatus->plugin_output = (char *)strdup("Service is not scheduled to be checked...");
-				}
 			}
 		}
+	}
 
 	new_svcstatus->next = NULL;
 	new_svcstatus->nexthash = NULL;
@@ -382,14 +391,13 @@ int add_service_status(servicestatus *new_svcstatus) {
 	if(servicestatus_list == NULL) {
 		servicestatus_list = new_svcstatus;
 		servicestatus_list_tail = new_svcstatus;
-		}
-	else {
+	} else {
 		servicestatus_list_tail->next = new_svcstatus;
 		servicestatus_list_tail = new_svcstatus;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -401,7 +409,8 @@ int add_service_status(servicestatus *new_svcstatus) {
 
 
 /* free all memory for status data */
-void free_status_data(void) {
+void free_status_data(void)
+{
 	hoststatus *this_hoststatus = NULL;
 	hoststatus *next_hoststatus = NULL;
 	servicestatus *this_svcstatus = NULL;
@@ -415,7 +424,7 @@ void free_status_data(void) {
 		my_free(this_hoststatus->long_plugin_output);
 		my_free(this_hoststatus->perf_data);
 		my_free(this_hoststatus);
-		}
+	}
 
 	/* free memory for the service status list */
 	for(this_svcstatus = servicestatus_list; this_svcstatus != NULL; this_svcstatus = next_svcstatus) {
@@ -426,7 +435,7 @@ void free_status_data(void) {
 		my_free(this_svcstatus->long_plugin_output);
 		my_free(this_svcstatus->perf_data);
 		my_free(this_svcstatus);
-		}
+	}
 
 	/* free hash lists reset list pointers */
 	my_free(hoststatus_hashlist);
@@ -435,7 +444,7 @@ void free_status_data(void) {
 	servicestatus_list = NULL;
 
 	return;
-	}
+}
 
 
 
@@ -446,7 +455,8 @@ void free_status_data(void) {
 
 
 /* find a host status entry */
-hoststatus *find_hoststatus(char *host_name) {
+hoststatus *find_hoststatus(char *host_name)
+{
 	hoststatus *temp_hoststatus = NULL;
 
 	if(host_name == NULL || hoststatus_hashlist == NULL)
@@ -458,11 +468,12 @@ hoststatus *find_hoststatus(char *host_name) {
 		return temp_hoststatus;
 
 	return NULL;
-	}
+}
 
 
 /* find a service status entry */
-servicestatus *find_servicestatus(char *host_name, char *svc_desc) {
+servicestatus *find_servicestatus(char *host_name, char *svc_desc)
+{
 	servicestatus *temp_servicestatus = NULL;
 
 	if(host_name == NULL || svc_desc == NULL || servicestatus_hashlist == NULL)
@@ -474,7 +485,7 @@ servicestatus *find_servicestatus(char *host_name, char *svc_desc) {
 		return temp_servicestatus;
 
 	return NULL;
-	}
+}
 
 
 
@@ -485,7 +496,8 @@ servicestatus *find_servicestatus(char *host_name, char *svc_desc) {
 
 
 /* gets the total number of services of a certain state for a specific host */
-int get_servicestatus_count(char *host_name, int type) {
+int get_servicestatus_count(char *host_name, int type)
+{
 	servicestatus *temp_status = NULL;
 	int count = 0;
 
@@ -496,10 +508,10 @@ int get_servicestatus_count(char *host_name, int type) {
 		if(temp_status->status & type) {
 			if(!strcmp(host_name, temp_status->host_name))
 				count++;
-			}
 		}
+	}
 
 	return count;
-	}
+}
 
 #endif

--- a/contrib/convertcfg.c
+++ b/contrib/convertcfg.c
@@ -28,7 +28,8 @@
 
 char *my_strsep(char **, const char *);
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	FILE *fp;
 	char *temp_ptr;
 	char *temp_ptr2;
@@ -91,13 +92,13 @@ int main(int argc, char **argv) {
 		printf("you will have to do some manual tweaking.\n");
 		printf("\n");
 		return -1;
-		}
+	}
 
 	fp = fopen(argv[1], "r");
 	if(fp == NULL) {
 		printf("Error: Could not open file '%s' for reading.\n", argv[1]);
 		return -1;
-		}
+	}
 
 	for(fgets(input, sizeof(input) - 1, fp); !feof(fp); fgets(input, sizeof(input) - 1, fp)) {
 
@@ -149,7 +150,7 @@ int main(int argc, char **argv) {
 				printf("\tsaturday\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* commands */
 		if(strstr(input, "command[") && !strcmp(argv[2], "commands")) {
@@ -167,7 +168,7 @@ int main(int argc, char **argv) {
 			printf("\tcommand_line\t%s\n", temp_ptr + 1);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* contacts */
 		if(strstr(input, "contact[") && !strcmp(argv[2], "contacts")) {
@@ -205,20 +206,19 @@ int main(int argc, char **argv) {
 				if(notify_warning == 1) {
 					printf("w,u");
 					option = 1;
-					}
+				}
 				if(notify_critical == 1) {
 					if(option == 1)
 						printf(",");
 					printf("c");
 					option = 1;
-					}
+				}
 				if(notify_recovery == 1) {
 					if(option == 1)
 						printf(",");
 					printf("r");
-					}
 				}
-			else
+			} else
 				printf("n");
 			printf("\n");
 
@@ -235,20 +235,19 @@ int main(int argc, char **argv) {
 				if(notify_down == 1) {
 					printf("d");
 					option = 1;
-					}
+				}
 				if(notify_unreachable == 1) {
 					if(option == 1)
 						printf(",");
 					printf("u");
 					option = 1;
-					}
+				}
 				if(notify_recovery == 1) {
 					if(option == 1)
 						printf(",");
 					printf("r");
-					}
 				}
-			else
+			} else
 				printf("n");
 			printf("\n");
 
@@ -269,7 +268,7 @@ int main(int argc, char **argv) {
 				printf("\tpager\t\t\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 
 		/* contactgroups */
@@ -291,7 +290,7 @@ int main(int argc, char **argv) {
 			printf("\tmembers\t\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* hosts */
 		if(strstr(input, "host[") && !strcmp(argv[2], "hosts")) {
@@ -314,7 +313,7 @@ int main(int argc, char **argv) {
 				printf("\t}\n\n");
 
 				have_template = 1;
-				}
+			}
 
 			temp_ptr2 = &input[0];
 			temp_ptr = my_strsep(&temp_ptr2, "[");
@@ -361,20 +360,19 @@ int main(int argc, char **argv) {
 				if(notify_down == 1) {
 					printf("d");
 					option = 1;
-					}
+				}
 				if(notify_unreachable == 1) {
 					if(option == 1)
 						printf(",");
 					printf("u");
 					option = 1;
-					}
+				}
 				if(notify_recovery == 1) {
 					if(option == 1)
 						printf(",");
 					printf("r");
-					}
 				}
-			else
+			} else
 				printf("n");
 			printf("\n");
 
@@ -383,7 +381,7 @@ int main(int argc, char **argv) {
 				printf("\tevent_handler\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* hostgroups */
 		if(strstr(input, "hostgroup[") && !strcmp(argv[2], "hostgroups")) {
@@ -407,7 +405,7 @@ int main(int argc, char **argv) {
 			printf("\tmembers\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 
 		/* services */
@@ -434,7 +432,7 @@ int main(int argc, char **argv) {
 				printf("\t}\n\n");
 
 				have_template = 1;
-				}
+			}
 
 			temp_ptr2 = &input[0];
 			temp_ptr = my_strsep(&temp_ptr2, "[");
@@ -487,20 +485,19 @@ int main(int argc, char **argv) {
 				if(notify_warning == 1) {
 					printf("w,u");
 					option = 1;
-					}
+				}
 				if(notify_critical == 1) {
 					if(option == 1)
 						printf(",");
 					printf("c");
 					option = 1;
-					}
+				}
 				if(notify_recovery == 1) {
 					if(option == 1)
 						printf(",");
 					printf("r");
-					}
 				}
-			else
+			} else
 				printf("n");
 			printf("\n");
 
@@ -513,7 +510,7 @@ int main(int argc, char **argv) {
 				printf("\tcheck_command\t\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* hostgroup escalations */
 		if(strstr(input, "hostgroupescalation[") && !strcmp(argv[2], "hostgroupescalations")) {
@@ -542,7 +539,7 @@ int main(int argc, char **argv) {
 			printf("\tnotification_interval\t\t%d\n", atoi(temp_ptr));
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* service escalations */
 		if(strstr(input, "serviceescalation[") && !strcmp(argv[2], "serviceescalations")) {
@@ -573,7 +570,7 @@ int main(int argc, char **argv) {
 			printf("\tnotification_interval\t\t%d\n", atoi(temp_ptr));
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 		/* service dependencies */
 		if(strstr(input, "servicedependency[") && !strcmp(argv[2], "servicedependencies")) {
@@ -613,7 +610,7 @@ int main(int argc, char **argv) {
 				printf("n");
 			printf("\t; These are the criteria for which notifications will be suppressed\n");
 			printf("\t}\n\n\n");
-			}
+		}
 
 
 		/* extended host info */
@@ -657,7 +654,7 @@ int main(int argc, char **argv) {
 				printf("\t3d_coords\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
+		}
 
 
 		/* extended service info */
@@ -688,21 +685,22 @@ int main(int argc, char **argv) {
 				printf("\ticon_image_alt\t\t%s\n", temp_ptr);
 
 			printf("\t}\n\n\n");
-			}
-
 		}
+
+	}
 
 
 	fclose(fp);
 
 	return 0;
-	}
+}
 
 
 
 /* fixes compiler problems under Solaris, since strsep() isn't included */
 /* this code is taken from the glibc source */
-char *my_strsep(char **stringp, const char *delim) {
+char *my_strsep(char **stringp, const char *delim)
+{
 	char *begin, *end;
 
 	begin = *stringp;
@@ -722,8 +720,8 @@ char *my_strsep(char **stringp, const char *delim) {
 				end = begin;
 			else
 				end = strchr(begin + 1, ch);
-			}
 		}
+	}
 
 	else
 		/* Find the end of the token.  */
@@ -734,12 +732,11 @@ char *my_strsep(char **stringp, const char *delim) {
 		/* Terminate the token and set *STRINGP past NUL character.  */
 		*end++ = '\0';
 		*stringp = end;
-		}
-	else
+	} else
 		/* No more delimiters; this is the last token.  */
 		*stringp = NULL;
 
 	return begin;
-	}
+}
 
 

--- a/contrib/daemonchk.c
+++ b/contrib/daemonchk.c
@@ -20,7 +20,8 @@ static char *ssprintf(char *str, const char *fmt, ...);
 static void terminate(int result, const char *fmt, ...);
 static void get_expire_time_string(time_t *raw_time, char *buffer, int buffer_length);
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	FILE *fp;
 	char *status_file = NULL;
 	char *lock_file = NULL;
@@ -47,31 +48,30 @@ int main(int argc, char **argv) {
 	if(getenv("REQUEST_METHOD")) {
 		process_cgivars();
 		document_header();
-		}
-	else {   /* get arguments */
+	} else { /* get arguments */
 		while((c = getopt(argc, argv, "+c:w:s:l:")) != EOF) {
 			switch(c) {
-				case 'c':
-					ct = atoi(optarg);
-					break;
-				case 'w':
-					wt = atoi(optarg);
-					break;
-				case 's':
-					status_file = optarg;
-					break;
-				case 'l':
-					lock_file = optarg;
-					break;
-				}
+			case 'c':
+				ct = atoi(optarg);
+				break;
+			case 'w':
+				wt = atoi(optarg);
+				break;
+			case 's':
+				status_file = optarg;
+				break;
+			case 'l':
+				lock_file = optarg;
+				break;
 			}
 		}
+	}
 
 	/* find status file, get lastmod time */
 	if(stat(status_file, &statbuf) == -1) {
 		printf("NAGIOS CRITICAL - could not find status log: %s\n", status_file);
 		exit(STATE_CRITICAL);
-		}
+	}
 	time(&current_time);
 	age = (int)(current_time - statbuf.st_mtime);
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
 	if(stat(lock_file, &statbuf) == -1) {
 		printf("NAGIOS CRITICAL - could not find lock file: %s\n", lock_file);
 		exit(STATE_CRITICAL);
-		}
+	}
 	fp = fopen(lock_file, "r");
 	fscanf(fp, "%d", &pid);
 	fclose(fp);
@@ -89,62 +89,58 @@ int main(int argc, char **argv) {
 		if(stat(proc_file, &statbuf) == -1) {
 			printf("NAGIOS CRITICAL - could not find proc file: %s\n", proc_file);
 			exit(STATE_CRITICAL);
-			}
 		}
-	else if(snprintf(proc_file, CHARLEN - 1, "/bin/ps -o pid -p %d", pid) &&
-	        (fp = popen(proc_file, "r")) != NULL) {
+	} else if(snprintf(proc_file, CHARLEN - 1, "/bin/ps -o pid -p %d", pid) &&
+	          (fp = popen(proc_file, "r")) != NULL) {
 		fgets(input_buffer, CHARLEN - 1, fp);
 		fgets(input_buffer, CHARLEN - 1, fp);
 		if(sscanf(input_buffer, "%d", &testpid) == 1) {
 			if(testpid != pid) {
 				printf("NAGIOS CRITICAL - could not find process(1): %d\n", pid);
 				exit(STATE_CRITICAL);
-				}
 			}
 		}
-	else if(snprintf(proc_file, CHARLEN - 1, "/bin/ps -eo pid") &&
-	        (fp = popen(proc_file, "r")) != NULL) {
+	} else if(snprintf(proc_file, CHARLEN - 1, "/bin/ps -eo pid") &&
+	          (fp = popen(proc_file, "r")) != NULL) {
 		found = FALSE;
 		fgets(input_buffer, CHARLEN - 1, fp);
 		while(fgets(input_buffer, CHARLEN - 1, fp)) {
 			if(sscanf(input_buffer, "%d", &testpid) == 1)
 				if(testpid == pid) found = TRUE;
-			}
+		}
 		if(!found) {
 			printf("NAGIOS CRITICAL - could not find process(2): %d\n", pid);
 			exit(STATE_CRITICAL);
-			}
 		}
-	else if(snprintf(proc_file, CHARLEN - 1, "/bin/ps -Ao pid") &&
-	        (fp = popen(proc_file, "r")) != NULL) {
+	} else if(snprintf(proc_file, CHARLEN - 1, "/bin/ps -Ao pid") &&
+	          (fp = popen(proc_file, "r")) != NULL) {
 		found = FALSE;
 		fgets(input_buffer, CHARLEN - 1, fp);
 		while(fgets(input_buffer, CHARLEN - 1, fp)) {
 			if(sscanf(input_buffer, "%d", &testpid) == 1)
 				if(testpid == pid) found = TRUE;
-			}
+		}
 		if(!found) {
 			printf("NAGIOS CRITICAL - could not find process(2): %d\n", pid);
 			exit(STATE_CRITICAL);
-			}
 		}
+	}
 
 	if(ct > 0 && ct < age) {
 		printf("NAGIOS CRITICAL - status written %d seconds ago\n", age);
 		exit(STATE_CRITICAL);
-		}
-	else if(wt > 0 && wt < age) {
+	} else if(wt > 0 && wt < age) {
 		printf("NAGIOS WARNING - status written %d seconds ago\n", age);
 		exit(STATE_WARNING);
-		}
-	else {
+	} else {
 		printf("NAGIOS ok - status written %d seconds ago\n", age);
 		exit(STATE_OK);
-		}
-
 	}
 
-static void document_header(void) {
+}
+
+static void document_header(void)
+{
 	char date_time[48];
 	time_t current_time;
 
@@ -161,9 +157,10 @@ static void document_header(void) {
 	printf("<body onunload=\"if (window.wnd && wnd.close) wnd.close(); return true;\">\n");
 
 	return;
-	}
+}
 
-static int process_cgivars(void) {
+static int process_cgivars(void)
+{
 	char **variables;
 	int error = FALSE;
 	int x;
@@ -175,13 +172,14 @@ static int process_cgivars(void) {
 		/* do some basic length checking on the variable identifier to prevent buffer overflows */
 		if(strlen(variables[x]) >= MAX_INPUT_BUFFER - 1) {
 			continue;
-			}
 		}
-	return error;
 	}
+	return error;
+}
 
 /* get date/time string used in META tags for page expiration */
-static void get_expire_time_string(time_t *raw_time, char *buffer, int buffer_length) {
+static void get_expire_time_string(time_t *raw_time, char *buffer, int buffer_length)
+{
 	time_t t;
 	struct tm *tm_ptr;
 	int day;
@@ -209,9 +207,10 @@ static void get_expire_time_string(time_t *raw_time, char *buffer, int buffer_le
 	buffer[buffer_length - 1] = '\x0';
 
 	return;
-	}
+}
 
-static char *strscpy(char *dest, const char *src) {
+static char *strscpy(char *dest, const char *src)
+{
 	int len;
 
 	if(src != NULL)
@@ -227,9 +226,10 @@ static char *strscpy(char *dest, const char *src) {
 	strncpy(dest, src, len);
 
 	return dest;
-	}
+}
 
-static char *ssprintf(char *str, const char *fmt, ...) {
+static char *ssprintf(char *str, const char *fmt, ...)
+{
 	va_list ap;
 	int nchars;
 	int size;
@@ -251,10 +251,9 @@ static char *ssprintf(char *str, const char *fmt, ...) {
 			if(nchars < size) {
 				va_end(ap);
 				return str;
-				}
-			else {
+			} else {
 				size = nchars + 1;
-				}
+			}
 
 		else
 			size *= 2;
@@ -263,14 +262,15 @@ static char *ssprintf(char *str, const char *fmt, ...) {
 
 		if(str == NULL)
 			terminate(STATE_UNKNOWN, "realloc failed in ssprintf");
-		}
-
 	}
 
-static void terminate(int result, const char *fmt, ...) {
+}
+
+static void terminate(int result, const char *fmt, ...)
+{
 	va_list ap;
 	va_start(ap, fmt);
 	vprintf(fmt, ap);
 	va_end(ap);
 	exit(result);
-	}
+}

--- a/contrib/nagios-worker.c
+++ b/contrib/nagios-worker.c
@@ -41,12 +41,10 @@ int main(int argc, char *argv[])
 		if ((opt = strchr(arg, '='))) {
 			opt = '\0';
 			opt++;
-		}
-		else if (i < argc - 1) {
+		} else if (i < argc - 1) {
 			opt = argv[i + 1];
 			i++;
-		}
-		else {
+		} else {
 			usage(argv[0]);
 			return 1;
 		}

--- a/indent.sh
+++ b/indent.sh
@@ -3,4 +3,4 @@ ARTISTIC_STYLE_OPTIONS=/dev/null
 
 export ARTISTIC_STYLE_OPTIONS
 
-astyle --style=banner --indent=tab --unpad-paren --pad-oper --suffix=.pre-indent "$@"
+astyle --style=knf --indent=tab --suffix=.pre-indent "$@"

--- a/lib/dkhash.c
+++ b/lib/dkhash.c
@@ -96,7 +96,7 @@ static dkhash_bucket *dkhash_get_bucket2(dkhash_table *t, const char *k1, const 
 	for (bkt = t->buckets[slot]; bkt; bkt = bkt->next) {
 		if (!strcmp(k1, bkt->key) && bkt->key2 && !strcmp(k2, bkt->key2))
 			return bkt;
-		}
+	}
 
 	return NULL;
 }
@@ -214,8 +214,7 @@ void *dkhash_remove(dkhash_table *t, const char *k1, const char *k2)
 			if (prev == bkt) {
 				/* first entry deleted */
 				t->buckets[slot] = bkt->next;
-			}
-			else {
+			} else {
 				prev->next = bkt->next;
 			}
 			t->entries--;
@@ -227,7 +226,8 @@ void *dkhash_remove(dkhash_table *t, const char *k1, const char *k2)
 	return NULL;
 }
 
-void dkhash_walk_data(dkhash_table *t, int (*walker)(void *)) {
+void dkhash_walk_data(dkhash_table *t, int (*walker)(void *))
+{
 	dkhash_bucket *bkt, *prev;
 	unsigned int i;
 
@@ -253,8 +253,7 @@ void dkhash_walk_data(dkhash_table *t, int (*walker)(void *)) {
 			dkhash_destroy_bucket(bkt);
 			if (depth) {
 				prev->next = next;
-			}
-			else {
+			} else {
 				t->buckets[i] = next;
 			}
 		}

--- a/lib/kvvec.c
+++ b/lib/kvvec.c
@@ -234,8 +234,8 @@ unsigned int kvvec_capacity(struct kvvec *kvv)
  * involved, and it will parse the kvvec2buf() produce nicely.
  */
 int buf2kvvec_prealloc(struct kvvec *kvv, char *str,
-			unsigned int len, const char kvsep,
-			const char pair_sep, int flags)
+                       unsigned int len, const char kvsep,
+                       const char pair_sep, int flags)
 {
 	unsigned int num_pairs = 0, i, offset = 0;
 
@@ -328,7 +328,7 @@ int buf2kvvec_prealloc(struct kvvec *kvv, char *str,
 }
 
 struct kvvec *buf2kvvec(char *str, unsigned int len, const char kvsep,
-			const char pair_sep, int flags)
+                        const char pair_sep, int flags)
 {
 	struct kvvec *kvv;
 

--- a/lib/nsock.c
+++ b/lib/nsock.c
@@ -15,13 +15,20 @@
 const char *nsock_strerror(int code)
 {
 	switch (code) {
-	case NSOCK_EBIND: return "bind() failed";
-	case NSOCK_ELISTEN: return "listen() failed";
-	case NSOCK_ESOCKET: return "socket() failed";
-	case NSOCK_EUNLINK: return "unlink() failed";
-	case NSOCK_ECONNECT: return "connect() failed";
-	case NSOCK_EFCNTL: return "fcntl() failed";
-	case NSOCK_EINVAL: return "Invalid arguments";
+	case NSOCK_EBIND:
+		return "bind() failed";
+	case NSOCK_ELISTEN:
+		return "listen() failed";
+	case NSOCK_ESOCKET:
+		return "socket() failed";
+	case NSOCK_EUNLINK:
+		return "unlink() failed";
+	case NSOCK_ECONNECT:
+		return "connect() failed";
+	case NSOCK_EFCNTL:
+		return "fcntl() failed";
+	case NSOCK_EINVAL:
+		return "Invalid arguments";
 	}
 
 	return "Unknown error";

--- a/lib/pqueue.c
+++ b/lib/pqueue.c
@@ -84,8 +84,8 @@ bubble_up(pqueue_t *q, unsigned int i)
 	pqueue_pri_t moving_pri = q->getpri(moving_node);
 
 	for (parent_node = parent(i);
-	        ((i > 1) && q->cmppri(q->getpri(q->d[parent_node]), moving_pri));
-	        i = parent_node, parent_node = parent(i)) {
+	     ((i > 1) && q->cmppri(q->getpri(q->d[parent_node]), moving_pri));
+	     i = parent_node, parent_node = parent(i)) {
 		q->d[i] = q->d[parent_node];
 		q->setpos(q->d[i], i);
 	}
@@ -120,7 +120,7 @@ percolate_down(pqueue_t *q, unsigned int i)
 	pqueue_pri_t moving_pri = q->getpri(moving_node);
 
 	while ((child_node = maxchild(q, i)) &&
-	        q->cmppri(moving_pri, q->getpri(q->d[child_node]))) {
+	       q->cmppri(moving_pri, q->getpri(q->d[child_node]))) {
 		q->d[i] = q->d[child_node];
 		q->setpos(q->d[i], i);
 		i = child_node;

--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -146,7 +146,10 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 		case 0:
 			return ret;
 
-		case ' ': case '\t': case '\r': case '\n':
+		case ' ':
+		case '\t':
+		case '\r':
+		case '\n':
 			if (is_state(STATE_INARG)) {
 				set_state(STATE_NONE);
 				argz[a++] = 0;
@@ -169,7 +172,10 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 			if (have_state(STATE_INDQ)) {
 				const char next = str[i + 1];
 				switch (next) {
-				case '"': case '\\': case '$': case '`':
+				case '"':
+				case '\\':
+				case '$':
+				case '`':
 					add_state(STATE_BSLASH);
 					continue;
 				}
@@ -223,7 +229,8 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 				add_ret(RUNCMD_HAS_REDIR);
 			}
 			break;
-		case '&': case ';':
+		case '&':
+		case ';':
 			if (!in_quotes) {
 				set_state(STATE_SPECIAL);
 				add_ret(RUNCMD_HAS_JOBCONTROL);
@@ -240,7 +247,8 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 			}
 			break;
 
-		case '(': case ')':
+		case '(':
+		case ')':
 			if (!in_quotes) {
 				add_ret(RUNCMD_HAS_PAREN);
 			}
@@ -255,12 +263,13 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 			}
 			break;
 
-		case '*': case '?':
+		case '*':
+		case '?':
 			if (!in_quotes) {
 				add_ret(RUNCMD_HAS_WILDCARD);
 			}
 
-			/* fallthrough */
+		/* fallthrough */
 
 		default:
 			break;
@@ -320,7 +329,7 @@ void runcmd_init(void)
 
 /* Start running a command */
 int runcmd_open(const char *cmd, int *pfd, int *pfderr, char **env,
-		void (*iobreg)(int, int, void *), void *iobregarg)
+                void (*iobreg)(int, int, void *), void *iobregarg)
 {
 	char **argv = NULL;
 	int cmd2strv_errors, argc = 0;
@@ -504,8 +513,7 @@ int runcmd_try_close(int fd, int *status, int sig)
 					result = kill(pid, sig);
 					sig = 0;
 					continue;
-				}
-				else return -1;
+				} else return -1;
 			} /* switch */
 		}
 	}
@@ -516,7 +524,8 @@ int runcmd_try_close(int fd, int *status, int sig)
 }
 
 /* sets or unsets an environment variable */
-int update_environment(char *name, char *value, int set) {
+int update_environment(char *name, char *value, int set)
+{
 #ifndef HAVE_SETENV
 	char *env_string = NULL;
 #endif

--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -39,7 +39,7 @@
 typedef struct skiplistnode_struct {
 	void *data;
 	struct skiplistnode_struct *forward[1]; /* this must be the last element of the struct, as we allocate # of elements during runtime*/
-	} skiplistnode;
+} skiplistnode;
 
 struct skiplist_struct {
 	int current_level;
@@ -50,13 +50,15 @@ struct skiplist_struct {
 	int append_duplicates;
 	int (*compare_function)(void *, void *);
 	skiplistnode *head;
-	};
+};
 
-unsigned long skiplist_num_items(skiplist *list) {
+unsigned long skiplist_num_items(skiplist *list)
+{
 	return list ? list->items : 0;
-	}
+}
 
-static skiplistnode *skiplist_new_node(skiplist *list, int node_levels) {
+static skiplistnode *skiplist_new_node(skiplist *list, int node_levels)
+{
 	skiplistnode *newnode = NULL;
 	register int x = 0;
 
@@ -75,13 +77,14 @@ static skiplistnode *skiplist_new_node(skiplist *list, int node_levels) {
 
 		/* initialize data pointer */
 		newnode->data = NULL;
-		}
-
-	return newnode;
 	}
 
+	return newnode;
+}
 
-skiplist *skiplist_new(int max_levels, float level_probability, int allow_duplicates, int append_duplicates, int (*compare_function)(void *, void *)) {
+
+skiplist *skiplist_new(int max_levels, float level_probability, int allow_duplicates, int append_duplicates, int (*compare_function)(void *, void *))
+{
 	skiplist *newlist = NULL;
 
 	/* alloc memory for new list structure */
@@ -98,13 +101,14 @@ skiplist *skiplist_new(int max_levels, float level_probability, int allow_duplic
 
 		/* initialize head node */
 		newlist->head = skiplist_new_node(newlist, max_levels);
-		}
-
-	return newlist;
 	}
 
+	return newlist;
+}
 
-static int skiplist_random_level(skiplist *list) {
+
+static int skiplist_random_level(skiplist *list)
+{
 	int level = 0;
 	float r = 0.0;
 
@@ -115,13 +119,14 @@ static int skiplist_random_level(skiplist *list) {
 		r = ((float)rand() / (float)RAND_MAX);
 		if(r > list->level_probability)
 			break;
-		}
-
-	return (level >= list->max_levels) ? list->max_levels - 1 : level;
 	}
 
+	return (level >= list->max_levels) ? list->max_levels - 1 : level;
+}
 
-int skiplist_insert(skiplist *list, void *data) {
+
+int skiplist_insert(skiplist *list, void *data)
+{
 	skiplistnode **update = NULL;
 	skiplistnode *thisnode = NULL;
 	skiplistnode *nextnode = NULL;
@@ -131,19 +136,19 @@ int skiplist_insert(skiplist *list, void *data) {
 
 	if(list == NULL || data == NULL) {
 		return SKIPLIST_ERROR_ARGS;
-		}
+	}
 
 	/* check to make sure we don't have duplicates */
 	/* NOTE: this could made be more efficient */
 	if(list->allow_duplicates == FALSE) {
 		if(skiplist_find_first(list, data, NULL))
 			return SKIPLIST_ERROR_DUPLICATE;
-		}
+	}
 
 	/* initialize update vector */
 	if((update = (skiplistnode **)malloc(sizeof(skiplistnode *) * list->max_levels)) == NULL) {
 		return SKIPLIST_ERROR_MEMORY;
-		}
+	}
 	for(x = 0; x < list->max_levels; x++)
 		update[x] = NULL;
 
@@ -155,16 +160,15 @@ int skiplist_insert(skiplist *list, void *data) {
 			if(list->append_duplicates == TRUE) {
 				if(list->compare_function(nextnode->data, data) > 0)
 					break;
-				}
-			else {
+			} else {
 				if(list->compare_function(nextnode->data, data) >= 0)
 					break;
-				}
-			thisnode = nextnode;
 			}
+			thisnode = nextnode;
+		}
 
 		update[level] = thisnode;
-		}
+	}
 
 	/* get a random level the new node should be inserted at */
 	level = skiplist_random_level(list);
@@ -175,14 +179,14 @@ int skiplist_insert(skiplist *list, void *data) {
 		list->current_level++;
 		level = list->current_level;
 		update[level] = list->head;
-		}
+	}
 
 	/* create a new node */
 	if((newnode = skiplist_new_node(list, level)) == NULL) {
 		/*printf("NODE ERROR\n");*/
 		free(update);
 		return SKIPLIST_ERROR_MEMORY;
-		}
+	}
 	newnode->data = data;
 
 	/* update pointers to insert node at proper location */
@@ -191,8 +195,7 @@ int skiplist_insert(skiplist *list, void *data) {
 		newnode->forward[level] = thisnode->forward[level];
 		thisnode->forward[level] = newnode;
 
-		}
-	while(--level >= 0);
+	} while(--level >= 0);
 
 	/* update counters */
 	list->items++;
@@ -201,11 +204,12 @@ int skiplist_insert(skiplist *list, void *data) {
 	free(update);
 
 	return SKIPLIST_OK;
-	}
+}
 
 
 
-int skiplist_empty(skiplist *list) {
+int skiplist_empty(skiplist *list)
+{
 	skiplistnode *this = NULL;
 	skiplistnode *next = NULL;
 	int level = 0;
@@ -217,7 +221,7 @@ int skiplist_empty(skiplist *list) {
 	for(this = list->head->forward[0]; this != NULL; this = next) {
 		next = this->forward[0];
 		free(this);
-		}
+	}
 
 	/* reset level pointers */
 	for(level = list->current_level; level >= 0; level--)
@@ -230,11 +234,12 @@ int skiplist_empty(skiplist *list) {
 	list->items = 0;
 
 	return OK;
-	}
+}
 
 
 
-int skiplist_free(skiplist **list) {
+int skiplist_free(skiplist **list)
+{
 	skiplistnode *this = NULL;
 	skiplistnode *next = NULL;
 
@@ -247,31 +252,33 @@ int skiplist_free(skiplist **list) {
 	for(this = (*list)->head; this != NULL; this = next) {
 		next = this->forward[0];
 		free(this);
-		}
+	}
 
 	/* free list structure */
 	free(*list);
 	*list = NULL;
 
 	return OK;
-	}
+}
 
 
 
 /* get first item in list */
-void *skiplist_peek(skiplist *list) {
+void *skiplist_peek(skiplist *list)
+{
 
 	if(list == NULL)
 		return NULL;
 
 	/* return first item */
 	return list->head->forward[0]->data;
-	}
+}
 
 
 
 /* get/remove first item in list */
-void *skiplist_pop(skiplist *list) {
+void *skiplist_pop(skiplist *list)
+{
 	skiplistnode *thisnode = NULL;
 	void *data = NULL;
 	int level = 0;
@@ -291,7 +298,7 @@ void *skiplist_pop(skiplist *list) {
 	for(level = 0; level <= list->current_level; level++) {
 		if(list->head->forward[level] == thisnode)
 			list->head->forward[level] = thisnode->forward[level];
-		}
+	}
 
 	/* free deleted node */
 	free(thisnode);
@@ -300,12 +307,13 @@ void *skiplist_pop(skiplist *list) {
 	list->items--;
 
 	return data;
-	}
+}
 
 
 
 /* get first item in list */
-void *skiplist_get_first(skiplist *list, void **node_ptr) {
+void *skiplist_get_first(skiplist *list, void **node_ptr)
+{
 	skiplistnode *thisnode = NULL;
 
 	if(list == NULL)
@@ -322,12 +330,13 @@ void *skiplist_get_first(skiplist *list, void **node_ptr) {
 		return thisnode->data;
 	else
 		return NULL;
-	}
+}
 
 
 
 /* get next item in list */
-void *skiplist_get_next(void **node_ptr) {
+void *skiplist_get_next(void **node_ptr)
+{
 	skiplistnode *thisnode = NULL;
 	skiplistnode *nextnode = NULL;
 
@@ -343,12 +352,13 @@ void *skiplist_get_next(void **node_ptr) {
 		return nextnode->data;
 	else
 		return NULL;
-	}
+}
 
 
 
 /* first first item in list */
-void *skiplist_find_first(skiplist *list, void *data, void **node_ptr) {
+void *skiplist_find_first(skiplist *list, void *data, void **node_ptr)
+{
 	skiplistnode *thisnode = NULL;
 	skiplistnode *nextnode = NULL;
 	int level = 0;
@@ -362,27 +372,27 @@ void *skiplist_find_first(skiplist *list, void *data, void **node_ptr) {
 			if(list->compare_function(nextnode->data, data) >= 0)
 				break;
 			thisnode = nextnode;
-			}
 		}
+	}
 
 	/* we found it! */
 	if(nextnode && list->compare_function(nextnode->data, data) == 0) {
 		if(node_ptr)
 			*node_ptr = (void *)nextnode;
 		return nextnode->data;
-		}
-	else {
+	} else {
 		if(node_ptr)
 			*node_ptr = NULL;
-		}
+	}
 
 	return NULL;
-	}
+}
 
 
 
 /* find next match */
-void *skiplist_find_next(skiplist *list, void *data, void **node_ptr) {
+void *skiplist_find_next(skiplist *list, void *data, void **node_ptr)
+{
 	skiplistnode *thisnode = NULL;
 	skiplistnode *nextnode = NULL;
 
@@ -398,17 +408,18 @@ void *skiplist_find_next(skiplist *list, void *data, void **node_ptr) {
 		if(list->compare_function(nextnode->data, data) == 0) {
 			*node_ptr = (void *)nextnode;
 			return nextnode->data;
-			}
 		}
+	}
 
 	*node_ptr = NULL;
 	return NULL;
-	}
+}
 
 
 
 /* delete first matching item from list */
-int skiplist_delete_first(skiplist *list, void *data) {
+int skiplist_delete_first(skiplist *list, void *data)
+{
 	skiplistnode **update = NULL;
 	skiplistnode *thisnode = NULL;
 	skiplistnode *nextnode = NULL;
@@ -433,9 +444,9 @@ int skiplist_delete_first(skiplist *list, void *data) {
 			if(list->compare_function(nextnode->data, data) >= 0)
 				break;
 			thisnode = nextnode;
-			}
-		update[level] = thisnode;
 		}
+		update[level] = thisnode;
+	}
 
 	/* we found a match! */
 	if(list->compare_function(nextnode->data, data) == 0) {
@@ -448,7 +459,7 @@ int skiplist_delete_first(skiplist *list, void *data) {
 				break;
 
 			thisnode->forward[level] = nextnode->forward[level];
-			}
+		}
 
 		/* free node memory */
 		free(nextnode);
@@ -462,18 +473,19 @@ int skiplist_delete_first(skiplist *list, void *data) {
 		list->items--;
 
 		deleted = TRUE;
-		}
+	}
 
 	/* free memory */
 	free(update);
 
 	return deleted;
-	}
+}
 
 
 
 /* delete all matching items from list */
-int skiplist_delete(skiplist *list, void *data) {
+int skiplist_delete(skiplist *list, void *data)
+{
 	int deleted = 0;
 	int total_deleted = 0;
 
@@ -482,12 +494,13 @@ int skiplist_delete(skiplist *list, void *data) {
 		total_deleted++;
 
 	return total_deleted;
-	}
+}
 
 
 
 /* delete specific node from list */
-int skiplist_delete_node(skiplist *list, void *node_ptr) {
+int skiplist_delete_node(skiplist *list, void *node_ptr)
+{
 	void *data = NULL;
 	skiplistnode **update = NULL;
 	skiplistnode *thenode = NULL;
@@ -524,9 +537,9 @@ int skiplist_delete_node(skiplist *list, void *node_ptr) {
 				break;
 
 			thisnode = nextnode;
-			}
-		update[level] = thisnode;
 		}
+		update[level] = thisnode;
+	}
 
 	/* we found a match! (value + pointers match) */
 	if(nextnode && list->compare_function(nextnode->data, data) == 0 && nextnode == thenode) {
@@ -539,7 +552,7 @@ int skiplist_delete_node(skiplist *list, void *node_ptr) {
 				break;
 
 			thisnode->forward[level] = nextnode->forward[level];
-			}
+		}
 
 		/* free node memory */
 		free(nextnode);
@@ -553,13 +566,13 @@ int skiplist_delete_node(skiplist *list, void *node_ptr) {
 		list->items--;
 
 		deleted = TRUE;
-		}
+	}
 
 	/* free memory */
 	free(update);
 
 	return deleted;
-	}
+}
 
 
 

--- a/lib/snprintf.c
+++ b/lib/snprintf.c
@@ -236,12 +236,12 @@ struct pr_chunk {
 	struct pr_chunk *min_star;
 	struct pr_chunk *max_star;
 	struct pr_chunk *next;
-	};
+};
 
 struct pr_chunk_x {
 	struct pr_chunk **chunks;
 	int num;
-	};
+};
 
 static size_t dopr(char *buffer, size_t maxlen, const char *format,
                    va_list args_in);
@@ -256,7 +256,8 @@ static struct pr_chunk *new_chunk(void);
 static int add_cnk_list_entry(struct pr_chunk_x **list,
                               int max_num, struct pr_chunk *chunk);
 
-static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args_in) {
+static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args_in)
+{
 	char ch;
 	int state;
 	int pflag;
@@ -288,268 +289,257 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 			state = DP_S_DONE;
 
 		switch(state) {
-			case DP_S_DEFAULT:
+		case DP_S_DEFAULT:
 
-				if(cnk) {
-					cnk->next = new_chunk();
-					cnk = cnk->next;
-					}
-				else {
-					cnk = new_chunk();
-					}
-				if(!cnk) goto done;
-				if(!chunks) chunks = cnk;
+			if(cnk) {
+				cnk->next = new_chunk();
+				cnk = cnk->next;
+			} else {
+				cnk = new_chunk();
+			}
+			if(!cnk) goto done;
+			if(!chunks) chunks = cnk;
 
-				if(ch == '%') {
-					state = DP_S_FLAGS;
-					ch = *format++;
-					}
-				else {
-					cnk->type = CNK_FMT_STR;
-					cnk->start = format - base - 1;
-					while((ch != '\0') && (ch != '%')) ch = *format++;
-					cnk->len = format - base - cnk->start - 1;
-					}
+			if(ch == '%') {
+				state = DP_S_FLAGS;
+				ch = *format++;
+			} else {
+				cnk->type = CNK_FMT_STR;
+				cnk->start = format - base - 1;
+				while((ch != '\0') && (ch != '%')) ch = *format++;
+				cnk->len = format - base - cnk->start - 1;
+			}
+			break;
+		case DP_S_FLAGS:
+			switch(ch) {
+			case '-':
+				cnk->flags |= DP_F_MINUS;
+				ch = *format++;
 				break;
-			case DP_S_FLAGS:
-				switch(ch) {
-					case '-':
-						cnk->flags |= DP_F_MINUS;
-						ch = *format++;
-						break;
-					case '+':
-						cnk->flags |= DP_F_PLUS;
-						ch = *format++;
-						break;
-					case ' ':
-						cnk->flags |= DP_F_SPACE;
-						ch = *format++;
-						break;
-					case '#':
-						cnk->flags |= DP_F_NUM;
-						ch = *format++;
-						break;
-					case '0':
-						cnk->flags |= DP_F_ZERO;
-						ch = *format++;
-						break;
-					case 'I':
-						/* internationalization not supported yet */
-						ch = *format++;
-						break;
-					default:
-						state = DP_S_MIN;
-						break;
-					}
+			case '+':
+				cnk->flags |= DP_F_PLUS;
+				ch = *format++;
 				break;
-			case DP_S_MIN:
-				if(isdigit((unsigned char)ch)) {
-					cnk->min = 10 * cnk->min + char_to_int(ch);
+			case ' ':
+				cnk->flags |= DP_F_SPACE;
+				ch = *format++;
+				break;
+			case '#':
+				cnk->flags |= DP_F_NUM;
+				ch = *format++;
+				break;
+			case '0':
+				cnk->flags |= DP_F_ZERO;
+				ch = *format++;
+				break;
+			case 'I':
+				/* internationalization not supported yet */
+				ch = *format++;
+				break;
+			default:
+				state = DP_S_MIN;
+				break;
+			}
+			break;
+		case DP_S_MIN:
+			if(isdigit((unsigned char)ch)) {
+				cnk->min = 10 * cnk->min + char_to_int(ch);
+				ch = *format++;
+			} else if(ch == '$') {
+				if(!pfirst && !pflag) {
+					/* parameters must be all positioned or none */
+					goto done;
+				}
+				if(pfirst) {
+					pfirst = 0;
+					pflag = 1;
+				}
+				if(cnk->min == 0)  /* what ?? */
+					goto done;
+				cnk->num = cnk->min;
+				cnk->min = 0;
+				ch = *format++;
+			} else if(ch == '*') {
+				if(pfirst) pfirst = 0;
+				cnk->min_star = new_chunk();
+				if(!cnk->min_star)  /* out of memory :-( */
+					goto done;
+				cnk->min_star->type = CNK_INT;
+				if(pflag) {
+					int num;
 					ch = *format++;
-					}
-				else if(ch == '$') {
-					if(!pfirst && !pflag) {
+					if(!isdigit((unsigned char)ch)) {
 						/* parameters must be all positioned or none */
 						goto done;
-						}
-					if(pfirst) {
-						pfirst = 0;
-						pflag = 1;
-						}
-					if(cnk->min == 0)  /* what ?? */
+					}
+					for(num = 0; isdigit((unsigned char)ch); ch = *format++) {
+						num = 10 * num + char_to_int(ch);
+					}
+					cnk->min_star->num = num;
+					if(ch != '$')  /* what ?? */
 						goto done;
-					cnk->num = cnk->min;
-					cnk->min = 0;
+				} else {
+					cnk->min_star->num = ++pnum;
+				}
+				max_pos = add_cnk_list_entry(&clist, max_pos, cnk->min_star);
+				if(max_pos == 0)  /* out of memory :-( */
+					goto done;
+				ch = *format++;
+				state = DP_S_DOT;
+			} else {
+				if(pfirst) pfirst = 0;
+				state = DP_S_DOT;
+			}
+			break;
+		case DP_S_DOT:
+			if(ch == '.') {
+				state = DP_S_MAX;
+				ch = *format++;
+			} else {
+				state = DP_S_MOD;
+			}
+			break;
+		case DP_S_MAX:
+			if(isdigit((unsigned char)ch)) {
+				if(cnk->max < 0)
+					cnk->max = 0;
+				cnk->max = 10 * cnk->max + char_to_int(ch);
+				ch = *format++;
+			} else if(ch == '$') {
+				if(!pfirst && !pflag) {
+					/* parameters must be all positioned or none */
+					goto done;
+				}
+				if(cnk->max <= 0)  /* what ?? */
+					goto done;
+				cnk->num = cnk->max;
+				cnk->max = -1;
+				ch = *format++;
+			} else if(ch == '*') {
+				cnk->max_star = new_chunk();
+				if(!cnk->max_star)  /* out of memory :-( */
+					goto done;
+				cnk->max_star->type = CNK_INT;
+				if(pflag) {
+					int num;
 					ch = *format++;
-					}
-				else if(ch == '*') {
-					if(pfirst) pfirst = 0;
-					cnk->min_star = new_chunk();
-					if(!cnk->min_star)  /* out of memory :-( */
-						goto done;
-					cnk->min_star->type = CNK_INT;
-					if(pflag) {
-						int num;
-						ch = *format++;
-						if(!isdigit((unsigned char)ch)) {
-							/* parameters must be all positioned or none */
-							goto done;
-							}
-						for(num = 0; isdigit((unsigned char)ch); ch = *format++) {
-							num = 10 * num + char_to_int(ch);
-							}
-						cnk->min_star->num = num;
-						if(ch != '$')  /* what ?? */
-							goto done;
-						}
-					else {
-						cnk->min_star->num = ++pnum;
-						}
-					max_pos = add_cnk_list_entry(&clist, max_pos, cnk->min_star);
-					if(max_pos == 0)  /* out of memory :-( */
-						goto done;
-					ch = *format++;
-					state = DP_S_DOT;
-					}
-				else {
-					if(pfirst) pfirst = 0;
-					state = DP_S_DOT;
-					}
-				break;
-			case DP_S_DOT:
-				if(ch == '.') {
-					state = DP_S_MAX;
-					ch = *format++;
-					}
-				else {
-					state = DP_S_MOD;
-					}
-				break;
-			case DP_S_MAX:
-				if(isdigit((unsigned char)ch)) {
-					if(cnk->max < 0)
-						cnk->max = 0;
-					cnk->max = 10 * cnk->max + char_to_int(ch);
-					ch = *format++;
-					}
-				else if(ch == '$') {
-					if(!pfirst && !pflag) {
+					if(!isdigit((unsigned char)ch)) {
 						/* parameters must be all positioned or none */
 						goto done;
-						}
-					if(cnk->max <= 0)  /* what ?? */
+					}
+					for(num = 0; isdigit((unsigned char)ch); ch = *format++) {
+						num = 10 * num + char_to_int(ch);
+					}
+					cnk->max_star->num = num;
+					if(ch != '$')  /* what ?? */
 						goto done;
-					cnk->num = cnk->max;
-					cnk->max = -1;
-					ch = *format++;
-					}
-				else if(ch == '*') {
-					cnk->max_star = new_chunk();
-					if(!cnk->max_star)  /* out of memory :-( */
-						goto done;
-					cnk->max_star->type = CNK_INT;
-					if(pflag) {
-						int num;
-						ch = *format++;
-						if(!isdigit((unsigned char)ch)) {
-							/* parameters must be all positioned or none */
-							goto done;
-							}
-						for(num = 0; isdigit((unsigned char)ch); ch = *format++) {
-							num = 10 * num + char_to_int(ch);
-							}
-						cnk->max_star->num = num;
-						if(ch != '$')  /* what ?? */
-							goto done;
-						}
-					else {
-						cnk->max_star->num = ++pnum;
-						}
-					max_pos = add_cnk_list_entry(&clist, max_pos, cnk->max_star);
-					if(max_pos == 0)  /* out of memory :-( */
-						goto done;
-
-					ch = *format++;
-					state = DP_S_MOD;
-					}
-				else {
-					state = DP_S_MOD;
-					}
-				break;
-			case DP_S_MOD:
-				switch(ch) {
-					case 'h':
-						cnk->cflags = DP_C_SHORT;
-						ch = *format++;
-						if(ch == 'h') {
-							cnk->cflags = DP_C_CHAR;
-							ch = *format++;
-							}
-						break;
-					case 'l':
-						cnk->cflags = DP_C_LONG;
-						ch = *format++;
-						if(ch == 'l') {	/* It's a long long */
-							cnk->cflags = DP_C_LLONG;
-							ch = *format++;
-							}
-						break;
-					case 'L':
-						cnk->cflags = DP_C_LDOUBLE;
-						ch = *format++;
-						break;
-					default:
-						break;
-					}
-				state = DP_S_CONV;
-				break;
-			case DP_S_CONV:
-				if(cnk->num == 0) cnk->num = ++pnum;
-				max_pos = add_cnk_list_entry(&clist, max_pos, cnk);
+				} else {
+					cnk->max_star->num = ++pnum;
+				}
+				max_pos = add_cnk_list_entry(&clist, max_pos, cnk->max_star);
 				if(max_pos == 0)  /* out of memory :-( */
 					goto done;
 
-				switch(ch) {
-					case 'd':
-					case 'i':
-						cnk->type = CNK_INT;
-						break;
-					case 'o':
-						cnk->type = CNK_OCTAL;
-						cnk->flags |= DP_F_UNSIGNED;
-						break;
-					case 'u':
-						cnk->type = CNK_UINT;
-						cnk->flags |= DP_F_UNSIGNED;
-						break;
-					case 'X':
-						cnk->flags |= DP_F_UP;
-					case 'x':
-						cnk->type = CNK_HEX;
-						cnk->flags |= DP_F_UNSIGNED;
-						break;
-					case 'A':
-						/* hex float not supported yet */
-					case 'E':
-					case 'G':
-					case 'F':
-						cnk->flags |= DP_F_UP;
-					case 'a':
-						/* hex float not supported yet */
-					case 'e':
-					case 'f':
-					case 'g':
-						cnk->type = CNK_FLOAT;
-						break;
-					case 'c':
-						cnk->type = CNK_CHAR;
-						break;
-					case 's':
-						cnk->type = CNK_STRING;
-						break;
-					case 'p':
-						cnk->type = CNK_PTR;
-						break;
-					case 'n':
-						cnk->type = CNK_NUM;
-						break;
-					case '%':
-						cnk->type = CNK_PRCNT;
-						break;
-					default:
-						/* Unknown, bail out*/
-						goto done;
-					}
 				ch = *format++;
-				state = DP_S_DEFAULT;
+				state = DP_S_MOD;
+			} else {
+				state = DP_S_MOD;
+			}
+			break;
+		case DP_S_MOD:
+			switch(ch) {
+			case 'h':
+				cnk->cflags = DP_C_SHORT;
+				ch = *format++;
+				if(ch == 'h') {
+					cnk->cflags = DP_C_CHAR;
+					ch = *format++;
+				}
 				break;
-			case DP_S_DONE:
+			case 'l':
+				cnk->cflags = DP_C_LONG;
+				ch = *format++;
+				if(ch == 'l') {	/* It's a long long */
+					cnk->cflags = DP_C_LLONG;
+					ch = *format++;
+				}
+				break;
+			case 'L':
+				cnk->cflags = DP_C_LDOUBLE;
+				ch = *format++;
 				break;
 			default:
-				/* hmm? */
-				break; /* some picky compilers need this */
+				break;
 			}
+			state = DP_S_CONV;
+			break;
+		case DP_S_CONV:
+			if(cnk->num == 0) cnk->num = ++pnum;
+			max_pos = add_cnk_list_entry(&clist, max_pos, cnk);
+			if(max_pos == 0)  /* out of memory :-( */
+				goto done;
+
+			switch(ch) {
+			case 'd':
+			case 'i':
+				cnk->type = CNK_INT;
+				break;
+			case 'o':
+				cnk->type = CNK_OCTAL;
+				cnk->flags |= DP_F_UNSIGNED;
+				break;
+			case 'u':
+				cnk->type = CNK_UINT;
+				cnk->flags |= DP_F_UNSIGNED;
+				break;
+			case 'X':
+				cnk->flags |= DP_F_UP;
+			case 'x':
+				cnk->type = CNK_HEX;
+				cnk->flags |= DP_F_UNSIGNED;
+				break;
+			case 'A':
+			/* hex float not supported yet */
+			case 'E':
+			case 'G':
+			case 'F':
+				cnk->flags |= DP_F_UP;
+			case 'a':
+			/* hex float not supported yet */
+			case 'e':
+			case 'f':
+			case 'g':
+				cnk->type = CNK_FLOAT;
+				break;
+			case 'c':
+				cnk->type = CNK_CHAR;
+				break;
+			case 's':
+				cnk->type = CNK_STRING;
+				break;
+			case 'p':
+				cnk->type = CNK_PTR;
+				break;
+			case 'n':
+				cnk->type = CNK_NUM;
+				break;
+			case '%':
+				cnk->type = CNK_PRCNT;
+				break;
+			default:
+				/* Unknown, bail out*/
+				goto done;
+			}
+			ch = *format++;
+			state = DP_S_DEFAULT;
+			break;
+		case DP_S_DONE:
+			break;
+		default:
+			/* hmm? */
+			break; /* some picky compilers need this */
 		}
+	}
 
 	/* retieve the format arguments */
 	for(pnum = 0; pnum < max_pos; pnum++) {
@@ -567,7 +557,7 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 			/* eat the parameter */
 			va_arg(args, int);
 			continue;
-			}
+		}
 		for(i = 1; i < clist[pnum].num; i++) {
 			if(clist[pnum].chunks[0]->type != clist[pnum].chunks[i]->type) {
 				/* nooo noo no!
@@ -575,102 +565,102 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 				 * must be of the same type
 				 */
 				goto done;
-				}
-			}
-		cnk = clist[pnum].chunks[0];
-		switch(cnk->type) {
-			case CNK_INT:
-				if(cnk->cflags == DP_C_SHORT)
-					cnk->value = va_arg(args, int);
-				else if(cnk->cflags == DP_C_LONG)
-					cnk->value = va_arg(args, long int);
-				else if(cnk->cflags == DP_C_LLONG)
-					cnk->value = va_arg(args, LLONG);
-				else
-					cnk->value = va_arg(args, int);
-
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->value = cnk->value;
-					}
-				break;
-
-			case CNK_OCTAL:
-			case CNK_UINT:
-			case CNK_HEX:
-				if(cnk->cflags == DP_C_SHORT)
-					cnk->value = va_arg(args, unsigned int);
-				else if(cnk->cflags == DP_C_LONG)
-					cnk->value = (long)va_arg(args, unsigned long int);
-				else if(cnk->cflags == DP_C_LLONG)
-					cnk->value = (LLONG)va_arg(args, unsigned LLONG);
-				else
-					cnk->value = (long)va_arg(args, unsigned int);
-
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->value = cnk->value;
-					}
-				break;
-
-			case CNK_FLOAT:
-				if(cnk->cflags == DP_C_LDOUBLE)
-					cnk->fvalue = va_arg(args, LDOUBLE);
-				else
-					cnk->fvalue = va_arg(args, double);
-
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->fvalue = cnk->fvalue;
-					}
-				break;
-
-			case CNK_CHAR:
-				cnk->value = va_arg(args, int);
-
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->value = cnk->value;
-					}
-				break;
-
-			case CNK_STRING:
-				cnk->strvalue = va_arg(args, char *);
-				if(!cnk->strvalue) cnk->strvalue = "(NULL)";
-
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->strvalue = cnk->strvalue;
-					}
-				break;
-
-			case CNK_PTR:
-				cnk->strvalue = va_arg(args, void *);
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->strvalue = cnk->strvalue;
-					}
-				break;
-
-			case CNK_NUM:
-				if(cnk->cflags == DP_C_CHAR)
-					cnk->pnum = va_arg(args, char *);
-				else if(cnk->cflags == DP_C_SHORT)
-					cnk->pnum = va_arg(args, short int *);
-				else if(cnk->cflags == DP_C_LONG)
-					cnk->pnum = va_arg(args, long int *);
-				else if(cnk->cflags == DP_C_LLONG)
-					cnk->pnum = va_arg(args, LLONG *);
-				else
-					cnk->pnum = va_arg(args, int *);
-
-				for(i = 1; i < clist[pnum].num; i++) {
-					clist[pnum].chunks[i]->pnum = cnk->pnum;
-					}
-				break;
-
-			case CNK_PRCNT:
-				break;
-
-			default:
-				/* what ?? */
-				goto done;
 			}
 		}
+		cnk = clist[pnum].chunks[0];
+		switch(cnk->type) {
+		case CNK_INT:
+			if(cnk->cflags == DP_C_SHORT)
+				cnk->value = va_arg(args, int);
+			else if(cnk->cflags == DP_C_LONG)
+				cnk->value = va_arg(args, long int);
+			else if(cnk->cflags == DP_C_LLONG)
+				cnk->value = va_arg(args, LLONG);
+			else
+				cnk->value = va_arg(args, int);
+
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->value = cnk->value;
+			}
+			break;
+
+		case CNK_OCTAL:
+		case CNK_UINT:
+		case CNK_HEX:
+			if(cnk->cflags == DP_C_SHORT)
+				cnk->value = va_arg(args, unsigned int);
+			else if(cnk->cflags == DP_C_LONG)
+				cnk->value = (long)va_arg(args, unsigned long int);
+			else if(cnk->cflags == DP_C_LLONG)
+				cnk->value = (LLONG)va_arg(args, unsigned LLONG);
+			else
+				cnk->value = (long)va_arg(args, unsigned int);
+
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->value = cnk->value;
+			}
+			break;
+
+		case CNK_FLOAT:
+			if(cnk->cflags == DP_C_LDOUBLE)
+				cnk->fvalue = va_arg(args, LDOUBLE);
+			else
+				cnk->fvalue = va_arg(args, double);
+
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->fvalue = cnk->fvalue;
+			}
+			break;
+
+		case CNK_CHAR:
+			cnk->value = va_arg(args, int);
+
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->value = cnk->value;
+			}
+			break;
+
+		case CNK_STRING:
+			cnk->strvalue = va_arg(args, char *);
+			if(!cnk->strvalue) cnk->strvalue = "(NULL)";
+
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->strvalue = cnk->strvalue;
+			}
+			break;
+
+		case CNK_PTR:
+			cnk->strvalue = va_arg(args, void *);
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->strvalue = cnk->strvalue;
+			}
+			break;
+
+		case CNK_NUM:
+			if(cnk->cflags == DP_C_CHAR)
+				cnk->pnum = va_arg(args, char *);
+			else if(cnk->cflags == DP_C_SHORT)
+				cnk->pnum = va_arg(args, short int *);
+			else if(cnk->cflags == DP_C_LONG)
+				cnk->pnum = va_arg(args, long int *);
+			else if(cnk->cflags == DP_C_LLONG)
+				cnk->pnum = va_arg(args, LLONG *);
+			else
+				cnk->pnum = va_arg(args, int *);
+
+			for(i = 1; i < clist[pnum].num; i++) {
+				clist[pnum].chunks[i]->pnum = cnk->pnum;
+			}
+			break;
+
+		case CNK_PRCNT:
+			break;
+
+		default:
+			/* what ?? */
+			goto done;
+		}
+	}
 	/* print out the actual string from chunks */
 	currlen = 0;
 	cnk = chunks;
@@ -684,78 +674,78 @@ static size_t dopr(char *buffer, size_t maxlen, const char *format, va_list args
 
 		switch(cnk->type) {
 
-			case CNK_FMT_STR:
-				if(maxlen != 0 && maxlen > currlen) {
-					if(maxlen > (currlen + cnk->len)) len = cnk->len;
-					else len = maxlen - currlen;
+		case CNK_FMT_STR:
+			if(maxlen != 0 && maxlen > currlen) {
+				if(maxlen > (currlen + cnk->len)) len = cnk->len;
+				else len = maxlen - currlen;
 
-					memcpy(&(buffer[currlen]), &(base[cnk->start]), len);
-					}
-				currlen += cnk->len;
-
-				break;
-
-			case CNK_INT:
-			case CNK_UINT:
-				fmtint(buffer, &currlen, maxlen, cnk->value, 10, min, max, cnk->flags);
-				break;
-
-			case CNK_OCTAL:
-				fmtint(buffer, &currlen, maxlen, cnk->value, 8, min, max, cnk->flags);
-				break;
-
-			case CNK_HEX:
-				fmtint(buffer, &currlen, maxlen, cnk->value, 16, min, max, cnk->flags);
-				break;
-
-			case CNK_FLOAT:
-				fmtfp(buffer, &currlen, maxlen, cnk->fvalue, min, max, cnk->flags);
-				break;
-
-			case CNK_CHAR:
-				dopr_outch(buffer, &currlen, maxlen, cnk->value);
-				break;
-
-			case CNK_STRING:
-				if(max == -1) {
-					max = strlen(cnk->strvalue);
-					}
-				fmtstr(buffer, &currlen, maxlen, cnk->strvalue, cnk->flags, min, max);
-				break;
-
-			case CNK_PTR:
-				fmtint(buffer, &currlen, maxlen, (long)(cnk->strvalue), 16, min, max, cnk->flags);
-				break;
-
-			case CNK_NUM:
-				if(cnk->cflags == DP_C_CHAR)
-					*((char *)(cnk->pnum)) = (char)currlen;
-				else if(cnk->cflags == DP_C_SHORT)
-					*((short int *)(cnk->pnum)) = (short int)currlen;
-				else if(cnk->cflags == DP_C_LONG)
-					*((long int *)(cnk->pnum)) = (long int)currlen;
-				else if(cnk->cflags == DP_C_LLONG)
-					*((LLONG *)(cnk->pnum)) = (LLONG)currlen;
-				else
-					*((int *)(cnk->pnum)) = (int)currlen;
-				break;
-
-			case CNK_PRCNT:
-				dopr_outch(buffer, &currlen, maxlen, '%');
-				break;
-
-			default:
-				/* what ?? */
-				goto done;
+				memcpy(&(buffer[currlen]), &(base[cnk->start]), len);
 			}
-		cnk = cnk->next;
+			currlen += cnk->len;
+
+			break;
+
+		case CNK_INT:
+		case CNK_UINT:
+			fmtint(buffer, &currlen, maxlen, cnk->value, 10, min, max, cnk->flags);
+			break;
+
+		case CNK_OCTAL:
+			fmtint(buffer, &currlen, maxlen, cnk->value, 8, min, max, cnk->flags);
+			break;
+
+		case CNK_HEX:
+			fmtint(buffer, &currlen, maxlen, cnk->value, 16, min, max, cnk->flags);
+			break;
+
+		case CNK_FLOAT:
+			fmtfp(buffer, &currlen, maxlen, cnk->fvalue, min, max, cnk->flags);
+			break;
+
+		case CNK_CHAR:
+			dopr_outch(buffer, &currlen, maxlen, cnk->value);
+			break;
+
+		case CNK_STRING:
+			if(max == -1) {
+				max = strlen(cnk->strvalue);
+			}
+			fmtstr(buffer, &currlen, maxlen, cnk->strvalue, cnk->flags, min, max);
+			break;
+
+		case CNK_PTR:
+			fmtint(buffer, &currlen, maxlen, (long)(cnk->strvalue), 16, min, max, cnk->flags);
+			break;
+
+		case CNK_NUM:
+			if(cnk->cflags == DP_C_CHAR)
+				*((char *)(cnk->pnum)) = (char)currlen;
+			else if(cnk->cflags == DP_C_SHORT)
+				*((short int *)(cnk->pnum)) = (short int)currlen;
+			else if(cnk->cflags == DP_C_LONG)
+				*((long int *)(cnk->pnum)) = (long int)currlen;
+			else if(cnk->cflags == DP_C_LLONG)
+				*((LLONG *)(cnk->pnum)) = (LLONG)currlen;
+			else
+				*((int *)(cnk->pnum)) = (int)currlen;
+			break;
+
+		case CNK_PRCNT:
+			dopr_outch(buffer, &currlen, maxlen, '%');
+			break;
+
+		default:
+			/* what ?? */
+			goto done;
 		}
+		cnk = cnk->next;
+	}
 	if(maxlen != 0) {
 		if(currlen < maxlen - 1)
 			buffer[currlen] = '\0';
 		else if(maxlen > 0)
 			buffer[maxlen - 1] = '\0';
-		}
+	}
 	ret = currlen;
 
 done:
@@ -763,18 +753,19 @@ done:
 		cnk = chunks->next;
 		free(chunks);
 		chunks = cnk;
-		}
+	}
 	if(clist) {
 		for(pnum = 0; pnum < max_pos; pnum++) {
 			if(clist[pnum].chunks) free(clist[pnum].chunks);
-			}
-		free(clist);
 		}
-	return ret;
+		free(clist);
 	}
+	return ret;
+}
 
 static void fmtstr(char *buffer, size_t *currlen, size_t maxlen,
-                   char *value, int flags, int min, int max) {
+                   char *value, int flags, int min, int max)
+{
 	int padlen, strln;     /* amount to pad */
 	int cnt = 0;
 
@@ -783,7 +774,7 @@ static void fmtstr(char *buffer, size_t *currlen, size_t maxlen,
 #endif
 	if(value == 0) {
 		value = "<NULL>";
-		}
+	}
 
 	for(strln = 0; strln < max && value[strln]; ++strln);  /* strlen */
 	padlen = min - strln;
@@ -795,21 +786,22 @@ static void fmtstr(char *buffer, size_t *currlen, size_t maxlen,
 	while(padlen > 0) {
 		dopr_outch(buffer, currlen, maxlen, ' ');
 		--padlen;
-		}
+	}
 	while(*value && (cnt < max)) {
 		dopr_outch(buffer, currlen, maxlen, *value++);
 		++cnt;
-		}
+	}
 	while(padlen < 0) {
 		dopr_outch(buffer, currlen, maxlen, ' ');
 		++padlen;
-		}
 	}
+}
 
 /* Have to handle DP_F_NUM (ie 0x and 0 alternates) */
 
 static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
-                   long value, int base, int min, int max, int flags) {
+                   long value, int base, int min, int max, int flags)
+{
 	int signvalue = 0;
 	unsigned long uvalue;
 	char convert[20];
@@ -827,14 +819,13 @@ static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
 		if(value < 0) {
 			signvalue = '-';
 			uvalue = -value;
-			}
-		else {
+		} else {
 			if(flags & DP_F_PLUS)   /* Do a sign (+/i) */
 				signvalue = '+';
 			else if(flags & DP_F_SPACE)
 				signvalue = ' ';
-			}
 		}
+	}
 
 	if(flags & DP_F_UP) caps = 1;  /* Should characters be upper case? */
 
@@ -843,8 +834,7 @@ static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
 		    (caps ? "0123456789ABCDEF" : "0123456789abcdef")
 		    [uvalue % (unsigned)base  ];
 		uvalue = (uvalue / (unsigned)base);
-		}
-	while(uvalue && (place < 20));
+	} while(uvalue && (place < 20));
 	if(place == 20) place--;
 	convert[place] = 0;
 
@@ -855,7 +845,7 @@ static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
 	if(flags & DP_F_ZERO) {
 		zpadlen = MAX(zpadlen, spadlen);
 		spadlen = 0;
-		}
+	}
 	if(flags & DP_F_MINUS)
 		spadlen = -spadlen; /* Left Justifty */
 
@@ -868,7 +858,7 @@ static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
 	while(spadlen > 0) {
 		dopr_outch(buffer, currlen, maxlen, ' ');
 		--spadlen;
-		}
+	}
 
 	/* Sign */
 	if(signvalue)
@@ -879,8 +869,8 @@ static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
 		while(zpadlen > 0) {
 			dopr_outch(buffer, currlen, maxlen, '0');
 			--zpadlen;
-			}
 		}
+	}
 
 	/* Digits */
 	while(place > 0)
@@ -890,30 +880,33 @@ static void fmtint(char *buffer, size_t *currlen, size_t maxlen,
 	while(spadlen < 0) {
 		dopr_outch(buffer, currlen, maxlen, ' ');
 		++spadlen;
-		}
 	}
+}
 
-static LDOUBLE abs_val(LDOUBLE value) {
+static LDOUBLE abs_val(LDOUBLE value)
+{
 	LDOUBLE result = value;
 
 	if(value < 0)
 		result = -value;
 
 	return result;
-	}
+}
 
-static LDOUBLE POW10(int exp) {
+static LDOUBLE POW10(int exp)
+{
 	LDOUBLE result = 1;
 
 	while(exp) {
 		result *= 10;
 		exp--;
-		}
-
-	return result;
 	}
 
-static LLONG ROUND(LDOUBLE value) {
+	return result;
+}
+
+static LLONG ROUND(LDOUBLE value)
+{
 	LLONG intpart;
 
 	intpart = (LLONG)value;
@@ -921,11 +914,12 @@ static LLONG ROUND(LDOUBLE value) {
 	if(value >= 0.5) intpart++;
 
 	return intpart;
-	}
+}
 
 /* a replacement for modf that doesn't need the math library. Should
    be portable, but slow */
-static double my_modf(double x0, double *iptr) {
+static double my_modf(double x0, double *iptr)
+{
 	int i;
 	long l;
 	double x = x0;
@@ -936,13 +930,13 @@ static double my_modf(double x0, double *iptr) {
 		if(l <= (x + 1) && l >= (x - 1)) break;
 		x *= 0.1;
 		f *= 10.0;
-		}
+	}
 
 	if(i == 100) {
 		/* yikes! the number is beyond what we can handle. What do we do? */
 		(*iptr) = 0;
 		return 0;
-		}
+	}
 
 	if(i != 0) {
 		double i2;
@@ -951,15 +945,16 @@ static double my_modf(double x0, double *iptr) {
 		ret = my_modf(x0 - l * f, &i2);
 		(*iptr) = l * f + i2;
 		return ret;
-		}
+	}
 
 	(*iptr) = l;
 	return x - (*iptr);
-	}
+}
 
 
 static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
-                  LDOUBLE fvalue, int min, int max, int flags) {
+                  LDOUBLE fvalue, int min, int max, int flags)
+{
 	int signvalue = 0;
 	double ufvalue;
 	char iconvert[311];
@@ -985,16 +980,14 @@ static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
 
 	if(fvalue < 0) {
 		signvalue = '-';
-		}
-	else {
+	} else {
 		if(flags & DP_F_PLUS) {  /* Do a sign (+/i) */
 			signvalue = '+';
-			}
-		else {
+		} else {
 			if(flags & DP_F_SPACE)
 				signvalue = ' ';
-			}
 		}
+	}
 
 #if 0
 	if(flags & DP_F_UP) caps = 1;  /* Should characters be upper case? */
@@ -1023,7 +1016,7 @@ static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
 	if(fracpart >= POW10(max)) {
 		intpart++;
 		fracpart -= POW10(max);
-		}
+	}
 
 
 	/* Convert integer part */
@@ -1035,8 +1028,7 @@ static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
 		/* printf ("%llf, %f, %x\n", temp, intpart, idx); */
 		iconvert[iplace++] =
 		    (caps ? "0123456789ABCDEF" : "0123456789abcdef")[idx];
-		}
-	while(intpart && (iplace < 311));
+	} while(intpart && (iplace < 311));
 	if(iplace == 311) iplace--;
 	iconvert[iplace] = 0;
 
@@ -1050,10 +1042,9 @@ static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
 			/* printf ("%lf, %lf, %ld\n", temp, fracpart, idx ); */
 			fconvert[fplace++] =
 			    (caps ? "0123456789ABCDEF" : "0123456789abcdef")[idx];
-			}
-		while(fracpart && (fplace < 311));
+		} while(fracpart && (fplace < 311));
 		if(fplace == 311) fplace--;
-		}
+	}
 	fconvert[fplace] = 0;
 
 	/* -1 for decimal point, another -1 if we are printing a sign */
@@ -1070,16 +1061,16 @@ static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
 			dopr_outch(buffer, currlen, maxlen, signvalue);
 			--padlen;
 			signvalue = 0;
-			}
+		}
 		while(padlen > 0) {
 			dopr_outch(buffer, currlen, maxlen, '0');
 			--padlen;
-			}
 		}
+	}
 	while(padlen > 0) {
 		dopr_outch(buffer, currlen, maxlen, ' ');
 		--padlen;
-		}
+	}
 	if(signvalue)
 		dopr_outch(buffer, currlen, maxlen, signvalue);
 
@@ -1100,26 +1091,28 @@ static void fmtfp(char *buffer, size_t *currlen, size_t maxlen,
 		while(zpadlen > 0) {
 			dopr_outch(buffer, currlen, maxlen, '0');
 			--zpadlen;
-			}
+		}
 
 		while(fplace > 0)
 			dopr_outch(buffer, currlen, maxlen, fconvert[--fplace]);
-		}
+	}
 
 	while(padlen < 0) {
 		dopr_outch(buffer, currlen, maxlen, ' ');
 		++padlen;
-		}
 	}
+}
 
-static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c) {
+static void dopr_outch(char *buffer, size_t *currlen, size_t maxlen, char c)
+{
 	if(*currlen < maxlen) {
 		buffer[(*currlen)] = c;
-		}
-	(*currlen)++;
 	}
+	(*currlen)++;
+}
 
-static struct pr_chunk *new_chunk(void) {
+static struct pr_chunk *new_chunk(void)
+{
 	struct pr_chunk *new_c = (struct pr_chunk *)malloc(sizeof(struct pr_chunk));
 
 	if(!new_c)
@@ -1142,10 +1135,11 @@ static struct pr_chunk *new_chunk(void) {
 	new_c->next = NULL;
 
 	return new_c;
-	}
+}
 
 static int add_cnk_list_entry(struct pr_chunk_x **list,
-                              int max_num, struct pr_chunk *chunk) {
+                              int max_num, struct pr_chunk *chunk)
+{
 	struct pr_chunk_x *l;
 	struct pr_chunk **c;
 	int max;
@@ -1158,52 +1152,50 @@ static int add_cnk_list_entry(struct pr_chunk_x **list,
 		if(*list == NULL) {
 			l = (struct pr_chunk_x *)malloc(sizeof(struct pr_chunk_x) * max);
 			pos = 0;
-			}
-		else {
+		} else {
 			l = (struct pr_chunk_x *)realloc(*list, sizeof(struct pr_chunk_x) * max);
 			pos = max_num;
-			}
+		}
 		if(l == NULL) {
 			for(i = 0; i < max; i++) {
 				if((*list)[i].chunks) free((*list)[i].chunks);
-				}
-			return 0;
 			}
+			return 0;
+		}
 		for(i = pos; i < max; i++) {
 			l[i].chunks = NULL;
 			l[i].num = 0;
-			}
 		}
-	else {
+	} else {
 		l = *list;
 		max = max_num;
-		}
+	}
 
 	i = chunk->num - 1;
 	cnum = l[i].num + 1;
 	if(l[i].chunks == NULL) {
 		c = (struct pr_chunk **)malloc(sizeof(struct pr_chunk *) * cnum);
-		}
-	else {
+	} else {
 		c = (struct pr_chunk **)realloc(l[i].chunks, sizeof(struct pr_chunk *) * cnum);
-		}
+	}
 	if(c == NULL) {
 		for(i = 0; i < max; i++) {
 			if(l[i].chunks) free(l[i].chunks);
-			}
-		return 0;
 		}
+		return 0;
+	}
 	c[l[i].num] = chunk;
 	l[i].chunks = c;
 	l[i].num = cnum;
 
 	*list = l;
 	return max;
-	}
+}
 
-int smb_vsnprintf(char *str, size_t count, const char *fmt, va_list args) {
+int smb_vsnprintf(char *str, size_t count, const char *fmt, va_list args)
+{
 	return dopr(str, count, fmt, args);
-	}
+}
 #define vsnprintf smb_vsnprintf
 #endif
 
@@ -1214,7 +1206,8 @@ int smb_vsnprintf(char *str, size_t count, const char *fmt, va_list args) {
  * that doesn't work properly according to the autoconf test.
  */
 #if !defined(HAVE_SNPRINTF) || !defined(HAVE_C99_VSNPRINTF)
-int smb_snprintf(char *str, size_t count, const char *fmt, ...) {
+int smb_snprintf(char *str, size_t count, const char *fmt, ...)
+{
 	size_t ret;
 	va_list ap;
 
@@ -1222,14 +1215,15 @@ int smb_snprintf(char *str, size_t count, const char *fmt, ...) {
 	ret = vsnprintf(str, count, fmt, ap);
 	va_end(ap);
 	return ret;
-	}
+}
 #define snprintf smb_snprintf
 #endif
 
 #endif
 
 #ifndef HAVE_VASPRINTF
-int vasprintf(char **ptr, const char *format, va_list ap) {
+int vasprintf(char **ptr, const char *format, va_list ap)
+{
 	int ret;
 	va_list ap2;
 
@@ -1246,12 +1240,13 @@ int vasprintf(char **ptr, const char *format, va_list ap) {
 	ret = vsnprintf(*ptr, ret + 1, format, ap2);
 
 	return ret;
-	}
+}
 #endif
 
 
 #ifndef HAVE_ASPRINTF
-int asprintf(char **ptr, const char *format, ...) {
+int asprintf(char **ptr, const char *format, ...)
+{
 	va_list ap;
 	int ret;
 
@@ -1261,14 +1256,15 @@ int asprintf(char **ptr, const char *format, ...) {
 	va_end(ap);
 
 	return ret;
-	}
+}
 #endif
 
 #ifdef TEST_SNPRINTF
 
 int sprintf(char *str, const char *fmt, ...);
 
-int main(void) {
+int main(void)
+{
 	char buf1[1024];
 	char buf2[1024];
 	char *buf3;
@@ -1290,7 +1286,7 @@ int main(void) {
 		"%-8.8f",
 		"%-9.9f",
 		NULL
-		};
+	};
 	double fp_nums[] = { 6442452944.1234, -1.5, 134.21, 91340.2, 341.1234, 203.9, 0.96, 0.996,
 	                     0.9996, 1.996, 4.136, 5.030201, 0.00205,
 	                     /* END LIST */ 0
@@ -1307,7 +1303,7 @@ int main(void) {
 		"%4d",
 		"%d",
 		NULL
-		};
+	};
 	long int_nums[] = { -1, 134, 91340, 341, 0203, 0, 1234567890};
 	char *str_fmt[] = {
 		"%10.5s",
@@ -1323,7 +1319,7 @@ int main(void) {
 		"%.10s",
 		"%10s",
 		NULL
-		};
+	};
 	char *str_vals[] = {"hello", "a", "", "a longer string", NULL};
 	int x, y;
 	int fail = 0;
@@ -1343,10 +1339,10 @@ int main(void) {
 				printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 				       fp_fmt[x], l1, buf1, l2, buf2);
 				fail++;
-				}
-			num++;
 			}
+			num++;
 		}
+	}
 
 	for(x = 0; int_fmt[x] ; x++) {
 		for(y = 0; int_nums[y] != 0 ; y++) {
@@ -1359,10 +1355,10 @@ int main(void) {
 				printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 				       int_fmt[x], l1, buf1, l2, buf2);
 				fail++;
-				}
-			num++;
 			}
+			num++;
 		}
+	}
 
 	for(x = 0; str_fmt[x] ; x++) {
 		for(y = 0; str_vals[y] != 0 ; y++) {
@@ -1375,18 +1371,17 @@ int main(void) {
 				printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 				       str_fmt[x], l1, buf1, l2, buf2);
 				fail++;
-				}
-			num++;
 			}
+			num++;
 		}
+	}
 
 #define BUFSZ 2048
 
 	buf1[0] = buf2[0] = '\0';
 	if((buf3 = malloc(BUFSZ)) == NULL) {
 		fail++;
-		}
-	else {
+	} else {
 		num++;
 		memset(buf3, 'a', BUFSZ);
 		snprintf(buf1, sizeof(buf1), "%.*s", 1, buf3);
@@ -1394,8 +1389,8 @@ int main(void) {
 		if(strcmp(buf1, "a") != 0) {
 			printf("length limit buf1 '%s' expected 'a'\n", buf1);
 			fail++;
-			}
 		}
+	}
 
 	buf1[0] = buf2[0] = '\0';
 	l1 = snprintf(buf1, sizeof(buf1), "%4$*1$d %2$s %3$*1$.*1$f", 3, "pos test", 12.3456, 9);
@@ -1405,7 +1400,7 @@ int main(void) {
 		printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 		       "%4$*1$d %2$s %3$*1$.*1$f", l1, buf1, l2, buf2);
 		fail++;
-		}
+	}
 
 	buf1[0] = buf2[0] = '\0';
 	l1 = snprintf(buf1, sizeof(buf1), "%4$*4$d %2$s %3$*4$.*4$f", 3, "pos test", 12.3456, 9);
@@ -1415,7 +1410,7 @@ int main(void) {
 		printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 		       "%4$*1$d %2$s %3$*1$.*1$f", l1, buf1, l2, buf2);
 		fail++;
-		}
+	}
 #if 0
 	buf1[0] = buf2[0] = '\0';
 	l1 = snprintf(buf1, sizeof(buf1), "%lld", (LLONG)1234567890);
@@ -1425,7 +1420,7 @@ int main(void) {
 		printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 		       "%lld", l1, buf1, l2, buf2);
 		fail++;
-		}
+	}
 
 	buf1[0] = buf2[0] = '\0';
 	l1 = snprintf(buf1, sizeof(buf1), "%Lf", (LDOUBLE)890.1234567890123);
@@ -1435,12 +1430,12 @@ int main(void) {
 		printf("snprintf doesn't match Format: %s\n\tsnprintf(%d) = [%s]\n\t sprintf(%d) = [%s]\n",
 		       "%Lf", l1, buf1, l2, buf2);
 		fail++;
-		}
+	}
 #endif
 	printf("%d tests failed out of %d.\n", fail, num);
 
 	printf("seeing how many digits we support\n");
-		{
+	{
 		double v0 = 0.12345678901234567890123456789012345678901;
 		for(x = 0; x < 100; x++) {
 			double p = pow(10, x);
@@ -1450,10 +1445,10 @@ int main(void) {
 			if(strcmp(buf1, buf2)) {
 				printf("we seem to support %d digits\n", x - 1);
 				break;
-				}
 			}
 		}
+	}
 
 	return 0;
-	}
+}
 #endif /* TEST_SNPRINTF */

--- a/lib/squeue.c
+++ b/lib/squeue.c
@@ -231,12 +231,13 @@ unsigned int squeue_size(squeue_t *q)
 	return pqueue_size(q);
 }
 
-int squeue_evt_when_is_after(squeue_event *evt, struct timeval *reftime) {
+int squeue_evt_when_is_after(squeue_event *evt, struct timeval *reftime)
+{
 	if(!evt) return -1;
 
 	if((reftime->tv_sec > evt->when.tv_sec) ||
-			((reftime->tv_sec == evt->when.tv_sec) &&
-			(reftime->tv_usec > evt->when.tv_usec))) {
+	   ((reftime->tv_sec == evt->when.tv_sec) &&
+	    (reftime->tv_usec > evt->when.tv_usec))) {
 		return 1;
 	}
 	return 0;

--- a/lib/t-utils.c
+++ b/lib/t-utils.c
@@ -54,7 +54,7 @@ int t_end(void)
 	if (!t_depth || failed) {
 		t_indent(t_depth);
 		printf("Test results: %s%u passed%s, %s%u failed%s\n",
-			   green, passed, reset, failed ? red : "", failed, failed ? reset : "");
+		       green, passed, reset, failed ? red : "", failed, failed ? reset : "");
 	}
 
 	return failed ? EXIT_FAILURE : EXIT_SUCCESS;
@@ -87,8 +87,7 @@ int t_ok(int success, const char *fmt, ...)
 		va_start(ap, fmt);
 		t_okv(success, fmt, ap);
 		va_end(ap);
-	}
-	else
+	} else
 		t_okv(success, NULL, NULL);
 
 	return success;

--- a/lib/test-fanout.c
+++ b/lib/test-fanout.c
@@ -84,9 +84,9 @@ int main(int argc, char **argv)
 	destroyed = 0;
 	fot = fanout_create(512);
 	ok_int(fanout_remove(fot, 12398) == NULL, 1,
-		"remove on empty table must yield NULL");
+	       "remove on empty table must yield NULL");
 	ok_int(fanout_get(fot, 123887987) == NULL, 1,
-		"get on empty table must yield NULL");
+	       "get on empty table must yield NULL");
 	for (k = 0; k < 16385; k++) {
 		struct test_data *tdata = calloc(1, sizeof(*td));
 		tdata->key = k;
@@ -96,9 +96,9 @@ int main(int argc, char **argv)
 	td = fanout_get(fot, k - 1);
 	ok_int(td != NULL, 1, "get must get what add inserts");
 	ok_int(fanout_remove(fot, k + 1) == NULL, 1,
-		"remove on non-inserted key must yield NULL");
+	       "remove on non-inserted key must yield NULL");
 	ok_int(fanout_get(fot, k + 1) == NULL, 1,
-		"get on non-inserted must yield NULL");
+	       "get on non-inserted must yield NULL");
 	fanout_destroy(fot, pdest);
 	ok_int((int)destroyed, (int)k, "destroy counter while free()'ing");
 

--- a/lib/test-iocache.c
+++ b/lib/test-iocache.c
@@ -47,7 +47,7 @@ static int test_delimiter(const char *delim, unsigned int delim_len)
 		test(!memcmp(ptr, sc[i].str, len), "memcmp() check, string %d, delim_len %d", i, delim_len);
 		if (error) {
 			printf("delim_len: %d. i: %d; len: %lu; sc[i].len: %d\n",
-				   delim_len, i, len, sc[i].len);
+			       delim_len, i, len, sc[i].len);
 			printf("sc[i].str: %s\n", sc[i].str);
 			printf("ptr      : %s\n", ptr);
 			printf("strlen(sc[i].str): %lu\n", strlen(sc[i].str));

--- a/lib/test-kvvec.c
+++ b/lib/test-kvvec.c
@@ -22,7 +22,7 @@ static int walker(struct key_value *kv, void *discard)
 
 	if (discard && vec) {
 		t_ok(!kv_compare(&vec->kv[step], kv), "step %d on walk %d",
-			 step, walks);
+		     step, walks);
 	}
 
 	step++;
@@ -113,9 +113,9 @@ int main(int argc, char **argv)
 		kv2 = &kvv2->kv[i];
 		if (!test(!kv_compare(kv1, kv2), "kv pair %d must match", i)) {
 			printf("%d failed: [%s=%s] (%d+%d) != [%s=%s (%d+%d)]\n",
-				   i,
-				   kv1->key, kv1->value, kv1->key_len, kv1->value_len,
-				   kv2->key, kv2->value, kv2->key_len, kv2->value_len);
+			       i,
+			       kv1->key, kv1->value, kv1->key_len, kv1->value_len,
+			       kv2->key, kv2->value, kv2->key_len, kv2->value_len);
 		}
 	}
 
@@ -123,8 +123,7 @@ int main(int argc, char **argv)
 	test(kvvb2->bufsize == kvvb->bufsize, "bufsizes must match");
 
 	if (kvvb2->buflen == kvvb->buflen && kvvb2->bufsize == kvvb->bufsize &&
-		!memcmp(kvvb2->buf, kvvb->buf, kvvb->bufsize))
-	{
+	    !memcmp(kvvb2->buf, kvvb->buf, kvvb->bufsize)) {
 		t_pass("kvvec -> buf -> kvvec conversion works flawlessly");
 	} else {
 		t_fail("kvvec -> buf -> kvvec conversion failed :'(");
@@ -142,10 +141,10 @@ int main(int argc, char **argv)
 		for (i = 0; i < k.kv_pairs; i++) {
 			struct key_value *kv = &k.kv[i];
 			test(kv->key_len == kv->value_len, "%d.%d; key_len=%d; value_len=%d (%s = %s)",
-				 j, i, kv->key_len, kv->value_len, kv->key, kv->value);
+			     j, i, kv->key_len, kv->value_len, kv->key, kv->value);
 			test(kv->value_len == (int)strlen(kv->value),
-				 "%d.%d; kv->value_len(%d) == strlen(%s)(%d)",
-				 j, i, kv->value_len, kv->value, (int)strlen(kv->value));
+			     "%d.%d; kv->value_len(%d) == strlen(%s)(%d)",
+			     j, i, kv->value_len, kv->value, (int)strlen(kv->value));
 		}
 	}
 

--- a/lib/test-squeue.c
+++ b/lib/test-squeue.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv)
 	if (x != &b) {
 		printf("about to fail pretty fucking hard...\n");
 		printf("ea: %p; &b: %p; &c: %p; ed: %p; x: %p\n",
-			   &a, &b, &c, &d, x);
+		       &a, &b, &c, &d, x);
 	}
 	t(x == &b);
 	t(x->id == b.id);

--- a/lib/worker.c
+++ b/lib/worker.c
@@ -246,9 +246,9 @@ int finish_job(child_process *cp, int reason)
 
 	if (running_jobs != squeue_size(sq)) {
 		wlog("running_jobs(%d) != squeue_size(sq) (%d)\n",
-			 running_jobs, squeue_size(sq));
+		     running_jobs, squeue_size(sq));
 		wlog("started: %d; running: %d; finished: %d\n",
-			 started, running_jobs, started - running_jobs);
+		     started, running_jobs, started - running_jobs);
 	}
 
 	cp->ei->runtime = tv_delta_f(&cp->ei->start, &cp->ei->stop);
@@ -383,7 +383,7 @@ static void kill_job(child_process *cp, int reason)
 			 * reap attempt later.
 			 */
 			if (reason == ESTALE) {
-wlog("tv.tv_sec is currently %d", tv.tv_sec);
+				wlog("tv.tv_sec is currently %d", tv.tv_sec);
 				tv.tv_sec += 5;
 				wlog("Failed to reap child with pid %d. Next attempt @ %lu.%lu", cp->ei->pid, tv.tv_sec, tv.tv_usec);
 			} else {
@@ -487,14 +487,14 @@ static void reap_jobs(void)
 			if (cp->ei->state != ESTALE)
 				finish_job(cp, cp->ei->state);
 			destroy_job(cp);
-		}
-		else if (!pid || (pid < 0 && errno == ECHILD)) {
+		} else if (!pid || (pid < 0 && errno == ECHILD)) {
 			reapable = 0;
 		}
 	} while (reapable);
 }
 
-void cmd_iobroker_register(int fdout, int fderr, void *arg) {
+void cmd_iobroker_register(int fdout, int fderr, void *arg)
+{
 	/* We must never block, even if plugins issue '_exit()' */
 	fcntl(fdout, F_SETFL, O_NONBLOCK);
 	fcntl(fderr, F_SETFL, O_NONBLOCK);
@@ -506,7 +506,8 @@ void cmd_iobroker_register(int fdout, int fderr, void *arg) {
 	}
 }
 
-char **env_from_kvvec(struct kvvec *kvv_env) {
+char **env_from_kvvec(struct kvvec *kvv_env)
+{
 
 	int i;
 	char **env;
@@ -530,8 +531,8 @@ int start_cmd(child_process *cp)
 
 	char **env = env_from_kvvec(cp->env);
 
-	cp->outstd.fd = runcmd_open(cp->cmd, pfd, pfderr, env, 
-			cmd_iobroker_register, cp);
+	cp->outstd.fd = runcmd_open(cp->cmd, pfd, pfderr, env,
+	                            cmd_iobroker_register, cp);
 	my_free(env);
 	if (cp->outstd.fd < 0) {
 		return -1;
@@ -763,7 +764,7 @@ void enter_worker(int sd, int (*cb)(child_process*))
 
 			if (cp->ei->state == ESTALE) {
 				if(cp->ei->sq_event &&
-						squeue_evt_when_is_after(cp->ei->sq_event, &now)) {
+				   squeue_evt_when_is_after(cp->ei->sq_event, &now)) {
 					/* If the state is already stale, there is a already
 						a job to kill the child on the queue so don't
 						add another one here. */

--- a/lib/wproc.c
+++ b/lib/wproc.c
@@ -89,7 +89,7 @@ static void child_exited(int sig)
 
 	result = wait3(&status, 0, &ru);
 	printf("wait3() status: %d; return %d: %s\n",
-		 status, result, strerror(errno));
+	       status, result, strerror(errno));
 	if (WIFEXITED(status)) {
 		printf("Child with pid %d exited normally\n", result);
 	}
@@ -119,7 +119,7 @@ static int print_input(int sd, int events, void *wp_)
 			/* double the size */
 			iocache_grow(wp->ioc, iocache_size(wp->ioc));
 			printf("Growing iocache for worker %d. sizes old/new %lu/%lu\n",
-				   wp->pid, size, iocache_size(wp->ioc));
+			       wp->pid, size, iocache_size(wp->ioc));
 		} else {
 			printf("iocache_size() for worker %d is already at max\n", wp->pid);
 		}
@@ -154,7 +154,7 @@ static int print_input(int sd, int events, void *wp_)
 	}
 
 	printf("iocache: available: %lu; size: %lu; capacity: %lu\n",
-		   iocache_available(wp->ioc), iocache_size(wp->ioc), iocache_capacity(wp->ioc));
+	       iocache_available(wp->ioc), iocache_size(wp->ioc), iocache_capacity(wp->ioc));
 	printf("Got %d packets in %ld bytes (ret: %d)\n", pkt, tot_bytes, ret);
 
 	return 0;
@@ -178,7 +178,7 @@ static int send_command(int sd, int events, void *discard)
 	}
 	if (ret < 0) {
 		printf("main: Failed to read() from fd %d: %s",
-			   sd, strerror(errno));
+		       sd, strerror(errno));
 	}
 
 	/* this happens when we're reading from stdin */

--- a/module/helloworld.c
+++ b/module/helloworld.c
@@ -44,7 +44,8 @@ int helloworld_handle_data(int, void *);
 
 
 /* this function gets called when the module is loaded by the event broker */
-int nebmodule_init(int flags, char *args, nebmodule *handle) {
+int nebmodule_init(int flags, char *args, nebmodule *handle)
+{
 	char temp_buffer[1024];
 	time_t current_time;
 	unsigned long interval;
@@ -77,11 +78,12 @@ int nebmodule_init(int flags, char *args, nebmodule *handle) {
 	neb_register_callback(NEBCALLBACK_AGGREGATED_STATUS_DATA, helloworld_module_handle, 0, helloworld_handle_data);
 
 	return 0;
-	}
+}
 
 
 /* this function gets called when the module is unloaded by the event broker */
-int nebmodule_deinit(int flags, int reason) {
+int nebmodule_deinit(int flags, int reason)
+{
 	char temp_buffer[1024];
 
 	/* deregister for all events we previously registered for... */
@@ -93,11 +95,12 @@ int nebmodule_deinit(int flags, int reason) {
 	write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
 
 	return 0;
-	}
+}
 
 
 /* gets called every X minutes by an event in the scheduling queue */
-void helloworld_reminder_message(char *message) {
+void helloworld_reminder_message(char *message)
+{
 	char temp_buffer[1024];
 
 	/* log a message to the Nagios log file */
@@ -106,34 +109,35 @@ void helloworld_reminder_message(char *message) {
 	write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
 
 	return;
-	}
+}
 
 
 /* handle data from Nagios daemon */
-int helloworld_handle_data(int event_type, void *data) {
+int helloworld_handle_data(int event_type, void *data)
+{
 	nebstruct_aggregated_status_data *agsdata = NULL;
 	char temp_buffer[1024];
 
 	/* what type of event/data do we have? */
 	switch(event_type) {
 
-		case NEBCALLBACK_AGGREGATED_STATUS_DATA:
+	case NEBCALLBACK_AGGREGATED_STATUS_DATA:
 
-			/* an aggregated status data dump just started or ended... */
-			if((agsdata = (nebstruct_aggregated_status_data *)data)) {
+		/* an aggregated status data dump just started or ended... */
+		if((agsdata = (nebstruct_aggregated_status_data *)data)) {
 
-				/* log a message to the Nagios log file */
-				snprintf(temp_buffer, sizeof(temp_buffer) - 1, "helloworld: An aggregated status update just %s.", (agsdata->type == NEBTYPE_AGGREGATEDSTATUS_STARTDUMP) ? "started" : "finished");
-				temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
-				write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
-				}
-
-			break;
-
-		default:
-			break;
+			/* log a message to the Nagios log file */
+			snprintf(temp_buffer, sizeof(temp_buffer) - 1, "helloworld: An aggregated status update just %s.", (agsdata->type == NEBTYPE_AGGREGATEDSTATUS_STARTDUMP) ? "started" : "finished");
+			temp_buffer[sizeof(temp_buffer) - 1] = '\x0';
+			write_to_all_logs(temp_buffer, NSLOG_INFO_MESSAGE);
 		}
 
-	return 0;
+		break;
+
+	default:
+		break;
 	}
+
+	return 0;
+}
 

--- a/t-tap/stub_broker.c
+++ b/t-tap/stub_broker.c
@@ -6,8 +6,14 @@ void broker_adaptive_service_data(int type, int flags, int attr, service *svc, i
 void broker_adaptive_contact_data(int type, int flags, int attr, contact *cntct, int command_type, unsigned long modattr, unsigned long modattrs, unsigned long modhattr, unsigned long modhattrs, unsigned long modsattr, unsigned long modsattrs, struct timeval *timestamp) {}
 void broker_external_command(int type, int flags, int attr, int command_type, time_t entry_time, char *command_string, char *command_args, struct timeval *timestamp) {}
 void broker_acknowledgement_data(int type, int flags, int attr, int acknowledgement_type, void *data, char *ack_author, char *ack_data, int subtype, int notify_contacts, int persistent_comment, struct timeval *timestamp) {}
-int broker_host_check(int type, int flags, int attr, host *hst, int check_type, int state, int state_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, char *output, char *long_output, char *perfdata, struct timeval *timestamp, check_result *cr) { return OK; }
-int broker_service_check(int type, int flags, int attr, service *svc, int check_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, struct timeval *timestamp, check_result *cr) { return OK; }
+int broker_host_check(int type, int flags, int attr, host *hst, int check_type, int state, int state_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, char *output, char *long_output, char *perfdata, struct timeval *timestamp, check_result *cr)
+{
+	return OK;
+}
+int broker_service_check(int type, int flags, int attr, service *svc, int check_type, struct timeval start_time, struct timeval end_time, char *cmd, double latency, double exectime, int timeout, int early_timeout, int retcode, char *cmdline, struct timeval *timestamp, check_result *cr)
+{
+	return OK;
+}
 void broker_program_state(int type, int flags, int attr, struct timeval *timestamp) {}
 void broker_system_command(int type, int flags, int attr, struct timeval start_time, struct timeval end_time, double exectime, int timeout, int early_timeout, int retcode, char *cmd, char *output, struct timeval *timestamp) {}
 void broker_log_data(int type, int flags, int attr, char *data, unsigned long data_type, time_t entry_time, struct timeval *timestamp) {}

--- a/t-tap/stub_checks.c
+++ b/t-tap/stub_checks.c
@@ -1,3 +1,6 @@
 void schedule_host_check(host *hst, time_t check_time, int options) {}
 void schedule_service_check(service *svc, time_t check_time, int options) {}
-int handle_async_host_check_result(host *temp_host, check_result *queued_check_result) { return OK; }
+int handle_async_host_check_result(host *temp_host, check_result *queued_check_result)
+{
+	return OK;
+}

--- a/t-tap/stub_commands.c
+++ b/t-tap/stub_commands.c
@@ -1,3 +1,6 @@
 /* Stub file for routines from commands.c */
 
-int close_command_file(void) { return OK; }
+int close_command_file(void)
+{
+	return OK;
+}

--- a/t-tap/stub_downtime.c
+++ b/t-tap/stub_downtime.c
@@ -3,4 +3,7 @@ unsigned long next_downtime_id = 0;
 int schedule_downtime(int type, char *host_name, char *service_description, time_t entry_time, char *author, char *comment_data, time_t start_time, time_t end_time, int fixed, unsigned long triggered_by, unsigned long duration, unsigned long *new_downtime_id) {}
 int unschedule_downtime(int type, unsigned long downtime_id) {}
 int check_pending_flex_host_downtime(host *hst) {}
-int check_pending_flex_service_downtime(service *svc) { return OK; }
+int check_pending_flex_service_downtime(service *svc)
+{
+	return OK;
+}

--- a/t-tap/stub_events.c
+++ b/t-tap/stub_events.c
@@ -1,4 +1,7 @@
 /* Stub for base/events.c */
-timed_event *schedule_new_event(int event_type, int high_priority, time_t run_time, int recurring, unsigned long event_interval, void *timing_func, int compensate_for_time_change, void *event_data, void *event_args, int event_options) { return NULL; }
+timed_event *schedule_new_event(int event_type, int high_priority, time_t run_time, int recurring, unsigned long event_interval, void *timing_func, int compensate_for_time_change, void *event_data, void *event_args, int event_options)
+{
+	return NULL;
+}
 void add_event(squeue_t *sq, timed_event *event) {}
 void remove_event(squeue_t *sq, timed_event *event) {}

--- a/t-tap/stub_logging.c
+++ b/t-tap/stub_logging.c
@@ -1,7 +1,19 @@
 /* Stub for base/logging.c */
 int write_to_all_logs(char *buffer, unsigned long data_type) {}
-int log_host_event(host *hst) { return OK; }
-int log_service_event(service *svc) { return OK; }
+int log_host_event(host *hst)
+{
+	return OK;
+}
+int log_service_event(service *svc)
+{
+	return OK;
+}
 void logit(int data_type, int display, const char *fmt, ...) {}
-int fix_log_file_owner(uid_t uid, gid_t gid) { return 0; }
-int close_log_file(void) { return 0; }
+int fix_log_file_owner(uid_t uid, gid_t gid)
+{
+	return 0;
+}
+int close_log_file(void)
+{
+	return 0;
+}

--- a/t-tap/stub_macros.c
+++ b/t-tap/stub_macros.c
@@ -1,13 +1,43 @@
 /* Stub file for routines from macros.c */
 char *macro_user[MAX_USER_MACROS];
 
-int init_macros(void) { return OK; }
-int grab_host_macros_r(nagios_macros *mac, host *hst) { return OK; }
-int grab_service_macros_r(nagios_macros *mac, service *svc) { return OK; }
-int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffer, int options) { return OK; }
-int clear_volatile_macros_r(nagios_macros *mac) { return OK; }
-int clear_host_macros_r(nagios_macros *mac) { return OK; }
-int free_macrox_names(void) { return OK; }
-nagios_macros *get_global_macros(void) { return NULL; }
-int clear_argv_macros_r(nagios_macros *mac) { return OK; }
-int set_all_macro_environment_vars_r(nagios_macros *mac, int set) { return OK; }
+int init_macros(void)
+{
+	return OK;
+}
+int grab_host_macros_r(nagios_macros *mac, host *hst)
+{
+	return OK;
+}
+int grab_service_macros_r(nagios_macros *mac, service *svc)
+{
+	return OK;
+}
+int process_macros_r(nagios_macros *mac, char *input_buffer, char **output_buffer, int options)
+{
+	return OK;
+}
+int clear_volatile_macros_r(nagios_macros *mac)
+{
+	return OK;
+}
+int clear_host_macros_r(nagios_macros *mac)
+{
+	return OK;
+}
+int free_macrox_names(void)
+{
+	return OK;
+}
+nagios_macros *get_global_macros(void)
+{
+	return NULL;
+}
+int clear_argv_macros_r(nagios_macros *mac)
+{
+	return OK;
+}
+int set_all_macro_environment_vars_r(nagios_macros *mac, int set)
+{
+	return OK;
+}

--- a/t-tap/stub_nebmods.c
+++ b/t-tap/stub_nebmods.c
@@ -1,6 +1,18 @@
 /* Stub file for routines from nebmods.c */
 
-int neb_free_callback_list(void) { return OK; }
-int neb_unload_all_modules(int flags, int reason) { return OK; }
-int neb_free_module_list(void) { return OK; }
-int neb_deinit_modules(void) { return OK; }
+int neb_free_callback_list(void)
+{
+	return OK;
+}
+int neb_unload_all_modules(int flags, int reason)
+{
+	return OK;
+}
+int neb_free_module_list(void)
+{
+	return OK;
+}
+int neb_deinit_modules(void)
+{
+	return OK;
+}

--- a/t-tap/stub_netutils.c
+++ b/t-tap/stub_netutils.c
@@ -1,5 +1,14 @@
 /* Stub file for routines from netutils.c */
 
-int my_tcp_connect(const char *host_name, int port, int *sd, int timeout) { return OK; }
-int my_sendall(int s, const char *buf, int *len, int timeout) { return OK; }
-int my_recvall(int s, char *buf, int *len, int timeout) { return OK; }
+int my_tcp_connect(const char *host_name, int port, int *sd, int timeout)
+{
+	return OK;
+}
+int my_sendall(int s, const char *buf, int *len, int timeout)
+{
+	return OK;
+}
+int my_recvall(int s, char *buf, int *len, int timeout)
+{
+	return OK;
+}

--- a/t-tap/stub_objects.c
+++ b/t-tap/stub_objects.c
@@ -1,9 +1,33 @@
 /* Stub file for common/objects.c */
-service *find_service(const char *host_name, const char *svc_desc) { return NULL; }
-host *find_host(const char *name) { return NULL; }
-hostgroup *find_hostgroup(const char *name) { return NULL; }
-contactgroup *find_contactgroup(const char *name) { return NULL; }
-servicegroup *find_servicegroup(const char *name) { return NULL; }
-contact *find_contact(const char *name) { return NULL; }
-command *find_command(const char *name) { return NULL; }
-timeperiod *find_timeperiod(const char *name) { return NULL; }
+service *find_service(const char *host_name, const char *svc_desc)
+{
+	return NULL;
+}
+host *find_host(const char *name)
+{
+	return NULL;
+}
+hostgroup *find_hostgroup(const char *name)
+{
+	return NULL;
+}
+contactgroup *find_contactgroup(const char *name)
+{
+	return NULL;
+}
+servicegroup *find_servicegroup(const char *name)
+{
+	return NULL;
+}
+contact *find_contact(const char *name)
+{
+	return NULL;
+}
+command *find_command(const char *name)
+{
+	return NULL;
+}
+timeperiod *find_timeperiod(const char *name)
+{
+	return NULL;
+}

--- a/t-tap/stub_perfdata.c
+++ b/t-tap/stub_perfdata.c
@@ -1,2 +1,5 @@
 int update_host_performance_data(host *hst) {}
-int update_service_performance_data(service *svc) { return OK; }
+int update_service_performance_data(service *svc)
+{
+	return OK;
+}

--- a/t-tap/stub_sehandlers.c
+++ b/t-tap/stub_sehandlers.c
@@ -1,4 +1,10 @@
 int obsessive_compulsive_host_check_processor(host *hst) {}
-int obsessive_compulsive_service_check_processor(service *svc) { return OK; }
+int obsessive_compulsive_service_check_processor(service *svc)
+{
+	return OK;
+}
 int handle_host_event(host *hst) {}
-int handle_service_event(service *svc) { return OK; }
+int handle_service_event(service *svc)
+{
+	return OK;
+}

--- a/t-tap/stub_statusdata.c
+++ b/t-tap/stub_statusdata.c
@@ -1,6 +1,9 @@
 /* Stub for common/statusdata.c */
 int update_service_status(service *svc, int aggregated_dump) {}
-int update_host_status(host *hst, int aggregated_dump) { return OK; }
+int update_host_status(host *hst, int aggregated_dump)
+{
+	return OK;
+}
 #ifndef TEST_CHECKS_C
 int update_program_status(int aggregated_dump) {}
 #endif

--- a/t-tap/stub_workers.c
+++ b/t-tap/stub_workers.c
@@ -1,2 +1,5 @@
 /* Stub file for routines from macros.c */
-int wproc_run_check(check_result *cr, char *cmd, nagios_macros *mac) { return OK; }
+int wproc_run_check(check_result *cr, char *cmd, nagios_macros *mac)
+{
+	return OK;
+}

--- a/t-tap/stub_xodtemplate.c
+++ b/t-tap/stub_xodtemplate.c
@@ -1,3 +1,6 @@
 /* Stub file for routines from xodtemplate.c */
 
-int xodtemplate_read_config_data(const char *main_config_file, int options) { return OK; }
+int xodtemplate_read_config_data(const char *main_config_file, int options)
+{
+	return OK;
+}

--- a/t-tap/test-stubs.c
+++ b/t-tap/test-stubs.c
@@ -71,9 +71,10 @@ int handle_scheduled_downtime_by_id(unsigned long long1) {}
 #ifndef TEST_LOGGING
 int log_host_event(host *hst) {}
 int log_service_event_flag = 0;
-int log_service_event(service *svc) {
+int log_service_event(service *svc)
+{
 	log_service_event_flag++;
-	}
+}
 int rotate_log_file(time_t time_t1) {}
 void logit(int int1, int int2, const char *fmt, ...) {}
 #endif
@@ -171,10 +172,11 @@ void reschedule_event(timed_event *event, timed_event **event_list, timed_event 
 int process_passive_service_check(time_t check_time, char *host_name, char *svc_description, int return_code, char *output) {}
 int             soft_state_dependencies = FALSE;
 int             additional_freshness_latency = DEFAULT_ADDITIONAL_FRESHNESS_LATENCY;
-hostdependency *get_first_hostdependency_by_dependent_host(char *host_name, void **ptr) {
+hostdependency *get_first_hostdependency_by_dependent_host(char *host_name, void **ptr)
+{
 	/* Return NULL so check_host_dependencies returns back */
 	return NULL;
-	}
+}
 hostdependency *get_next_hostdependency_by_dependent_host(char *host_name, void **ptr) {}
 int             currently_running_host_checks = 0;
 int my_system_r(nagios_macros *mac, char *cmd, int timeout, int *early_timeout, double *exectime, char **output, int max_output_length) {}

--- a/t-tap/test_checks.c
+++ b/t-tap/test_checks.c
@@ -55,7 +55,8 @@ int found_log_rechecking_host_when_service_wobbles = 0;
 int found_log_run_async_host_check = 0;
 check_result *tmp_check_result;
 
-void setup_check_result() {
+void setup_check_result()
+{
 	struct timeval start_time, finish_time;
 	start_time.tv_sec = 1234567890L;
 	start_time.tv_usec = 0L;
@@ -73,10 +74,11 @@ void setup_check_result() {
 	tmp_check_result->latency = 0.6969;
 	tmp_check_result->start_time = start_time;
 	tmp_check_result->finish_time = finish_time;
-	}
+}
 
 int c = 0;
-int update_program_status(int aggregated_dump) {
+int update_program_status(int aggregated_dump)
+{
 	c++;
 	/* printf ("# In the update_program_status hook: %d\n", c); */
 
@@ -84,9 +86,10 @@ int update_program_status(int aggregated_dump) {
 	if(c > 10) {
 		sigshutdown = TRUE;
 		c = 0;
-		}
 	}
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+}
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	va_list ap;
 	char *buffer = NULL;
 
@@ -95,17 +98,18 @@ int log_debug_info(int level, int verbosity, const char *fmt, ...) {
 	vasprintf(&buffer, fmt, ap);
 	if(strcmp(buffer, "Service wobbled between non-OK states, so we'll recheck the host state...\n") == 0) {
 		found_log_rechecking_host_when_service_wobbles++;
-		}
+	}
 	if(strcmp(buffer, "run_async_host_check()\n") == 0) {
 		found_log_run_async_host_check++;
-		}
+	}
 	free(buffer);
 	va_end(ap);
-	}
+}
 
 
 void
-setup_objects(time_t time) {
+setup_objects(time_t time)
+{
 	timed_event *new_event = NULL;
 
 	enable_predictive_service_dependency_checks = FALSE;
@@ -153,10 +157,11 @@ setup_objects(time_t time) {
 	svc2->retry_interval = 1;
 	svc2->check_interval = 5;
 
-	}
+}
 
 int
-main(int argc, char **argv) {
+main(int argc, char **argv)
+{
 	time_t now = 0L;
 
 
@@ -416,5 +421,5 @@ main(int argc, char **argv) {
 
 
 	return exit_status();
-	}
+}
 

--- a/t-tap/test_commands.c
+++ b/t-tap/test_commands.c
@@ -36,12 +36,13 @@
 #include "stub_macros.c"
 #include "tap.h"
 
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	va_list ap;
 	va_start(ap, fmt);
 	/* vprintf( fmt, ap ); */
 	va_end(ap);
-	}
+}
 
 char *temp_path;
 int date_format;
@@ -79,31 +80,35 @@ char *test_comment = NULL;
 int deleted = 1;
 scheduled_downtime *find_host_downtime_by_name(char *hostname) {}
 scheduled_downtime *find_host_service_downtime_by_name(char *hostname, char *service_description) {}
-int delete_downtime_by_start_time_comment(time_t start_time, char *comment) {
+int delete_downtime_by_start_time_comment(time_t start_time, char *comment)
+{
 	test_start_time = start_time;
 	test_comment = comment;
 	return deleted;
-	}
+}
 
-int delete_downtime_by_hostname_service_description_start_time_comment(char *hostname, char *service_description, time_t start_time, char *comment) {
+int delete_downtime_by_hostname_service_description_start_time_comment(char *hostname, char *service_description, time_t start_time, char *comment)
+{
 	test_hostname = hostname;
 	test_servicename = service_description;
 	test_start_time = start_time;
 	test_comment = comment;
 	return deleted;
-	}
+}
 
-void reset_vars() {
+void reset_vars()
+{
 	test_start_time = 0L;
 	test_hostname = NULL;
 	test_servicename = NULL;
 	test_comment = NULL;
-	}
+}
 
 hostgroup *temp_hostgroup = NULL;
 
 int
-main() {
+main()
+{
 	time_t now = 0L;
 
 	plan_tests(62);
@@ -206,5 +211,5 @@ main() {
 
 
 	return exit_status();
-	}
+}
 

--- a/t-tap/test_downtime.c
+++ b/t-tap/test_downtime.c
@@ -31,12 +31,13 @@
 #include "tap.h"
 
 void logit(int data_type, int display, const char *fmt, ...) {}
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	va_list ap;
 	va_start(ap, fmt);
 	/* vprintf( fmt, ap ); */
 	va_end(ap);
-	}
+}
 
 timed_event *event_list_high = NULL;
 timed_event *event_list_high_tail = NULL;
@@ -46,7 +47,8 @@ unsigned long next_downtime_id = 1L;
 extern scheduled_downtime *scheduled_downtime_list;
 
 int
-main(int argc, char **argv) {
+main(int argc, char **argv)
+{
 	time_t now = 0L;
 	time_t temp_start_time = 1234567890L;
 	time_t temp_end_time = 2134567890L;
@@ -102,7 +104,7 @@ main(int argc, char **argv) {
 
 	for(temp_downtime = scheduled_downtime_list, i = 0; temp_downtime != NULL; temp_downtime = temp_downtime->next, i++) {
 		diag("downtime id: %d", temp_downtime->downtime_id);
-		}
+	}
 	ok(i == 3, "Got 3 downtimes left: %d", i);
 
 	unschedule_downtime(HOST_DOWNTIME, 3);
@@ -161,7 +163,7 @@ main(int argc, char **argv) {
 
 	for(temp_downtime = scheduled_downtime_list, i = 0; temp_downtime != NULL; temp_downtime = temp_downtime->next, i++) {
 		diag("downtime id: %d", temp_downtime->downtime_id);
-		}
+	}
 	ok(i == 4, "Got 4 downtimes left: %d", i);
 
 	unschedule_downtime(HOST_DOWNTIME, 9);
@@ -175,5 +177,5 @@ main(int argc, char **argv) {
 
 
 	return exit_status();
-	}
+}
 

--- a/t-tap/test_events.c
+++ b/t-tap/test_events.c
@@ -89,11 +89,12 @@ service  *service_list;
 
 int check_for_expired_comment(unsigned long temp_long) {}
 void broker_timed_event(int int1, int int2, int int3, timed_event *timed_event1, struct timeval *timeval1) {}
-int perform_scheduled_host_check(host *temp_host, int int1, double double1) {
+int perform_scheduled_host_check(host *temp_host, int int1, double double1)
+{
 	time_t now = 0L;
 	time(&now);
 	temp_host->last_check = now;
-	}
+}
 int check_for_expired_downtime(void) {}
 int reap_check_results(void) {}
 void check_host_result_freshness() {}
@@ -107,13 +108,14 @@ void check_service_result_freshness() {}
 int check_time_against_period(time_t time_t1, timeperiod *timeperiod) {}
 time_t get_next_log_rotation_time(void) {}
 void check_for_orphaned_services() {}
-int run_scheduled_service_check(service *service1, int int1, double double1) {
+int run_scheduled_service_check(service *service1, int int1, double double1)
+{
 	currently_running_service_checks++;
 	time_t now = 0L;
 	time(&now);
 	service1->last_check = now;
 	/* printf("Currently running service checks: %d\n", currently_running_service_checks); */
-	}
+}
 int handle_scheduled_downtime_by_id(unsigned long long1) {}
 int rotate_log_file(time_t time_t1) {}
 time_t get_next_host_notification_time(host *temp_host, time_t time_t1) {}
@@ -121,7 +123,8 @@ void get_next_valid_time(time_t time_t1, time_t *time_t2, timeperiod *temp_timep
 void logit(int int1, int int2, const char *fmt, ...) {}
 
 int c = 0;
-int update_program_status(int aggregated_dump) {
+int update_program_status(int aggregated_dump)
+{
 	c++;
 	/* printf ("# In the update_program_status hook: %d\n", c); */
 
@@ -129,16 +132,17 @@ int update_program_status(int aggregated_dump) {
 	if(c > 10) {
 		sigshutdown = TRUE;
 		c = 0;
-		}
 	}
+}
 int update_service_status(service *svc, int aggregated_dump) {}
 int update_all_status_data(void) {}
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	va_list ap;
 	va_start(ap, fmt);
 	/* vprintf( fmt, ap ); */
 	va_end(ap);
-	}
+}
 int update_host_status(host *hst, int aggregated_dump) {}
 
 /* Test variables */
@@ -146,7 +150,8 @@ service *svc1 = NULL, *svc2 = NULL, *svc3 = NULL;
 host *host1 = NULL;
 
 void
-setup_events(time_t time) {
+setup_events(time_t time)
+{
 	timed_event *new_event = NULL;
 
 	/* First service is a normal one */
@@ -194,10 +199,11 @@ setup_events(time_t time) {
 	new_event->timing_func = NULL;
 	new_event->compensate_for_time_change = TRUE;
 	reschedule_event(new_event, &event_list_low, &event_list_low_tail);
-	}
+}
 
 void
-setup_events_with_host(time_t time) {
+setup_events_with_host(time_t time)
+{
 	timed_event *new_event = NULL;
 
 	/* First service is a normal one */
@@ -247,10 +253,11 @@ setup_events_with_host(time_t time) {
 	new_event->timing_func = NULL;
 	new_event->compensate_for_time_change = TRUE;
 	reschedule_event(new_event, &event_list_low, &event_list_low_tail);
-	}
+}
 
 int
-main(int argc, char **argv) {
+main(int argc, char **argv)
+{
 	time_t now = 0L;
 
 	plan_tests(10);
@@ -296,7 +303,7 @@ main(int argc, char **argv) {
 	timed_event *temp_event = NULL;
 	while((temp_event = event_list_low) != NULL) {
 		remove_event(temp_event, &event_list_low, &event_list_low_tail);
-		}
+	}
 
 	sigshutdown = FALSE;
 	currently_running_service_checks = 0;
@@ -312,5 +319,5 @@ main(int argc, char **argv) {
 	ok(svc3->next_check == now + 300, "svc3 rescheduled ahead - normal interval");
 
 	return exit_status();
-	}
+}
 

--- a/t-tap/test_logging.c
+++ b/t-tap/test_logging.c
@@ -45,20 +45,22 @@ int use_large_installation_tweaks = DEFAULT_USE_LARGE_INSTALLATION_TWEAKS;
 
 char *saved_source;
 char *saved_dest;
-int my_rename(char *source, char *dest) {
+int my_rename(char *source, char *dest)
+{
 	char *temp = "renamefailure";
 	saved_source = strdup(source);
 	saved_dest = strdup(dest);
 	if(strcmp(source, "renamefailure") == 0) {
 		return ERROR;
-		}
-	return rename(source, dest);
 	}
+	return rename(source, dest);
+}
 
 void update_program_status() {}
 
 int
-main(int argc, char **argv) {
+main(int argc, char **argv)
+{
 	time_t rotation_time;
 	struct stat stat_info, stat_new;
 	char *log_filename_localtime = NULL;
@@ -101,4 +103,4 @@ main(int argc, char **argv) {
 	ok(stat_info.st_mode == stat_new.st_mode, "Mode for new log file kept same as original log file");
 
 	return exit_status();
-	}
+}

--- a/t-tap/test_macros.c
+++ b/t-tap/test_macros.c
@@ -39,68 +39,86 @@
 /*****************************************************************************/
 /*                             Dummy functions                               */
 /*****************************************************************************/
-void logit(int data_type, int display, const char *fmt, ...) {
+void logit(int data_type, int display, const char *fmt, ...)
+{
 }
-int my_sendall(int s, char *buf, int *len, int timeout) {
+int my_sendall(int s, char *buf, int *len, int timeout)
+{
 	return 0;
 }
 
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	return 0;
 }
 
-int neb_free_callback_list(void) {
+int neb_free_callback_list(void)
+{
 	return 0;
 }
 
-int neb_deinit_modules(void) {
+int neb_deinit_modules(void)
+{
 	return 0;
 }
 void broker_program_state(int type, int flags, int attr,
-		struct timeval *timestamp) {
+                          struct timeval *timestamp)
+{
 }
-int neb_unload_all_modules(int flags, int reason) {
+int neb_unload_all_modules(int flags, int reason)
+{
 	return 0;
 }
-int neb_add_module(char *filename, char *args, int should_be_loaded) {
+int neb_add_module(char *filename, char *args, int should_be_loaded)
+{
 	return 0;
 }
 void broker_system_command(int type, int flags, int attr,
-		struct timeval start_time, struct timeval end_time, double exectime,
-		int timeout, int early_timeout, int retcode, char *cmd, char *output,
-		struct timeval *timestamp) {
+                           struct timeval start_time, struct timeval end_time, double exectime,
+                           int timeout, int early_timeout, int retcode, char *cmd, char *output,
+                           struct timeval *timestamp)
+{
 }
 
 timed_event *schedule_new_event(int event_type, int high_priority,
-		time_t run_time, int recurring, unsigned long event_interval,
-		void *timing_func, int compensate_for_time_change, void *event_data,
-		void *event_args, int event_options) {
+                                time_t run_time, int recurring, unsigned long event_interval,
+                                void *timing_func, int compensate_for_time_change, void *event_data,
+                                void *event_args, int event_options)
+{
 	return NULL ;
 }
-int my_tcp_connect(char *host_name, int port, int *sd, int timeout) {
+int my_tcp_connect(char *host_name, int port, int *sd, int timeout)
+{
 	return 0;
 }
-int my_recvall(int s, char *buf, int *len, int timeout) {
+int my_recvall(int s, char *buf, int *len, int timeout)
+{
 	return 0;
 }
-int neb_free_module_list(void) {
+int neb_free_module_list(void)
+{
 	return 0;
 }
-int close_command_file(void) {
+int close_command_file(void)
+{
 	return 0;
 }
-int close_log_file(void) {
+int close_log_file(void)
+{
 	return 0;
 }
-int fix_log_file_owner(uid_t uid, gid_t gid) {
+int fix_log_file_owner(uid_t uid, gid_t gid)
+{
 	return 0;
 }
 int handle_async_service_check_result(service *temp_service,
-		check_result *queued_check_result) {
+                                      check_result *queued_check_result)
+{
 	return 0;
 }
 int handle_async_host_check_result(host *temp_host,
-		check_result *queued_check_result) {
+                                   check_result *queued_check_result)
+{
 	return 0;
 }
 
@@ -109,14 +127,16 @@ int handle_async_host_check_result(host *temp_host,
 /*****************************************************************************/
 
 host test_host = { .name = "name'&%", .address = "address'&%", .notes_url =
-		"notes_url'&%($HOSTNOTES$)", .notes = "notes'&%($HOSTACTIONURL$)",
-		.action_url = "action_url'&%", .plugin_output = "name'&%" };
+                       "notes_url'&%($HOSTNOTES$)", .notes = "notes'&%($HOSTACTIONURL$)",
+                   .action_url = "action_url'&%", .plugin_output = "name'&%"
+                 };
 
 /*****************************************************************************/
 /*                             Helper functions                              */
 /*****************************************************************************/
 
-void init_environment() {
+void init_environment()
+{
 	char *p;
 
 	my_free(illegal_output_chars);
@@ -128,7 +148,8 @@ void init_environment() {
 	}
 }
 
-nagios_macros *setup_macro_object(void) {
+nagios_macros *setup_macro_object(void)
+{
 	nagios_macros *mac = (nagios_macros *) calloc(1, sizeof(nagios_macros));
 	grab_host_macros_r(mac, &test_host);
 	return mac;
@@ -147,7 +168,8 @@ nagios_macros *setup_macro_object(void) {
 /*                             Tests                                         */
 /*****************************************************************************/
 
-void test_escaping(nagios_macros *mac) {
+void test_escaping(nagios_macros *mac)
+{
 	char *output;
 
 	/* Nothing should be changed... options == 0 */
@@ -166,17 +188,17 @@ void test_escaping(nagios_macros *mac) {
 	 */
 	RUN_MACRO_TEST( "$HOSTOUTPUT$ '&%", "name'&% '&%", ESCAPE_MACRO_CHARS);
 	RUN_MACRO_TEST( "$HOSTOUTPUT$ '&%", "name% '&%",
-			STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
+	                STRIP_ILLEGAL_MACRO_CHARS | ESCAPE_MACRO_CHARS);
 
 	/* $HOSTNAME$ should be url-encoded, but not the tailing chars */
 	RUN_MACRO_TEST( "$HOSTNAME$ '&%", "name%27%26%25 '&%",
-			URL_ENCODE_MACRO_CHARS);
+	                URL_ENCODE_MACRO_CHARS);
 
 	/* The notes in the notesurl should be url-encoded, no more encoding should
 	 * exist
 	 */
 	RUN_MACRO_TEST( "$HOSTNOTESURL$ '&%",
-			"notes_url'&%(notes%27%26%25%28action_url%27%26%25%29) '&%", 0);
+	                "notes_url'&%(notes%27%26%25%28action_url%27%26%25%29) '&%", 0);
 
 	/* '& in the source string shouldn't be removed, because HOSTNOTESURL
 	 * doesn't accept STRIP_ILLEGAL_MACRO_CHARS, as in the url. the macros
@@ -184,22 +206,23 @@ void test_escaping(nagios_macros *mac) {
 	 * and '
 	 */
 	RUN_MACRO_TEST( "$HOSTNOTESURL$ '&%",
-			"notes_url'&%(notes%27%26%25%28action_url%27%26%25%29) '&%",
-			STRIP_ILLEGAL_MACRO_CHARS);
+	                "notes_url'&%(notes%27%26%25%28action_url%27%26%25%29) '&%",
+	                STRIP_ILLEGAL_MACRO_CHARS);
 
 	/* This should double-encode some chars ($HOSTNOTESURL$ should contain
 	 * url-encoded chars, and should itself be url-encoded
 	 */
 	RUN_MACRO_TEST( "$HOSTNOTESURL$ '&%",
-			"notes_url%27%26%25%28notes%2527%2526%2525%2528action_url%2527%2526%2525%2529%29 '&%",
-			URL_ENCODE_MACRO_CHARS);
+	                "notes_url%27%26%25%28notes%2527%2526%2525%2528action_url%2527%2526%2525%2529%29 '&%",
+	                URL_ENCODE_MACRO_CHARS);
 }
 
 /*****************************************************************************/
 /*                             Main function                                 */
 /*****************************************************************************/
 
-int main(void) {
+int main(void)
+{
 	nagios_macros *mac;
 
 	plan_tests(9);

--- a/t-tap/test_nagios_config.c
+++ b/t-tap/test_nagios_config.c
@@ -241,12 +241,13 @@ timed_event *event_list_high_tail = NULL;
 void logit(int data_type, int display, const char *fmt, ...) {}
 int my_sendall(int s, char *buf, int *len, int timeout) {}
 int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp) {}
-int log_debug_info(int level, int verbosity, const char *fmt, ...) {
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
 	va_list ap;
 	va_start(ap, fmt);
 	/* vprintf( fmt, ap ); */
 	va_end(ap);
-	}
+}
 
 int neb_free_callback_list(void) {}
 void broker_program_status(int type, int flags, int attr, struct timeval *timestamp) {}
@@ -275,7 +276,8 @@ void check_for_host_flapping(host *hst, int update, int actual_check, int allow_
 int service_notification(service *svc, int type, char *not_author, char *not_data, int options) {}
 
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 	int error = FALSE;
 	char *buffer = NULL;
@@ -310,18 +312,18 @@ int main(int argc, char **argv) {
 	for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
 		c++;
 		//printf("Hostgroup=%s\n", temp_hostgroup->group_name);
-		}
+	}
 	ok(c == 2, "Found all hostgroups");
 
 	temp_hostgroup = find_hostgroup("hostgroup1");
 	for(temp_member = temp_hostgroup->members; temp_member != NULL; temp_member = temp_member->next) {
 		//printf("host pointer=%d\n", temp_member->host_ptr);
-		}
+	}
 
 	temp_hostgroup = find_hostgroup("hostgroup2");
 	for(temp_member = temp_hostgroup->members; temp_member != NULL; temp_member = temp_member->next) {
 		//printf("host pointer=%d\n", temp_member->host_ptr);
-		}
+	}
 
 	temp_host = find_host("host1");
 	ok(temp_host->current_state == 0, "State is assumed OK on initial load");
@@ -345,6 +347,6 @@ int main(int argc, char **argv) {
 	my_free(config_file);
 
 	return exit_status();
-	}
+}
 
 

--- a/t-tap/test_timeperiods.c
+++ b/t-tap/test_timeperiods.c
@@ -46,31 +46,80 @@
 
 /* Dummy functions */
 void logit(int data_type, int display, const char *fmt, ...) {}
-int my_sendall(int s, char *buf, int *len, int timeout) { return 0; }
+int my_sendall(int s, char *buf, int *len, int timeout)
+{
+	return 0;
+}
 void free_comment_data(void) {}
-int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp) { return 0; }
-int log_debug_info(int level, int verbosity, const char *fmt, ...) { return 0; }
+int write_to_log(char *buffer, unsigned long data_type, time_t *timestamp)
+{
+	return 0;
+}
+int log_debug_info(int level, int verbosity, const char *fmt, ...)
+{
+	return 0;
+}
 
-int neb_free_callback_list(void) { return 0; }
+int neb_free_callback_list(void)
+{
+	return 0;
+}
 void broker_program_status(int type, int flags, int attr, struct timeval *timestamp) {}
-int neb_deinit_modules(void) { return 0; }
+int neb_deinit_modules(void)
+{
+	return 0;
+}
 void broker_program_state(int type, int flags, int attr, struct timeval *timestamp) {}
 void broker_comment_data(int type, int flags, int attr, int comment_type, int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long comment_id, struct timeval *timestamp) {}
-int neb_unload_all_modules(int flags, int reason) { return 0; }
-int neb_add_module(char *filename, char *args, int should_be_loaded) { return 0; }
+int neb_unload_all_modules(int flags, int reason)
+{
+	return 0;
+}
+int neb_add_module(char *filename, char *args, int should_be_loaded)
+{
+	return 0;
+}
 void broker_system_command(int type, int flags, int attr, struct timeval start_time, struct timeval end_time, double exectime, int timeout, int early_timeout, int retcode, char *cmd, char *output, struct timeval *timestamp) {}
 
-timed_event *schedule_new_event(int event_type, int high_priority, time_t run_time, int recurring, unsigned long event_interval, void *timing_func, int compensate_for_time_change, void *event_data, void *event_args, int event_options) { return NULL; }
-int my_tcp_connect(char *host_name, int port, int *sd, int timeout) { return 0; }
-int my_recvall(int s, char *buf, int *len, int timeout) { return 0; }
-int neb_free_module_list(void) { return 0; }
-int close_command_file(void) { return 0; }
-int close_log_file(void) { return 0; }
-int fix_log_file_owner(uid_t uid, gid_t gid) { return 0; }
-int handle_async_service_check_result(service *temp_service, check_result *queued_check_result) { return 0; }
-int handle_async_host_check_result(host *temp_host, check_result *queued_check_result) { return 0; }
+timed_event *schedule_new_event(int event_type, int high_priority, time_t run_time, int recurring, unsigned long event_interval, void *timing_func, int compensate_for_time_change, void *event_data, void *event_args, int event_options)
+{
+	return NULL;
+}
+int my_tcp_connect(char *host_name, int port, int *sd, int timeout)
+{
+	return 0;
+}
+int my_recvall(int s, char *buf, int *len, int timeout)
+{
+	return 0;
+}
+int neb_free_module_list(void)
+{
+	return 0;
+}
+int close_command_file(void)
+{
+	return 0;
+}
+int close_log_file(void)
+{
+	return 0;
+}
+int fix_log_file_owner(uid_t uid, gid_t gid)
+{
+	return 0;
+}
+int handle_async_service_check_result(service *temp_service, check_result *queued_check_result)
+{
+	return 0;
+}
+int handle_async_host_check_result(host *temp_host, check_result *queued_check_result)
+{
+	return 0;
+}
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 	int c = 0;
 	time_t current_time;
@@ -138,7 +187,7 @@ int main(int argc, char **argv) {
 		ok(test_time == chosen_valid_time, "get_next_valid_time always returns same time");
 		test_time += 1800;
 		c++;
-		}
+	}
 
 	putenv("TZ=Europe/London");
 	tzset();
@@ -151,7 +200,7 @@ int main(int argc, char **argv) {
 		ok(test_time == chosen_valid_time, "get_next_valid_time always returns same time, time_t=%lu", test_time);
 		test_time += 1800;
 		c++;
-		}
+	}
 
 	/* 2009-11-01 is the day when clocks go back an hour in America. Bug happens during 23:00 to 00:00 */
 	/* This is 23:01:01 */
@@ -169,7 +218,7 @@ int main(int argc, char **argv) {
 		ok(test_time == chosen_valid_time, "get_next_valid_time always returns same time, time_t=%lu", test_time);
 		test_time += 1800;
 		c++;
-		}
+	}
 
 
 
@@ -321,4 +370,4 @@ int main(int argc, char **argv) {
 	my_free(config_file);
 
 	return exit_status();
-	}
+}

--- a/t-tap/test_xsddefault.c
+++ b/t-tap/test_xsddefault.c
@@ -44,7 +44,8 @@
 extern comment *comment_list;
 extern scheduled_downtime *scheduled_downtime_list;
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
 	int result;
 	int c;
 	int last_id;
@@ -71,10 +72,10 @@ int main(int argc, char **argv) {
 		if(temp_comment->comment_id <= last_id) {
 			result = ERROR;
 			break;
-			}
+		}
 		last_id = temp_comment->comment_id;
 		temp_comment = temp_comment->next;
-		}
+	}
 	ok(c == 12, "Got %d comments - expected 12", c);
 	ok(result == OK, "All comments in order");
 
@@ -87,14 +88,14 @@ int main(int argc, char **argv) {
 		if(temp_downtime->start_time < last_time) {
 			result = ERROR;
 			break;
-			}
+		}
 		last_time = temp_downtime->start_time;
 		temp_downtime = temp_downtime->next;
-		}
+	}
 	ok(c == 20, "Got %d downtimes - expected 20", c);
 	ok(result == OK, "All downtimes in order");
 
 	return exit_status();
-	}
+}
 
 

--- a/tap/src/tap.c
+++ b/tap/src/tap.c
@@ -68,7 +68,8 @@ static void _cleanup(void);
  */
 unsigned int
 _gen_result(int ok, const char *func, char *file, unsigned int line,
-            char *test_name, ...) {
+            char *test_name, ...)
+{
 	va_list ap;
 	char *local_test_name = NULL;
 	char *c;
@@ -94,20 +95,20 @@ _gen_result(int ok, const char *func, char *file, unsigned int line,
 				if(!isdigit(*c) && !isspace(*c)) {
 					name_is_digits = 0;
 					break;
-					}
 				}
+			}
 
 			if(name_is_digits) {
 				diag("    You named your test '%s'.  You shouldn't use numbers for your test names.", local_test_name);
 				diag("    Very confusing.");
-				}
 			}
 		}
+	}
 
 	if(!ok) {
 		printf("not ");
 		failures++;
-		}
+	}
 
 	printf("ok %d", test_count);
 
@@ -122,13 +123,12 @@ _gen_result(int ok, const char *func, char *file, unsigned int line,
 				if(*c == '#')
 					fputc('\\', stdout);
 				fputc((int)*c, stdout);
-				}
+			}
 			funlockfile(stdout);
-			}
-		else {	/* vasprintf() failed, use a fixed message */
+		} else {	/* vasprintf() failed, use a fixed message */
 			printf("%s", todo_msg_fixed);
-			}
 		}
+	}
 
 	/* If we're in a todo_start() block then flag the test as being
 	   TODO.  todo_msg should contain the message to print at this
@@ -141,7 +141,7 @@ _gen_result(int ok, const char *func, char *file, unsigned int line,
 		printf(" # TODO %s", todo_msg ? todo_msg : todo_msg_fixed);
 		if(!ok)
 			failures--;
-		}
+	}
 
 	printf("\n");
 
@@ -156,14 +156,15 @@ _gen_result(int ok, const char *func, char *file, unsigned int line,
 	/* We only care (when testing) that ok is positive, but here we
 	   specifically only want to return 1 or 0 */
 	return ok ? 1 : 0;
-	}
+}
 
 /*
  * Initialise the TAP library.  Will only do so once, however many times it's
  * called.
  */
 void
-_tap_init(void) {
+_tap_init(void)
+{
 	static int run_once = 0;
 
 	LOCK;
@@ -176,16 +177,17 @@ _tap_init(void) {
 		   with Test::Harness */
 		setbuf(stdout, 0);
 		run_once = 1;
-		}
+	}
 
 	UNLOCK;
-	}
+}
 
 /*
  * Note that there's no plan.
  */
 int
-plan_no_plan(void) {
+plan_no_plan(void)
+{
 
 	LOCK;
 
@@ -196,7 +198,7 @@ plan_no_plan(void) {
 		test_died = 1;
 		UNLOCK;
 		exit(255);
-		}
+	}
 
 	have_plan = 1;
 	no_plan = 1;
@@ -204,13 +206,14 @@ plan_no_plan(void) {
 	UNLOCK;
 
 	return 0;
-	}
+}
 
 /*
  * Note that the plan is to skip all tests
  */
 int
-plan_skip_all(char *reason) {
+plan_skip_all(char *reason)
+{
 
 	LOCK;
 
@@ -228,13 +231,14 @@ plan_skip_all(char *reason) {
 	UNLOCK;
 
 	exit(0);
-	}
+}
 
 /*
  * Note the number of tests that will be run.
  */
 int
-plan_tests(unsigned int tests) {
+plan_tests(unsigned int tests)
+{
 
 	LOCK;
 
@@ -245,14 +249,14 @@ plan_tests(unsigned int tests) {
 		test_died = 1;
 		UNLOCK;
 		exit(255);
-		}
+	}
 
 	if(tests == 0) {
 		fprintf(stderr, "You said to run 0 tests!  You've got to run something.\n");
 		test_died = 1;
 		UNLOCK;
 		exit(255);
-		}
+	}
 
 	have_plan = 1;
 
@@ -261,10 +265,11 @@ plan_tests(unsigned int tests) {
 	UNLOCK;
 
 	return 0;
-	}
+}
 
 unsigned int
-diag(char *fmt, ...) {
+diag(char *fmt, ...)
+{
 	va_list ap;
 
 	LOCK;
@@ -280,10 +285,11 @@ diag(char *fmt, ...) {
 	UNLOCK;
 
 	return 0;
-	}
+}
 
 void
-_expected_tests(unsigned int tests) {
+_expected_tests(unsigned int tests)
+{
 
 	LOCK;
 
@@ -291,10 +297,11 @@ _expected_tests(unsigned int tests) {
 	e_tests = tests;
 
 	UNLOCK;
-	}
+}
 
 int
-skip(unsigned int n, char *fmt, ...) {
+skip(unsigned int n, char *fmt, ...)
+{
 	va_list ap;
 	char *skip_msg;
 
@@ -309,17 +316,18 @@ skip(unsigned int n, char *fmt, ...) {
 		printf("ok %d # skip %s\n", test_count,
 		       skip_msg != NULL ?
 		       skip_msg : "libtap():malloc() failed");
-		}
+	}
 
 	free(skip_msg);
 
 	UNLOCK;
 
 	return 1;
-	}
+}
 
 void
-todo_start(char *fmt, ...) {
+todo_start(char *fmt, ...)
+{
 	va_list ap;
 
 	LOCK;
@@ -331,10 +339,11 @@ todo_start(char *fmt, ...) {
 	todo = 1;
 
 	UNLOCK;
-	}
+}
 
 void
-todo_end(void) {
+todo_end(void)
+{
 
 	LOCK;
 
@@ -342,10 +351,11 @@ todo_end(void) {
 	free(todo_msg);
 
 	UNLOCK;
-	}
+}
 
 int
-exit_status(void) {
+exit_status(void)
+{
 	int r;
 
 	LOCK;
@@ -354,7 +364,7 @@ exit_status(void) {
 	if(no_plan || !have_plan) {
 		UNLOCK;
 		return failures;
-		}
+	}
 
 	/* Ran too many tests?  Return the number of tests that were run
 	   that shouldn't have been */
@@ -362,7 +372,7 @@ exit_status(void) {
 		r = test_count - e_tests;
 		UNLOCK;
 		return r;
-		}
+	}
 
 	/* Return the number of tests that failed + the number of tests
 	   that weren't run */
@@ -370,14 +380,15 @@ exit_status(void) {
 	UNLOCK;
 
 	return r;
-	}
+}
 
 /*
  * Cleanup at the end of the run, produce any final output that might be
  * required.
  */
 void
-_cleanup(void) {
+_cleanup(void)
+{
 
 	LOCK;
 
@@ -388,38 +399,38 @@ _cleanup(void) {
 		diag("Looks like your test died before it could output anything.");
 		UNLOCK;
 		return;
-		}
+	}
 
 	if(test_died) {
 		diag("Looks like your test died just after %d.", test_count);
 		UNLOCK;
 		return;
-		}
+	}
 
 
 	/* No plan provided, but now we know how many tests were run, and can
 	   print the header at the end */
 	if(!skip_all && (no_plan || !have_plan)) {
 		printf("1..%d\n", test_count);
-		}
+	}
 
 	if((have_plan && !no_plan) && e_tests < test_count) {
 		diag("Looks like you planned %d tests but ran %d extra.",
 		     e_tests, test_count - e_tests);
 		UNLOCK;
 		return;
-		}
+	}
 
 	if((have_plan || !no_plan) && e_tests > test_count) {
 		diag("Looks like you planned %d tests but only ran %d.",
 		     e_tests, test_count);
 		UNLOCK;
 		return;
-		}
+	}
 
 	if(failures)
 		diag("Looks like you failed %d tests of %d.",
 		     failures, test_count);
 
 	UNLOCK;
-	}
+}

--- a/tap/tests/diag/test.c
+++ b/tap/tests/diag/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	plan_tests(2);
@@ -42,4 +43,4 @@ main(int argc, char *argv[]) {
 	ok(0, "test 2") || diag("ok() passed, and shouldn't");
 
 	return exit_status();
-	}
+}

--- a/tap/tests/fail/test.c
+++ b/tap/tests/fail/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(2);
@@ -42,4 +43,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/ok/ok-hash/test.c
+++ b/tap/tests/ok/ok-hash/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(4);
@@ -48,4 +49,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/ok/ok-numeric/test.c
+++ b/tap/tests/ok/ok-numeric/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(3);
@@ -45,4 +46,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/ok/ok/test.c
+++ b/tap/tests/ok/ok/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(5);
@@ -51,4 +52,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/pass/test.c
+++ b/tap/tests/pass/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(2);
@@ -42,4 +43,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/no-tests/test.c
+++ b/tap/tests/plan/no-tests/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(0);
@@ -39,4 +40,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/no_plan/test.c
+++ b/tap/tests/plan/no_plan/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_no_plan();
@@ -39,4 +40,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/not-enough-tests/test.c
+++ b/tap/tests/plan/not-enough-tests/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(1);
@@ -45,4 +46,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/sane/test.c
+++ b/tap/tests/plan/sane/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(1);
@@ -39,4 +40,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/skip_all/test.c
+++ b/tap/tests/plan/skip_all/test.c
@@ -27,11 +27,12 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_skip_all("No good reason");
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/too-many-plans/test.c
+++ b/tap/tests/plan/too-many-plans/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(1);
@@ -45,4 +46,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/plan/too-many-tests/test.c
+++ b/tap/tests/plan/too-many-tests/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 
 	rc = plan_tests(5);
@@ -42,4 +43,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/skip/test.c
+++ b/tap/tests/skip/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 	unsigned int side_effect = 0;
 
@@ -43,14 +44,13 @@ main(int argc, char *argv[]) {
 		if(1) {
 			rc = skip(1, "Testing skipping");
 			continue;
-			}
+		}
 
 		side_effect++;
 
 		ok(side_effect == 1, "side_effect checked out");
 
-		}
-	while(0);
+	} while(0);
 
 	diag("Returned: %d", rc);
 
@@ -66,4 +66,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/tap/tests/todo/test.c
+++ b/tap/tests/todo/test.c
@@ -29,7 +29,8 @@
 #include "tap.h"
 
 int
-main(int argc, char *argv[]) {
+main(int argc, char *argv[])
+{
 	unsigned int rc = 0;
 	unsigned int side_effect = 0;
 
@@ -64,4 +65,4 @@ main(int argc, char *argv[]) {
 	diag("Returned: %d", rc);
 
 	return exit_status();
-	}
+}

--- a/worker/ping/worker-ping.c
+++ b/worker/ping/worker-ping.c
@@ -43,11 +43,12 @@ void		print_license( void);
 void		print_usage( char *);
 void		print_version( void);
 void		parse_worker_command_line( int, char **, char **, int *, char **,
-					char **, char **);
+                                       char **, char **);
 static int	worker( const char *);
 
 /* Everything starts here */
-main( int argc, char **argv, char **env) {
+main( int argc, char **argv, char **env)
+{
 	int daemon_mode = FALSE;
 	char *worker_socket;
 	char *worker_user = ( char *)0;
@@ -58,7 +59,7 @@ main( int argc, char **argv, char **env) {
 	}
 
 	parse_worker_command_line( argc, argv, env, &daemon_mode, &worker_socket,
-			&worker_user, &worker_group);
+	                           &worker_user, &worker_group);
 
 	if( FALSE == daemon_mode) {
 		print_version();
@@ -74,8 +75,8 @@ main( int argc, char **argv, char **env) {
 	if( TRUE == daemon_mode) {
 		if( daemon_init() == ERROR) {
 			fprintf( stderr,
-					"Bailing out due to failure to daemonize. (PID=%d)\n",
-					( int)getpid());
+			         "Bailing out due to failure to daemonize. (PID=%d)\n",
+			         ( int)getpid());
 			exit( 1);
 		}
 	}
@@ -87,8 +88,9 @@ main( int argc, char **argv, char **env) {
 }
 
 void parse_worker_command_line( int argc, char **argv, char **env,
-		int *daemon_mode, char **worker_socket, char **worker_user,
-		char **worker_group) {
+                                int *daemon_mode, char **worker_socket, char **worker_user,
+                                char **worker_group)
+{
 	int c = 0;
 	int display_usage = FALSE;
 	int display_license = FALSE;
@@ -116,43 +118,43 @@ void parse_worker_command_line( int argc, char **argv, char **env,
 
 		switch( c) {
 
-			case '?': /* usage */
-			case 'h':
-				display_usage = TRUE;
-				break;
+		case '?': /* usage */
+		case 'h':
+			display_usage = TRUE;
+			break;
 
-			case 'V': /* version */
-				display_license = TRUE;
-				break;
+		case 'V': /* version */
+			display_license = TRUE;
+			break;
 
-			case 'd': /* daemon mode */
-				*daemon_mode = TRUE;
-				break;
+		case 'd': /* daemon mode */
+			*daemon_mode = TRUE;
+			break;
 
-			case 'W':
-				*worker_socket = optarg;
-				break;
+		case 'W':
+			*worker_socket = optarg;
+			break;
 
-			case 'u':
-				*worker_user = optarg;
-				break;
+		case 'u':
+			*worker_user = optarg;
+			break;
 
-			case 'g':
-				*worker_group = optarg;
-				break;
+		case 'g':
+			*worker_group = optarg;
+			break;
 
-			case ':':
-				printf( "Missing argument for command line option '%c'.\n\n",
-						optopt);
-				print_usage( argv[ 0]);
-				exit( 1);
-				break;
+		case ':':
+			printf( "Missing argument for command line option '%c'.\n\n",
+			        optopt);
+			print_usage( argv[ 0]);
+			exit( 1);
+			break;
 
-			default:
-				printf( "Unknown command line option '%c'.\n\n", c);
-				print_usage( argv[ 0]);
-				exit( 1);
-				break;
+		default:
+			printf( "Unknown command line option '%c'.\n\n", c);
+			print_usage( argv[ 0]);
+			exit( 1);
+			break;
 		}
 	}
 
@@ -169,7 +171,8 @@ void parse_worker_command_line( int argc, char **argv, char **env,
 
 }
 
-void print_license( void) {
+void print_license( void)
+{
 	printf( "\nThis program is free software; you can redistribute it and/or modify\n");
 	printf( "it under the terms of the GNU General Public License version 2 as\n");
 	printf( "published by the Free Software Foundation.\n\n");
@@ -182,7 +185,8 @@ void print_license( void) {
 	printf( "Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.\n\n");
 }
 
-void print_usage( char *program_name) {
+void print_usage( char *program_name)
+{
 	printf( "\nUsage: %s [-?|-h|--help] [-V|--version] [-d]\n", program_name);
 	printf( "        -W /path/to/socket -u user -g group\n");
 	printf( "\n");
@@ -200,7 +204,8 @@ void print_usage( char *program_name) {
 	printf( "\n");
 }
 
-void print_version( void) {
+void print_version( void)
+{
 	printf( "\nNagios Core 4 Ping Worker %s\n", PING_WORKER_VERSION);
 	printf( "Copyright (c) 2013-present Nagios Core Development Team\n");
 	printf( "        and Community Contributors\n");
@@ -219,7 +224,7 @@ static int worker( const char *path)
 	sd = nsock_unix( path, NSOCK_TCP | NSOCK_CONNECT);
 	if( sd < 0) {
 		printf( "Failed to connect to query socket '%s': %s: %s\n",
-				path, nsock_strerror( sd), strerror( errno));
+		        path, nsock_strerror( sd), strerror( errno));
 		return 1;
 	}
 
@@ -245,7 +250,8 @@ static int worker( const char *path)
 	return 0;
 }
 
-int drop_privileges( char *user, char *group) {
+int drop_privileges( char *user, char *group)
+{
 	uid_t uid = -1;
 	gid_t gid = -1;
 	struct group *grp = NULL;
@@ -266,10 +272,9 @@ int drop_privileges( char *user, char *group) {
 			grp = ( struct group *)getgrnam( group);
 			if( NULL != grp) {
 				gid = ( gid_t)(grp->gr_gid);
-			}
-			else {
+			} else {
 				fprintf( stderr,
-					"Warning: Could not get group entry for '%s'\n", group);
+				         "Warning: Could not get group entry for '%s'\n", group);
 			}
 		}
 
@@ -282,7 +287,7 @@ int drop_privileges( char *user, char *group) {
 		if( gid != getegid()) {
 			if( setgid( gid) == -1) {
 				fprintf( stderr, "Warning: Could not set effective GID=%d\n",
-						( int)gid);
+				         ( int)gid);
 				result = PW_ERROR;
 			}
 		}
@@ -296,10 +301,9 @@ int drop_privileges( char *user, char *group) {
 			pw = ( struct passwd *)getpwnam( user);
 			if( NULL != pw) {
 				uid = ( uid_t)(pw->pw_uid);
-			}
-			else {
+			} else {
 				fprintf( stderr,
-						"Warning: Could not get passwd entry for '%s'\n", user);
+				         "Warning: Could not get passwd entry for '%s'\n", user);
 			}
 		}
 
@@ -316,12 +320,11 @@ int drop_privileges( char *user, char *group) {
 			if( initgroups( user, gid) == -1) {
 				if( EPERM == errno) {
 					fprintf( stderr, "Warning: Unable to change supplementary "
-							"groups using initgroups() -- I hope you know what "
-							"you're doing\n");
-				}
-				else {
+					         "groups using initgroups() -- I hope you know what "
+					         "you're doing\n");
+				} else {
 					fprintf( stderr, "Warning: Possibly root user failed "
-							"dropping privileges with initgroups()\n");
+					         "dropping privileges with initgroups()\n");
 					return PW_ERROR;
 				}
 			}
@@ -329,7 +332,7 @@ int drop_privileges( char *user, char *group) {
 #endif
 		if( setuid( uid) == -1) {
 			fprintf( stderr, "Warning: Could not set effective UID=%d\n",
-					( int)uid);
+			         ( int)uid);
 			result = PW_ERROR;
 		}
 	}
@@ -337,7 +340,8 @@ int drop_privileges( char *user, char *group) {
 	return result;
 }
 
-int daemon_init( void) {
+int daemon_init( void)
+{
 	pid_t pid = -1;
 	int pidno = 0;
 	int lockfile = 0;
@@ -355,8 +359,7 @@ int daemon_init( void) {
 #ifdef DAEMON_DUMPS_CORE
 	if( NULL != homedir) {
 		chdir( homedir);
-	}
-	else {
+	} else {
 #endif
 		chdir( "/");
 #ifdef DAEMON_DUMPS_CORE
@@ -378,7 +381,7 @@ int daemon_init( void) {
 
 #ifdef USE_LOCKFILE
 	lockfile = open( lock_file,
-			O_RDWR | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
+	                 O_RDWR | O_CREAT, S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 
 	if( lockfile < 0) {
 		logit( NSLOG_RUNTIME_ERROR, TRUE, "Failed to obtain lock on file %s: %s\n", lock_file, strerror(errno));
@@ -433,8 +436,7 @@ int daemon_init( void) {
 		if( EACCES == errno || EAGAIN == errno) {
 			fcntl( lockfile, F_GETLK, &lock);
 			logit( NSLOG_RUNTIME_ERROR, TRUE, "Lockfile '%s' looks like its already held by another instance of Nagios (PID %d).  Bailing out...", lock_file, (int)lock.l_pid);
-			}
-		else {
+		} else {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Cannot lock lockfile '%s': %s. Bailing out...", lock_file, strerror(errno));
 
 		}

--- a/xdata/xcddefault.c
+++ b/xdata/xcddefault.c
@@ -39,7 +39,8 @@
 
 
 /* initialize comment data */
-int xcddefault_initialize_comment_data(void) {
+int xcddefault_initialize_comment_data(void)
+{
 	comment *temp_comment = NULL;
 
 	/* find the new starting index for comment id if its missing*/
@@ -47,15 +48,15 @@ int xcddefault_initialize_comment_data(void) {
 		for(temp_comment = comment_list; temp_comment != NULL; temp_comment = temp_comment->next) {
 			if(temp_comment->comment_id >= next_comment_id)
 				next_comment_id = temp_comment->comment_id + 1;
-			}
 		}
+	}
 
 	/* initialize next comment id if necessary */
 	if(next_comment_id == 0L)
 		next_comment_id = 1;
 
 	return OK;
-	}
+}
 
 
 /******************************************************************/
@@ -64,7 +65,8 @@ int xcddefault_initialize_comment_data(void) {
 
 
 /* adds a new host comment */
-int xcddefault_add_new_host_comment(int entry_type, char *host_name, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id) {
+int xcddefault_add_new_host_comment(int entry_type, char *host_name, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id)
+{
 
 	/* find the next valid comment id */
 	while(find_host_comment(next_comment_id) != NULL)
@@ -81,11 +83,12 @@ int xcddefault_add_new_host_comment(int entry_type, char *host_name, time_t entr
 	next_comment_id++;
 
 	return OK;
-	}
+}
 
 
 /* adds a new service comment */
-int xcddefault_add_new_service_comment(int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id) {
+int xcddefault_add_new_service_comment(int entry_type, char *host_name, char *svc_description, time_t entry_time, char *author_name, char *comment_data, int persistent, int source, int expires, time_t expire_time, unsigned long *comment_id)
+{
 
 	/* find the next valid comment id */
 	while(find_service_comment(next_comment_id) != NULL)
@@ -102,4 +105,4 @@ int xcddefault_add_new_service_comment(int entry_type, char *host_name, char *sv
 	next_comment_id++;
 
 	return OK;
-	}
+}

--- a/xdata/xodtemplate.c
+++ b/xdata/xodtemplate.c
@@ -160,12 +160,13 @@ static bitmap *service_map = NULL, *parent_map = NULL;
 
 
 /* returns the name of a numbered config file */
-static const char *xodtemplate_config_file_name(int cfgfile) {
+static const char *xodtemplate_config_file_name(int cfgfile)
+{
 	if(cfgfile <= xodtemplate_current_config_file)
 		return xodtemplate_config_files[cfgfile - 1];
 
 	return "?";
-	}
+}
 
 
 
@@ -174,17 +175,19 @@ static const char *xodtemplate_config_file_name(int cfgfile) {
 /******************************************************************/
 
 #ifndef NSCGI
-static void xodtemplate_free_template_skiplists(void) {
+static void xodtemplate_free_template_skiplists(void)
+{
 	int x = 0;
 
 	for(x = 0; x < NUM_XOBJECT_SKIPLISTS; x++) {
 		skiplist_free(&xobject_template_skiplists[x]);
-		}
 	}
+}
 #endif
 
 /* process all config files - both core and CGIs pass in name of main config file */
-int xodtemplate_read_config_data(const char *main_config_file, int options) {
+int xodtemplate_read_config_data(const char *main_config_file, int options)
+{
 #ifdef NSCORE
 	char *cfgfile = NULL;
 	char *config_base_dir = NULL;
@@ -203,7 +206,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 		printf("Error: No main config file passed to object routines!\n");
 #endif
 		return ERROR;
-		}
+	}
 
 	timing_point("Reading config data from '%s'\n", main_config_file);
 
@@ -237,7 +240,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 		printf("Unable to allocate memory!\n");
 #endif
 		return ERROR;
-		}
+	}
 
 	/* are the objects we're reading already pre-sorted? */
 	presorted_objects = FALSE;
@@ -260,7 +263,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 			my_free(xodtemplate_config_files);
 			printf("Unable to allocate memory!\n");
 			return ERROR;
-			}
+		}
 		config_base_dir = (char *)strdup(dirname(cfgfile));
 		my_free(cfgfile);
 
@@ -270,7 +273,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 			my_free(xodtemplate_config_files);
 			printf("Unable to open main config file '%s'\n", main_config_file);
 			return ERROR;
-			}
+		}
 
 		/* daemon reads all config files/dirs specified in the main config file */
 		/* read in all lines from the main config file */
@@ -301,8 +304,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 
 				if(config_base_dir != NULL && val[0] != '/') {
 					asprintf(&cfgfile, "%s/%s", config_base_dir, val);
-					}
-				else
+				} else
 					cfgfile = strdup(val);
 
 				/* process the config file... */
@@ -313,15 +315,14 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 				/* if there was an error processing the config file, break out of loop */
 				if(result == ERROR)
 					break;
-				}
+			}
 
 			/* process all files in a config directory */
 			else if(!strcmp(var, "xodtemplate_config_dir") || !strcmp(var, "cfg_dir")) {
 
 				if(config_base_dir != NULL && val[0] != '/') {
 					asprintf(&cfgfile, "%s/%s", config_base_dir, val);
-					}
-				else
+				} else
 					cfgfile = strdup(val);
 
 				/* strip trailing / if necessary */
@@ -336,14 +337,14 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 				/* if there was an error processing the config file, break out of loop */
 				if(result == ERROR)
 					break;
-				}
 			}
+		}
 
 		/* free memory and close the file */
 		my_free(config_base_dir);
 		my_free(input);
 		mmap_fclose(thefile);
-		}
+	}
 
 	if(test_scheduling == TRUE)
 		gettimeofday(&tv[1], NULL);
@@ -373,7 +374,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 
 		/* cleanup some additive inheritance stuff... */
 		xodtemplate_clean_additive_strings();
-		}
+	}
 #endif
 
 	/* do the meat and potatoes stuff... */
@@ -382,7 +383,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 	if(!host_map || !contact_map) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to create bitmaps for resolving objects\n");
 		return ERROR;
-		}
+	}
 
 	if(result == OK)
 		result = xodtemplate_recombobulate_contactgroups();
@@ -403,7 +404,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 		if(test_scheduling == TRUE)
 			gettimeofday(&tv[5], NULL);
 		timing_point("Created %u services (dupes possible)\n", xodcount.services);
-		}
+	}
 #endif
 
 	/* now we have an accurate service count */
@@ -411,7 +412,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 	if(!service_map) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Failed to create service map\n");
 		return ERROR;
-		}
+	}
 
 	if(result == OK)
 		result = xodtemplate_recombobulate_servicegroups();
@@ -432,7 +433,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 		timing_point("Done propagating inherited object properties\n");
 		if(test_scheduling == TRUE)
 			gettimeofday(&tv[8], NULL);
-		}
+	}
 #endif
 
 	if(test_scheduling == TRUE)
@@ -461,8 +462,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 			runtime[6] = (double)((double)(tv[7].tv_sec - tv[6].tv_sec) + (double)((tv[7].tv_usec - tv[6].tv_usec) / 1000.0) / 1000.0);
 			runtime[7] = (double)((double)(tv[8].tv_sec - tv[7].tv_sec) + (double)((tv[8].tv_usec - tv[7].tv_usec) / 1000.0) / 1000.0);
 			runtime[8] = (double)((double)(tv[10].tv_sec - tv[9].tv_sec) + (double)((tv[10].tv_usec - tv[9].tv_usec) / 1000.0) / 1000.0);
-			}
-		else {
+		} else {
 			runtime[1] = 0.0;
 			runtime[2] = 0.0;
 			runtime[3] = 0.0;
@@ -471,7 +471,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 			runtime[6] = 0.0;
 			runtime[7] = 0.0;
 			runtime[8] = (double)((double)(tv[10].tv_sec - tv[1].tv_sec) + (double)((tv[10].tv_usec - tv[1].tv_usec) / 1000.0) / 1000.0);
-			}
+		}
 		runtime[9] = (double)((double)(tv[11].tv_sec - tv[10].tv_sec) + (double)((tv[11].tv_usec - tv[10].tv_usec) / 1000.0) / 1000.0);
 		runtime[10] = (double)((double)(tv[11].tv_sec - tv[0].tv_sec) + (double)((tv[11].tv_usec - tv[0].tv_usec) / 1000.0) / 1000.0);
 
@@ -499,7 +499,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 			printf("* = %.6lf sec (%.2f%%) estimated savings", (runtime[10] - runtime[9] - runtime[8] - runtime[0]) / 4, ((runtime[10] - runtime[9] - runtime[8] - runtime[0]) / runtime[10]) * 25.0);
 		printf("\n");
 		printf("\n\n");
-		}
+	}
 #endif
 
 	bitmap_destroy(contact_map);
@@ -507,11 +507,12 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 	bitmap_destroy(service_map);
 
 	return result;
-	}
+}
 
 
 /* process all files in a specific config directory */
-int xodtemplate_process_config_dir(char *dirname, int options) {
+int xodtemplate_process_config_dir(char *dirname, int options)
+{
 	char file[MAX_FILENAME_LENGTH];
 	DIR *dirp = NULL;
 	struct dirent *dirfile = NULL;
@@ -529,7 +530,7 @@ int xodtemplate_process_config_dir(char *dirname, int options) {
 	if(dirp == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not open config directory '%s' for reading.\n", dirname);
 		return ERROR;
-		}
+	}
 
 	/* process all files in the directory... */
 	while((dirfile = readdir(dirp)) != NULL) {
@@ -547,50 +548,51 @@ int xodtemplate_process_config_dir(char *dirname, int options) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Could not open config directory member '%s' for reading.\n", file);
 			closedir(dirp);
 			return ERROR;
-			}
+		}
 
 		switch(stat_buf.st_mode & S_IFMT) {
 
-			case S_IFREG:
-				x = strlen(dirfile->d_name);
-				if(x <= 4 || strcmp(dirfile->d_name + (x - 4), ".cfg"))
-					break;
-
-				/* process the config file */
-				result = xodtemplate_process_config_file(file, options);
-
-				if(result == ERROR) {
-					closedir(dirp);
-					return ERROR;
-					}
-
+		case S_IFREG:
+			x = strlen(dirfile->d_name);
+			if(x <= 4 || strcmp(dirfile->d_name + (x - 4), ".cfg"))
 				break;
 
-			case S_IFDIR:
-				/* recurse into subdirectories... */
-				result = xodtemplate_process_config_dir(file, options);
+			/* process the config file */
+			result = xodtemplate_process_config_file(file, options);
 
-				if(result == ERROR) {
-					closedir(dirp);
-					return ERROR;
-					}
-
-				break;
-
-			default:
-				/* everything else we ignore */
-				break;
+			if(result == ERROR) {
+				closedir(dirp);
+				return ERROR;
 			}
+
+			break;
+
+		case S_IFDIR:
+			/* recurse into subdirectories... */
+			result = xodtemplate_process_config_dir(file, options);
+
+			if(result == ERROR) {
+				closedir(dirp);
+				return ERROR;
+			}
+
+			break;
+
+		default:
+			/* everything else we ignore */
+			break;
 		}
+	}
 
 	closedir(dirp);
 
 	return result;
-	}
+}
 
 
 /* process data in a specific config file */
-int xodtemplate_process_config_file(char *filename, int options) {
+int xodtemplate_process_config_file(char *filename, int options)
+{
 	mmapfile *thefile = NULL;
 	char *input = NULL;
 	register int in_definition = FALSE;
@@ -614,13 +616,13 @@ int xodtemplate_process_config_file(char *filename, int options) {
 		xodtemplate_config_files = (char **)realloc(xodtemplate_config_files, (xodtemplate_current_config_file + 256) * sizeof(char **));
 		if(xodtemplate_config_files == NULL)
 			return ERROR;
-		}
+	}
 
 	/* open the config file for reading */
 	if((thefile = mmap_fopen(filename)) == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open config file '%s' for reading: %s\n", filename, strerror(errno));
 		return ERROR;
-		}
+	}
 
 	/* read in all lines from the config file */
 	while(1) {
@@ -641,8 +643,8 @@ int xodtemplate_process_config_file(char *filename, int options) {
 					break;
 				else if(input[x - 1] != '\\')
 					break;
-				}
 			}
+		}
 		input[x] = '\x0';
 
 		/* strip input */
@@ -664,7 +666,7 @@ int xodtemplate_process_config_file(char *filename, int options) {
 					break;
 				else
 					input[y++] = input[x];
-				}
+			}
 			input[y] = '\x0';
 
 			/* make sure an object type is specified... */
@@ -672,7 +674,7 @@ int xodtemplate_process_config_file(char *filename, int options) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: No object type specified in file '%s' on line %d.\n", filename, current_line);
 				result = ERROR;
 				break;
-				}
+			}
 
 			/* check validity of object type */
 			if(strcmp(input, "timeperiod") && strcmp(input, "command") && strcmp(input, "contact") && strcmp(input, "contactgroup") && strcmp(input, "host") && strcmp(input, "hostgroup") && strcmp(input, "servicegroup") && strcmp(input, "service") && strcmp(input, "servicedependency") && strcmp(input, "serviceescalation") && strcmp(input, "hostgroupescalation") && strcmp(input, "hostdependency") && strcmp(input, "hostescalation")) {
@@ -680,26 +682,26 @@ int xodtemplate_process_config_file(char *filename, int options) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid object definition type '%s' in file '%s' on line %d.\n", input, filename, current_line);
 					result = ERROR;
 					break;
-					}
-					logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: Extinfo objects are deprecated and will be removed in future versions\n");
 				}
+				logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: Extinfo objects are deprecated and will be removed in future versions\n");
+			}
 
 			/* we're already in an object definition... */
 			if(in_definition == TRUE) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unexpected start of object definition in file '%s' on line %d.  Make sure you close preceding objects before starting a new one.\n", filename, current_line);
 				result = ERROR;
 				break;
-				}
+			}
 
 			/* start a new definition */
 			if(xodtemplate_begin_object_definition(input, options, xodtemplate_current_config_file, current_line) == ERROR) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add object definition in file '%s' on line %d.\n", filename, current_line);
 				result = ERROR;
 				break;
-				}
+			}
 
 			in_definition = TRUE;
-			}
+		}
 
 		/* we're currently inside an object definition */
 		else if(in_definition == TRUE) {
@@ -714,8 +716,8 @@ int xodtemplate_process_config_file(char *filename, int options) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not complete object definition in file '%s' on line %d. Have you named all your objects?\n", filename, current_line);
 					result = ERROR;
 					break;
-					}
 				}
+			}
 
 			/* this is a directive inside an object definition */
 			else {
@@ -725,9 +727,9 @@ int xodtemplate_process_config_file(char *filename, int options) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add object property in file '%s' on line %d.\n", filename, current_line);
 					result = ERROR;
 					break;
-					}
 				}
 			}
+		}
 
 		/* include another file */
 		else if(strstr(input, "include_file=") == input) {
@@ -739,8 +741,8 @@ int xodtemplate_process_config_file(char *filename, int options) {
 				result = xodtemplate_process_config_file(ptr, options);
 				if(result == ERROR)
 					break;
-				}
 			}
+		}
 
 		/* include a directory */
 		else if(strstr(input, "include_dir") == input) {
@@ -752,16 +754,16 @@ int xodtemplate_process_config_file(char *filename, int options) {
 				result = xodtemplate_process_config_dir(ptr, options);
 				if(result == ERROR)
 					break;
-				}
 			}
+		}
 
 		/* unexpected token or statement */
 		else {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unexpected token or statement in file '%s' on line %d.\n", filename, current_line);
 			result = ERROR;
 			break;
-			}
 		}
+	}
 
 	/* free memory and close file */
 	my_free(input);
@@ -771,10 +773,10 @@ int xodtemplate_process_config_file(char *filename, int options) {
 	if(in_definition == TRUE && result == OK) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unexpected EOF in file '%s' on line %d - check for a missing closing bracket.\n", filename, current_line);
 		result = ERROR;
-		}
+	}
 
 	return result;
-	}
+}
 
 
 
@@ -821,7 +823,8 @@ int xodtemplate_process_config_file(char *filename, int options) {
 	} while (0)
 
 /* starts a new object definition */
-int xodtemplate_begin_object_definition(char *input, int options, int cfgfile, int start_line) {
+int xodtemplate_begin_object_definition(char *input, int options, int cfgfile, int start_line)
+{
 	int result = OK;
 	xodtemplate_timeperiod *new_timeperiod = NULL;
 	xodtemplate_command *new_command = NULL;
@@ -872,191 +875,192 @@ int xodtemplate_begin_object_definition(char *input, int options, int cfgfile, i
 
 	/* check to see if we should process this type of object */
 	switch(xodtemplate_current_object_type) {
-		case XODTEMPLATE_TIMEPERIOD:
-			if(!(options & READ_TIMEPERIODS))
-				return OK;
-			break;
-		case XODTEMPLATE_COMMAND:
-			if(!(options & READ_COMMANDS))
-				return OK;
-			break;
-		case XODTEMPLATE_CONTACT:
-			if(!(options & READ_CONTACTS))
-				return OK;
-			break;
-		case XODTEMPLATE_CONTACTGROUP:
-			if(!(options & READ_CONTACTGROUPS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOST:
-			if(!(options & READ_HOSTS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTGROUP:
-			if(!(options & READ_HOSTGROUPS))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEGROUP:
-			if(!(options & READ_SERVICEGROUPS))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICE:
-			if(!(options & READ_SERVICES))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEDEPENDENCY:
-			if(!(options & READ_SERVICEDEPENDENCIES))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEESCALATION:
-			if(!(options & READ_SERVICEESCALATIONS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTDEPENDENCY:
-			if(!(options & READ_HOSTDEPENDENCIES))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTESCALATION:
-			if(!(options & READ_HOSTESCALATIONS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTEXTINFO:
-			if(!(options & READ_HOSTEXTINFO))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEEXTINFO:
-			if(!(options & READ_SERVICEEXTINFO))
-				return OK;
-			break;
-		default:
-			return ERROR;
-			break;
-		}
+	case XODTEMPLATE_TIMEPERIOD:
+		if(!(options & READ_TIMEPERIODS))
+			return OK;
+		break;
+	case XODTEMPLATE_COMMAND:
+		if(!(options & READ_COMMANDS))
+			return OK;
+		break;
+	case XODTEMPLATE_CONTACT:
+		if(!(options & READ_CONTACTS))
+			return OK;
+		break;
+	case XODTEMPLATE_CONTACTGROUP:
+		if(!(options & READ_CONTACTGROUPS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOST:
+		if(!(options & READ_HOSTS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTGROUP:
+		if(!(options & READ_HOSTGROUPS))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEGROUP:
+		if(!(options & READ_SERVICEGROUPS))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICE:
+		if(!(options & READ_SERVICES))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEDEPENDENCY:
+		if(!(options & READ_SERVICEDEPENDENCIES))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEESCALATION:
+		if(!(options & READ_SERVICEESCALATIONS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTDEPENDENCY:
+		if(!(options & READ_HOSTDEPENDENCIES))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTESCALATION:
+		if(!(options & READ_HOSTESCALATIONS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTEXTINFO:
+		if(!(options & READ_HOSTEXTINFO))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEEXTINFO:
+		if(!(options & READ_SERVICEEXTINFO))
+			return OK;
+		break;
+	default:
+		return ERROR;
+		break;
+	}
 
 
 
 	/* add a new (blank) object */
 	switch(xodtemplate_current_object_type) {
 
-		case XODTEMPLATE_TIMEPERIOD:
-			xod_begin_def(timeperiod);
-			break;
+	case XODTEMPLATE_TIMEPERIOD:
+		xod_begin_def(timeperiod);
+		break;
 
-		case XODTEMPLATE_COMMAND:
-			xod_begin_def(command);
-			break;
+	case XODTEMPLATE_COMMAND:
+		xod_begin_def(command);
+		break;
 
-		case XODTEMPLATE_CONTACTGROUP:
-			xod_begin_def(contactgroup);
-			break;
+	case XODTEMPLATE_CONTACTGROUP:
+		xod_begin_def(contactgroup);
+		break;
 
-		case XODTEMPLATE_HOSTGROUP:
-			xod_begin_def(hostgroup);
-			break;
+	case XODTEMPLATE_HOSTGROUP:
+		xod_begin_def(hostgroup);
+		break;
 
-		case XODTEMPLATE_SERVICEGROUP:
-			xod_begin_def(servicegroup);
-			break;
+	case XODTEMPLATE_SERVICEGROUP:
+		xod_begin_def(servicegroup);
+		break;
 
-		case XODTEMPLATE_SERVICEDEPENDENCY:
-			xod_begin_def(servicedependency);
-			break;
+	case XODTEMPLATE_SERVICEDEPENDENCY:
+		xod_begin_def(servicedependency);
+		break;
 
-		case XODTEMPLATE_SERVICEESCALATION:
-			xod_begin_def(serviceescalation);
-			new_serviceescalation->first_notification = -2;
-			new_serviceescalation->last_notification = -2;
-			break;
+	case XODTEMPLATE_SERVICEESCALATION:
+		xod_begin_def(serviceescalation);
+		new_serviceescalation->first_notification = -2;
+		new_serviceescalation->last_notification = -2;
+		break;
 
-		case XODTEMPLATE_CONTACT:
-			xod_begin_def(contact);
+	case XODTEMPLATE_CONTACT:
+		xod_begin_def(contact);
 
-			new_contact->minimum_value = 0;
-			new_contact->host_notifications_enabled = TRUE;
-			new_contact->service_notifications_enabled = TRUE;
-			new_contact->can_submit_commands = TRUE;
-			new_contact->retain_status_information = TRUE;
-			new_contact->retain_nonstatus_information = TRUE;
-			break;
+		new_contact->minimum_value = 0;
+		new_contact->host_notifications_enabled = TRUE;
+		new_contact->service_notifications_enabled = TRUE;
+		new_contact->can_submit_commands = TRUE;
+		new_contact->retain_status_information = TRUE;
+		new_contact->retain_nonstatus_information = TRUE;
+		break;
 
-		case XODTEMPLATE_HOST:
-			xod_begin_def(host);
+	case XODTEMPLATE_HOST:
+		xod_begin_def(host);
 
-			new_host->hourly_value = 0;
-			new_host->check_interval = 5.0;
-			new_host->retry_interval = 1.0;
-			new_host->active_checks_enabled = TRUE;
-			new_host->passive_checks_enabled = TRUE;
-			new_host->obsess = TRUE;
-			new_host->max_check_attempts = -2;
-			new_host->event_handler_enabled = TRUE;
-			new_host->flap_detection_enabled = TRUE;
-			new_host->flap_detection_options = OPT_ALL;
-			new_host->notifications_enabled = TRUE;
-			new_host->notification_interval = 30.0;
-			new_host->process_perf_data = TRUE;
-			new_host->x_2d = -1;
-			new_host->y_2d = -1;
-			new_host->retain_status_information = TRUE;
-			new_host->retain_nonstatus_information = TRUE;
-			break;
+		new_host->hourly_value = 0;
+		new_host->check_interval = 5.0;
+		new_host->retry_interval = 1.0;
+		new_host->active_checks_enabled = TRUE;
+		new_host->passive_checks_enabled = TRUE;
+		new_host->obsess = TRUE;
+		new_host->max_check_attempts = -2;
+		new_host->event_handler_enabled = TRUE;
+		new_host->flap_detection_enabled = TRUE;
+		new_host->flap_detection_options = OPT_ALL;
+		new_host->notifications_enabled = TRUE;
+		new_host->notification_interval = 30.0;
+		new_host->process_perf_data = TRUE;
+		new_host->x_2d = -1;
+		new_host->y_2d = -1;
+		new_host->retain_status_information = TRUE;
+		new_host->retain_nonstatus_information = TRUE;
+		break;
 
-		case XODTEMPLATE_SERVICE:
-			xod_begin_def(service);
+	case XODTEMPLATE_SERVICE:
+		xod_begin_def(service);
 
-			new_service->hourly_value = 0;
-			new_service->initial_state = STATE_OK;
-			new_service->max_check_attempts = -2;
-			new_service->check_interval = 5.0;
-			new_service->retry_interval = 1.0;
-			new_service->active_checks_enabled = TRUE;
-			new_service->passive_checks_enabled = TRUE;
-			new_service->parallelize_check = TRUE;
-			new_service->obsess = TRUE;
-			new_service->event_handler_enabled = TRUE;
-			new_service->flap_detection_enabled = TRUE;
-			new_service->flap_detection_options = OPT_ALL;
-			new_service->notifications_enabled = TRUE;
-			new_service->notification_interval = 30.0;
-			new_service->process_perf_data = TRUE;
-			new_service->retain_status_information = TRUE;
-			new_service->retain_nonstatus_information = TRUE;
+		new_service->hourly_value = 0;
+		new_service->initial_state = STATE_OK;
+		new_service->max_check_attempts = -2;
+		new_service->check_interval = 5.0;
+		new_service->retry_interval = 1.0;
+		new_service->active_checks_enabled = TRUE;
+		new_service->passive_checks_enabled = TRUE;
+		new_service->parallelize_check = TRUE;
+		new_service->obsess = TRUE;
+		new_service->event_handler_enabled = TRUE;
+		new_service->flap_detection_enabled = TRUE;
+		new_service->flap_detection_options = OPT_ALL;
+		new_service->notifications_enabled = TRUE;
+		new_service->notification_interval = 30.0;
+		new_service->process_perf_data = TRUE;
+		new_service->retain_status_information = TRUE;
+		new_service->retain_nonstatus_information = TRUE;
 
-			/* true service, so is not from host group */
-			new_service->is_from_hostgroup = 0;
-			break;
+		/* true service, so is not from host group */
+		new_service->is_from_hostgroup = 0;
+		break;
 
-		case XODTEMPLATE_HOSTDEPENDENCY:
-			xod_begin_def(hostdependency);
-			break;
+	case XODTEMPLATE_HOSTDEPENDENCY:
+		xod_begin_def(hostdependency);
+		break;
 
-		case XODTEMPLATE_HOSTESCALATION:
-			xod_begin_def(hostescalation);
-			new_hostescalation->first_notification = -2;
-			new_hostescalation->last_notification = -2;
-			break;
+	case XODTEMPLATE_HOSTESCALATION:
+		xod_begin_def(hostescalation);
+		new_hostescalation->first_notification = -2;
+		new_hostescalation->last_notification = -2;
+		break;
 
-		case XODTEMPLATE_HOSTEXTINFO:
-			xod_begin_def(hostextinfo);
+	case XODTEMPLATE_HOSTEXTINFO:
+		xod_begin_def(hostextinfo);
 
-			new_hostextinfo->x_2d = -1;
-			new_hostextinfo->y_2d = -1;
-			break;
+		new_hostextinfo->x_2d = -1;
+		new_hostextinfo->y_2d = -1;
+		break;
 
-		case XODTEMPLATE_SERVICEEXTINFO:
-			xod_begin_def(serviceextinfo);
-			break;
+	case XODTEMPLATE_SERVICEEXTINFO:
+		xod_begin_def(serviceextinfo);
+		break;
 
-		default:
-			return ERROR;
-			break;
-		}
+	default:
+		return ERROR;
+		break;
+	}
 
 	return result;
-	}
+}
 #undef xod_begin_def /* we don't need this anymore */
 
-static const char *xodtemplate_type_name(unsigned int id) {
+static const char *xodtemplate_type_name(unsigned int id)
+{
 	static const char *otype_name[] = {
 		"NONE", "timeperiod", "commmand", "contact", "contactgroup",
 		"host", "hostgroup", "service", "servicedependency",
@@ -1067,16 +1071,18 @@ static const char *xodtemplate_type_name(unsigned int id) {
 		return otype_name[0];
 	return otype_name[id];
 
-	}
+}
 
-static void xodtemplate_obsoleted(const char *var, int start_line) {
+static void xodtemplate_obsoleted(const char *var, int start_line)
+{
 	logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: %s is obsoleted and no longer has any effect in %s type objects (config file '%s', starting at line %d)\n",
-		 var, xodtemplate_type_name(xodtemplate_current_object_type),
-		 xodtemplate_config_file_name(xodtemplate_current_config_file), start_line);
-	}
+	      var, xodtemplate_type_name(xodtemplate_current_object_type),
+	      xodtemplate_config_file_name(xodtemplate_current_config_file), start_line);
+}
 
 /* adds a property to an object definition */
-int xodtemplate_add_object_property(char *input, int options) {
+int xodtemplate_add_object_property(char *input, int options)
+{
 	int result = OK;
 	char *variable = NULL;
 	char *value = NULL;
@@ -1110,66 +1116,66 @@ int xodtemplate_add_object_property(char *input, int options) {
 
 	/* check to see if we should process this type of object */
 	switch(xodtemplate_current_object_type) {
-		case XODTEMPLATE_TIMEPERIOD:
-			if(!(options & READ_TIMEPERIODS))
-				return OK;
-			break;
-		case XODTEMPLATE_COMMAND:
-			if(!(options & READ_COMMANDS))
-				return OK;
-			break;
-		case XODTEMPLATE_CONTACT:
-			if(!(options & READ_CONTACTS))
-				return OK;
-			break;
-		case XODTEMPLATE_CONTACTGROUP:
-			if(!(options & READ_CONTACTGROUPS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOST:
-			if(!(options & READ_HOSTS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTGROUP:
-			if(!(options & READ_HOSTGROUPS))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEGROUP:
-			if(!(options & READ_SERVICEGROUPS))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICE:
-			if(!(options & READ_SERVICES))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEDEPENDENCY:
-			if(!(options & READ_SERVICEDEPENDENCIES))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEESCALATION:
-			if(!(options & READ_SERVICEESCALATIONS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTDEPENDENCY:
-			if(!(options & READ_HOSTDEPENDENCIES))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTESCALATION:
-			if(!(options & READ_HOSTESCALATIONS))
-				return OK;
-			break;
-		case XODTEMPLATE_HOSTEXTINFO:
-			if(!(options & READ_HOSTEXTINFO))
-				return OK;
-			break;
-		case XODTEMPLATE_SERVICEEXTINFO:
-			if(!(options & READ_SERVICEEXTINFO))
-				return OK;
-			break;
-		default:
-			return ERROR;
-			break;
-		}
+	case XODTEMPLATE_TIMEPERIOD:
+		if(!(options & READ_TIMEPERIODS))
+			return OK;
+		break;
+	case XODTEMPLATE_COMMAND:
+		if(!(options & READ_COMMANDS))
+			return OK;
+		break;
+	case XODTEMPLATE_CONTACT:
+		if(!(options & READ_CONTACTS))
+			return OK;
+		break;
+	case XODTEMPLATE_CONTACTGROUP:
+		if(!(options & READ_CONTACTGROUPS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOST:
+		if(!(options & READ_HOSTS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTGROUP:
+		if(!(options & READ_HOSTGROUPS))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEGROUP:
+		if(!(options & READ_SERVICEGROUPS))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICE:
+		if(!(options & READ_SERVICES))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEDEPENDENCY:
+		if(!(options & READ_SERVICEDEPENDENCIES))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEESCALATION:
+		if(!(options & READ_SERVICEESCALATIONS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTDEPENDENCY:
+		if(!(options & READ_HOSTDEPENDENCIES))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTESCALATION:
+		if(!(options & READ_HOSTESCALATIONS))
+			return OK;
+		break;
+	case XODTEMPLATE_HOSTEXTINFO:
+		if(!(options & READ_HOSTEXTINFO))
+			return OK;
+		break;
+	case XODTEMPLATE_SERVICEEXTINFO:
+		if(!(options & READ_SERVICEEXTINFO))
+			return OK;
+		break;
+	default:
+		return ERROR;
+		break;
+	}
 
 	/* get variable name */
 	variable = input;
@@ -1178,8 +1184,8 @@ int xodtemplate_add_object_property(char *input, int options) {
 		if(variable[x] == ' ' || variable[x] == '\t') {
 			variable[x] = 0;
 			break;
-			}
 		}
+	}
 
 	/* get variable value */
 	value = input + x + 1;
@@ -1190,2291 +1196,2041 @@ int xodtemplate_add_object_property(char *input, int options) {
 
 	switch(xodtemplate_current_object_type) {
 
-		case XODTEMPLATE_TIMEPERIOD:
+	case XODTEMPLATE_TIMEPERIOD:
 
-			temp_timeperiod = (xodtemplate_timeperiod *)xodtemplate_current_object;
+		temp_timeperiod = (xodtemplate_timeperiod *)xodtemplate_current_object;
 
-			if(!strcmp(variable, "use")) {
-				if((temp_timeperiod->template = (char *)strdup(value)) == NULL)
+		if(!strcmp(variable, "use")) {
+			if((temp_timeperiod->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_timeperiod->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add timeperiod to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[TIMEPERIOD_SKIPLIST], (void *)temp_timeperiod);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for timeperiod '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_timeperiod->_config_file), temp_timeperiod->_start_line);
 					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_timeperiod->name = (char *)strdup(value)) == NULL)
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
 					result = ERROR;
-
-				if(result == OK) {
-					/* add timeperiod to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[TIMEPERIOD_SKIPLIST], (void *)temp_timeperiod);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for timeperiod '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_timeperiod->_config_file), temp_timeperiod->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
+					break;
 				}
-			else if(!strcmp(variable, "timeperiod_name")) {
-				if((temp_timeperiod->timeperiod_name = (char *)strdup(value)) == NULL)
+			}
+		} else if(!strcmp(variable, "timeperiod_name")) {
+			if((temp_timeperiod->timeperiod_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add timeperiod to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[TIMEPERIOD_SKIPLIST], (void *)temp_timeperiod);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for timeperiod '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_timeperiod->_config_file), temp_timeperiod->_start_line);
 					result = ERROR;
-
-				if(result == OK) {
-					/* add timeperiod to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[TIMEPERIOD_SKIPLIST], (void *)temp_timeperiod);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for timeperiod '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_timeperiod->_config_file), temp_timeperiod->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "alias")) {
-				if((temp_timeperiod->alias = (char *)strdup(value)) == NULL)
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
 					result = ERROR;
-				}
-			else if(!strcmp(variable, "exclude")) {
-				if((temp_timeperiod->exclusions = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_timeperiod->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else if(xodtemplate_parse_timeperiod_directive(temp_timeperiod, variable, value) == OK)
-				result = OK;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid timeperiod object directive '%s'.\n", variable);
-				return ERROR;
-				}
-			break;
-
-
-
-		case XODTEMPLATE_COMMAND:
-
-			temp_command = (xodtemplate_command *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_command->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-				if((temp_command->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add command to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[COMMAND_SKIPLIST], (void *)temp_command);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for command '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_command->_config_file), temp_command->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "command_name")) {
-				if((temp_command->command_name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add command to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[COMMAND_SKIPLIST], (void *)temp_command);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for command '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_command->_config_file), temp_command->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "command_line")) {
-				if((temp_command->command_line = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_command->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid command object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		case XODTEMPLATE_CONTACTGROUP:
-
-			temp_contactgroup = (xodtemplate_contactgroup *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_contactgroup->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_contactgroup->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add contactgroup to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[CONTACTGROUP_SKIPLIST], (void *)temp_contactgroup);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contactgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contactgroup->_config_file), temp_contactgroup->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "contactgroup_name")) {
-				if((temp_contactgroup->contactgroup_name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add contactgroup to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[CONTACTGROUP_SKIPLIST], (void *)temp_contactgroup);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contactgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contactgroup->_config_file), temp_contactgroup->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "alias")) {
-				if((temp_contactgroup->alias = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "members")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(temp_contactgroup->members == NULL)
-						temp_contactgroup->members = (char *)strdup(value);
-					else {
-						temp_contactgroup->members = (char *)realloc(temp_contactgroup->members, strlen(temp_contactgroup->members) + strlen(value) + 2);
-						if(temp_contactgroup->members != NULL) {
-							strcat(temp_contactgroup->members, ",");
-							strcat(temp_contactgroup->members, value);
-							}
-						}
-					if(temp_contactgroup->members == NULL)
-						result = ERROR;
-					}
-				temp_contactgroup->have_members = TRUE;
-				}
-			else if(!strcmp(variable, "contactgroup_members")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(temp_contactgroup->contactgroup_members == NULL)
-						temp_contactgroup->contactgroup_members = (char *)strdup(value);
-					else {
-						temp_contactgroup->contactgroup_members = (char *)realloc(temp_contactgroup->contactgroup_members, strlen(temp_contactgroup->contactgroup_members) + strlen(value) + 2);
-						if(temp_contactgroup->contactgroup_members != NULL) {
-							strcat(temp_contactgroup->contactgroup_members, ",");
-							strcat(temp_contactgroup->contactgroup_members, value);
-							}
-						}
-					if(temp_contactgroup->contactgroup_members == NULL)
-						result = ERROR;
-					}
-				temp_contactgroup->have_contactgroup_members = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_contactgroup->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid contactgroup object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		case XODTEMPLATE_HOSTGROUP:
-
-			temp_hostgroup = (xodtemplate_hostgroup *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_hostgroup->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_hostgroup->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add hostgroup to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[HOSTGROUP_SKIPLIST], (void *)temp_hostgroup);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for hostgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "hostgroup_name")) {
-				if((temp_hostgroup->hostgroup_name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add hostgroup to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[HOSTGROUP_SKIPLIST], (void *)temp_hostgroup);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for hostgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "alias")) {
-				if((temp_hostgroup->alias = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "members")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(temp_hostgroup->members == NULL)
-						temp_hostgroup->members = (char *)strdup(value);
-					else {
-						temp_hostgroup->members = (char *)realloc(temp_hostgroup->members, strlen(temp_hostgroup->members) + strlen(value) + 2);
-						if(temp_hostgroup->members != NULL) {
-							strcat(temp_hostgroup->members, ",");
-							strcat(temp_hostgroup->members, value);
-							}
-						}
-					if(temp_hostgroup->members == NULL)
-						result = ERROR;
-					}
-				temp_hostgroup->have_members = TRUE;
-				}
-			else if(!strcmp(variable, "hostgroup_members")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(temp_hostgroup->hostgroup_members == NULL)
-						temp_hostgroup->hostgroup_members = (char *)strdup(value);
-					else {
-						temp_hostgroup->hostgroup_members = (char *)realloc(temp_hostgroup->hostgroup_members, strlen(temp_hostgroup->hostgroup_members) + strlen(value) + 2);
-						if(temp_hostgroup->hostgroup_members != NULL) {
-							strcat(temp_hostgroup->hostgroup_members, ",");
-							strcat(temp_hostgroup->hostgroup_members, value);
-							}
-						}
-					if(temp_hostgroup->hostgroup_members == NULL)
-						result = ERROR;
-					}
-				temp_hostgroup->have_hostgroup_members = TRUE;
-				}
-			else if(!strcmp(variable, "notes")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostgroup->notes = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostgroup->have_notes = TRUE;
-				}
-			else if(!strcmp(variable, "notes_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostgroup->notes_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostgroup->have_notes_url = TRUE;
-				}
-			else if(!strcmp(variable, "action_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostgroup->action_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostgroup->have_action_url = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_hostgroup->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostgroup object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-
-		case XODTEMPLATE_SERVICEGROUP:
-
-			temp_servicegroup = (xodtemplate_servicegroup *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_servicegroup->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_servicegroup->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add servicegroup to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[SERVICEGROUP_SKIPLIST], (void *)temp_servicegroup);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for servicegroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "servicegroup_name")) {
-				if((temp_servicegroup->servicegroup_name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add servicegroup to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[SERVICEGROUP_SKIPLIST], (void *)temp_servicegroup);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for servicegroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "alias")) {
-				if((temp_servicegroup->alias = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "members")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(temp_servicegroup->members == NULL)
-						temp_servicegroup->members = (char *)strdup(value);
-					else {
-						temp_servicegroup->members = (char *)realloc(temp_servicegroup->members, strlen(temp_servicegroup->members) + strlen(value) + 2);
-						if(temp_servicegroup->members != NULL) {
-							strcat(temp_servicegroup->members, ",");
-							strcat(temp_servicegroup->members, value);
-							}
-						}
-					if(temp_servicegroup->members == NULL)
-						result = ERROR;
-					}
-				temp_servicegroup->have_members = TRUE;
-				}
-			else if(!strcmp(variable, "servicegroup_members")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(temp_servicegroup->servicegroup_members == NULL)
-						temp_servicegroup->servicegroup_members = (char *)strdup(value);
-					else {
-						temp_servicegroup->servicegroup_members = (char *)realloc(temp_servicegroup->servicegroup_members, strlen(temp_servicegroup->servicegroup_members) + strlen(value) + 2);
-						if(temp_servicegroup->servicegroup_members != NULL) {
-							strcat(temp_servicegroup->servicegroup_members, ",");
-							strcat(temp_servicegroup->servicegroup_members, value);
-							}
-						}
-					if(temp_servicegroup->servicegroup_members == NULL)
-						result = ERROR;
-					}
-				temp_servicegroup->have_servicegroup_members = TRUE;
-				}
-			else if(!strcmp(variable, "notes")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicegroup->notes = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicegroup->have_notes = TRUE;
-				}
-			else if(!strcmp(variable, "notes_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicegroup->notes_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicegroup->have_notes_url = TRUE;
-				}
-			else if(!strcmp(variable, "action_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicegroup->action_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicegroup->have_action_url = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_servicegroup->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid servicegroup object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-
-		case XODTEMPLATE_SERVICEDEPENDENCY:
-
-			temp_servicedependency = (xodtemplate_servicedependency *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_servicedependency->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_servicedependency->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add dependency to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[SERVICEDEPENDENCY_SKIPLIST], (void *)temp_servicedependency);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service dependency '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_servicedependency->_config_file), temp_servicedependency->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "servicegroup") || !strcmp(variable, "servicegroups") || !strcmp(variable, "servicegroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->servicegroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_servicegroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "host") || !strcmp(variable, "host_name") || !strcmp(variable, "master_host") || !strcmp(variable, "master_host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "description") || !strcmp(variable, "service_description") || !strcmp(variable, "master_description") || !strcmp(variable, "master_service_description")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->service_description = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_service_description = TRUE;
-				}
-			else if(!strcmp(variable, "dependent_servicegroup") || !strcmp(variable, "dependent_servicegroups") || !strcmp(variable, "dependent_servicegroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->dependent_servicegroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_dependent_servicegroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "dependent_hostgroup") || !strcmp(variable, "dependent_hostgroups") || !strcmp(variable, "dependent_hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->dependent_hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_dependent_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "dependent_host") || !strcmp(variable, "dependent_host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->dependent_host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_dependent_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "dependent_description") || !strcmp(variable, "dependent_service_description")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->dependent_service_description = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_dependent_service_description = TRUE;
-				}
-			else if(!strcmp(variable, "dependency_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_servicedependency->dependency_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_servicedependency->have_dependency_period = TRUE;
-				}
-			else if(!strcmp(variable, "inherits_parent")) {
-				temp_servicedependency->inherits_parent = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_servicedependency->have_inherits_parent = TRUE;
-				}
-			else if(!strcmp(variable, "execution_failure_options") || !strcmp(variable, "execution_failure_criteria")) {
-				temp_servicedependency->have_execution_failure_options = TRUE;
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
-						flag_set(temp_servicedependency->execution_failure_options, OPT_OK);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_servicedependency->execution_failure_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_servicedependency->execution_failure_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_servicedependency->execution_failure_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
-						flag_set(temp_servicedependency->execution_failure_options, OPT_PENDING);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_servicedependency->execution_failure_options = OPT_NOTHING;
-						temp_servicedependency->have_execution_failure_options = FALSE;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_servicedependency->execution_failure_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid execution dependency option '%s' in servicedependency definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				}
-			else if(!strcmp(variable, "notification_failure_options") || !strcmp(variable, "notification_failure_criteria")) {
-				temp_servicedependency->have_notification_failure_options = TRUE;
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
-						flag_set(temp_servicedependency->notification_failure_options, OPT_OK);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_servicedependency->notification_failure_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_servicedependency->notification_failure_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_servicedependency->notification_failure_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
-						flag_set(temp_servicedependency->notification_failure_options, OPT_PENDING);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_servicedependency->notification_failure_options = OPT_NOTHING;
-						temp_servicedependency->have_notification_failure_options = FALSE;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_servicedependency->notification_failure_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification dependency option '%s' in servicedependency definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				}
-			else if(!strcmp(variable, "register"))
-				temp_servicedependency->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid servicedependency object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-
-		case XODTEMPLATE_SERVICEESCALATION:
-
-			temp_serviceescalation = (xodtemplate_serviceescalation *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_serviceescalation->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_serviceescalation->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add escalation to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[SERVICEESCALATION_SKIPLIST], (void *)temp_serviceescalation);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service escalation '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_serviceescalation->_config_file), temp_serviceescalation->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "host") || !strcmp(variable, "host_name")) {
-
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "description") || !strcmp(variable, "service_description")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->service_description = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_service_description = TRUE;
-				}
-			else if(!strcmp(variable, "servicegroup") || !strcmp(variable, "servicegroups") || !strcmp(variable, "servicegroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->servicegroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_servicegroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "contact_groups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->contact_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_contact_groups = TRUE;
-				}
-			else if(!strcmp(variable, "contacts")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->contacts = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_contacts = TRUE;
-				}
-			else if(!strcmp(variable, "escalation_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceescalation->escalation_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceescalation->have_escalation_period = TRUE;
-				}
-			else if(!strcmp(variable, "first_notification")) {
-				temp_serviceescalation->first_notification = atoi(value);
-				temp_serviceescalation->have_first_notification = TRUE;
-				}
-			else if(!strcmp(variable, "last_notification")) {
-				temp_serviceescalation->last_notification = atoi(value);
-				temp_serviceescalation->have_last_notification = TRUE;
-				}
-			else if(!strcmp(variable, "notification_interval")) {
-				temp_serviceescalation->notification_interval = strtod(value, NULL);
-				temp_serviceescalation->have_notification_interval = TRUE;
-				}
-			else if(!strcmp(variable, "escalation_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_serviceescalation->escalation_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_serviceescalation->escalation_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_serviceescalation->escalation_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
-						flag_set(temp_serviceescalation->escalation_options, OPT_RECOVERY);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_serviceescalation->escalation_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_serviceescalation->escalation_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid escalation option '%s' in serviceescalation definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_serviceescalation->have_escalation_options = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_serviceescalation->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid serviceescalation object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-
-		case XODTEMPLATE_CONTACT:
-
-			temp_contact = (xodtemplate_contact *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_contact->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_contact->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add contact to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[CONTACT_SKIPLIST], (void *)temp_contact);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contact '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contact->_config_file), temp_contact->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "contact_name")) {
-				if((temp_contact->contact_name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add contact to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[CONTACT_SKIPLIST], (void *)temp_contact);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contact '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contact->_config_file), temp_contact->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				temp_contact->id = xodcount.contacts++;
-				}
-			else if(!strcmp(variable, "alias")) {
-				if((temp_contact->alias = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "contact_groups") || !strcmp(variable, "contactgroups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->contact_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_contact_groups = TRUE;
-				}
-			else if(!strcmp(variable, "email")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->email = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_email = TRUE;
-				}
-			else if(!strcmp(variable, "pager")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->pager = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_pager = TRUE;
-				}
-			else if(strstr(variable, "address") == variable) {
-				x = atoi(variable + 7);
-				if(x < 1 || x > MAX_XODTEMPLATE_CONTACT_ADDRESSES)
-					result = ERROR;
-				else if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->address[x - 1] = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				if(result == OK)
-					temp_contact->have_address[x - 1] = TRUE;
-				}
-			else if(!strcmp(variable, "host_notification_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->host_notification_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_host_notification_period = TRUE;
-				}
-			else if(!strcmp(variable, "host_notification_commands")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->host_notification_commands = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_host_notification_commands = TRUE;
-				}
-			else if(!strcmp(variable, "service_notification_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->service_notification_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_service_notification_period = TRUE;
-				}
-			else if(!strcmp(variable, "service_notification_commands")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_contact->service_notification_commands = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_contact->have_service_notification_commands = TRUE;
-				}
-			else if(!strcmp(variable, "host_notification_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_contact->host_notification_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_contact->host_notification_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
-						flag_set(temp_contact->host_notification_options, OPT_RECOVERY);
-					else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
-						flag_set(temp_contact->host_notification_options, OPT_FLAPPING);
-					else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
-						flag_set(temp_contact->host_notification_options, OPT_DOWNTIME);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_contact->host_notification_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_contact->host_notification_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid host notification option '%s' in contact definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_contact->have_host_notification_options = TRUE;
-				}
-			else if(!strcmp(variable, "service_notification_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_contact->service_notification_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_contact->service_notification_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_contact->service_notification_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
-						flag_set(temp_contact->service_notification_options, OPT_RECOVERY);
-					else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
-						flag_set(temp_contact->service_notification_options, OPT_FLAPPING);
-					else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
-						flag_set(temp_contact->service_notification_options, OPT_DOWNTIME);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_contact->service_notification_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_contact->service_notification_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid service notification option '%s' in contact definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_contact->have_service_notification_options = TRUE;
-				}
-			else if(!strcmp(variable, "host_notifications_enabled")) {
-				temp_contact->host_notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_contact->have_host_notifications_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "service_notifications_enabled")) {
-				temp_contact->service_notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_contact->have_service_notifications_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "can_submit_commands")) {
-				temp_contact->can_submit_commands = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_contact->have_can_submit_commands = TRUE;
-				}
-			else if(!strcmp(variable, "retain_status_information")) {
-				temp_contact->retain_status_information = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_contact->have_retain_status_information = TRUE;
-				}
-			else if(!strcmp(variable, "retain_nonstatus_information")) {
-				temp_contact->retain_nonstatus_information = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_contact->have_retain_nonstatus_information = TRUE;
-				}
-			else if(!strcmp(variable, "minimum_importance") ||
-					!strcmp(variable, "minimum_value")) {
-				if(!strcmp(variable, "minimum_value")) {
-					logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: The minimum_value attribute is deprecated and will be removed in future versions. Please use minimum_importance instead.\n");
-					}
-				temp_contact->minimum_value = strtoul(value, NULL, 10);
-				temp_contact->have_minimum_value = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_contact->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else if(variable[0] == '_') {
-
-				/* get the variable name */
-				customvarname = (char *)strdup(variable + 1);
-
-				/* make sure we have a variable name */
-				if(customvarname == NULL || !strcmp(customvarname, "")) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Null custom variable name.\n");
-					my_free(customvarname);
-					return ERROR;
-					}
-
-				/* get the variable value */
-				if(strcmp(value, XODTEMPLATE_NULL))
-					customvarvalue = (char *)strdup(value);
-				else
-					customvarvalue = NULL;
-
-				/* add the custom variable */
-				if(xodtemplate_add_custom_variable_to_contact(temp_contact, customvarname, customvarvalue) == NULL) {
-					my_free(customvarname);
-					my_free(customvarvalue);
-					return ERROR;
-					}
-
-				/* free memory */
-				my_free(customvarname);
-				my_free(customvarvalue);
-				}
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid contact object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-
-		case XODTEMPLATE_HOST:
-
-			temp_host = (xodtemplate_host *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_host->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_host->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add host to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[HOST_SKIPLIST], (void *)temp_host);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "host_name")) {
-				if((temp_host->host_name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add host to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[HOST_SKIPLIST], (void *)temp_host);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				temp_host->id = xodcount.hosts++;
-				}
-			else if(!strcmp(variable, "display_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->display_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_display_name = TRUE;
-				}
-			else if(!strcmp(variable, "alias")) {
-				if((temp_host->alias = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "address")) {
-				if((temp_host->address = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "parents")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->parents = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_parents = TRUE;
-				}
-			else if(!strcmp(variable, "host_groups") || !strcmp(variable, "hostgroups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->host_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_host_groups = TRUE;
-				}
-			else if(!strcmp(variable, "contact_groups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->contact_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_contact_groups = TRUE;
-				}
-			else if(!strcmp(variable, "contacts")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->contacts = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_contacts = TRUE;
-				}
-			else if(!strcmp(variable, "notification_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->notification_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_notification_period = TRUE;
-				}
-			else if(!strcmp(variable, "check_command")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->check_command = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_check_command = TRUE;
-				}
-			else if(!strcmp(variable, "check_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->check_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_check_period = TRUE;
-				}
-			else if(!strcmp(variable, "event_handler")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->event_handler = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_event_handler = TRUE;
-				}
-			else if(!strcmp(variable, "failure_prediction_options")) {
-				xodtemplate_obsoleted(variable, temp_host->_start_line);
-				}
-			else if(!strcmp(variable, "notes")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->notes = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_notes = TRUE;
-				}
-			else if(!strcmp(variable, "notes_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->notes_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_notes_url = TRUE;
-				}
-			else if(!strcmp(variable, "action_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->action_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_action_url = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->icon_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_icon_image = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image_alt")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->icon_image_alt = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_icon_image_alt = TRUE;
-				}
-			else if(!strcmp(variable, "vrml_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->vrml_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_vrml_image = TRUE;
-				}
-			else if(!strcmp(variable, "gd2_image") || !strcmp(variable, "statusmap_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_host->statusmap_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_host->have_statusmap_image = TRUE;
-				}
-			else if(!strcmp(variable, "initial_state")) {
-				if(!strcmp(value, "o") || !strcmp(value, "up"))
-					temp_host->initial_state = 0; /* HOST_UP */
-				else if(!strcmp(value, "d") || !strcmp(value, "down"))
-					temp_host->initial_state = 1; /* HOST_DOWN */
-				else if(!strcmp(value, "u") || !strcmp(value, "unreachable"))
-					temp_host->initial_state = 2; /* HOST_UNREACHABLE */
-				else {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid initial state '%s' in host definition.\n", value);
-					result = ERROR;
-					}
-				temp_host->have_initial_state = TRUE;
-				}
-			else if(!strcmp(variable, "check_interval") || !strcmp(variable, "normal_check_interval")) {
-				temp_host->check_interval = strtod(value, NULL);
-				temp_host->have_check_interval = TRUE;
-				}
-			else if(!strcmp(variable, "retry_interval") || !strcmp(variable, "retry_check_interval")) {
-				temp_host->retry_interval = strtod(value, NULL);
-				temp_host->have_retry_interval = TRUE;
-				}
-			else if(!strcmp(variable, "importance") ||
-					!strcmp(variable, "hourly_value")) {
-				if(!strcmp(variable, "hourly_value")) {
-					logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: The hourly_value attribute is deprecated and will be removed in future versions. Please use importance instead.\n");
-					}
-				temp_host->hourly_value = (unsigned int)strtoul(value, NULL, 10);
-				temp_host->have_hourly_value = 1;
-				}
-			else if(!strcmp(variable, "max_check_attempts")) {
-				temp_host->max_check_attempts = atoi(value);
-				temp_host->have_max_check_attempts = TRUE;
-				}
-			else if(!strcmp(variable, "checks_enabled") || !strcmp(variable, "active_checks_enabled")) {
-				temp_host->active_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_active_checks_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "passive_checks_enabled")) {
-				temp_host->passive_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_passive_checks_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "event_handler_enabled")) {
-				temp_host->event_handler_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_event_handler_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "check_freshness")) {
-				temp_host->check_freshness = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_check_freshness = TRUE;
-				}
-			else if(!strcmp(variable, "freshness_threshold")) {
-				temp_host->freshness_threshold = atoi(value);
-				temp_host->have_freshness_threshold = TRUE;
-				}
-			else if(!strcmp(variable, "low_flap_threshold")) {
-				temp_host->low_flap_threshold = strtod(value, NULL);
-				temp_host->have_low_flap_threshold = TRUE;
-				}
-			else if(!strcmp(variable, "high_flap_threshold")) {
-				temp_host->high_flap_threshold = strtod(value, NULL);
-				temp_host->have_high_flap_threshold = TRUE;
-				}
-			else if(!strcmp(variable, "flap_detection_enabled")) {
-				temp_host->flap_detection_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_flap_detection_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "flap_detection_options")) {
-
-				/* user is specifying something, so discard defaults... */
-				temp_host->flap_detection_options = OPT_NOTHING;
-
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
-						flag_set(temp_host->flap_detection_options, OPT_UP);
-					else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_host->flap_detection_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_host->flap_detection_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_host->flap_detection_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_host->flap_detection_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid flap detection option '%s' in host definition.\n", temp_ptr);
-						result = ERROR;
-						}
-					}
-				temp_host->have_flap_detection_options = TRUE;
-				}
-			else if(!strcmp(variable, "notification_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_host->notification_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_host->notification_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
-						flag_set(temp_host->notification_options, OPT_RECOVERY);
-					else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
-						flag_set(temp_host->notification_options, OPT_FLAPPING);
-					else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
-						flag_set(temp_host->notification_options, OPT_DOWNTIME);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_host->notification_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_host->notification_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification option '%s' in host definition.\n", temp_ptr);
-						result = ERROR;
-						}
-					}
-				temp_host->have_notification_options = TRUE;
-				}
-			else if(!strcmp(variable, "notifications_enabled")) {
-				temp_host->notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_notifications_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "notification_interval")) {
-				temp_host->notification_interval = strtod(value, NULL);
-				temp_host->have_notification_interval = TRUE;
-				}
-			else if(!strcmp(variable, "first_notification_delay")) {
-				temp_host->first_notification_delay = strtod(value, NULL);
-				temp_host->have_first_notification_delay = TRUE;
-				}
-			else if(!strcmp(variable, "stalking_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
-						flag_set(temp_host->stalking_options, OPT_UP);
-					else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_host->stalking_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_host->stalking_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_host->stalking_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_host->stalking_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid stalking option '%s' in host definition.\n", temp_ptr);
-						result = ERROR;
-						}
-					}
-				temp_host->have_stalking_options = TRUE;
-				}
-			else if(!strcmp(variable, "process_perf_data")) {
-				temp_host->process_perf_data = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_process_perf_data = TRUE;
-				}
-			else if(!strcmp(variable, "failure_prediction_enabled")) {
-				xodtemplate_obsoleted(variable, temp_host->_start_line);
-				}
-			else if(!strcmp(variable, "2d_coords")) {
-				if((temp_ptr = strtok(value, ", ")) == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in host definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_host->x_2d = atoi(temp_ptr);
-				if((temp_ptr = strtok(NULL, ", ")) == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in host definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_host->y_2d = atoi(temp_ptr);
-				temp_host->have_2d_coords = TRUE;
-				}
-			else if(!strcmp(variable, "3d_coords")) {
-				if((temp_ptr = strtok(value, ", ")) == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in host definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_host->x_3d = strtod(temp_ptr, NULL);
-				if((temp_ptr = strtok(NULL, ", ")) == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in host definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_host->y_3d = strtod(temp_ptr, NULL);
-				if((temp_ptr = strtok(NULL, ", ")) == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in host definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_host->z_3d = strtod(temp_ptr, NULL);
-				temp_host->have_3d_coords = TRUE;
-				}
-			else if(!strcmp(variable, "obsess_over_host") || !strcmp(variable, "obsess")) {
-				temp_host->obsess = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_obsess = TRUE;
-				}
-			else if(!strcmp(variable, "retain_status_information")) {
-				temp_host->retain_status_information = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_retain_status_information = TRUE;
-				}
-			else if(!strcmp(variable, "retain_nonstatus_information")) {
-				temp_host->retain_nonstatus_information = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_host->have_retain_nonstatus_information = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_host->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else if(variable[0] == '_') {
-
-				/* get the variable name */
-				customvarname = (char *)strdup(variable + 1);
-
-				/* make sure we have a variable name */
-				if(customvarname == NULL || !strcmp(customvarname, "")) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Null custom variable name.\n");
-					my_free(customvarname);
-					return ERROR;
-					}
-
-				/* get the variable value */
-				customvarvalue = NULL;
-				if(strcmp(value, XODTEMPLATE_NULL))
-					customvarvalue = (char *)strdup(value);
-
-				/* add the custom variable */
-				if(xodtemplate_add_custom_variable_to_host(temp_host, customvarname, customvarvalue) == NULL) {
-					my_free(customvarname);
-					my_free(customvarvalue);
-					return ERROR;
-					}
-
-				/* free memory */
-				my_free(customvarname);
-				my_free(customvarvalue);
-				}
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid host object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		case XODTEMPLATE_SERVICE:
-
-			temp_service = (xodtemplate_service *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_service->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_service->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add service to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "host") || !strcmp(variable, "hosts") || !strcmp(variable, "host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_host_name = TRUE;
-
-				/* NOTE: services are added to the skiplist in xodtemplate_duplicate_services(), except if daemon is using precached config */
-				if(result == OK && force_skiplists == TRUE  && temp_service->host_name != NULL && temp_service->service_description != NULL) {
-					/* add service to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							temp_service->id = xodcount.services++;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "service_description") || !strcmp(variable, "description")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->service_description = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_service_description = TRUE;
-
-				/* NOTE: services are added to the skiplist in xodtemplate_duplicate_services(), except if daemon is using precached config */
-				if(result == OK && force_skiplists == TRUE  && temp_service->host_name != NULL && temp_service->service_description != NULL) {
-					/* add service to template skiplist for fast searches */
-					result = skiplist_insert(xobject_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							temp_service->id = xodcount.services++;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "display_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->display_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_display_name = TRUE;
-				}
-			else if(!strcmp(variable, "parents")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->parents = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_parents = TRUE;
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "service_groups") || !strcmp(variable, "servicegroups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->service_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_service_groups = TRUE;
-				}
-			else if(!strcmp(variable, "check_command")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if(value[0] == '!') {
-						temp_service->have_important_check_command = TRUE;
-						temp_ptr = value + 1;
-						}
-					else
-						temp_ptr = value;
-					if((temp_service->check_command = (char *)strdup(temp_ptr)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_check_command = TRUE;
-				}
-			else if(!strcmp(variable, "check_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->check_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_check_period = TRUE;
-				}
-			else if(!strcmp(variable, "event_handler")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->event_handler = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_event_handler = TRUE;
-				}
-			else if(!strcmp(variable, "notification_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->notification_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_notification_period = TRUE;
-				}
-			else if(!strcmp(variable, "contact_groups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->contact_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_contact_groups = TRUE;
-				}
-			else if(!strcmp(variable, "contacts")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->contacts = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_contacts = TRUE;
-				}
-			else if(!strcmp(variable, "failure_prediction_options")) {
-				xodtemplate_obsoleted(variable, temp_service->_start_line);
-				}
-			else if(!strcmp(variable, "notes")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->notes = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_notes = TRUE;
-				}
-			else if(!strcmp(variable, "notes_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->notes_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_notes_url = TRUE;
-				}
-			else if(!strcmp(variable, "action_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->action_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_action_url = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->icon_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_icon_image = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image_alt")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_service->icon_image_alt = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_service->have_icon_image_alt = TRUE;
-				}
-			else if(!strcmp(variable, "initial_state")) {
-				if(!strcmp(value, "o") || !strcmp(value, "ok"))
-					temp_service->initial_state = STATE_OK;
-				else if(!strcmp(value, "w") || !strcmp(value, "warning"))
-					temp_service->initial_state = STATE_WARNING;
-				else if(!strcmp(value, "u") || !strcmp(value, "unknown"))
-					temp_service->initial_state = STATE_UNKNOWN;
-				else if(!strcmp(value, "c") || !strcmp(value, "critical"))
-					temp_service->initial_state = STATE_CRITICAL;
-				else {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid initial state '%s' in service definition.\n", value);
-					result = ERROR;
-					}
-				temp_service->have_initial_state = TRUE;
-				}
-			else if(!strcmp(variable, "importance") ||
-					!strcmp(variable, "hourly_value")) {
-				if(!strcmp(variable, "hourly_value")) {
-					logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: The hourly_value attribute is deprecated and will be removed in future versions. Please use importance instead.\n");
-					}
-				temp_service->hourly_value = (unsigned int)strtoul(value, NULL, 10);
-				temp_service->have_hourly_value = 1;
-				}
-			else if(!strcmp(variable, "max_check_attempts")) {
-				temp_service->max_check_attempts = atoi(value);
-				temp_service->have_max_check_attempts = TRUE;
-				}
-			else if(!strcmp(variable, "check_interval") || !strcmp(variable, "normal_check_interval")) {
-				temp_service->check_interval = strtod(value, NULL);
-				temp_service->have_check_interval = TRUE;
-				}
-			else if(!strcmp(variable, "retry_interval") || !strcmp(variable, "retry_check_interval")) {
-				temp_service->retry_interval = strtod(value, NULL);
-				temp_service->have_retry_interval = TRUE;
-				}
-			else if(!strcmp(variable, "active_checks_enabled")) {
-				temp_service->active_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_active_checks_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "passive_checks_enabled")) {
-				temp_service->passive_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_passive_checks_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "parallelize_check")) {
-				temp_service->parallelize_check = atoi(value);
-				temp_service->have_parallelize_check = TRUE;
-				}
-			else if(!strcmp(variable, "is_volatile")) {
-				temp_service->is_volatile = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_is_volatile = TRUE;
-				}
-			else if(!strcmp(variable, "obsess_over_service") || !strcmp(variable, "obsess")) {
-				temp_service->obsess = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_obsess = TRUE;
-				}
-			else if(!strcmp(variable, "event_handler_enabled")) {
-				temp_service->event_handler_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_event_handler_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "check_freshness")) {
-				temp_service->check_freshness = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_check_freshness = TRUE;
-				}
-			else if(!strcmp(variable, "freshness_threshold")) {
-				temp_service->freshness_threshold = atoi(value);
-				temp_service->have_freshness_threshold = TRUE;
-				}
-			else if(!strcmp(variable, "low_flap_threshold")) {
-				temp_service->low_flap_threshold = strtod(value, NULL);
-				temp_service->have_low_flap_threshold = TRUE;
-				}
-			else if(!strcmp(variable, "high_flap_threshold")) {
-				temp_service->high_flap_threshold = strtod(value, NULL);
-				temp_service->have_high_flap_threshold = TRUE;
-				}
-			else if(!strcmp(variable, "flap_detection_enabled")) {
-				temp_service->flap_detection_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_flap_detection_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "flap_detection_options")) {
-
-				/* user is specifying something, so discard defaults... */
-				temp_service->flap_detection_options = OPT_NOTHING;
-
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
-						flag_set(temp_service->flap_detection_options, OPT_OK);
-					else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_service->flap_detection_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_service->flap_detection_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_service->flap_detection_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_service->flap_detection_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_service->flap_detection_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid flap detection option '%s' in service definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_service->have_flap_detection_options = TRUE;
-				}
-			else if(!strcmp(variable, "notification_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_service->notification_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_service->notification_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_service->notification_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
-						flag_set(temp_service->notification_options, OPT_RECOVERY);
-					else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
-						flag_set(temp_service->notification_options, OPT_FLAPPING);
-					else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
-						flag_set(temp_service->notification_options, OPT_DOWNTIME);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_service->notification_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_service->notification_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification option '%s' in service definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_service->have_notification_options = TRUE;
-				}
-			else if(!strcmp(variable, "notifications_enabled")) {
-				temp_service->notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_notifications_enabled = TRUE;
-				}
-			else if(!strcmp(variable, "notification_interval")) {
-				temp_service->notification_interval = strtod(value, NULL);
-				temp_service->have_notification_interval = TRUE;
-				}
-			else if(!strcmp(variable, "first_notification_delay")) {
-				temp_service->first_notification_delay = strtod(value, NULL);
-				temp_service->have_first_notification_delay = TRUE;
-				}
-			else if(!strcmp(variable, "stalking_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
-						flag_set(temp_service->stalking_options, OPT_OK);
-					else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
-						flag_set(temp_service->stalking_options, OPT_WARNING);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
-						flag_set(temp_service->stalking_options, OPT_UNKNOWN);
-					else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
-						flag_set(temp_service->stalking_options, OPT_CRITICAL);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_service->stalking_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_service->stalking_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid stalking option '%s' in service definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_service->have_stalking_options = TRUE;
-				}
-			else if(!strcmp(variable, "process_perf_data")) {
-				temp_service->process_perf_data = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_process_perf_data = TRUE;
-				}
-			else if(!strcmp(variable, "failure_prediction_enabled")) {
-				xodtemplate_obsoleted(variable, temp_service->_start_line);
-				}
-			else if(!strcmp(variable, "retain_status_information")) {
-				temp_service->retain_status_information = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_retain_status_information = TRUE;
-				}
-			else if(!strcmp(variable, "retain_nonstatus_information")) {
-				temp_service->retain_nonstatus_information = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_service->have_retain_nonstatus_information = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_service->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else if(variable[0] == '_') {
-
-				/* get the variable name */
-				customvarname = (char *)strdup(variable + 1);
-
-				/* make sure we have a variable name */
-				if(customvarname == NULL || !strcmp(customvarname, "")) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Null custom variable name.\n");
-					my_free(customvarname);
-					return ERROR;
-					}
-
-				/* get the variable value */
-				if(strcmp(value, XODTEMPLATE_NULL))
-					customvarvalue = (char *)strdup(value);
-				else
-					customvarvalue = NULL;
-
-				/* add the custom variable */
-				if(xodtemplate_add_custom_variable_to_service(temp_service, customvarname, customvarvalue) == NULL) {
-					my_free(customvarname);
-					my_free(customvarvalue);
-					return ERROR;
-					}
-
-				/* free memory */
-				my_free(customvarname);
-				my_free(customvarvalue);
-				}
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid service object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		case XODTEMPLATE_HOSTDEPENDENCY:
-
-			temp_hostdependency = (xodtemplate_hostdependency *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_hostdependency->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_hostdependency->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add dependency to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[HOSTDEPENDENCY_SKIPLIST], (void *)temp_hostdependency);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host dependency '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostdependency->_config_file), temp_hostdependency->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostdependency->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostdependency->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "host") || !strcmp(variable, "host_name") || !strcmp(variable, "master_host") || !strcmp(variable, "master_host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostdependency->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostdependency->have_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "dependent_hostgroup") || !strcmp(variable, "dependent_hostgroups") || !strcmp(variable, "dependent_hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostdependency->dependent_hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostdependency->have_dependent_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "dependent_host") || !strcmp(variable, "dependent_host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostdependency->dependent_host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostdependency->have_dependent_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "dependency_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostdependency->dependency_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostdependency->have_dependency_period = TRUE;
-				}
-			else if(!strcmp(variable, "inherits_parent")) {
-				temp_hostdependency->inherits_parent = (atoi(value) > 0) ? TRUE : FALSE;
-				temp_hostdependency->have_inherits_parent = TRUE;
-				}
-			else if(!strcmp(variable, "notification_failure_options") || !strcmp(variable, "notification_failure_criteria")) {
-				temp_hostdependency->have_notification_failure_options = TRUE;
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
-						flag_set(temp_hostdependency->notification_failure_options, OPT_UP);
-					else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_hostdependency->notification_failure_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_hostdependency->notification_failure_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
-						flag_set(temp_hostdependency->notification_failure_options, OPT_PENDING);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_hostdependency->notification_failure_options = OPT_NOTHING;
-						temp_hostdependency->have_notification_failure_options = FALSE;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_hostdependency->notification_failure_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification dependency option '%s' in hostdependency definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				}
-			else if(!strcmp(variable, "execution_failure_options") || !strcmp(variable, "execution_failure_criteria")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
-						flag_set(temp_hostdependency->execution_failure_options, OPT_UP);
-					else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_hostdependency->execution_failure_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_hostdependency->execution_failure_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
-						flag_set(temp_hostdependency->execution_failure_options, OPT_PENDING);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_hostdependency->execution_failure_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_hostdependency->execution_failure_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid execution dependency option '%s' in hostdependency definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_hostdependency->have_execution_failure_options = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_hostdependency->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostdependency object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-
-		case XODTEMPLATE_HOSTESCALATION:
-
-			temp_hostescalation = (xodtemplate_hostescalation *)xodtemplate_current_object;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_hostescalation->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_hostescalation->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add escalation to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[HOSTESCALATION_SKIPLIST], (void *)temp_hostescalation);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host escalation '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostescalation->_config_file), temp_hostescalation->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostescalation->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostescalation->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "host") || !strcmp(variable, "host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostescalation->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostescalation->have_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "contact_groups")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostescalation->contact_groups = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostescalation->have_contact_groups = TRUE;
-				}
-			else if(!strcmp(variable, "contacts")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostescalation->contacts = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostescalation->have_contacts = TRUE;
-				}
-			else if(!strcmp(variable, "escalation_period")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostescalation->escalation_period = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostescalation->have_escalation_period = TRUE;
-				}
-			else if(!strcmp(variable, "first_notification")) {
-				temp_hostescalation->first_notification = atoi(value);
-				temp_hostescalation->have_first_notification = TRUE;
-				}
-			else if(!strcmp(variable, "last_notification")) {
-				temp_hostescalation->last_notification = atoi(value);
-				temp_hostescalation->have_last_notification = TRUE;
-				}
-			else if(!strcmp(variable, "notification_interval")) {
-				temp_hostescalation->notification_interval = strtod(value, NULL);
-				temp_hostescalation->have_notification_interval = TRUE;
-				}
-			else if(!strcmp(variable, "escalation_options")) {
-				for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
-					if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
-						flag_set(temp_hostescalation->escalation_options, OPT_DOWN);
-					else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
-						flag_set(temp_hostescalation->escalation_options, OPT_UNREACHABLE);
-					else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
-						flag_set(temp_hostescalation->escalation_options, OPT_RECOVERY);
-					else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
-						temp_hostescalation->escalation_options = OPT_NOTHING;
-						}
-					else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
-						temp_hostescalation->escalation_options = OPT_ALL;
-						}
-					else {
-						logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid escalation option '%s' in hostescalation definition.\n", temp_ptr);
-						return ERROR;
-						}
-					}
-				temp_hostescalation->have_escalation_options = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_hostescalation->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostescalation object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		case XODTEMPLATE_HOSTEXTINFO:
-
-			temp_hostextinfo = xodtemplate_hostextinfo_list;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_hostextinfo->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_hostextinfo->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[HOSTEXTINFO_SKIPLIST], (void *)temp_hostextinfo);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for extended host info '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostextinfo->_config_file), temp_hostextinfo->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "notes")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->notes = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_notes = TRUE;
-				}
-			else if(!strcmp(variable, "notes_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->notes_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_notes_url = TRUE;
-				}
-			else if(!strcmp(variable, "action_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->action_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_action_url = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->icon_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_icon_image = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image_alt")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->icon_image_alt = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_icon_image_alt = TRUE;
-				}
-			else if(!strcmp(variable, "vrml_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->vrml_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_vrml_image = TRUE;
-				}
-			else if(!strcmp(variable, "gd2_image") || !strcmp(variable, "statusmap_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_hostextinfo->statusmap_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_hostextinfo->have_statusmap_image = TRUE;
-				}
-			else if(!strcmp(variable, "2d_coords")) {
-				temp_ptr = strtok(value, ", ");
-				if(temp_ptr == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in extended host info definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_hostextinfo->x_2d = atoi(temp_ptr);
-				temp_ptr = strtok(NULL, ", ");
-				if(temp_ptr == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in extended host info definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_hostextinfo->y_2d = atoi(temp_ptr);
-				temp_hostextinfo->have_2d_coords = TRUE;
-				}
-			else if(!strcmp(variable, "3d_coords")) {
-				temp_ptr = strtok(value, ", ");
-				if(temp_ptr == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in extended host info definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_hostextinfo->x_3d = strtod(temp_ptr, NULL);
-				temp_ptr = strtok(NULL, ", ");
-				if(temp_ptr == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in extended host info definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_hostextinfo->y_3d = strtod(temp_ptr, NULL);
-				temp_ptr = strtok(NULL, ", ");
-				if(temp_ptr == NULL) {
-					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in extended host info definition.\n", temp_ptr);
-					return ERROR;
-					}
-				temp_hostextinfo->z_3d = strtod(temp_ptr, NULL);
-				temp_hostextinfo->have_3d_coords = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_hostextinfo->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostextinfo object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		case XODTEMPLATE_SERVICEEXTINFO:
-
-			temp_serviceextinfo = xodtemplate_serviceextinfo_list;
-
-			if(!strcmp(variable, "use")) {
-				if((temp_serviceextinfo->template = (char *)strdup(value)) == NULL)
-					result = ERROR;
-				}
-			else if(!strcmp(variable, "name")) {
-
-				if((temp_serviceextinfo->name = (char *)strdup(value)) == NULL)
-					result = ERROR;
-
-				if(result == OK) {
-					/* add to template skiplist for fast searches */
-					result = skiplist_insert(xobject_template_skiplists[SERVICEEXTINFO_SKIPLIST], (void *)temp_serviceextinfo);
-					switch(result) {
-						case SKIPLIST_ERROR_DUPLICATE:
-							logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for extended service info '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_serviceextinfo->_config_file), temp_serviceextinfo->_start_line);
-							result = ERROR;
-							break;
-						case SKIPLIST_OK:
-							result = OK;
-							break;
-						default:
-							result = ERROR;
-							break;
-						}
-					}
-				}
-			else if(!strcmp(variable, "host_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->host_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_host_name = TRUE;
-				}
-			else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroup_name")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->hostgroup_name = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_hostgroup_name = TRUE;
-				}
-			else if(!strcmp(variable, "service_description")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->service_description = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_service_description = TRUE;
-				}
-			else if(!strcmp(variable, "notes")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->notes = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_notes = TRUE;
-				}
-			else if(!strcmp(variable, "notes_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->notes_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_notes_url = TRUE;
-				}
-			else if(!strcmp(variable, "action_url")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->action_url = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_action_url = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->icon_image = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_icon_image = TRUE;
-				}
-			else if(!strcmp(variable, "icon_image_alt")) {
-				if(strcmp(value, XODTEMPLATE_NULL)) {
-					if((temp_serviceextinfo->icon_image_alt = (char *)strdup(value)) == NULL)
-						result = ERROR;
-					}
-				temp_serviceextinfo->have_icon_image_alt = TRUE;
-				}
-			else if(!strcmp(variable, "register"))
-				temp_serviceextinfo->register_object = (atoi(value) > 0) ? TRUE : FALSE;
-			else {
-				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid serviceextinfo object directive '%s'.\n", variable);
-				return ERROR;
-				}
-
-			break;
-
-		default:
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "alias")) {
+			if((temp_timeperiod->alias = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "exclude")) {
+			if((temp_timeperiod->exclusions = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "register"))
+			temp_timeperiod->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else if(xodtemplate_parse_timeperiod_directive(temp_timeperiod, variable, value) == OK)
+			result = OK;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid timeperiod object directive '%s'.\n", variable);
 			return ERROR;
-			break;
+		}
+		break;
+
+
+
+	case XODTEMPLATE_COMMAND:
+
+		temp_command = (xodtemplate_command *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_command->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+			if((temp_command->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add command to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[COMMAND_SKIPLIST], (void *)temp_command);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for command '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_command->_config_file), temp_command->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "command_name")) {
+			if((temp_command->command_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add command to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[COMMAND_SKIPLIST], (void *)temp_command);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for command '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_command->_config_file), temp_command->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "command_line")) {
+			if((temp_command->command_line = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "register"))
+			temp_command->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid command object directive '%s'.\n", variable);
+			return ERROR;
 		}
 
-	return result;
+		break;
+
+	case XODTEMPLATE_CONTACTGROUP:
+
+		temp_contactgroup = (xodtemplate_contactgroup *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_contactgroup->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_contactgroup->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add contactgroup to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[CONTACTGROUP_SKIPLIST], (void *)temp_contactgroup);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contactgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contactgroup->_config_file), temp_contactgroup->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "contactgroup_name")) {
+			if((temp_contactgroup->contactgroup_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add contactgroup to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[CONTACTGROUP_SKIPLIST], (void *)temp_contactgroup);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contactgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contactgroup->_config_file), temp_contactgroup->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "alias")) {
+			if((temp_contactgroup->alias = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "members")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(temp_contactgroup->members == NULL)
+					temp_contactgroup->members = (char *)strdup(value);
+				else {
+					temp_contactgroup->members = (char *)realloc(temp_contactgroup->members, strlen(temp_contactgroup->members) + strlen(value) + 2);
+					if(temp_contactgroup->members != NULL) {
+						strcat(temp_contactgroup->members, ",");
+						strcat(temp_contactgroup->members, value);
+					}
+				}
+				if(temp_contactgroup->members == NULL)
+					result = ERROR;
+			}
+			temp_contactgroup->have_members = TRUE;
+		} else if(!strcmp(variable, "contactgroup_members")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(temp_contactgroup->contactgroup_members == NULL)
+					temp_contactgroup->contactgroup_members = (char *)strdup(value);
+				else {
+					temp_contactgroup->contactgroup_members = (char *)realloc(temp_contactgroup->contactgroup_members, strlen(temp_contactgroup->contactgroup_members) + strlen(value) + 2);
+					if(temp_contactgroup->contactgroup_members != NULL) {
+						strcat(temp_contactgroup->contactgroup_members, ",");
+						strcat(temp_contactgroup->contactgroup_members, value);
+					}
+				}
+				if(temp_contactgroup->contactgroup_members == NULL)
+					result = ERROR;
+			}
+			temp_contactgroup->have_contactgroup_members = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_contactgroup->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid contactgroup object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+	case XODTEMPLATE_HOSTGROUP:
+
+		temp_hostgroup = (xodtemplate_hostgroup *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_hostgroup->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_hostgroup->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add hostgroup to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[HOSTGROUP_SKIPLIST], (void *)temp_hostgroup);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for hostgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "hostgroup_name")) {
+			if((temp_hostgroup->hostgroup_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add hostgroup to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[HOSTGROUP_SKIPLIST], (void *)temp_hostgroup);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for hostgroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "alias")) {
+			if((temp_hostgroup->alias = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "members")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(temp_hostgroup->members == NULL)
+					temp_hostgroup->members = (char *)strdup(value);
+				else {
+					temp_hostgroup->members = (char *)realloc(temp_hostgroup->members, strlen(temp_hostgroup->members) + strlen(value) + 2);
+					if(temp_hostgroup->members != NULL) {
+						strcat(temp_hostgroup->members, ",");
+						strcat(temp_hostgroup->members, value);
+					}
+				}
+				if(temp_hostgroup->members == NULL)
+					result = ERROR;
+			}
+			temp_hostgroup->have_members = TRUE;
+		} else if(!strcmp(variable, "hostgroup_members")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(temp_hostgroup->hostgroup_members == NULL)
+					temp_hostgroup->hostgroup_members = (char *)strdup(value);
+				else {
+					temp_hostgroup->hostgroup_members = (char *)realloc(temp_hostgroup->hostgroup_members, strlen(temp_hostgroup->hostgroup_members) + strlen(value) + 2);
+					if(temp_hostgroup->hostgroup_members != NULL) {
+						strcat(temp_hostgroup->hostgroup_members, ",");
+						strcat(temp_hostgroup->hostgroup_members, value);
+					}
+				}
+				if(temp_hostgroup->hostgroup_members == NULL)
+					result = ERROR;
+			}
+			temp_hostgroup->have_hostgroup_members = TRUE;
+		} else if(!strcmp(variable, "notes")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostgroup->notes = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostgroup->have_notes = TRUE;
+		} else if(!strcmp(variable, "notes_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostgroup->notes_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostgroup->have_notes_url = TRUE;
+		} else if(!strcmp(variable, "action_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostgroup->action_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostgroup->have_action_url = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_hostgroup->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostgroup object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+
+	case XODTEMPLATE_SERVICEGROUP:
+
+		temp_servicegroup = (xodtemplate_servicegroup *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_servicegroup->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_servicegroup->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add servicegroup to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[SERVICEGROUP_SKIPLIST], (void *)temp_servicegroup);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for servicegroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "servicegroup_name")) {
+			if((temp_servicegroup->servicegroup_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add servicegroup to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[SERVICEGROUP_SKIPLIST], (void *)temp_servicegroup);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for servicegroup '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "alias")) {
+			if((temp_servicegroup->alias = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "members")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(temp_servicegroup->members == NULL)
+					temp_servicegroup->members = (char *)strdup(value);
+				else {
+					temp_servicegroup->members = (char *)realloc(temp_servicegroup->members, strlen(temp_servicegroup->members) + strlen(value) + 2);
+					if(temp_servicegroup->members != NULL) {
+						strcat(temp_servicegroup->members, ",");
+						strcat(temp_servicegroup->members, value);
+					}
+				}
+				if(temp_servicegroup->members == NULL)
+					result = ERROR;
+			}
+			temp_servicegroup->have_members = TRUE;
+		} else if(!strcmp(variable, "servicegroup_members")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(temp_servicegroup->servicegroup_members == NULL)
+					temp_servicegroup->servicegroup_members = (char *)strdup(value);
+				else {
+					temp_servicegroup->servicegroup_members = (char *)realloc(temp_servicegroup->servicegroup_members, strlen(temp_servicegroup->servicegroup_members) + strlen(value) + 2);
+					if(temp_servicegroup->servicegroup_members != NULL) {
+						strcat(temp_servicegroup->servicegroup_members, ",");
+						strcat(temp_servicegroup->servicegroup_members, value);
+					}
+				}
+				if(temp_servicegroup->servicegroup_members == NULL)
+					result = ERROR;
+			}
+			temp_servicegroup->have_servicegroup_members = TRUE;
+		} else if(!strcmp(variable, "notes")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicegroup->notes = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicegroup->have_notes = TRUE;
+		} else if(!strcmp(variable, "notes_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicegroup->notes_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicegroup->have_notes_url = TRUE;
+		} else if(!strcmp(variable, "action_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicegroup->action_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicegroup->have_action_url = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_servicegroup->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid servicegroup object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+
+	case XODTEMPLATE_SERVICEDEPENDENCY:
+
+		temp_servicedependency = (xodtemplate_servicedependency *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_servicedependency->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_servicedependency->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add dependency to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[SERVICEDEPENDENCY_SKIPLIST], (void *)temp_servicedependency);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service dependency '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_servicedependency->_config_file), temp_servicedependency->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "servicegroup") || !strcmp(variable, "servicegroups") || !strcmp(variable, "servicegroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->servicegroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_servicegroup_name = TRUE;
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "host") || !strcmp(variable, "host_name") || !strcmp(variable, "master_host") || !strcmp(variable, "master_host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_host_name = TRUE;
+		} else if(!strcmp(variable, "description") || !strcmp(variable, "service_description") || !strcmp(variable, "master_description") || !strcmp(variable, "master_service_description")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->service_description = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_service_description = TRUE;
+		} else if(!strcmp(variable, "dependent_servicegroup") || !strcmp(variable, "dependent_servicegroups") || !strcmp(variable, "dependent_servicegroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->dependent_servicegroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_dependent_servicegroup_name = TRUE;
+		} else if(!strcmp(variable, "dependent_hostgroup") || !strcmp(variable, "dependent_hostgroups") || !strcmp(variable, "dependent_hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->dependent_hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_dependent_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "dependent_host") || !strcmp(variable, "dependent_host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->dependent_host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_dependent_host_name = TRUE;
+		} else if(!strcmp(variable, "dependent_description") || !strcmp(variable, "dependent_service_description")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->dependent_service_description = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_dependent_service_description = TRUE;
+		} else if(!strcmp(variable, "dependency_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_servicedependency->dependency_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_servicedependency->have_dependency_period = TRUE;
+		} else if(!strcmp(variable, "inherits_parent")) {
+			temp_servicedependency->inherits_parent = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_servicedependency->have_inherits_parent = TRUE;
+		} else if(!strcmp(variable, "execution_failure_options") || !strcmp(variable, "execution_failure_criteria")) {
+			temp_servicedependency->have_execution_failure_options = TRUE;
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
+					flag_set(temp_servicedependency->execution_failure_options, OPT_OK);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_servicedependency->execution_failure_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_servicedependency->execution_failure_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_servicedependency->execution_failure_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
+					flag_set(temp_servicedependency->execution_failure_options, OPT_PENDING);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_servicedependency->execution_failure_options = OPT_NOTHING;
+					temp_servicedependency->have_execution_failure_options = FALSE;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_servicedependency->execution_failure_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid execution dependency option '%s' in servicedependency definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+		} else if(!strcmp(variable, "notification_failure_options") || !strcmp(variable, "notification_failure_criteria")) {
+			temp_servicedependency->have_notification_failure_options = TRUE;
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
+					flag_set(temp_servicedependency->notification_failure_options, OPT_OK);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_servicedependency->notification_failure_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_servicedependency->notification_failure_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_servicedependency->notification_failure_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
+					flag_set(temp_servicedependency->notification_failure_options, OPT_PENDING);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_servicedependency->notification_failure_options = OPT_NOTHING;
+					temp_servicedependency->have_notification_failure_options = FALSE;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_servicedependency->notification_failure_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification dependency option '%s' in servicedependency definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+		} else if(!strcmp(variable, "register"))
+			temp_servicedependency->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid servicedependency object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+
+	case XODTEMPLATE_SERVICEESCALATION:
+
+		temp_serviceescalation = (xodtemplate_serviceescalation *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_serviceescalation->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_serviceescalation->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add escalation to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[SERVICEESCALATION_SKIPLIST], (void *)temp_serviceescalation);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service escalation '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_serviceescalation->_config_file), temp_serviceescalation->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "host") || !strcmp(variable, "host_name")) {
+
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_host_name = TRUE;
+		} else if(!strcmp(variable, "description") || !strcmp(variable, "service_description")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->service_description = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_service_description = TRUE;
+		} else if(!strcmp(variable, "servicegroup") || !strcmp(variable, "servicegroups") || !strcmp(variable, "servicegroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->servicegroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_servicegroup_name = TRUE;
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "contact_groups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->contact_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_contact_groups = TRUE;
+		} else if(!strcmp(variable, "contacts")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->contacts = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_contacts = TRUE;
+		} else if(!strcmp(variable, "escalation_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceescalation->escalation_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceescalation->have_escalation_period = TRUE;
+		} else if(!strcmp(variable, "first_notification")) {
+			temp_serviceescalation->first_notification = atoi(value);
+			temp_serviceescalation->have_first_notification = TRUE;
+		} else if(!strcmp(variable, "last_notification")) {
+			temp_serviceescalation->last_notification = atoi(value);
+			temp_serviceescalation->have_last_notification = TRUE;
+		} else if(!strcmp(variable, "notification_interval")) {
+			temp_serviceescalation->notification_interval = strtod(value, NULL);
+			temp_serviceescalation->have_notification_interval = TRUE;
+		} else if(!strcmp(variable, "escalation_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_serviceescalation->escalation_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_serviceescalation->escalation_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_serviceescalation->escalation_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
+					flag_set(temp_serviceescalation->escalation_options, OPT_RECOVERY);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_serviceescalation->escalation_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_serviceescalation->escalation_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid escalation option '%s' in serviceescalation definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_serviceescalation->have_escalation_options = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_serviceescalation->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid serviceescalation object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+
+	case XODTEMPLATE_CONTACT:
+
+		temp_contact = (xodtemplate_contact *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_contact->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_contact->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add contact to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[CONTACT_SKIPLIST], (void *)temp_contact);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contact '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contact->_config_file), temp_contact->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "contact_name")) {
+			if((temp_contact->contact_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add contact to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[CONTACT_SKIPLIST], (void *)temp_contact);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for contact '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_contact->_config_file), temp_contact->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+			temp_contact->id = xodcount.contacts++;
+		} else if(!strcmp(variable, "alias")) {
+			if((temp_contact->alias = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "contact_groups") || !strcmp(variable, "contactgroups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->contact_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_contact_groups = TRUE;
+		} else if(!strcmp(variable, "email")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->email = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_email = TRUE;
+		} else if(!strcmp(variable, "pager")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->pager = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_pager = TRUE;
+		} else if(strstr(variable, "address") == variable) {
+			x = atoi(variable + 7);
+			if(x < 1 || x > MAX_XODTEMPLATE_CONTACT_ADDRESSES)
+				result = ERROR;
+			else if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->address[x - 1] = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			if(result == OK)
+				temp_contact->have_address[x - 1] = TRUE;
+		} else if(!strcmp(variable, "host_notification_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->host_notification_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_host_notification_period = TRUE;
+		} else if(!strcmp(variable, "host_notification_commands")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->host_notification_commands = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_host_notification_commands = TRUE;
+		} else if(!strcmp(variable, "service_notification_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->service_notification_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_service_notification_period = TRUE;
+		} else if(!strcmp(variable, "service_notification_commands")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_contact->service_notification_commands = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_contact->have_service_notification_commands = TRUE;
+		} else if(!strcmp(variable, "host_notification_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_contact->host_notification_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_contact->host_notification_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
+					flag_set(temp_contact->host_notification_options, OPT_RECOVERY);
+				else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
+					flag_set(temp_contact->host_notification_options, OPT_FLAPPING);
+				else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
+					flag_set(temp_contact->host_notification_options, OPT_DOWNTIME);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_contact->host_notification_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_contact->host_notification_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid host notification option '%s' in contact definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_contact->have_host_notification_options = TRUE;
+		} else if(!strcmp(variable, "service_notification_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_contact->service_notification_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_contact->service_notification_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_contact->service_notification_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
+					flag_set(temp_contact->service_notification_options, OPT_RECOVERY);
+				else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
+					flag_set(temp_contact->service_notification_options, OPT_FLAPPING);
+				else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
+					flag_set(temp_contact->service_notification_options, OPT_DOWNTIME);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_contact->service_notification_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_contact->service_notification_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid service notification option '%s' in contact definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_contact->have_service_notification_options = TRUE;
+		} else if(!strcmp(variable, "host_notifications_enabled")) {
+			temp_contact->host_notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_contact->have_host_notifications_enabled = TRUE;
+		} else if(!strcmp(variable, "service_notifications_enabled")) {
+			temp_contact->service_notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_contact->have_service_notifications_enabled = TRUE;
+		} else if(!strcmp(variable, "can_submit_commands")) {
+			temp_contact->can_submit_commands = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_contact->have_can_submit_commands = TRUE;
+		} else if(!strcmp(variable, "retain_status_information")) {
+			temp_contact->retain_status_information = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_contact->have_retain_status_information = TRUE;
+		} else if(!strcmp(variable, "retain_nonstatus_information")) {
+			temp_contact->retain_nonstatus_information = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_contact->have_retain_nonstatus_information = TRUE;
+		} else if(!strcmp(variable, "minimum_importance") ||
+		          !strcmp(variable, "minimum_value")) {
+			if(!strcmp(variable, "minimum_value")) {
+				logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: The minimum_value attribute is deprecated and will be removed in future versions. Please use minimum_importance instead.\n");
+			}
+			temp_contact->minimum_value = strtoul(value, NULL, 10);
+			temp_contact->have_minimum_value = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_contact->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else if(variable[0] == '_') {
+
+			/* get the variable name */
+			customvarname = (char *)strdup(variable + 1);
+
+			/* make sure we have a variable name */
+			if(customvarname == NULL || !strcmp(customvarname, "")) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Null custom variable name.\n");
+				my_free(customvarname);
+				return ERROR;
+			}
+
+			/* get the variable value */
+			if(strcmp(value, XODTEMPLATE_NULL))
+				customvarvalue = (char *)strdup(value);
+			else
+				customvarvalue = NULL;
+
+			/* add the custom variable */
+			if(xodtemplate_add_custom_variable_to_contact(temp_contact, customvarname, customvarvalue) == NULL) {
+				my_free(customvarname);
+				my_free(customvarvalue);
+				return ERROR;
+			}
+
+			/* free memory */
+			my_free(customvarname);
+			my_free(customvarvalue);
+		} else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid contact object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+
+	case XODTEMPLATE_HOST:
+
+		temp_host = (xodtemplate_host *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_host->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_host->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add host to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[HOST_SKIPLIST], (void *)temp_host);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "host_name")) {
+			if((temp_host->host_name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add host to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[HOST_SKIPLIST], (void *)temp_host);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+			temp_host->id = xodcount.hosts++;
+		} else if(!strcmp(variable, "display_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->display_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_display_name = TRUE;
+		} else if(!strcmp(variable, "alias")) {
+			if((temp_host->alias = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "address")) {
+			if((temp_host->address = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "parents")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->parents = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_parents = TRUE;
+		} else if(!strcmp(variable, "host_groups") || !strcmp(variable, "hostgroups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->host_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_host_groups = TRUE;
+		} else if(!strcmp(variable, "contact_groups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->contact_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_contact_groups = TRUE;
+		} else if(!strcmp(variable, "contacts")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->contacts = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_contacts = TRUE;
+		} else if(!strcmp(variable, "notification_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->notification_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_notification_period = TRUE;
+		} else if(!strcmp(variable, "check_command")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->check_command = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_check_command = TRUE;
+		} else if(!strcmp(variable, "check_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->check_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_check_period = TRUE;
+		} else if(!strcmp(variable, "event_handler")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->event_handler = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_event_handler = TRUE;
+		} else if(!strcmp(variable, "failure_prediction_options")) {
+			xodtemplate_obsoleted(variable, temp_host->_start_line);
+		} else if(!strcmp(variable, "notes")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->notes = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_notes = TRUE;
+		} else if(!strcmp(variable, "notes_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->notes_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_notes_url = TRUE;
+		} else if(!strcmp(variable, "action_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->action_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_action_url = TRUE;
+		} else if(!strcmp(variable, "icon_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->icon_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_icon_image = TRUE;
+		} else if(!strcmp(variable, "icon_image_alt")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->icon_image_alt = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_icon_image_alt = TRUE;
+		} else if(!strcmp(variable, "vrml_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->vrml_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_vrml_image = TRUE;
+		} else if(!strcmp(variable, "gd2_image") || !strcmp(variable, "statusmap_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_host->statusmap_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_host->have_statusmap_image = TRUE;
+		} else if(!strcmp(variable, "initial_state")) {
+			if(!strcmp(value, "o") || !strcmp(value, "up"))
+				temp_host->initial_state = 0; /* HOST_UP */
+			else if(!strcmp(value, "d") || !strcmp(value, "down"))
+				temp_host->initial_state = 1; /* HOST_DOWN */
+			else if(!strcmp(value, "u") || !strcmp(value, "unreachable"))
+				temp_host->initial_state = 2; /* HOST_UNREACHABLE */
+			else {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid initial state '%s' in host definition.\n", value);
+				result = ERROR;
+			}
+			temp_host->have_initial_state = TRUE;
+		} else if(!strcmp(variable, "check_interval") || !strcmp(variable, "normal_check_interval")) {
+			temp_host->check_interval = strtod(value, NULL);
+			temp_host->have_check_interval = TRUE;
+		} else if(!strcmp(variable, "retry_interval") || !strcmp(variable, "retry_check_interval")) {
+			temp_host->retry_interval = strtod(value, NULL);
+			temp_host->have_retry_interval = TRUE;
+		} else if(!strcmp(variable, "importance") ||
+		          !strcmp(variable, "hourly_value")) {
+			if(!strcmp(variable, "hourly_value")) {
+				logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: The hourly_value attribute is deprecated and will be removed in future versions. Please use importance instead.\n");
+			}
+			temp_host->hourly_value = (unsigned int)strtoul(value, NULL, 10);
+			temp_host->have_hourly_value = 1;
+		} else if(!strcmp(variable, "max_check_attempts")) {
+			temp_host->max_check_attempts = atoi(value);
+			temp_host->have_max_check_attempts = TRUE;
+		} else if(!strcmp(variable, "checks_enabled") || !strcmp(variable, "active_checks_enabled")) {
+			temp_host->active_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_active_checks_enabled = TRUE;
+		} else if(!strcmp(variable, "passive_checks_enabled")) {
+			temp_host->passive_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_passive_checks_enabled = TRUE;
+		} else if(!strcmp(variable, "event_handler_enabled")) {
+			temp_host->event_handler_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_event_handler_enabled = TRUE;
+		} else if(!strcmp(variable, "check_freshness")) {
+			temp_host->check_freshness = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_check_freshness = TRUE;
+		} else if(!strcmp(variable, "freshness_threshold")) {
+			temp_host->freshness_threshold = atoi(value);
+			temp_host->have_freshness_threshold = TRUE;
+		} else if(!strcmp(variable, "low_flap_threshold")) {
+			temp_host->low_flap_threshold = strtod(value, NULL);
+			temp_host->have_low_flap_threshold = TRUE;
+		} else if(!strcmp(variable, "high_flap_threshold")) {
+			temp_host->high_flap_threshold = strtod(value, NULL);
+			temp_host->have_high_flap_threshold = TRUE;
+		} else if(!strcmp(variable, "flap_detection_enabled")) {
+			temp_host->flap_detection_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_flap_detection_enabled = TRUE;
+		} else if(!strcmp(variable, "flap_detection_options")) {
+
+			/* user is specifying something, so discard defaults... */
+			temp_host->flap_detection_options = OPT_NOTHING;
+
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
+					flag_set(temp_host->flap_detection_options, OPT_UP);
+				else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_host->flap_detection_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_host->flap_detection_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_host->flap_detection_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_host->flap_detection_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid flap detection option '%s' in host definition.\n", temp_ptr);
+					result = ERROR;
+				}
+			}
+			temp_host->have_flap_detection_options = TRUE;
+		} else if(!strcmp(variable, "notification_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_host->notification_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_host->notification_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
+					flag_set(temp_host->notification_options, OPT_RECOVERY);
+				else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
+					flag_set(temp_host->notification_options, OPT_FLAPPING);
+				else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
+					flag_set(temp_host->notification_options, OPT_DOWNTIME);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_host->notification_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_host->notification_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification option '%s' in host definition.\n", temp_ptr);
+					result = ERROR;
+				}
+			}
+			temp_host->have_notification_options = TRUE;
+		} else if(!strcmp(variable, "notifications_enabled")) {
+			temp_host->notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_notifications_enabled = TRUE;
+		} else if(!strcmp(variable, "notification_interval")) {
+			temp_host->notification_interval = strtod(value, NULL);
+			temp_host->have_notification_interval = TRUE;
+		} else if(!strcmp(variable, "first_notification_delay")) {
+			temp_host->first_notification_delay = strtod(value, NULL);
+			temp_host->have_first_notification_delay = TRUE;
+		} else if(!strcmp(variable, "stalking_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
+					flag_set(temp_host->stalking_options, OPT_UP);
+				else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_host->stalking_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_host->stalking_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_host->stalking_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_host->stalking_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid stalking option '%s' in host definition.\n", temp_ptr);
+					result = ERROR;
+				}
+			}
+			temp_host->have_stalking_options = TRUE;
+		} else if(!strcmp(variable, "process_perf_data")) {
+			temp_host->process_perf_data = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_process_perf_data = TRUE;
+		} else if(!strcmp(variable, "failure_prediction_enabled")) {
+			xodtemplate_obsoleted(variable, temp_host->_start_line);
+		} else if(!strcmp(variable, "2d_coords")) {
+			if((temp_ptr = strtok(value, ", ")) == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in host definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_host->x_2d = atoi(temp_ptr);
+			if((temp_ptr = strtok(NULL, ", ")) == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in host definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_host->y_2d = atoi(temp_ptr);
+			temp_host->have_2d_coords = TRUE;
+		} else if(!strcmp(variable, "3d_coords")) {
+			if((temp_ptr = strtok(value, ", ")) == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in host definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_host->x_3d = strtod(temp_ptr, NULL);
+			if((temp_ptr = strtok(NULL, ", ")) == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in host definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_host->y_3d = strtod(temp_ptr, NULL);
+			if((temp_ptr = strtok(NULL, ", ")) == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in host definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_host->z_3d = strtod(temp_ptr, NULL);
+			temp_host->have_3d_coords = TRUE;
+		} else if(!strcmp(variable, "obsess_over_host") || !strcmp(variable, "obsess")) {
+			temp_host->obsess = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_obsess = TRUE;
+		} else if(!strcmp(variable, "retain_status_information")) {
+			temp_host->retain_status_information = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_retain_status_information = TRUE;
+		} else if(!strcmp(variable, "retain_nonstatus_information")) {
+			temp_host->retain_nonstatus_information = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_host->have_retain_nonstatus_information = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_host->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else if(variable[0] == '_') {
+
+			/* get the variable name */
+			customvarname = (char *)strdup(variable + 1);
+
+			/* make sure we have a variable name */
+			if(customvarname == NULL || !strcmp(customvarname, "")) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Null custom variable name.\n");
+				my_free(customvarname);
+				return ERROR;
+			}
+
+			/* get the variable value */
+			customvarvalue = NULL;
+			if(strcmp(value, XODTEMPLATE_NULL))
+				customvarvalue = (char *)strdup(value);
+
+			/* add the custom variable */
+			if(xodtemplate_add_custom_variable_to_host(temp_host, customvarname, customvarvalue) == NULL) {
+				my_free(customvarname);
+				my_free(customvarvalue);
+				return ERROR;
+			}
+
+			/* free memory */
+			my_free(customvarname);
+			my_free(customvarvalue);
+		} else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid host object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+	case XODTEMPLATE_SERVICE:
+
+		temp_service = (xodtemplate_service *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_service->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_service->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add service to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "host") || !strcmp(variable, "hosts") || !strcmp(variable, "host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_host_name = TRUE;
+
+			/* NOTE: services are added to the skiplist in xodtemplate_duplicate_services(), except if daemon is using precached config */
+			if(result == OK && force_skiplists == TRUE  && temp_service->host_name != NULL && temp_service->service_description != NULL) {
+				/* add service to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					temp_service->id = xodcount.services++;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "service_description") || !strcmp(variable, "description")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->service_description = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_service_description = TRUE;
+
+			/* NOTE: services are added to the skiplist in xodtemplate_duplicate_services(), except if daemon is using precached config */
+			if(result == OK && force_skiplists == TRUE  && temp_service->host_name != NULL && temp_service->service_description != NULL) {
+				/* add service to template skiplist for fast searches */
+				result = skiplist_insert(xobject_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					temp_service->id = xodcount.services++;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "display_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->display_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_display_name = TRUE;
+		} else if(!strcmp(variable, "parents")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->parents = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_parents = TRUE;
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "service_groups") || !strcmp(variable, "servicegroups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->service_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_service_groups = TRUE;
+		} else if(!strcmp(variable, "check_command")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if(value[0] == '!') {
+					temp_service->have_important_check_command = TRUE;
+					temp_ptr = value + 1;
+				} else
+					temp_ptr = value;
+				if((temp_service->check_command = (char *)strdup(temp_ptr)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_check_command = TRUE;
+		} else if(!strcmp(variable, "check_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->check_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_check_period = TRUE;
+		} else if(!strcmp(variable, "event_handler")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->event_handler = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_event_handler = TRUE;
+		} else if(!strcmp(variable, "notification_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->notification_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_notification_period = TRUE;
+		} else if(!strcmp(variable, "contact_groups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->contact_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_contact_groups = TRUE;
+		} else if(!strcmp(variable, "contacts")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->contacts = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_contacts = TRUE;
+		} else if(!strcmp(variable, "failure_prediction_options")) {
+			xodtemplate_obsoleted(variable, temp_service->_start_line);
+		} else if(!strcmp(variable, "notes")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->notes = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_notes = TRUE;
+		} else if(!strcmp(variable, "notes_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->notes_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_notes_url = TRUE;
+		} else if(!strcmp(variable, "action_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->action_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_action_url = TRUE;
+		} else if(!strcmp(variable, "icon_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->icon_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_icon_image = TRUE;
+		} else if(!strcmp(variable, "icon_image_alt")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_service->icon_image_alt = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_service->have_icon_image_alt = TRUE;
+		} else if(!strcmp(variable, "initial_state")) {
+			if(!strcmp(value, "o") || !strcmp(value, "ok"))
+				temp_service->initial_state = STATE_OK;
+			else if(!strcmp(value, "w") || !strcmp(value, "warning"))
+				temp_service->initial_state = STATE_WARNING;
+			else if(!strcmp(value, "u") || !strcmp(value, "unknown"))
+				temp_service->initial_state = STATE_UNKNOWN;
+			else if(!strcmp(value, "c") || !strcmp(value, "critical"))
+				temp_service->initial_state = STATE_CRITICAL;
+			else {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid initial state '%s' in service definition.\n", value);
+				result = ERROR;
+			}
+			temp_service->have_initial_state = TRUE;
+		} else if(!strcmp(variable, "importance") ||
+		          !strcmp(variable, "hourly_value")) {
+			if(!strcmp(variable, "hourly_value")) {
+				logit(NSLOG_CONFIG_WARNING, TRUE, "WARNING: The hourly_value attribute is deprecated and will be removed in future versions. Please use importance instead.\n");
+			}
+			temp_service->hourly_value = (unsigned int)strtoul(value, NULL, 10);
+			temp_service->have_hourly_value = 1;
+		} else if(!strcmp(variable, "max_check_attempts")) {
+			temp_service->max_check_attempts = atoi(value);
+			temp_service->have_max_check_attempts = TRUE;
+		} else if(!strcmp(variable, "check_interval") || !strcmp(variable, "normal_check_interval")) {
+			temp_service->check_interval = strtod(value, NULL);
+			temp_service->have_check_interval = TRUE;
+		} else if(!strcmp(variable, "retry_interval") || !strcmp(variable, "retry_check_interval")) {
+			temp_service->retry_interval = strtod(value, NULL);
+			temp_service->have_retry_interval = TRUE;
+		} else if(!strcmp(variable, "active_checks_enabled")) {
+			temp_service->active_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_active_checks_enabled = TRUE;
+		} else if(!strcmp(variable, "passive_checks_enabled")) {
+			temp_service->passive_checks_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_passive_checks_enabled = TRUE;
+		} else if(!strcmp(variable, "parallelize_check")) {
+			temp_service->parallelize_check = atoi(value);
+			temp_service->have_parallelize_check = TRUE;
+		} else if(!strcmp(variable, "is_volatile")) {
+			temp_service->is_volatile = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_is_volatile = TRUE;
+		} else if(!strcmp(variable, "obsess_over_service") || !strcmp(variable, "obsess")) {
+			temp_service->obsess = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_obsess = TRUE;
+		} else if(!strcmp(variable, "event_handler_enabled")) {
+			temp_service->event_handler_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_event_handler_enabled = TRUE;
+		} else if(!strcmp(variable, "check_freshness")) {
+			temp_service->check_freshness = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_check_freshness = TRUE;
+		} else if(!strcmp(variable, "freshness_threshold")) {
+			temp_service->freshness_threshold = atoi(value);
+			temp_service->have_freshness_threshold = TRUE;
+		} else if(!strcmp(variable, "low_flap_threshold")) {
+			temp_service->low_flap_threshold = strtod(value, NULL);
+			temp_service->have_low_flap_threshold = TRUE;
+		} else if(!strcmp(variable, "high_flap_threshold")) {
+			temp_service->high_flap_threshold = strtod(value, NULL);
+			temp_service->have_high_flap_threshold = TRUE;
+		} else if(!strcmp(variable, "flap_detection_enabled")) {
+			temp_service->flap_detection_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_flap_detection_enabled = TRUE;
+		} else if(!strcmp(variable, "flap_detection_options")) {
+
+			/* user is specifying something, so discard defaults... */
+			temp_service->flap_detection_options = OPT_NOTHING;
+
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
+					flag_set(temp_service->flap_detection_options, OPT_OK);
+				else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_service->flap_detection_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_service->flap_detection_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_service->flap_detection_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_service->flap_detection_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_service->flap_detection_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid flap detection option '%s' in service definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_service->have_flap_detection_options = TRUE;
+		} else if(!strcmp(variable, "notification_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_service->notification_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_service->notification_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_service->notification_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
+					flag_set(temp_service->notification_options, OPT_RECOVERY);
+				else if(!strcmp(temp_ptr, "f") || !strcmp(temp_ptr, "flapping"))
+					flag_set(temp_service->notification_options, OPT_FLAPPING);
+				else if(!strcmp(temp_ptr, "s") || !strcmp(temp_ptr, "downtime"))
+					flag_set(temp_service->notification_options, OPT_DOWNTIME);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_service->notification_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_service->notification_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification option '%s' in service definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_service->have_notification_options = TRUE;
+		} else if(!strcmp(variable, "notifications_enabled")) {
+			temp_service->notifications_enabled = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_notifications_enabled = TRUE;
+		} else if(!strcmp(variable, "notification_interval")) {
+			temp_service->notification_interval = strtod(value, NULL);
+			temp_service->have_notification_interval = TRUE;
+		} else if(!strcmp(variable, "first_notification_delay")) {
+			temp_service->first_notification_delay = strtod(value, NULL);
+			temp_service->have_first_notification_delay = TRUE;
+		} else if(!strcmp(variable, "stalking_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "ok"))
+					flag_set(temp_service->stalking_options, OPT_OK);
+				else if(!strcmp(temp_ptr, "w") || !strcmp(temp_ptr, "warning"))
+					flag_set(temp_service->stalking_options, OPT_WARNING);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unknown"))
+					flag_set(temp_service->stalking_options, OPT_UNKNOWN);
+				else if(!strcmp(temp_ptr, "c") || !strcmp(temp_ptr, "critical"))
+					flag_set(temp_service->stalking_options, OPT_CRITICAL);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_service->stalking_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_service->stalking_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid stalking option '%s' in service definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_service->have_stalking_options = TRUE;
+		} else if(!strcmp(variable, "process_perf_data")) {
+			temp_service->process_perf_data = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_process_perf_data = TRUE;
+		} else if(!strcmp(variable, "failure_prediction_enabled")) {
+			xodtemplate_obsoleted(variable, temp_service->_start_line);
+		} else if(!strcmp(variable, "retain_status_information")) {
+			temp_service->retain_status_information = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_retain_status_information = TRUE;
+		} else if(!strcmp(variable, "retain_nonstatus_information")) {
+			temp_service->retain_nonstatus_information = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_service->have_retain_nonstatus_information = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_service->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else if(variable[0] == '_') {
+
+			/* get the variable name */
+			customvarname = (char *)strdup(variable + 1);
+
+			/* make sure we have a variable name */
+			if(customvarname == NULL || !strcmp(customvarname, "")) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Null custom variable name.\n");
+				my_free(customvarname);
+				return ERROR;
+			}
+
+			/* get the variable value */
+			if(strcmp(value, XODTEMPLATE_NULL))
+				customvarvalue = (char *)strdup(value);
+			else
+				customvarvalue = NULL;
+
+			/* add the custom variable */
+			if(xodtemplate_add_custom_variable_to_service(temp_service, customvarname, customvarvalue) == NULL) {
+				my_free(customvarname);
+				my_free(customvarvalue);
+				return ERROR;
+			}
+
+			/* free memory */
+			my_free(customvarname);
+			my_free(customvarvalue);
+		} else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid service object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+	case XODTEMPLATE_HOSTDEPENDENCY:
+
+		temp_hostdependency = (xodtemplate_hostdependency *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_hostdependency->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_hostdependency->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add dependency to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[HOSTDEPENDENCY_SKIPLIST], (void *)temp_hostdependency);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host dependency '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostdependency->_config_file), temp_hostdependency->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostdependency->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostdependency->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "host") || !strcmp(variable, "host_name") || !strcmp(variable, "master_host") || !strcmp(variable, "master_host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostdependency->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostdependency->have_host_name = TRUE;
+		} else if(!strcmp(variable, "dependent_hostgroup") || !strcmp(variable, "dependent_hostgroups") || !strcmp(variable, "dependent_hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostdependency->dependent_hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostdependency->have_dependent_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "dependent_host") || !strcmp(variable, "dependent_host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostdependency->dependent_host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostdependency->have_dependent_host_name = TRUE;
+		} else if(!strcmp(variable, "dependency_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostdependency->dependency_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostdependency->have_dependency_period = TRUE;
+		} else if(!strcmp(variable, "inherits_parent")) {
+			temp_hostdependency->inherits_parent = (atoi(value) > 0) ? TRUE : FALSE;
+			temp_hostdependency->have_inherits_parent = TRUE;
+		} else if(!strcmp(variable, "notification_failure_options") || !strcmp(variable, "notification_failure_criteria")) {
+			temp_hostdependency->have_notification_failure_options = TRUE;
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
+					flag_set(temp_hostdependency->notification_failure_options, OPT_UP);
+				else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_hostdependency->notification_failure_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_hostdependency->notification_failure_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
+					flag_set(temp_hostdependency->notification_failure_options, OPT_PENDING);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_hostdependency->notification_failure_options = OPT_NOTHING;
+					temp_hostdependency->have_notification_failure_options = FALSE;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_hostdependency->notification_failure_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid notification dependency option '%s' in hostdependency definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+		} else if(!strcmp(variable, "execution_failure_options") || !strcmp(variable, "execution_failure_criteria")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "o") || !strcmp(temp_ptr, "up"))
+					flag_set(temp_hostdependency->execution_failure_options, OPT_UP);
+				else if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_hostdependency->execution_failure_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_hostdependency->execution_failure_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "p") || !strcmp(temp_ptr, "pending"))
+					flag_set(temp_hostdependency->execution_failure_options, OPT_PENDING);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_hostdependency->execution_failure_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_hostdependency->execution_failure_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid execution dependency option '%s' in hostdependency definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_hostdependency->have_execution_failure_options = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_hostdependency->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostdependency object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+
+	case XODTEMPLATE_HOSTESCALATION:
+
+		temp_hostescalation = (xodtemplate_hostescalation *)xodtemplate_current_object;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_hostescalation->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_hostescalation->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add escalation to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[HOSTESCALATION_SKIPLIST], (void *)temp_hostescalation);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for host escalation '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostescalation->_config_file), temp_hostescalation->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroups") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostescalation->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostescalation->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "host") || !strcmp(variable, "host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostescalation->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostescalation->have_host_name = TRUE;
+		} else if(!strcmp(variable, "contact_groups")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostescalation->contact_groups = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostescalation->have_contact_groups = TRUE;
+		} else if(!strcmp(variable, "contacts")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostescalation->contacts = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostescalation->have_contacts = TRUE;
+		} else if(!strcmp(variable, "escalation_period")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostescalation->escalation_period = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostescalation->have_escalation_period = TRUE;
+		} else if(!strcmp(variable, "first_notification")) {
+			temp_hostescalation->first_notification = atoi(value);
+			temp_hostescalation->have_first_notification = TRUE;
+		} else if(!strcmp(variable, "last_notification")) {
+			temp_hostescalation->last_notification = atoi(value);
+			temp_hostescalation->have_last_notification = TRUE;
+		} else if(!strcmp(variable, "notification_interval")) {
+			temp_hostescalation->notification_interval = strtod(value, NULL);
+			temp_hostescalation->have_notification_interval = TRUE;
+		} else if(!strcmp(variable, "escalation_options")) {
+			for(temp_ptr = strtok(value, ", "); temp_ptr; temp_ptr = strtok(NULL, ", ")) {
+				if(!strcmp(temp_ptr, "d") || !strcmp(temp_ptr, "down"))
+					flag_set(temp_hostescalation->escalation_options, OPT_DOWN);
+				else if(!strcmp(temp_ptr, "u") || !strcmp(temp_ptr, "unreachable"))
+					flag_set(temp_hostescalation->escalation_options, OPT_UNREACHABLE);
+				else if(!strcmp(temp_ptr, "r") || !strcmp(temp_ptr, "recovery"))
+					flag_set(temp_hostescalation->escalation_options, OPT_RECOVERY);
+				else if(!strcmp(temp_ptr, "n") || !strcmp(temp_ptr, "none")) {
+					temp_hostescalation->escalation_options = OPT_NOTHING;
+				} else if(!strcmp(temp_ptr, "a") || !strcmp(temp_ptr, "all")) {
+					temp_hostescalation->escalation_options = OPT_ALL;
+				} else {
+					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid escalation option '%s' in hostescalation definition.\n", temp_ptr);
+					return ERROR;
+				}
+			}
+			temp_hostescalation->have_escalation_options = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_hostescalation->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostescalation object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+	case XODTEMPLATE_HOSTEXTINFO:
+
+		temp_hostextinfo = xodtemplate_hostextinfo_list;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_hostextinfo->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_hostextinfo->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[HOSTEXTINFO_SKIPLIST], (void *)temp_hostextinfo);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for extended host info '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_hostextinfo->_config_file), temp_hostextinfo->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_host_name = TRUE;
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "notes")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->notes = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_notes = TRUE;
+		} else if(!strcmp(variable, "notes_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->notes_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_notes_url = TRUE;
+		} else if(!strcmp(variable, "action_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->action_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_action_url = TRUE;
+		} else if(!strcmp(variable, "icon_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->icon_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_icon_image = TRUE;
+		} else if(!strcmp(variable, "icon_image_alt")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->icon_image_alt = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_icon_image_alt = TRUE;
+		} else if(!strcmp(variable, "vrml_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->vrml_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_vrml_image = TRUE;
+		} else if(!strcmp(variable, "gd2_image") || !strcmp(variable, "statusmap_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_hostextinfo->statusmap_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_hostextinfo->have_statusmap_image = TRUE;
+		} else if(!strcmp(variable, "2d_coords")) {
+			temp_ptr = strtok(value, ", ");
+			if(temp_ptr == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in extended host info definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_hostextinfo->x_2d = atoi(temp_ptr);
+			temp_ptr = strtok(NULL, ", ");
+			if(temp_ptr == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 2d_coords value '%s' in extended host info definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_hostextinfo->y_2d = atoi(temp_ptr);
+			temp_hostextinfo->have_2d_coords = TRUE;
+		} else if(!strcmp(variable, "3d_coords")) {
+			temp_ptr = strtok(value, ", ");
+			if(temp_ptr == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in extended host info definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_hostextinfo->x_3d = strtod(temp_ptr, NULL);
+			temp_ptr = strtok(NULL, ", ");
+			if(temp_ptr == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in extended host info definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_hostextinfo->y_3d = strtod(temp_ptr, NULL);
+			temp_ptr = strtok(NULL, ", ");
+			if(temp_ptr == NULL) {
+				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid 3d_coords value '%s' in extended host info definition.\n", temp_ptr);
+				return ERROR;
+			}
+			temp_hostextinfo->z_3d = strtod(temp_ptr, NULL);
+			temp_hostextinfo->have_3d_coords = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_hostextinfo->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid hostextinfo object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+	case XODTEMPLATE_SERVICEEXTINFO:
+
+		temp_serviceextinfo = xodtemplate_serviceextinfo_list;
+
+		if(!strcmp(variable, "use")) {
+			if((temp_serviceextinfo->template = (char *)strdup(value)) == NULL)
+				result = ERROR;
+		} else if(!strcmp(variable, "name")) {
+
+			if((temp_serviceextinfo->name = (char *)strdup(value)) == NULL)
+				result = ERROR;
+
+			if(result == OK) {
+				/* add to template skiplist for fast searches */
+				result = skiplist_insert(xobject_template_skiplists[SERVICEEXTINFO_SKIPLIST], (void *)temp_serviceextinfo);
+				switch(result) {
+				case SKIPLIST_ERROR_DUPLICATE:
+					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for extended service info '%s' (config file '%s', starting on line %d)\n", value, xodtemplate_config_file_name(temp_serviceextinfo->_config_file), temp_serviceextinfo->_start_line);
+					result = ERROR;
+					break;
+				case SKIPLIST_OK:
+					result = OK;
+					break;
+				default:
+					result = ERROR;
+					break;
+				}
+			}
+		} else if(!strcmp(variable, "host_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->host_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_host_name = TRUE;
+		} else if(!strcmp(variable, "hostgroup") || !strcmp(variable, "hostgroup_name")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->hostgroup_name = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_hostgroup_name = TRUE;
+		} else if(!strcmp(variable, "service_description")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->service_description = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_service_description = TRUE;
+		} else if(!strcmp(variable, "notes")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->notes = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_notes = TRUE;
+		} else if(!strcmp(variable, "notes_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->notes_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_notes_url = TRUE;
+		} else if(!strcmp(variable, "action_url")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->action_url = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_action_url = TRUE;
+		} else if(!strcmp(variable, "icon_image")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->icon_image = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_icon_image = TRUE;
+		} else if(!strcmp(variable, "icon_image_alt")) {
+			if(strcmp(value, XODTEMPLATE_NULL)) {
+				if((temp_serviceextinfo->icon_image_alt = (char *)strdup(value)) == NULL)
+					result = ERROR;
+			}
+			temp_serviceextinfo->have_icon_image_alt = TRUE;
+		} else if(!strcmp(variable, "register"))
+			temp_serviceextinfo->register_object = (atoi(value) > 0) ? TRUE : FALSE;
+		else {
+			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid serviceextinfo object directive '%s'.\n", variable);
+			return ERROR;
+		}
+
+		break;
+
+	default:
+		return ERROR;
+		break;
 	}
+
+	return result;
+}
 
 
 
@@ -3486,7 +3242,8 @@ int xodtemplate_add_object_property(char *input, int options) {
 		} \
 	} while(0)
 /* completes an object definition */
-int xodtemplate_end_object_definition(int options) {
+int xodtemplate_end_object_definition(int options)
+{
 	int result = OK;
 
 	switch(xodtemplate_current_object_type) {
@@ -3524,36 +3281,40 @@ int xodtemplate_end_object_definition(int options) {
 	xodtemplate_current_object_type = XODTEMPLATE_NONE;
 
 	return result;
-	}
+}
 
 
 
 /* adds a custom variable to a host */
-xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_host(xodtemplate_host *hst, char *varname, char *varvalue) {
+xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_host(xodtemplate_host *hst, char *varname, char *varvalue)
+{
 
 	return xodtemplate_add_custom_variable_to_object(&hst->custom_variables, varname, varvalue);
-	}
+}
 
 
 
 /* adds a custom variable to a service */
-xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_service(xodtemplate_service *svc, char *varname, char *varvalue) {
+xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_service(xodtemplate_service *svc, char *varname, char *varvalue)
+{
 
 	return xodtemplate_add_custom_variable_to_object(&svc->custom_variables, varname, varvalue);
-	}
+}
 
 
 
 /* adds a custom variable to a contact */
-xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_contact(xodtemplate_contact *cntct, char *varname, char *varvalue) {
+xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_contact(xodtemplate_contact *cntct, char *varname, char *varvalue)
+{
 
 	return xodtemplate_add_custom_variable_to_object(&cntct->custom_variables, varname, varvalue);
-	}
+}
 
 
 
 /* adds a custom variable to an object */
-xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_object(xodtemplate_customvariablesmember **object_ptr, char *varname, char *varvalue) {
+xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_object(xodtemplate_customvariablesmember **object_ptr, char *varname, char *varvalue)
+{
 	xodtemplate_customvariablesmember *new_customvariablesmember = NULL;
 	register int x = 0;
 
@@ -3570,15 +3331,14 @@ xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_object(xod
 	if((new_customvariablesmember->variable_name = (char *)strdup(varname)) == NULL) {
 		my_free(new_customvariablesmember);
 		return NULL;
-		}
+	}
 	if(varvalue) {
 		if((new_customvariablesmember->variable_value = (char *)strdup(varvalue)) == NULL) {
 			my_free(new_customvariablesmember->variable_name);
 			my_free(new_customvariablesmember);
 			return NULL;
-			}
 		}
-	else
+	} else
 		new_customvariablesmember->variable_value = NULL;
 
 	/* convert varname to all uppercase (saves CPU time during macro functions) */
@@ -3590,12 +3350,13 @@ xodtemplate_customvariablesmember *xodtemplate_add_custom_variable_to_object(xod
 	*object_ptr = new_customvariablesmember;
 
 	return new_customvariablesmember;
-	}
+}
 
 
 
 /* parses a timeperod directive... :-) */
-int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char *var, char *val) {
+int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char *var, char *val)
+{
 	char *input = NULL;
 	char temp_buffer[5][MAX_INPUT_BUFFER] = {"", "", "", "", ""};
 	int items = 0;
@@ -3632,7 +3393,7 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 		/* add timerange exception */
 		if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_CALENDAR_DATE, syear, smon - 1, smday, 0, 0, eyear, emon - 1, emday, 0, 0, skip_interval, temp_buffer[0]) == NULL)
 			result = ERROR;
-		}
+	}
 
 	else if((items = sscanf(input, "%4d-%2d-%2d / %d %[0-9:, -]", &syear, &smon, &smday, &skip_interval, temp_buffer[0])) == 5) {
 		eyear = syear;
@@ -3641,13 +3402,13 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 		/* add timerange exception */
 		if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_CALENDAR_DATE, syear, smon - 1, smday, 0, 0, eyear, emon - 1, emday, 0, 0, skip_interval, temp_buffer[0]) == NULL)
 			result = ERROR;
-		}
+	}
 
 	else if((items = sscanf(input, "%4d-%2d-%2d - %4d-%2d-%2d %[0-9:, -]", &syear, &smon, &smday, &eyear, &emon, &emday, temp_buffer[0])) == 7) {
 		/* add timerange exception */
 		if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_CALENDAR_DATE, syear, smon - 1, smday, 0, 0, eyear, emon - 1, emday, 0, 0, 0, temp_buffer[0]) == NULL)
 			result = ERROR;
-		}
+	}
 
 	else if((items = sscanf(input, "%4d-%2d-%2d %[0-9:, -]", &syear, &smon, &smday, temp_buffer[0])) == 4) {
 		eyear = syear;
@@ -3656,7 +3417,7 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 		/* add timerange exception */
 		if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_CALENDAR_DATE, syear, smon - 1, smday, 0, 0, eyear, emon - 1, emday, 0, 0, 0, temp_buffer[0]) == NULL)
 			result = ERROR;
-		}
+	}
 
 	/* other types... */
 	else if((items = sscanf(input, "%[a-z] %d %[a-z] - %[a-z] %d %[a-z] / %d %[0-9:, -]", temp_buffer[0], &swday_offset, temp_buffer[1], temp_buffer[2], &ewday_offset, temp_buffer[3], &skip_interval, temp_buffer[4])) == 8) {
@@ -3665,8 +3426,8 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_WEEK_DAY, 0, smon, 0, swday, swday_offset, 0, emon, 0, ewday, ewday_offset, skip_interval, temp_buffer[4]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d - %[a-z] %d / %d %[0-9:, -]", temp_buffer[0], &smday, temp_buffer[1], &emday, &skip_interval, temp_buffer[2])) == 6) {
 		/* february 1 - march 15 / 3 */
@@ -3679,21 +3440,19 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_WEEK_DAY, 0, 0, 0, swday, swday_offset, 0, 0, 0, ewday, ewday_offset, skip_interval, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
-		else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK && (result = xodtemplate_get_month_from_string(temp_buffer[1], &emon)) == OK) {
+		} else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK && (result = xodtemplate_get_month_from_string(temp_buffer[1], &emon)) == OK) {
 			/* february 1 - march 15 / 3 */
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DATE, 0, smon, smday, 0, 0, 0, emon, emday, 0, 0, skip_interval, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
-		else if(!strcmp(temp_buffer[0], "day")  && !strcmp(temp_buffer[1], "day")) {
+		} else if(!strcmp(temp_buffer[0], "day")  && !strcmp(temp_buffer[1], "day")) {
 			/* day 4 - 6 / 2 */
 			/* add timeperiod exception */
 			result = OK;
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DAY, 0, 0, smday, 0, 0, 0, 0, emday, 0, 0, skip_interval, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d - %d / %d %[0-9:, -]", temp_buffer[0], &smday, &emday, &skip_interval, temp_buffer[1])) == 5) {
 		/* february 1 - 15 / 3 */
@@ -3707,22 +3466,20 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_WEEK_DAY, 0, 0, 0, swday, swday_offset, 0, 0, 0, ewday, ewday_offset, skip_interval, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
-		else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK) {
+		} else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK) {
 			/* february 3 - 5 */
 			emon = smon;
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DATE, 0, smon, smday, 0, 0, 0, emon, emday, 0, 0, skip_interval, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
-		else if(!strcmp(temp_buffer[0], "day")) {
+		} else if(!strcmp(temp_buffer[0], "day")) {
 			/* day 1 - 4 */
 			/* add timeperiod exception */
 			result = OK;
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DAY, 0, 0, smday, 0, 0, 0, 0, emday, 0, 0, skip_interval, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d %[a-z] - %[a-z] %d %[a-z] %[0-9:, -]", temp_buffer[0], &swday_offset, temp_buffer[1], temp_buffer[2], &ewday_offset, temp_buffer[3], temp_buffer[4])) == 7) {
 		/* wednesday 1 january - thursday 2 july */
@@ -3730,8 +3487,8 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_WEEK_DAY, 0, smon, 0, swday, swday_offset, 0, emon, 0, ewday, ewday_offset, 0, temp_buffer[4]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d - %d %[0-9:, -]", temp_buffer[0], &smday, &emday, temp_buffer[1])) == 4) {
 		/* february 3 - 5 */
@@ -3745,22 +3502,20 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_WEEK_DAY, 0, 0, 0, swday, swday_offset, 0, 0, 0, ewday, ewday_offset, 0, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
-		else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK) {
+		} else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK) {
 			/* february 3 - 5 */
 			emon = smon;
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DATE, 0, smon, smday, 0, 0, 0, emon, emday, 0, 0, 0, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
-		else if(!strcmp(temp_buffer[0], "day")) {
+		} else if(!strcmp(temp_buffer[0], "day")) {
 			/* day 1 - 4 */
 			/* add timeperiod exception */
 			result = OK;
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DAY, 0, 0, smday, 0, 0, 0, 0, emday, 0, 0, 0, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d - %[a-z] %d %[0-9:, -]", temp_buffer[0], &smday, temp_buffer[1], &emday, temp_buffer[2])) == 5) {
 		/* february 1 - march 15 */
@@ -3773,21 +3528,19 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_WEEK_DAY, 0, 0, 0, swday, swday_offset, 0, 0, 0, ewday, ewday_offset, 0, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
-		else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK && (result = xodtemplate_get_month_from_string(temp_buffer[1], &emon)) == OK) {
+		} else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK && (result = xodtemplate_get_month_from_string(temp_buffer[1], &emon)) == OK) {
 			/* february 1 - march 15 */
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DATE, 0, smon, smday, 0, 0, 0, emon, emday, 0, 0, 0, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
-		else if(!strcmp(temp_buffer[0], "day")  && !strcmp(temp_buffer[1], "day")) {
+		} else if(!strcmp(temp_buffer[0], "day")  && !strcmp(temp_buffer[1], "day")) {
 			/* day 1 - day 5 */
 			/* add timeperiod exception */
 			result = OK;
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DAY, 0, 0, smday, 0, 0, 0, 0, emday, 0, 0, 0, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d%*[ \t]%[0-9:, -]", temp_buffer[0], &smday, temp_buffer[1])) == 3) {
 		/* february 3 */
@@ -3801,24 +3554,22 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_WEEK_DAY, 0, 0, 0, swday, swday_offset, 0, 0, 0, ewday, ewday_offset, 0, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
-		else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK) {
+		} else if((result = xodtemplate_get_month_from_string(temp_buffer[0], &smon)) == OK) {
 			/* february 3 */
 			emon = smon;
 			emday = smday;
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DATE, 0, smon, smday, 0, 0, 0, emon, emday, 0, 0, 0, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
-		else if(!strcmp(temp_buffer[0], "day")) {
+		} else if(!strcmp(temp_buffer[0], "day")) {
 			/* day 1 */
 			emday = smday;
 			/* add timeperiod exception */
 			result = OK;
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_DAY, 0, 0, smday, 0, 0, 0, 0, emday, 0, 0, 0, temp_buffer[1]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %d %[a-z] %[0-9:, -]", temp_buffer[0], &swday_offset, temp_buffer[1], temp_buffer[2])) == 4) {
 		/* thursday 3 february */
@@ -3829,8 +3580,8 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add timeperiod exception */
 			if(xodtemplate_add_exception_to_timeperiod(tperiod, DATERANGE_MONTH_WEEK_DAY, 0, smon, 0, swday, swday_offset, 0, emon, 0, ewday, ewday_offset, 0, temp_buffer[2]) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else if((items = sscanf(input, "%[a-z] %[0-9:, -]", temp_buffer[0], temp_buffer[1])) == 2) {
 		/* monday */
@@ -3838,8 +3589,8 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 			/* add normal weekday timerange */
 			if((tperiod->timeranges[swday] = (char *)strdup(temp_buffer[1])) == NULL)
 				result = ERROR;
-			}
 		}
+	}
 
 	else
 		result = ERROR;
@@ -3847,19 +3598,20 @@ int xodtemplate_parse_timeperiod_directive(xodtemplate_timeperiod *tperiod, char
 #ifdef NSCORE
 	if(result == ERROR) {
 		printf("Error: Could not parse timeperiod directive '%s'!\n", input);
-		}
+	}
 #endif
 
 	/* free memory */
 	my_free(input);
 
 	return result;
-	}
+}
 
 
 
 /* add a new exception to a timeperiod */
-xodtemplate_daterange *xodtemplate_add_exception_to_timeperiod(xodtemplate_timeperiod *period, int type, int syear, int smon, int smday, int swday, int swday_offset, int eyear, int emon, int emday, int ewday, int ewday_offset, int skip_interval, char *timeranges) {
+xodtemplate_daterange *xodtemplate_add_exception_to_timeperiod(xodtemplate_timeperiod *period, int type, int syear, int smon, int smday, int swday, int swday_offset, int eyear, int emon, int emday, int ewday, int ewday_offset, int skip_interval, char *timeranges)
+{
 	xodtemplate_daterange *new_daterange = NULL;
 
 	/* make sure we have the data we need */
@@ -3891,11 +3643,12 @@ xodtemplate_daterange *xodtemplate_add_exception_to_timeperiod(xodtemplate_timep
 	period->exceptions[type] = new_daterange;
 
 	return new_daterange;
-	}
+}
 
 
 
-int xodtemplate_get_month_from_string(char *str, int *month) {
+int xodtemplate_get_month_from_string(char *str, int *month)
+{
 	const char *months[12] = {"january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december"};
 	int x = 0;
 
@@ -3906,16 +3659,17 @@ int xodtemplate_get_month_from_string(char *str, int *month) {
 		if(!strcmp(str, months[x])) {
 			*month = x;
 			return OK;
-			}
 		}
-
-	return ERROR;
 	}
 
+	return ERROR;
+}
 
 
 
-int xodtemplate_get_weekday_from_string(char *str, int *weekday) {
+
+int xodtemplate_get_weekday_from_string(char *str, int *weekday)
+{
 	const char *days[7] = {"sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"};
 	int x = 0;
 
@@ -3926,11 +3680,11 @@ int xodtemplate_get_weekday_from_string(char *str, int *weekday) {
 		if(!strcmp(str, days[x])) {
 			*weekday = x;
 			return OK;
-			}
 		}
+	}
 
 	return ERROR;
-	}
+}
 
 
 
@@ -3941,7 +3695,8 @@ int xodtemplate_get_weekday_from_string(char *str, int *weekday) {
 #ifdef NSCORE
 
 /* duplicates service definitions */
-int xodtemplate_duplicate_services(void) {
+int xodtemplate_duplicate_services(void)
+{
 	int result = OK;
 	xodtemplate_service *temp_service = NULL;
 
@@ -3962,12 +3717,12 @@ int xodtemplate_duplicate_services(void) {
 		if((temp_service->hostgroup_name == NULL && temp_service->host_name == NULL) || temp_service->service_description == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service has no hosts and/or service_description (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
 			return ERROR;
-			}
+		}
 
 		if(temp_service->hostgroup_name != NULL) {
 			if(xodtemplate_expand_hostgroups(&glist, host_map, temp_service->hostgroup_name, temp_service->_config_file, temp_service->_start_line) == ERROR) {
 				return ERROR;
-				}
+			}
 			/* no longer needed */
 			my_free(temp_service->hostgroup_name);
 
@@ -3976,22 +3731,21 @@ int xodtemplate_duplicate_services(void) {
 				if(!allow_empty_hostgroup_assignment) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand hostgroups and/or hosts specified in service (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
 					return ERROR;
-					}
-				else if (allow_empty_hostgroup_assignment == 2) {
+				} else if (allow_empty_hostgroup_assignment == 2) {
 					logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Could not expand hostgroups and/or hosts specified in service (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
-					}
 				}
 			}
+		}
 
 		/* now find direct hosts */
 		if(temp_service->host_name) {
 			if (xodtemplate_expand_hosts(&hlist, host_map, temp_service->host_name, temp_service->_config_file, temp_service->_start_line) != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to expand host list '%s' for service '%s' (%s:%d)\n",
-					  temp_service->host_name, temp_service->service_description,
-					  xodtemplate_config_file_name(temp_service->_config_file),
-					  temp_service->_start_line);
+				      temp_service->host_name, temp_service->service_description,
+				      xodtemplate_config_file_name(temp_service->_config_file),
+				      temp_service->_start_line);
 				return ERROR;
-				}
+			}
 			/* we don't need this anymore now that we have the hlist */
 			my_free(temp_service->host_name);
 		}
@@ -4034,15 +3788,14 @@ int xodtemplate_duplicate_services(void) {
 				if(!next && !hlist->next) {
 					temp_service->id = xodcount.services++;
 					temp_service->host_name = h->host_name;
-					}
-				else {
+				} else {
 					/* duplicate service definition */
 					result = xodtemplate_duplicate_service(temp_service, h->host_name, hg != &fake_hg);
-					}
 				}
-			free_objectlist(&fake_hg.member_list);
 			}
+			free_objectlist(&fake_hg.member_list);
 		}
+	}
 
 	/***************************************/
 	/* SKIPLIST STUFF FOR FAST SORT/SEARCH */
@@ -4060,23 +3813,23 @@ int xodtemplate_duplicate_services(void) {
 
 		if(temp_service->is_from_hostgroup) {
 			continue;
-			}
+		}
 
 
 		result = skiplist_insert(xobject_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
 		switch(result) {
-			case SKIPLIST_ERROR_DUPLICATE:
-				logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' on host '%s' (config file '%s', starting on line %d)\n", temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
-				result = ERROR;
-				break;
-			case SKIPLIST_OK:
-				result = OK;
-				break;
-			default:
-				result = ERROR;
-				break;
-			}
+		case SKIPLIST_ERROR_DUPLICATE:
+			logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' on host '%s' (config file '%s', starting on line %d)\n", temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
+			result = ERROR;
+			break;
+		case SKIPLIST_OK:
+			result = OK;
+			break;
+		default:
+			result = ERROR;
+			break;
 		}
+	}
 
 
 	/* second loop for host group service definition*/
@@ -4093,27 +3846,27 @@ int xodtemplate_duplicate_services(void) {
 
 		if(!temp_service->is_from_hostgroup) {
 			continue;
-			}
+		}
 
 		temp_service->is_from_hostgroup = 0;
 
 		result = skiplist_insert(xobject_skiplists[SERVICE_SKIPLIST], (void *)temp_service);
 		switch(result) {
-			case SKIPLIST_ERROR_DUPLICATE:
-				logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' on host '%s' (config file '%s', starting on line %d)\n", temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
-				result = ERROR;
-				break;
-			case SKIPLIST_OK:
-				result = OK;
-				break;
-			default:
-				result = ERROR;
-				break;
-			}
+		case SKIPLIST_ERROR_DUPLICATE:
+			logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Duplicate definition found for service '%s' on host '%s' (config file '%s', starting on line %d)\n", temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
+			result = ERROR;
+			break;
+		case SKIPLIST_OK:
+			result = OK;
+			break;
+		default:
+			result = ERROR;
+			break;
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 /**
@@ -4245,7 +3998,8 @@ static int xodtemplate_create_service_list(objectlist **ret, bitmap *reject_map,
 }
 
 /* duplicates object definitions */
-int xodtemplate_duplicate_objects(void) {
+int xodtemplate_duplicate_objects(void)
+{
 	int result = OK;
 	xodtemplate_hostescalation *temp_hostescalation = NULL;
 	xodtemplate_serviceescalation *temp_serviceescalation = NULL;
@@ -4272,7 +4026,7 @@ int xodtemplate_duplicate_objects(void) {
 		if(master_hostlist == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand hostgroups and/or hosts specified in host escalation (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_hostescalation->_config_file), temp_hostescalation->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* add a copy of the hostescalation for every host in the hostgroup/host name list */
 		for(list = master_hostlist; list; list = next) {
@@ -4290,7 +4044,7 @@ int xodtemplate_duplicate_objects(void) {
 				my_free(temp_hostescalation->hostgroup_name);
 				temp_hostescalation->host_name = h->host_name;
 				continue;
-				}
+			}
 
 			/* duplicate hostescalation definition */
 			result = xodtemplate_duplicate_hostescalation(temp_hostescalation, h->host_name);
@@ -4299,9 +4053,9 @@ int xodtemplate_duplicate_objects(void) {
 			if(result == ERROR) {
 				free_objectlist(&next);
 				return ERROR;
-				}
 			}
 		}
+	}
 	timing_point("Created %u hostescalations (dupes possible)\n", xodcount.hostescalations);
 
 
@@ -4344,7 +4098,7 @@ int xodtemplate_duplicate_objects(void) {
 				temp_serviceescalation->host_name = s->host_name;
 				temp_serviceescalation->service_description = s->service_description;
 				continue;
-				}
+			}
 
 			/* duplicate service escalation definition */
 			result = xodtemplate_duplicate_serviceescalation(temp_serviceescalation, s->host_name, s->service_description);
@@ -4353,9 +4107,9 @@ int xodtemplate_duplicate_objects(void) {
 			if(result == ERROR) {
 				free_objectlist(&next);
 				return ERROR;
-				}
 			}
 		}
+	}
 	timing_point("Created %u serviceescalations (dupes possible)\n", xodcount.serviceescalations);
 
 
@@ -4372,7 +4126,7 @@ int xodtemplate_duplicate_objects(void) {
 		if(master_hostlist == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand hostgroups and/or hosts specified in extended host info (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_hostextinfo->_config_file), temp_hostextinfo->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* merge this extinfo with every host in the hostgroup/host name list */
 		for(list = master_hostlist; list; list = next) {
@@ -4382,7 +4136,7 @@ int xodtemplate_duplicate_objects(void) {
 
 			/* merge it. we ignore errors here */
 			xodtemplate_merge_host_extinfo_object(h, temp_hostextinfo);
-			}
+		}
 		/* might as well kill it off early */
 		my_free(temp_hostextinfo->template);
 		my_free(temp_hostextinfo->name);
@@ -4395,7 +4149,7 @@ int xodtemplate_duplicate_objects(void) {
 		my_free(temp_hostextinfo->vrml_image);
 		my_free(temp_hostextinfo->statusmap_image);
 		my_free(temp_hostextinfo);
-		}
+	}
 	timing_point("Done merging hostextinfo\n");
 
 
@@ -4414,7 +4168,7 @@ int xodtemplate_duplicate_objects(void) {
 		if(xodtemplate_create_service_list(&master_servicelist, service_map, temp_serviceextinfo->host_name, temp_serviceextinfo->hostgroup_name, NULL, temp_serviceextinfo->service_description, temp_serviceextinfo->_config_file, temp_serviceextinfo->_start_line) != OK) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand services specified in extended service info (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_serviceextinfo->_config_file), temp_serviceextinfo->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* merge this serviceextinfo with every service in the list */
 		for(list = master_servicelist; list; list = next) {
@@ -4424,7 +4178,7 @@ int xodtemplate_duplicate_objects(void) {
 			if(bitmap_isset(service_map, s->id))
 				continue;
 			xodtemplate_merge_service_extinfo_object(s, temp_serviceextinfo);
-			}
+		}
 		/* now we're done, so we might as well kill it off */
 		my_free(temp_serviceextinfo->template);
 		my_free(temp_serviceextinfo->name);
@@ -4437,16 +4191,17 @@ int xodtemplate_duplicate_objects(void) {
 		my_free(temp_serviceextinfo->icon_image);
 		my_free(temp_serviceextinfo->icon_image_alt);
 		my_free(temp_serviceextinfo);
-		}
+	}
 	timing_point("Done merging serviceextinfo\n");
 
 	return OK;
-	}
+}
 
 
 
 /* duplicates a service definition (with a new host name) */
-int xodtemplate_duplicate_service(xodtemplate_service *temp_service, char *host_name, int from_hg) {
+int xodtemplate_duplicate_service(xodtemplate_service *temp_service, char *host_name, int from_hg)
+{
 	xodtemplate_service *new_service = NULL;
 	int error = FALSE;
 
@@ -4478,20 +4233,21 @@ int xodtemplate_duplicate_service(xodtemplate_service *temp_service, char *host_
 		my_free(new_service->contacts);
 		my_free(new_service);
 		return ERROR;
-		}
+	}
 
 	/* add new service to head of list in memory */
 	new_service->next = xodtemplate_service_list;
 	xodtemplate_service_list = new_service;
 
 	return OK;
-	}
+}
 
 
 
 
 /* duplicates a host escalation definition (with a new host name) */
-int xodtemplate_duplicate_hostescalation(xodtemplate_hostescalation *temp_hostescalation, char *host_name) {
+int xodtemplate_duplicate_hostescalation(xodtemplate_hostescalation *temp_hostescalation, char *host_name)
+{
 	xodtemplate_hostescalation *new_hostescalation = NULL;
 	int error = FALSE;
 
@@ -4516,19 +4272,20 @@ int xodtemplate_duplicate_hostescalation(xodtemplate_hostescalation *temp_hostes
 		my_free(new_hostescalation->contacts);
 		my_free(new_hostescalation);
 		return ERROR;
-		}
+	}
 
 	/* add new hostescalation to head of list in memory */
 	new_hostescalation->next = xodtemplate_hostescalation_list;
 	xodtemplate_hostescalation_list = new_hostescalation;
 
 	return OK;
-	}
+}
 
 
 
 /* duplicates a service escalation definition (with a new host name and/or service description) */
-int xodtemplate_duplicate_serviceescalation(xodtemplate_serviceescalation *temp_serviceescalation, char *host_name, char *svc_description) {
+int xodtemplate_duplicate_serviceescalation(xodtemplate_serviceescalation *temp_serviceescalation, char *host_name, char *svc_description)
+{
 	xodtemplate_serviceescalation *new_serviceescalation = NULL;
 	int error = FALSE;
 
@@ -4552,14 +4309,14 @@ int xodtemplate_duplicate_serviceescalation(xodtemplate_serviceescalation *temp_
 		my_free(new_serviceescalation->contacts);
 		my_free(new_serviceescalation);
 		return ERROR;
-		}
+	}
 
 	/* add new serviceescalation to head of list in memory */
 	new_serviceescalation->next = xodtemplate_serviceescalation_list;
 	xodtemplate_serviceescalation_list = new_serviceescalation;
 
 	return OK;
-	}
+}
 
 /******************************************************************/
 /***************** OBJECT RESOLUTION FUNCTIONS ********************/
@@ -4568,7 +4325,8 @@ int xodtemplate_duplicate_serviceescalation(xodtemplate_serviceescalation *temp_
 
 /* inherit object properties */
 /* some missing defaults (notification options, etc.) are also applied here */
-int xodtemplate_inherit_object_properties(void) {
+int xodtemplate_inherit_object_properties(void)
+{
 	xodtemplate_host *temp_host = NULL;
 	xodtemplate_service *temp_service = NULL;
 	xodtemplate_serviceescalation *temp_serviceescalation = NULL;
@@ -4582,8 +4340,8 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_host->have_notification_options == FALSE) {
 			temp_host->notification_options = OPT_ALL;
 			temp_host->have_notification_options = TRUE;
-			}
 		}
+	}
 
 	/* services inherit some properties from their associated host... */
 	for(temp_service = xodtemplate_service_list; temp_service != NULL; temp_service = temp_service->next) {
@@ -4599,7 +4357,7 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_service->have_contact_groups == FALSE && temp_service->have_contacts == FALSE) {
 			xod_inherit_str(temp_service, temp_host, contact_groups);
 			xod_inherit_str(temp_service, temp_host, contacts);
-			}
+		}
 
 		/* services inherit notification interval from host if not already specified */
 		xod_inherit(temp_service, temp_host, notification_interval);
@@ -4611,8 +4369,8 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_service->have_notification_options == FALSE) {
 			temp_service->notification_options = OPT_ALL;
 			temp_service->have_notification_options = TRUE;
-			}
 		}
+	}
 
 	/* service escalations inherit some properties from their associated service... */
 	for(temp_serviceescalation = xodtemplate_serviceescalation_list; temp_serviceescalation != NULL; temp_serviceescalation = temp_serviceescalation->next) {
@@ -4633,7 +4391,7 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_serviceescalation->have_contact_groups == FALSE && temp_serviceescalation->have_contacts == FALSE) {
 			xod_inherit_str(temp_serviceescalation, temp_service, contact_groups);
 			xod_inherit_str(temp_serviceescalation, temp_service, contacts);
-			}
+		}
 
 		/* service escalations inherit notification interval from service if not already defined */
 		xod_inherit(temp_serviceescalation, temp_service, notification_interval);
@@ -4642,18 +4400,18 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_serviceescalation->have_escalation_period == FALSE && temp_service->have_notification_period == TRUE && temp_service->notification_period != NULL) {
 			temp_serviceescalation->escalation_period = (char *)strdup(temp_service->notification_period);
 			temp_serviceescalation->have_escalation_period = TRUE;
-			}
+		}
 
 		/* if escalation options are missing, assume all */
 		if(temp_serviceescalation->have_escalation_options == FALSE) {
 			temp_serviceescalation->escalation_options = OPT_ALL;
 			temp_serviceescalation->have_escalation_options = TRUE;
-			}
+		}
 
 		/* 03/05/08 clear additive string chars - not done in xodtemplate_clean_additive_strings() anymore */
 		xodtemplate_clean_additive_string(&temp_serviceescalation->contact_groups);
 		xodtemplate_clean_additive_string(&temp_serviceescalation->contacts);
-		}
+	}
 
 	/* host escalations inherit some properties from their associated host... */
 	for(temp_hostescalation = xodtemplate_hostescalation_list; temp_hostescalation != NULL; temp_hostescalation = temp_hostescalation->next) {
@@ -4674,7 +4432,7 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_hostescalation->have_contact_groups == FALSE && temp_hostescalation->have_contacts == FALSE) {
 			xod_inherit_str(temp_hostescalation, temp_host, contact_groups);
 			xod_inherit_str(temp_hostescalation, temp_host, contacts);
-			}
+		}
 
 		/* host escalations inherit notification interval from host if not already defined */
 		xod_inherit(temp_hostescalation, temp_host, notification_interval);
@@ -4683,21 +4441,21 @@ int xodtemplate_inherit_object_properties(void) {
 		if(temp_hostescalation->have_escalation_period == FALSE && temp_host->have_notification_period == TRUE && temp_host->notification_period != NULL) {
 			temp_hostescalation->escalation_period = (char *)strdup(temp_host->notification_period);
 			temp_hostescalation->have_escalation_period = TRUE;
-			}
+		}
 
 		/* if escalation options are missing, assume all */
 		if(temp_hostescalation->have_escalation_options == FALSE) {
 			temp_hostescalation->escalation_options = OPT_ALL;
 			temp_hostescalation->have_escalation_options = TRUE;
-			}
+		}
 
 		/* 03/05/08 clear additive string chars - not done in xodtemplate_clean_additive_strings() anymore */
 		xodtemplate_clean_additive_string(&temp_hostescalation->contact_groups);
 		xodtemplate_clean_additive_string(&temp_hostescalation->contacts);
-		}
+	}
 
 	return OK;
-	}
+}
 
 #endif
 
@@ -4714,7 +4472,7 @@ static int xodtemplate_register_and_destroy_hostescalation(void *he_)
 	result = xodtemplate_register_hostescalation(he);
 	if(he->is_copy == FALSE) {
 		my_free(he->escalation_period);
-		}
+	}
 	my_free(he->contact_groups);
 	my_free(he->contacts);
 	my_free(he);
@@ -4754,7 +4512,7 @@ static int xodtemplate_register_and_destroy_hostdependency(void *hd_)
 	if(master_hostlist == NULL && allow_empty_hostgroup_assignment==0) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand master hostgroups and/or hosts specified in host dependency (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_hostdependency->_config_file), temp_hostdependency->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* get list of dependent host names */
 	dependent_hostlist = xodtemplate_expand_hostgroups_and_hosts(temp_hostdependency->dependent_hostgroup_name, temp_hostdependency->dependent_host_name, temp_hostdependency->_config_file, temp_hostdependency->_start_line);
@@ -4762,7 +4520,7 @@ static int xodtemplate_register_and_destroy_hostdependency(void *hd_)
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand dependent hostgroups (%s) and/or hosts (%s) specified in host dependency (config file '%s', starting on line %d)\n", temp_hostdependency->dependent_hostgroup_name, temp_hostdependency->dependent_host_name, xodtemplate_config_file_name(temp_hostdependency->_config_file), temp_hostdependency->_start_line);
 		free_objectlist(&master_hostlist);
 		return ERROR;
-		}
+	}
 
 	my_free(temp_hostdependency->name);
 	my_free(temp_hostdependency->template);
@@ -4787,9 +4545,9 @@ static int xodtemplate_register_and_destroy_hostdependency(void *hd_)
 				free_objectlist(&dependent_hostlist);
 				free_objectlist(&next);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	free_objectlist(&dependent_hostlist);
 	my_free(temp_hostdependency->dependency_period);
@@ -4823,11 +4581,10 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 		my_free(temp_servicedependency->dependent_service_description);
 		my_free(temp_servicedependency->dependent_hostgroup_name);
 		return OK;
-		}
+	}
 
 	if(!temp_servicedependency->host_name && !temp_servicedependency->hostgroup_name
-	   && !temp_servicedependency->servicegroup_name)
-	{
+	   && !temp_servicedependency->servicegroup_name) {
 		/*
 		 * parent service is in exact. We must take children first
 		 * and build parent chain from same-host deps there
@@ -4841,8 +4598,8 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 		if (!temp_servicedependency->dependent_servicegroup_name) {
 			if (children_first || !temp_servicedependency->dependent_service_description) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Impossible service dependency definition\n (config file '%s', starting at line '%d')",
-					  xodtemplate_config_file_name(temp_servicedependency->_config_file),
-					  temp_servicedependency->_start_line);
+				      xodtemplate_config_file_name(temp_servicedependency->_config_file),
+				      temp_servicedependency->_start_line);
 				return ERROR;
 			}
 			same_host = TRUE;
@@ -4871,14 +4628,14 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 	/* now log errors and bail out if we failed to get members */
 	if(pret != OK) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand master service(s) (config file '%s', starting at line %d)\n",
-			  xodtemplate_config_file_name(temp_servicedependency->_config_file),
-			  temp_servicedependency->_start_line);
-		}
+		      xodtemplate_config_file_name(temp_servicedependency->_config_file),
+		      temp_servicedependency->_start_line);
+	}
 	if(cret != OK) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand dependent service(s) (at config file '%s', starting on line %d)\n",
-			  xodtemplate_config_file_name(temp_servicedependency->_config_file),
-			  temp_servicedependency->_start_line);
-		}
+		      xodtemplate_config_file_name(temp_servicedependency->_config_file),
+		      temp_servicedependency->_start_line);
+	}
 
 	if(cret != OK || pret != OK)
 		return ERROR;
@@ -4905,8 +4662,8 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 			children = NULL;
 			if(xodtemplate_expand_services(&children, service_map, p->host_name, dsdesc, temp_servicedependency->_config_file, temp_servicedependency->_start_line) != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to expand same-host servicedependency services (config file '%s', starting at line %d)\n",
-					  xodtemplate_config_file_name(temp_servicedependency->_config_file),
-					  temp_servicedependency->_start_line);
+				      xodtemplate_config_file_name(temp_servicedependency->_config_file),
+				      temp_servicedependency->_start_line);
 				return ERROR;
 			}
 		}
@@ -4928,9 +4685,9 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 			temp_servicedependency->dependent_service_description = c->service_description;
 			if(xodtemplate_register_servicedependency(temp_servicedependency) != OK) {
 				logit(NSLOG_VERIFICATION_WARNING, TRUE, "Error: Failed to register servicedependency from '%s;%s' to '%s;%s' (config file '%s', starting at line %d)\n",
-					  p->host_name, p->service_description,
-					  c->host_name, c->service_description,
-					  xodtemplate_config_file_name(temp_servicedependency->_config_file), temp_servicedependency->_start_line);
+				      p->host_name, p->service_description,
+				      c->host_name, c->service_description,
+				      xodtemplate_config_file_name(temp_servicedependency->_config_file), temp_servicedependency->_start_line);
 				return ERROR;
 			}
 		}
@@ -4955,7 +4712,8 @@ static int xodtemplate_register_and_destroy_servicedependency(void *sd_)
 
 
 /* resolves object definitions */
-int xodtemplate_resolve_objects(void) {
+int xodtemplate_resolve_objects(void)
+{
 	xodtemplate_timeperiod *temp_timeperiod = NULL;
 	xodtemplate_command *temp_command = NULL;
 	xodtemplate_contactgroup *temp_contactgroup = NULL;
@@ -4975,91 +4733,92 @@ int xodtemplate_resolve_objects(void) {
 	for(temp_timeperiod = xodtemplate_timeperiod_list; temp_timeperiod != NULL; temp_timeperiod = temp_timeperiod->next) {
 		if(xodtemplate_resolve_timeperiod(temp_timeperiod) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all command objects */
 	for(temp_command = xodtemplate_command_list; temp_command != NULL; temp_command = temp_command->next) {
 		if(xodtemplate_resolve_command(temp_command) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all contactgroup objects */
 	for(temp_contactgroup = xodtemplate_contactgroup_list; temp_contactgroup != NULL; temp_contactgroup = temp_contactgroup->next) {
 		if(xodtemplate_resolve_contactgroup(temp_contactgroup) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all hostgroup objects */
 	for(temp_hostgroup = xodtemplate_hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
 		if(xodtemplate_resolve_hostgroup(temp_hostgroup) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all servicegroup objects */
 	for(temp_servicegroup = xodtemplate_servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next) {
 		if(xodtemplate_resolve_servicegroup(temp_servicegroup) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all servicedependency objects */
 	for(temp_servicedependency = xodtemplate_servicedependency_list; temp_servicedependency != NULL; temp_servicedependency = temp_servicedependency->next) {
 		if(xodtemplate_resolve_servicedependency(temp_servicedependency) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all serviceescalation objects */
 	for(temp_serviceescalation = xodtemplate_serviceescalation_list; temp_serviceescalation != NULL; temp_serviceescalation = temp_serviceescalation->next) {
 		if(xodtemplate_resolve_serviceescalation(temp_serviceescalation) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all contact objects */
 	for(temp_contact = xodtemplate_contact_list; temp_contact != NULL; temp_contact = temp_contact->next) {
 		if(xodtemplate_resolve_contact(temp_contact) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all host objects */
 	for(temp_host = xodtemplate_host_list; temp_host != NULL; temp_host = temp_host->next) {
 		if(xodtemplate_resolve_host(temp_host) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all service objects */
 	for(temp_service = xodtemplate_service_list; temp_service != NULL; temp_service = temp_service->next) {
 		if(xodtemplate_resolve_service(temp_service) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all hostdependency objects */
 	for(temp_hostdependency = xodtemplate_hostdependency_list; temp_hostdependency != NULL; temp_hostdependency = temp_hostdependency->next) {
 		if(xodtemplate_resolve_hostdependency(temp_hostdependency) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all hostescalation objects */
 	for(temp_hostescalation = xodtemplate_hostescalation_list; temp_hostescalation != NULL; temp_hostescalation = temp_hostescalation->next) {
 		if(xodtemplate_resolve_hostescalation(temp_hostescalation) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all hostextinfo objects */
 	for(temp_hostextinfo = xodtemplate_hostextinfo_list; temp_hostextinfo != NULL; temp_hostextinfo = temp_hostextinfo->next) {
 		if(xodtemplate_resolve_hostextinfo(temp_hostextinfo) == ERROR)
 			return ERROR;
-		}
+	}
 
 	/* resolve all serviceextinfo objects */
 	for(temp_serviceextinfo = xodtemplate_serviceextinfo_list; temp_serviceextinfo != NULL; temp_serviceextinfo = temp_serviceextinfo->next) {
 		if(xodtemplate_resolve_serviceextinfo(temp_serviceextinfo) == ERROR)
 			return ERROR;
-		}
-
-	return OK;
 	}
 
+	return OK;
+}
+
 /* resolves a timeperiod object */
-int xodtemplate_resolve_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
+int xodtemplate_resolve_timeperiod(xodtemplate_timeperiod *this_timeperiod)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5092,7 +4851,7 @@ int xodtemplate_resolve_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in timeperiod definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template timeperiod... */
 		xodtemplate_resolve_timeperiod(template_timeperiod);
@@ -5102,7 +4861,7 @@ int xodtemplate_resolve_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 		xod_inherit_str_nohave(this_timeperiod, template_timeperiod, alias);
 		xod_inherit_str_nohave(this_timeperiod, template_timeperiod, exclusions);
 		for(x = 0; x < 7; x++)
-			xod_inherit_str_nohave(this_timeperiod, template_timeperiod, timeranges[x]);
+			    xod_inherit_str_nohave(this_timeperiod, template_timeperiod, timeranges[x]);
 
 		/* daterange exceptions require more work to apply missing ranges... */
 		for(x = 0; x < DATERANGE_TYPES; x++) {
@@ -5112,7 +4871,7 @@ int xodtemplate_resolve_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 				for(this_daterange = this_timeperiod->exceptions[x]; this_daterange != NULL; this_daterange = this_daterange->next) {
 					if((this_daterange->type == template_daterange->type) && (this_daterange->syear == template_daterange->syear) && (this_daterange->smon == template_daterange->smon) && (this_daterange->smday == template_daterange->smday) && (this_daterange->swday == template_daterange->swday) && (this_daterange->swday_offset == template_daterange->swday_offset) && (this_daterange->eyear == template_daterange->eyear) && (this_daterange->emon == template_daterange->emon) && (this_daterange->emday == template_daterange->emday) && (this_daterange->ewday == template_daterange->ewday) && (this_daterange->ewday_offset == template_daterange->ewday_offset) && (this_daterange->skip_interval == template_daterange->skip_interval))
 						break;
-					}
+				}
 
 				/* this daterange already exists in the timeperiod, so don't inherit it */
 				if(this_daterange != NULL)
@@ -5140,20 +4899,21 @@ int xodtemplate_resolve_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 				/* add new daterange to head of list (should it be added to the end instead?) */
 				new_daterange->next = this_timeperiod->exceptions[x];
 				this_timeperiod->exceptions[x] = new_daterange;
-				}
 			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 
 /* resolves a command object */
-int xodtemplate_resolve_command(xodtemplate_command *this_command) {
+int xodtemplate_resolve_command(xodtemplate_command *this_command)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5182,7 +4942,7 @@ int xodtemplate_resolve_command(xodtemplate_command *this_command) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in command definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_command->_config_file), this_command->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template command... */
 		xodtemplate_resolve_command(template_command);
@@ -5190,18 +4950,19 @@ int xodtemplate_resolve_command(xodtemplate_command *this_command) {
 		/* apply missing properties from template command... */
 		xod_inherit_str_nohave(this_command, template_command, command_name);
 		xod_inherit_str_nohave(this_command, template_command, command_line);
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 
 /* resolves a contactgroup object */
-int xodtemplate_resolve_contactgroup(xodtemplate_contactgroup *this_contactgroup) {
+int xodtemplate_resolve_contactgroup(xodtemplate_contactgroup *this_contactgroup)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5230,7 +4991,7 @@ int xodtemplate_resolve_contactgroup(xodtemplate_contactgroup *this_contactgroup
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in contactgroup definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_contactgroup->_config_file), this_contactgroup->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template contactgroup... */
 		xodtemplate_resolve_contactgroup(template_contactgroup);
@@ -5242,18 +5003,19 @@ int xodtemplate_resolve_contactgroup(xodtemplate_contactgroup *this_contactgroup
 		xodtemplate_get_inherited_string(&template_contactgroup->have_members, &template_contactgroup->members, &this_contactgroup->have_members, &this_contactgroup->members);
 		xodtemplate_get_inherited_string(&template_contactgroup->have_contactgroup_members, &template_contactgroup->contactgroup_members, &this_contactgroup->have_contactgroup_members, &this_contactgroup->contactgroup_members);
 
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 
 /* resolves a hostgroup object */
-int xodtemplate_resolve_hostgroup(xodtemplate_hostgroup *this_hostgroup) {
+int xodtemplate_resolve_hostgroup(xodtemplate_hostgroup *this_hostgroup)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5282,7 +5044,7 @@ int xodtemplate_resolve_hostgroup(xodtemplate_hostgroup *this_hostgroup) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in hostgroup definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_hostgroup->_config_file), this_hostgroup->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template hostgroup... */
 		xodtemplate_resolve_hostgroup(template_hostgroup);
@@ -5297,18 +5059,19 @@ int xodtemplate_resolve_hostgroup(xodtemplate_hostgroup *this_hostgroup) {
 		xod_inherit_str(this_hostgroup, template_hostgroup, notes);
 		xod_inherit_str(this_hostgroup, template_hostgroup, notes_url);
 		xod_inherit_str(this_hostgroup, template_hostgroup, action_url);
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 
 /* resolves a servicegroup object */
-int xodtemplate_resolve_servicegroup(xodtemplate_servicegroup *this_servicegroup) {
+int xodtemplate_resolve_servicegroup(xodtemplate_servicegroup *this_servicegroup)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5337,7 +5100,7 @@ int xodtemplate_resolve_servicegroup(xodtemplate_servicegroup *this_servicegroup
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in servicegroup definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_servicegroup->_config_file), this_servicegroup->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template servicegroup... */
 		xodtemplate_resolve_servicegroup(template_servicegroup);
@@ -5352,16 +5115,17 @@ int xodtemplate_resolve_servicegroup(xodtemplate_servicegroup *this_servicegroup
 		xod_inherit_str(this_servicegroup, template_servicegroup, notes);
 		xod_inherit_str(this_servicegroup, template_servicegroup, notes_url);
 		xod_inherit_str(this_servicegroup, template_servicegroup, action_url);
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 /* resolves a servicedependency object */
-int xodtemplate_resolve_servicedependency(xodtemplate_servicedependency *this_servicedependency) {
+int xodtemplate_resolve_servicedependency(xodtemplate_servicedependency *this_servicedependency)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5390,7 +5154,7 @@ int xodtemplate_resolve_servicedependency(xodtemplate_servicedependency *this_se
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in service dependency definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_servicedependency->_config_file), this_servicedependency->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template servicedependency... */
 		xodtemplate_resolve_servicedependency(template_servicedependency);
@@ -5409,29 +5173,30 @@ int xodtemplate_resolve_servicedependency(xodtemplate_servicedependency *this_se
 			if(this_servicedependency->dependency_period == NULL && template_servicedependency->dependency_period != NULL)
 				this_servicedependency->dependency_period = (char *)strdup(template_servicedependency->dependency_period);
 			this_servicedependency->have_dependency_period = TRUE;
-			}
+		}
 		if(this_servicedependency->have_inherits_parent == FALSE && template_servicedependency->have_inherits_parent == TRUE) {
 			this_servicedependency->inherits_parent = template_servicedependency->inherits_parent;
 			this_servicedependency->have_inherits_parent = TRUE;
-			}
+		}
 		if(this_servicedependency->have_execution_failure_options == FALSE && template_servicedependency->have_execution_failure_options == TRUE) {
 			this_servicedependency->execution_failure_options = template_servicedependency->execution_failure_options;
 			this_servicedependency->have_execution_failure_options = TRUE;
-			}
+		}
 		if(this_servicedependency->have_notification_failure_options == FALSE && template_servicedependency->have_notification_failure_options == TRUE) {
 			this_servicedependency->notification_failure_options = template_servicedependency->notification_failure_options;
 			this_servicedependency->have_notification_failure_options = TRUE;
-			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 /* resolves a serviceescalation object */
-int xodtemplate_resolve_serviceescalation(xodtemplate_serviceescalation *this_serviceescalation) {
+int xodtemplate_resolve_serviceescalation(xodtemplate_serviceescalation *this_serviceescalation)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5460,7 +5225,7 @@ int xodtemplate_resolve_serviceescalation(xodtemplate_serviceescalation *this_se
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in service escalation definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_serviceescalation->_config_file), this_serviceescalation->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template serviceescalation... */
 		xodtemplate_resolve_serviceescalation(template_serviceescalation);
@@ -5477,34 +5242,35 @@ int xodtemplate_resolve_serviceescalation(xodtemplate_serviceescalation *this_se
 			if(this_serviceescalation->escalation_period == NULL && template_serviceescalation->escalation_period != NULL)
 				this_serviceescalation->escalation_period = (char *)strdup(template_serviceescalation->escalation_period);
 			this_serviceescalation->have_escalation_period = TRUE;
-			}
+		}
 		if(this_serviceescalation->have_first_notification == FALSE && template_serviceescalation->have_first_notification == TRUE) {
 			this_serviceescalation->first_notification = template_serviceescalation->first_notification;
 			this_serviceescalation->have_first_notification = TRUE;
-			}
+		}
 		if(this_serviceescalation->have_last_notification == FALSE && template_serviceescalation->have_last_notification == TRUE) {
 			this_serviceescalation->last_notification = template_serviceescalation->last_notification;
 			this_serviceescalation->have_last_notification = TRUE;
-			}
+		}
 		if(this_serviceescalation->have_notification_interval == FALSE && template_serviceescalation->have_notification_interval == TRUE) {
 			this_serviceescalation->notification_interval = template_serviceescalation->notification_interval;
 			this_serviceescalation->have_notification_interval = TRUE;
-			}
+		}
 		if(this_serviceescalation->have_escalation_options == FALSE && template_serviceescalation->have_escalation_options == TRUE) {
 			this_serviceescalation->escalation_options = template_serviceescalation->escalation_options;
 			this_serviceescalation->have_escalation_options = TRUE;
-			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 /* resolves a contact object */
-int xodtemplate_resolve_contact(xodtemplate_contact *this_contact) {
+int xodtemplate_resolve_contact(xodtemplate_contact *this_contact)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5536,7 +5302,7 @@ int xodtemplate_resolve_contact(xodtemplate_contact *this_contact) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in contact definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_contact->_config_file), this_contact->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template contact... */
 		xodtemplate_resolve_contact(template_contact);
@@ -5548,7 +5314,7 @@ int xodtemplate_resolve_contact(xodtemplate_contact *this_contact) {
 		xod_inherit_str(this_contact, template_contact, email);
 		xod_inherit_str(this_contact, template_contact, pager);
 		for(x = 0; x < MAX_XODTEMPLATE_CONTACT_ADDRESSES; x++)
-			xod_inherit_str(this_contact, template_contact, address[x]);
+			    xod_inherit_str(this_contact, template_contact, address[x]);
 
 		xodtemplate_get_inherited_string(&template_contact->have_contact_groups, &template_contact->contact_groups, &this_contact->have_contact_groups, &this_contact->contact_groups);
 		xodtemplate_get_inherited_string(&template_contact->have_host_notification_commands, &template_contact->host_notification_commands, &this_contact->have_host_notification_commands, &this_contact->host_notification_commands);
@@ -5572,23 +5338,24 @@ int xodtemplate_resolve_contact(xodtemplate_contact *this_contact) {
 			for(this_customvariablesmember = this_contact->custom_variables; this_customvariablesmember != NULL; this_customvariablesmember = this_customvariablesmember->next) {
 				if(!strcmp(temp_customvariablesmember->variable_name, this_customvariablesmember->variable_name))
 					break;
-				}
+			}
 
 			/* we didn't find the same variable name, so add a new custom variable */
 			if(this_customvariablesmember == NULL)
 				xodtemplate_add_custom_variable_to_contact(this_contact, temp_customvariablesmember->variable_name, temp_customvariablesmember->variable_value);
-			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 /* resolves a host object */
-int xodtemplate_resolve_host(xodtemplate_host *this_host) {
+int xodtemplate_resolve_host(xodtemplate_host *this_host)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5619,7 +5386,7 @@ int xodtemplate_resolve_host(xodtemplate_host *this_host) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in host definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template host... */
 		xodtemplate_resolve_host(template_host);
@@ -5673,13 +5440,13 @@ int xodtemplate_resolve_host(xodtemplate_host *this_host) {
 			this_host->x_2d = template_host->x_2d;
 			this_host->y_2d = template_host->y_2d;
 			this_host->have_2d_coords = TRUE;
-			}
+		}
 		if(this_host->have_3d_coords == FALSE && template_host->have_3d_coords == TRUE) {
 			this_host->x_3d = template_host->x_3d;
 			this_host->y_3d = template_host->y_3d;
 			this_host->z_3d = template_host->z_3d;
 			this_host->have_3d_coords = TRUE;
-			}
+		}
 
 		xod_inherit(this_host, template_host, retain_status_information);
 		xod_inherit(this_host, template_host, retain_nonstatus_information);
@@ -5691,23 +5458,24 @@ int xodtemplate_resolve_host(xodtemplate_host *this_host) {
 			for(this_customvariablesmember = this_host->custom_variables; this_customvariablesmember != NULL; this_customvariablesmember = this_customvariablesmember->next) {
 				if(!strcmp(temp_customvariablesmember->variable_name, this_customvariablesmember->variable_name))
 					break;
-				}
+			}
 
 			/* we didn't find the same variable name, so add a new custom variable */
 			if(this_customvariablesmember == NULL)
 				xodtemplate_add_custom_variable_to_host(this_host, temp_customvariablesmember->variable_name, temp_customvariablesmember->variable_value);
-			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 /* resolves a service object */
-int xodtemplate_resolve_service(xodtemplate_service *this_service) {
+int xodtemplate_resolve_service(xodtemplate_service *this_service)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5738,7 +5506,7 @@ int xodtemplate_resolve_service(xodtemplate_service *this_service) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in service definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_service->_config_file), this_service->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template service... */
 		xodtemplate_resolve_service(template_service);
@@ -5758,8 +5526,8 @@ int xodtemplate_resolve_service(xodtemplate_service *this_service) {
 			if(template_service->have_important_check_command == TRUE) {
 				my_free(this_service->check_command);
 				this_service->have_check_command = FALSE;
-				}
 			}
+		}
 		xod_inherit_str(this_service, template_service, check_command);
 
 		xod_inherit_str(this_service, template_service, check_period);
@@ -5804,22 +5572,23 @@ int xodtemplate_resolve_service(xodtemplate_service *this_service) {
 			for(this_customvariablesmember = this_service->custom_variables; this_customvariablesmember != NULL; this_customvariablesmember = this_customvariablesmember->next) {
 				if(!strcmp(temp_customvariablesmember->variable_name, this_customvariablesmember->variable_name))
 					break;
-				}
+			}
 
 			/* we didn't find the same variable name, so add a new custom variable */
 			if(this_customvariablesmember == NULL)
 				xodtemplate_add_custom_variable_to_service(this_service, temp_customvariablesmember->variable_name, temp_customvariablesmember->variable_value);
-			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 /* resolves a hostdependency object */
-int xodtemplate_resolve_hostdependency(xodtemplate_hostdependency *this_hostdependency) {
+int xodtemplate_resolve_hostdependency(xodtemplate_hostdependency *this_hostdependency)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5848,7 +5617,7 @@ int xodtemplate_resolve_hostdependency(xodtemplate_hostdependency *this_hostdepe
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in host dependency definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_hostdependency->_config_file), this_hostdependency->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template hostdependency... */
 		xodtemplate_resolve_hostdependency(template_hostdependency);
@@ -5864,16 +5633,17 @@ int xodtemplate_resolve_hostdependency(xodtemplate_hostdependency *this_hostdepe
 		xod_inherit(this_hostdependency, template_hostdependency, inherits_parent);
 		xod_inherit(this_hostdependency, template_hostdependency, execution_failure_options);
 		xod_inherit(this_hostdependency, template_hostdependency, notification_failure_options);
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 /* resolves a hostescalation object */
-int xodtemplate_resolve_hostescalation(xodtemplate_hostescalation *this_hostescalation) {
+int xodtemplate_resolve_hostescalation(xodtemplate_hostescalation *this_hostescalation)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5902,7 +5672,7 @@ int xodtemplate_resolve_hostescalation(xodtemplate_hostescalation *this_hostesca
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in host escalation definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_hostescalation->_config_file), this_hostescalation->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template hostescalation... */
 		xodtemplate_resolve_hostescalation(template_hostescalation);
@@ -5918,17 +5688,18 @@ int xodtemplate_resolve_hostescalation(xodtemplate_hostescalation *this_hostesca
 		xod_inherit(this_hostescalation, template_hostescalation, last_notification);
 		xod_inherit(this_hostescalation, template_hostescalation, notification_interval);
 		xod_inherit(this_hostescalation, template_hostescalation, escalation_options);
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 /* resolves a hostextinfo object */
-int xodtemplate_resolve_hostextinfo(xodtemplate_hostextinfo *this_hostextinfo) {
+int xodtemplate_resolve_hostextinfo(xodtemplate_hostextinfo *this_hostextinfo)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -5957,7 +5728,7 @@ int xodtemplate_resolve_hostextinfo(xodtemplate_hostextinfo *this_hostextinfo) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in extended host info definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_hostextinfo->_config_file), this_hostextinfo->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template hostextinfo... */
 		xodtemplate_resolve_hostextinfo(template_hostextinfo);
@@ -5977,24 +5748,25 @@ int xodtemplate_resolve_hostextinfo(xodtemplate_hostextinfo *this_hostextinfo) {
 			this_hostextinfo->x_2d = template_hostextinfo->x_2d;
 			this_hostextinfo->y_2d = template_hostextinfo->y_2d;
 			this_hostextinfo->have_2d_coords = TRUE;
-			}
+		}
 		if(this_hostextinfo->have_3d_coords == FALSE && template_hostextinfo->have_3d_coords == TRUE) {
 			this_hostextinfo->x_3d = template_hostextinfo->x_3d;
 			this_hostextinfo->y_3d = template_hostextinfo->y_3d;
 			this_hostextinfo->z_3d = template_hostextinfo->z_3d;
 			this_hostextinfo->have_3d_coords = TRUE;
-			}
 		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
 /* resolves a serviceextinfo object */
-int xodtemplate_resolve_serviceextinfo(xodtemplate_serviceextinfo *this_serviceextinfo) {
+int xodtemplate_resolve_serviceextinfo(xodtemplate_serviceextinfo *this_serviceextinfo)
+{
 	char *temp_ptr = NULL;
 	char *template_names = NULL;
 	char *template_name_ptr = NULL;
@@ -6023,7 +5795,7 @@ int xodtemplate_resolve_serviceextinfo(xodtemplate_serviceextinfo *this_servicee
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Template '%s' specified in extended service info definition could not be not found (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_serviceextinfo->_config_file), this_serviceextinfo->_start_line);
 			my_free(template_names);
 			return ERROR;
-			}
+		}
 
 		/* resolve the template serviceextinfo... */
 		xodtemplate_resolve_serviceextinfo(template_serviceextinfo);
@@ -6037,12 +5809,12 @@ int xodtemplate_resolve_serviceextinfo(xodtemplate_serviceextinfo *this_servicee
 		xod_inherit_str(this_serviceextinfo, template_serviceextinfo, action_url);
 		xod_inherit_str(this_serviceextinfo, template_serviceextinfo, icon_image);
 		xod_inherit_str(this_serviceextinfo, template_serviceextinfo, icon_image_alt);
-		}
+	}
 
 	my_free(template_names);
 
 	return OK;
-	}
+}
 
 
 
@@ -6058,7 +5830,8 @@ int xodtemplate_resolve_serviceextinfo(xodtemplate_serviceextinfo *this_servicee
  * guarantees that the first member is always the same as the one listed
  * in the struct definition.
  */
-static int _xodtemplate_add_group_member(objectlist **list, bitmap *in, bitmap *reject, void *obj) {
+static int _xodtemplate_add_group_member(objectlist **list, bitmap *in, bitmap *reject, void *obj)
+{
 	xodtemplate_host *h = (xodtemplate_host *)obj;
 
 	if(!list || !obj)
@@ -6068,7 +5841,7 @@ static int _xodtemplate_add_group_member(objectlist **list, bitmap *in, bitmap *
 		return OK;
 	bitmap_set(in, h->id);
 	return prepend_object_to_objectlist(list, obj);
-	}
+}
 #define xodtemplate_add_group_member(g, m) \
 	_xodtemplate_add_group_member(&g->member_list, g->member_map, g->reject_map, m)
 #define xodtemplate_add_servicegroup_member xodtemplate_add_group_member
@@ -6077,7 +5850,8 @@ static int _xodtemplate_add_group_member(objectlist **list, bitmap *in, bitmap *
 
 
 /* recombobulates contactgroup definitions */
-static int xodtemplate_recombobulate_contactgroup_subgroups(xodtemplate_contactgroup *temp_contactgroup) {
+static int xodtemplate_recombobulate_contactgroup_subgroups(xodtemplate_contactgroup *temp_contactgroup)
+{
 	objectlist *mlist, *glist;
 
 	if(temp_contactgroup == NULL)
@@ -6102,27 +5876,28 @@ static int xodtemplate_recombobulate_contactgroup_subgroups(xodtemplate_contactg
 			inc->loop_status = XOD_LOOPY;
 			temp_contactgroup->loop_status = XOD_LOOPY;
 			break;
-			}
+		}
 
 		for(mlist = inc->member_list; mlist; mlist = mlist->next) {
 			xodtemplate_contact *c = (xodtemplate_contact *)mlist->object_ptr;
 			if(xodtemplate_add_contactgroup_member(temp_contactgroup, c) != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to add '%s' as a subgroup member contact of contactgroup '%s' from contactgroup '%s'\n",
-					  c->contact_name, temp_contactgroup->contactgroup_name, inc->contactgroup_name);
+				      c->contact_name, temp_contactgroup->contactgroup_name, inc->contactgroup_name);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	if(temp_contactgroup->loop_status == XOD_SEEN)
 		temp_contactgroup->loop_status = XOD_OK;
 
 	return temp_contactgroup->loop_status;
-	}
+}
 
 
 
-int xodtemplate_recombobulate_contactgroups(void) {
+int xodtemplate_recombobulate_contactgroups(void)
+{
 	xodtemplate_contact *temp_contact = NULL;
 	xodtemplate_contactgroup *temp_contactgroup = NULL;
 	char *contactgroup_names = NULL;
@@ -6144,7 +5919,7 @@ int xodtemplate_recombobulate_contactgroups(void) {
 		if(!(temp_contactgroup->member_map = bitmap_create(xodcount.contacts))) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not create contactgroup bitmap\n");
 			return ERROR;
-			}
+		}
 
 		if(temp_contactgroup->contactgroup_members) {
 			xodtemplate_contactgroup *cg;
@@ -6160,11 +5935,11 @@ int xodtemplate_recombobulate_contactgroups(void) {
 				if(!(cg = xodtemplate_find_real_contactgroup(ptr))) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find member group '%s' specified in contactgroup '%s' (config file '%s', starting on line %d)\n", ptr, temp_contactgroup->contactgroup_name, xodtemplate_config_file_name(temp_contactgroup->_config_file), temp_contactgroup->_start_line);
 					return ERROR;
-					}
-				add_object_to_objectlist(&temp_contactgroup->group_list, cg);
 				}
-			my_free(temp_contactgroup->contactgroup_members);
+				add_object_to_objectlist(&temp_contactgroup->group_list, cg);
 			}
+			my_free(temp_contactgroup->contactgroup_members);
+		}
 
 		/* move on if we have no members */
 		if(temp_contactgroup->members == NULL)
@@ -6174,16 +5949,16 @@ int xodtemplate_recombobulate_contactgroups(void) {
 		if(!use_precached_objects && !(temp_contactgroup->reject_map = bitmap_create(xodcount.contacts))) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not create reject map for contactgroup '%s'", temp_contactgroup->contactgroup_name);
 			return ERROR;
-			}
+		}
 
 		/* get list of contacts in the contactgroup */
 		if(xodtemplate_expand_contacts(&accept, temp_contactgroup->reject_map, temp_contactgroup->members, temp_contactgroup->_config_file, temp_contactgroup->_start_line) != OK) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to expand contacts for contactgroup '%s' (config file '%s', starting at line %d)\n",
-				  temp_contactgroup->contactgroup_name,
-				  xodtemplate_config_file_name(temp_contactgroup->_config_file),
-				  temp_contactgroup->_start_line);
+			      temp_contactgroup->contactgroup_name,
+			      xodtemplate_config_file_name(temp_contactgroup->_config_file),
+			      temp_contactgroup->_start_line);
 			return ERROR;
-			}
+		}
 
 		my_free(temp_contactgroup->members);
 		for(list = accept; list; list = next) {
@@ -6191,8 +5966,8 @@ int xodtemplate_recombobulate_contactgroups(void) {
 			next = list->next;
 			free(list);
 			xodtemplate_add_contactgroup_member(temp_contactgroup, temp_contact);
-			}
 		}
+	}
 
 	/* if we're using precached objects we can bail out now */
 	if(use_precached_objects)
@@ -6208,9 +5983,9 @@ int xodtemplate_recombobulate_contactgroups(void) {
 		/* preprocess the contactgroup list, to change "grp1,grp2,grp3,!grp2" into "grp1,grp3" */
 		if((contactgroup_names = xodtemplate_process_contactgroup_names(temp_contact->contact_groups, temp_contact->_config_file, temp_contact->_start_line)) == NULL) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Failed to process contactgroups for contact '%s' (config file '%s', starting at line %d)\n",
-				  temp_contact->contact_name, xodtemplate_config_file_name(temp_contact->_config_file),	temp_contact->_start_line);
+			      temp_contact->contact_name, xodtemplate_config_file_name(temp_contact->_config_file),	temp_contact->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* process the list of contactgroups */
 		for(temp_ptr = strtok(contactgroup_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
@@ -6224,20 +5999,20 @@ int xodtemplate_recombobulate_contactgroups(void) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find contactgroup '%s' specified in contact '%s' definition (config file '%s', starting on line %d)\n", temp_ptr, temp_contact->contact_name, xodtemplate_config_file_name(temp_contact->_config_file), temp_contact->_start_line);
 				my_free(contactgroup_names);
 				return ERROR;
-				}
+			}
 
 			if(!temp_contactgroup->member_map && !(temp_contactgroup->member_map = bitmap_create(xodcount.contacts))) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to create member map for contactgroup '%s'\n",
-					  temp_contactgroup->contactgroup_name);
+				      temp_contactgroup->contactgroup_name);
 				return ERROR;
-				}
+			}
 			/* add this contact to the contactgroup members directive */
 			xodtemplate_add_contactgroup_member(temp_contactgroup, temp_contact);
-			}
+		}
 
 		/* free memory */
 		my_free(contactgroup_names);
-		}
+	}
 
 	/* expand subgroup membership recursively */
 	for(temp_contactgroup = xodtemplate_contactgroup_list; temp_contactgroup; temp_contactgroup = temp_contactgroup->next) {
@@ -6250,11 +6025,12 @@ int xodtemplate_recombobulate_contactgroups(void) {
 	}
 
 	return OK;
-	}
+}
 
 
 
-static int xodtemplate_recombobulate_hostgroup_subgroups(xodtemplate_hostgroup *temp_hostgroup) {
+static int xodtemplate_recombobulate_hostgroup_subgroups(xodtemplate_hostgroup *temp_hostgroup)
+{
 	objectlist *mlist, *glist;
 
 	if(temp_hostgroup == NULL)
@@ -6279,27 +6055,28 @@ static int xodtemplate_recombobulate_hostgroup_subgroups(xodtemplate_hostgroup *
 			inc->loop_status = XOD_LOOPY;
 			temp_hostgroup->loop_status = XOD_LOOPY;
 			break;
-			}
+		}
 		for(mlist = inc->member_list; mlist; mlist = mlist->next) {
 			xodtemplate_host *h = (xodtemplate_host *)mlist->object_ptr;
 			if (xodtemplate_add_hostgroup_member(temp_hostgroup, mlist->object_ptr) != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to add '%s' as a subgroup member host of hostgroup '%s' from hostgroup '%s'\n",
-					  h->host_name, temp_hostgroup->hostgroup_name, inc->hostgroup_name);
+				      h->host_name, temp_hostgroup->hostgroup_name, inc->hostgroup_name);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	if(temp_hostgroup->loop_status == XOD_SEEN)
 		temp_hostgroup->loop_status = XOD_OK;
 
 	return temp_hostgroup->loop_status;
-	}
+}
 
 
 
 /* recombobulates hostgroup definitions */
-int xodtemplate_recombobulate_hostgroups(void) {
+int xodtemplate_recombobulate_hostgroups(void)
+{
 	xodtemplate_host *temp_host = NULL;
 	xodtemplate_hostgroup *temp_hostgroup = NULL;
 	char *hostgroup_names = NULL;
@@ -6322,7 +6099,7 @@ int xodtemplate_recombobulate_hostgroups(void) {
 		if (!(temp_hostgroup->member_map = bitmap_create(xodcount.hosts))) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not create member map for hostgroup '%s'\n", temp_hostgroup->hostgroup_name);
 			return ERROR;
-			}
+		}
 
 		/* resolve groups into a group-list */
 		for(next_ptr = ptr = temp_hostgroup->hostgroup_members; next_ptr; ptr = next_ptr + 1) {
@@ -6338,9 +6115,9 @@ int xodtemplate_recombobulate_hostgroups(void) {
 			if (!(hg = xodtemplate_find_real_hostgroup(ptr))) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find member group '%s' specified in hostgroup '%s' (config file '%s', starting on line %d)\n", ptr, temp_hostgroup->hostgroup_name, xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
 				return ERROR;
-				}
-			add_object_to_objectlist(&temp_hostgroup->group_list, hg);
 			}
+			add_object_to_objectlist(&temp_hostgroup->group_list, hg);
+		}
 
 		/* move on if we have no members */
 		if(temp_hostgroup->members == NULL)
@@ -6350,7 +6127,7 @@ int xodtemplate_recombobulate_hostgroups(void) {
 		if(!use_precached_objects && !(temp_hostgroup->reject_map = bitmap_create(xodcount.hosts))) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not create reject map for hostgroup '%s'\n", temp_hostgroup->hostgroup_name);
 			return ERROR;
-			}
+		}
 
 		/* get list of hosts in the hostgroup */
 		xodtemplate_expand_hosts(&accept, temp_hostgroup->reject_map, temp_hostgroup->members, temp_hostgroup->_config_file, temp_hostgroup->_start_line);
@@ -6358,7 +6135,7 @@ int xodtemplate_recombobulate_hostgroups(void) {
 		if (!accept && !bitmap_count_set_bits(temp_hostgroup->reject_map)) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand members specified in hostgroup (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(temp_hostgroup->_config_file), temp_hostgroup->_start_line);
 			return ERROR;
-			}
+		}
 
 		my_free(temp_hostgroup->members);
 
@@ -6367,8 +6144,8 @@ int xodtemplate_recombobulate_hostgroups(void) {
 			next = list->next;
 			free(list);
 			xodtemplate_add_hostgroup_member(temp_hostgroup, temp_host);
-			}
 		}
+	}
 
 	/* if we're using precached objects we can bail out now */
 	if(use_precached_objects)
@@ -6389,9 +6166,9 @@ int xodtemplate_recombobulate_hostgroups(void) {
 		/* 10/18/07 EG an empty return value means an error occured */
 		if((hostgroup_names = xodtemplate_process_hostgroup_names(temp_host->host_groups, temp_host->_config_file, temp_host->_start_line)) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to process hostgroup names for host '%s' (config file '%s', starting at line %d)\n",
-				  temp_host->host_name, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
+			      temp_host->host_name, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* process the list of hostgroups */
 		for(temp_ptr = strtok(hostgroup_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
@@ -6405,38 +6182,39 @@ int xodtemplate_recombobulate_hostgroups(void) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find hostgroup '%s' specified in host '%s' definition (config file '%s', starting on line %d)\n", temp_ptr, temp_host->host_name, xodtemplate_config_file_name(temp_host->_config_file), temp_host->_start_line);
 				my_free(hostgroup_names);
 				return ERROR;
-				}
+			}
 			if(!temp_hostgroup->member_map && !(temp_hostgroup->member_map = bitmap_create(xodcount.hosts))) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Failed to create bitmap to join host '%s' to group '%s'\n",
-					  temp_host->host_name, temp_hostgroup->hostgroup_name);
+				      temp_host->host_name, temp_hostgroup->hostgroup_name);
 				return ERROR;
-				}
+			}
 
 			/* add ourselves to the hostgroup member list */
 			xodtemplate_add_hostgroup_member(temp_hostgroup, temp_host);
-			}
+		}
 
 		/* free memory */
 		my_free(hostgroup_names);
-		}
+	}
 
 	/* expand subgroup membership recursively */
 	for(temp_hostgroup = xodtemplate_hostgroup_list; temp_hostgroup; temp_hostgroup = temp_hostgroup->next) {
 		if(xodtemplate_recombobulate_hostgroup_subgroups(temp_hostgroup) != XOD_OK) {
 			return ERROR;
-			}
+		}
 		/* rejects are no longer necessary */
 		bitmap_destroy(temp_hostgroup->reject_map);
 		/* make sure we don't recursively add subgroup members again */
 		free_objectlist(&temp_hostgroup->group_list);
-		}
-
-	return OK;
 	}
 
+	return OK;
+}
 
 
-static int xodtemplate_recombobulate_servicegroup_subgroups(xodtemplate_servicegroup *temp_servicegroup) {
+
+static int xodtemplate_recombobulate_servicegroup_subgroups(xodtemplate_servicegroup *temp_servicegroup)
+{
 	objectlist *mlist, *glist;
 
 	if(temp_servicegroup == NULL)
@@ -6457,30 +6235,31 @@ static int xodtemplate_recombobulate_servicegroup_subgroups(xodtemplate_serviceg
 			if(result == ERROR)
 				return ERROR;
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Servicegroups '%s' and '%s' are part of a servicegroup_members include loop\n",
-				  temp_servicegroup->servicegroup_name, inc->servicegroup_name);
+			      temp_servicegroup->servicegroup_name, inc->servicegroup_name);
 			inc->loop_status = XOD_LOOPY;
 			temp_servicegroup->loop_status = XOD_LOOPY;
 			break;
-			}
+		}
 		for(mlist = inc->member_list; mlist; mlist = mlist->next) {
 			xodtemplate_service *s = (xodtemplate_service *)mlist->object_ptr;
 			if(xodtemplate_add_servicegroup_member(temp_servicegroup, s) != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to add service '%s' on host '%s' as a subgroup member of servicegroup '%s' from servicegroup '%s'\n",
-					  s->host_name, s->service_description, temp_servicegroup->servicegroup_name, inc->servicegroup_name);
+				      s->host_name, s->service_description, temp_servicegroup->servicegroup_name, inc->servicegroup_name);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	if(temp_servicegroup->loop_status == XOD_SEEN)
 		temp_servicegroup->loop_status = XOD_OK;
 
 	return temp_servicegroup->loop_status;
-	}
+}
 
 /* recombobulates servicegroup definitions */
 /***** THIS NEEDS TO BE CALLED AFTER OBJECTS (SERVICES) ARE RESOLVED AND DUPLICATED *****/
-int xodtemplate_recombobulate_servicegroups(void) {
+int xodtemplate_recombobulate_servicegroups(void)
+{
 	xodtemplate_service *temp_service = NULL;
 	xodtemplate_servicegroup *temp_servicegroup = NULL;
 	char *servicegroup_names = NULL;
@@ -6500,7 +6279,7 @@ int xodtemplate_recombobulate_servicegroups(void) {
 		if(!(temp_servicegroup->member_map = bitmap_create(xodcount.services))) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not create member map for servicegroup '%s'\n", temp_servicegroup->servicegroup_name);
 			return ERROR;
-			}
+		}
 
 		/* resolve groups into a group-list */
 		if(temp_servicegroup->servicegroup_members) {
@@ -6519,9 +6298,9 @@ int xodtemplate_recombobulate_servicegroups(void) {
 				add_object_to_objectlist(&temp_servicegroup->group_list, sg);
 				if(!next_ptr)
 					break;
-				}
-			my_free(temp_servicegroup->servicegroup_members);
 			}
+			my_free(temp_servicegroup->servicegroup_members);
+		}
 
 		/* move on if we have no members */
 		if(temp_servicegroup->members == NULL)
@@ -6531,14 +6310,14 @@ int xodtemplate_recombobulate_servicegroups(void) {
 		if(!use_precached_objects && !(temp_servicegroup->reject_map = bitmap_create(xodcount.services))) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not create reject map for hostgroup '%s'\n", temp_servicegroup->servicegroup_name);
 			return ERROR;
-			}
+		}
 
 		/* get list of service members in the servicegroup */
 		xodtemplate_expand_services(&accept, temp_servicegroup->reject_map, NULL, temp_servicegroup->members, temp_servicegroup->_config_file, temp_servicegroup->_start_line);
 		if(!accept && !bitmap_count_set_bits(temp_servicegroup->reject_map)) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not expand members specified in servicegroup '%s' (config file '%s', starting at line %d)\n", temp_servicegroup->servicegroup_name, xodtemplate_config_file_name(temp_servicegroup->_config_file), temp_servicegroup->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* we don't need this anymore */
 		my_free(temp_servicegroup->members);
@@ -6548,8 +6327,8 @@ int xodtemplate_recombobulate_servicegroups(void) {
 			next = list->next;
 			free(list);
 			xodtemplate_add_servicegroup_member(temp_servicegroup, s);
-			}
 		}
+	}
 
 	/* if we're using precached objects we can bail out now */
 	if(use_precached_objects == TRUE)
@@ -6570,9 +6349,9 @@ int xodtemplate_recombobulate_servicegroups(void) {
 		/* 10/19/07 EG an empry return value means an error occured */
 		if((servicegroup_names = xodtemplate_process_servicegroup_names(temp_service->service_groups, temp_service->_config_file, temp_service->_start_line)) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to process servicegroup names for service '%s' on host '%s' (config file '%s', starting at line %d)\n",
-				  temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
+			      temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
 			return ERROR;
-			}
+		}
 
 		/* process the list of servicegroups */
 		for(temp_ptr = strtok(servicegroup_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
@@ -6586,33 +6365,33 @@ int xodtemplate_recombobulate_servicegroups(void) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find servicegroup '%s' specified in service '%s' on host '%s' definition (config file '%s', starting on line %d)\n", temp_ptr, temp_service->service_description, temp_service->host_name, xodtemplate_config_file_name(temp_service->_config_file), temp_service->_start_line);
 				my_free(servicegroup_names);
 				return ERROR;
-				}
+			}
 
 			if(!temp_servicegroup->member_map && !(temp_servicegroup->member_map = bitmap_create(xodcount.services))) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to create member map for service group %s\n", temp_servicegroup->servicegroup_name);
 				return ERROR;
-				}
+			}
 			/* add ourselves as members to the group */
 			xodtemplate_add_servicegroup_member(temp_servicegroup, temp_service);
 		}
 
 		/* free servicegroup names */
 		my_free(servicegroup_names);
-		}
+	}
 
 	/* expand subgroup membership recursively */
 	for(temp_servicegroup = xodtemplate_servicegroup_list; temp_servicegroup; temp_servicegroup = temp_servicegroup->next) {
 		if(xodtemplate_recombobulate_servicegroup_subgroups(temp_servicegroup) != XOD_OK) {
 			return ERROR;
-			}
+		}
 		/* rejects are no longer necessary */
 		bitmap_destroy(temp_servicegroup->reject_map);
 		/* make sure we don't recursively add subgroup members again */
 		free_objectlist(&temp_servicegroup->group_list);
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -6624,7 +6403,8 @@ int xodtemplate_recombobulate_servicegroups(void) {
 #ifdef NSCORE
 
 /* finds a specific timeperiod object */
-xodtemplate_timeperiod *xodtemplate_find_timeperiod(char *name) {
+xodtemplate_timeperiod *xodtemplate_find_timeperiod(char *name)
+{
 	xodtemplate_timeperiod temp_timeperiod;
 
 	if(name == NULL)
@@ -6633,11 +6413,12 @@ xodtemplate_timeperiod *xodtemplate_find_timeperiod(char *name) {
 	temp_timeperiod.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[TIMEPERIOD_SKIPLIST], &temp_timeperiod, NULL);
-	}
+}
 
 
 /* finds a specific command object */
-xodtemplate_command *xodtemplate_find_command(char *name) {
+xodtemplate_command *xodtemplate_find_command(char *name)
+{
 	xodtemplate_command temp_command;
 
 	if(name == NULL)
@@ -6646,12 +6427,13 @@ xodtemplate_command *xodtemplate_find_command(char *name) {
 	temp_command.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[COMMAND_SKIPLIST], &temp_command, NULL);
-	}
+}
 
 #endif
 
 /* finds a specific contactgroup object */
-xodtemplate_contactgroup *xodtemplate_find_contactgroup(char *name) {
+xodtemplate_contactgroup *xodtemplate_find_contactgroup(char *name)
+{
 	xodtemplate_contactgroup temp_contactgroup;
 
 	if(name == NULL)
@@ -6660,11 +6442,12 @@ xodtemplate_contactgroup *xodtemplate_find_contactgroup(char *name) {
 	temp_contactgroup.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[CONTACTGROUP_SKIPLIST], &temp_contactgroup, NULL);
-	}
+}
 
 
 /* finds a specific contactgroup object by its REAL name, not its TEMPLATE name */
-xodtemplate_contactgroup *xodtemplate_find_real_contactgroup(char *name) {
+xodtemplate_contactgroup *xodtemplate_find_real_contactgroup(char *name)
+{
 	xodtemplate_contactgroup temp_contactgroup;
 
 	if(name == NULL)
@@ -6673,11 +6456,12 @@ xodtemplate_contactgroup *xodtemplate_find_real_contactgroup(char *name) {
 	temp_contactgroup.contactgroup_name = name;
 
 	return skiplist_find_first(xobject_skiplists[CONTACTGROUP_SKIPLIST], &temp_contactgroup, NULL);
-	}
+}
 
 
 /* finds a specific hostgroup object */
-xodtemplate_hostgroup *xodtemplate_find_hostgroup(char *name) {
+xodtemplate_hostgroup *xodtemplate_find_hostgroup(char *name)
+{
 	xodtemplate_hostgroup temp_hostgroup;
 
 	if(name == NULL)
@@ -6686,11 +6470,12 @@ xodtemplate_hostgroup *xodtemplate_find_hostgroup(char *name) {
 	temp_hostgroup.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[HOSTGROUP_SKIPLIST], &temp_hostgroup, NULL);
-	}
+}
 
 
 /* finds a specific hostgroup object by its REAL name, not its TEMPLATE name */
-xodtemplate_hostgroup *xodtemplate_find_real_hostgroup(char *name) {
+xodtemplate_hostgroup *xodtemplate_find_real_hostgroup(char *name)
+{
 	xodtemplate_hostgroup temp_hostgroup;
 
 	if(name == NULL)
@@ -6699,11 +6484,12 @@ xodtemplate_hostgroup *xodtemplate_find_real_hostgroup(char *name) {
 	temp_hostgroup.hostgroup_name = name;
 
 	return skiplist_find_first(xobject_skiplists[HOSTGROUP_SKIPLIST], &temp_hostgroup, NULL);
-	}
+}
 
 
 /* finds a specific servicegroup object */
-xodtemplate_servicegroup *xodtemplate_find_servicegroup(char *name) {
+xodtemplate_servicegroup *xodtemplate_find_servicegroup(char *name)
+{
 	xodtemplate_servicegroup temp_servicegroup;
 
 	if(name == NULL)
@@ -6712,11 +6498,12 @@ xodtemplate_servicegroup *xodtemplate_find_servicegroup(char *name) {
 	temp_servicegroup.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[SERVICEGROUP_SKIPLIST], &temp_servicegroup, NULL);
-	}
+}
 
 
 /* finds a specific servicegroup object by its REAL name, not its TEMPLATE name */
-xodtemplate_servicegroup *xodtemplate_find_real_servicegroup(char *name) {
+xodtemplate_servicegroup *xodtemplate_find_real_servicegroup(char *name)
+{
 	xodtemplate_servicegroup temp_servicegroup;
 
 	if(name == NULL)
@@ -6725,11 +6512,12 @@ xodtemplate_servicegroup *xodtemplate_find_real_servicegroup(char *name) {
 	temp_servicegroup.servicegroup_name = name;
 
 	return skiplist_find_first(xobject_skiplists[SERVICEGROUP_SKIPLIST], &temp_servicegroup, NULL);
-	}
+}
 
 
 /* finds a specific servicedependency object */
-xodtemplate_servicedependency *xodtemplate_find_servicedependency(char *name) {
+xodtemplate_servicedependency *xodtemplate_find_servicedependency(char *name)
+{
 	xodtemplate_servicedependency temp_servicedependency;
 
 	if(name == NULL)
@@ -6738,11 +6526,12 @@ xodtemplate_servicedependency *xodtemplate_find_servicedependency(char *name) {
 	temp_servicedependency.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[SERVICEDEPENDENCY_SKIPLIST], &temp_servicedependency, NULL);
-	}
+}
 
 
 /* finds a specific serviceescalation object */
-xodtemplate_serviceescalation *xodtemplate_find_serviceescalation(char *name) {
+xodtemplate_serviceescalation *xodtemplate_find_serviceescalation(char *name)
+{
 	xodtemplate_serviceescalation temp_serviceescalation;
 
 	if(name == NULL)
@@ -6751,11 +6540,12 @@ xodtemplate_serviceescalation *xodtemplate_find_serviceescalation(char *name) {
 	temp_serviceescalation.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[SERVICEESCALATION_SKIPLIST], &temp_serviceescalation, NULL);
-	}
+}
 
 
 /* finds a specific contact object */
-xodtemplate_contact *xodtemplate_find_contact(char *name) {
+xodtemplate_contact *xodtemplate_find_contact(char *name)
+{
 	xodtemplate_contact temp_contact;
 
 	if(name == NULL)
@@ -6764,11 +6554,12 @@ xodtemplate_contact *xodtemplate_find_contact(char *name) {
 	temp_contact.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[CONTACT_SKIPLIST], &temp_contact, NULL);
-	}
+}
 
 
 /* finds a specific contact object by its REAL name, not its TEMPLATE name */
-xodtemplate_contact *xodtemplate_find_real_contact(char *name) {
+xodtemplate_contact *xodtemplate_find_real_contact(char *name)
+{
 	xodtemplate_contact temp_contact;
 
 	if(name == NULL)
@@ -6777,11 +6568,12 @@ xodtemplate_contact *xodtemplate_find_real_contact(char *name) {
 	temp_contact.contact_name = name;
 
 	return skiplist_find_first(xobject_skiplists[CONTACT_SKIPLIST], &temp_contact, NULL);
-	}
+}
 
 
 /* finds a specific host object */
-xodtemplate_host *xodtemplate_find_host(char *name) {
+xodtemplate_host *xodtemplate_find_host(char *name)
+{
 	xodtemplate_host temp_host;
 
 	if(name == NULL)
@@ -6790,11 +6582,12 @@ xodtemplate_host *xodtemplate_find_host(char *name) {
 	temp_host.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[HOST_SKIPLIST], &temp_host, NULL);
-	}
+}
 
 
 /* finds a specific host object by its REAL name, not its TEMPLATE name */
-xodtemplate_host *xodtemplate_find_real_host(char *name) {
+xodtemplate_host *xodtemplate_find_real_host(char *name)
+{
 	xodtemplate_host temp_host;
 
 	if(name == NULL)
@@ -6803,11 +6596,12 @@ xodtemplate_host *xodtemplate_find_real_host(char *name) {
 	temp_host.host_name = name;
 
 	return skiplist_find_first(xobject_skiplists[HOST_SKIPLIST], &temp_host, NULL);
-	}
+}
 
 
 /* finds a specific hostdependency object */
-xodtemplate_hostdependency *xodtemplate_find_hostdependency(char *name) {
+xodtemplate_hostdependency *xodtemplate_find_hostdependency(char *name)
+{
 	xodtemplate_hostdependency temp_hostdependency;
 
 	if(name == NULL)
@@ -6816,11 +6610,12 @@ xodtemplate_hostdependency *xodtemplate_find_hostdependency(char *name) {
 	temp_hostdependency.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[HOSTDEPENDENCY_SKIPLIST], &temp_hostdependency, NULL);
-	}
+}
 
 
 /* finds a specific hostescalation object */
-xodtemplate_hostescalation *xodtemplate_find_hostescalation(char *name) {
+xodtemplate_hostescalation *xodtemplate_find_hostescalation(char *name)
+{
 	xodtemplate_hostescalation temp_hostescalation;
 
 	if(name == NULL)
@@ -6829,11 +6624,12 @@ xodtemplate_hostescalation *xodtemplate_find_hostescalation(char *name) {
 	temp_hostescalation.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[HOSTESCALATION_SKIPLIST], &temp_hostescalation, NULL);
-	}
+}
 
 
 /* finds a specific hostextinfo object */
-xodtemplate_hostextinfo *xodtemplate_find_hostextinfo(char *name) {
+xodtemplate_hostextinfo *xodtemplate_find_hostextinfo(char *name)
+{
 	xodtemplate_hostextinfo temp_hostextinfo;
 
 	if(name == NULL)
@@ -6842,11 +6638,12 @@ xodtemplate_hostextinfo *xodtemplate_find_hostextinfo(char *name) {
 	temp_hostextinfo.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[HOSTEXTINFO_SKIPLIST], &temp_hostextinfo, NULL);
-	}
+}
 
 
 /* finds a specific serviceextinfo object */
-xodtemplate_serviceextinfo *xodtemplate_find_serviceextinfo(char *name) {
+xodtemplate_serviceextinfo *xodtemplate_find_serviceextinfo(char *name)
+{
 	xodtemplate_serviceextinfo temp_serviceextinfo;
 
 	if(name == NULL)
@@ -6855,11 +6652,12 @@ xodtemplate_serviceextinfo *xodtemplate_find_serviceextinfo(char *name) {
 	temp_serviceextinfo.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[SERVICEEXTINFO_SKIPLIST], &temp_serviceextinfo, NULL);
-	}
+}
 
 
 /* finds a specific service object */
-xodtemplate_service *xodtemplate_find_service(char *name) {
+xodtemplate_service *xodtemplate_find_service(char *name)
+{
 	xodtemplate_service temp_service;
 
 	if(name == NULL)
@@ -6868,10 +6666,11 @@ xodtemplate_service *xodtemplate_find_service(char *name) {
 	temp_service.name = name;
 
 	return skiplist_find_first(xobject_template_skiplists[SERVICE_SKIPLIST], &temp_service, NULL);
-	}
+}
 
 /* finds a specific service object by its REAL name, not its TEMPLATE name */
-xodtemplate_service *xodtemplate_find_real_service(char *host_name, char *service_description) {
+xodtemplate_service *xodtemplate_find_real_service(char *host_name, char *service_description)
+{
 	xodtemplate_service temp_service;
 
 	if(host_name == NULL || service_description == NULL)
@@ -6881,7 +6680,7 @@ xodtemplate_service *xodtemplate_find_real_service(char *host_name, char *servic
 	temp_service.service_description = service_description;
 
 	return skiplist_find_first(xobject_skiplists[SERVICE_SKIPLIST], &temp_service, NULL);
-	}
+}
 
 
 
@@ -6905,9 +6704,9 @@ static int xodtemplate_register_contactgroup_members(xodtemplate_contactgroup *t
 		if (!add_contact_to_contactgroup(cg, c->contact_name)) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Bad member of contactgroup '%s' (config file '%s', starting on line %d)\n", cg->group_name, xodtemplate_config_file_name(this_contactgroup->_config_file), this_contactgroup->_start_line);
 			return -1;
-			}
-		num_regs++;
 		}
+		num_regs++;
+	}
 	return num_regs;
 }
 
@@ -6926,11 +6725,11 @@ static int xodtemplate_register_hostgroup_members(xodtemplate_hostgroup *this_ho
 		if (!add_host_to_hostgroup(hg, h->host_name)) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Bad member of hostgrop '%s' (config file '%s', starting on line %d)\n", hg->group_name, xodtemplate_config_file_name(this_hostgroup->_config_file), this_hostgroup->_start_line);
 			return -1;
-			}
-		num_regs++;
 		}
-	return num_regs;
+		num_regs++;
 	}
+	return num_regs;
+}
 
 static int xodtemplate_register_servicegroup_members(xodtemplate_servicegroup *this_servicegroup)
 {
@@ -6948,12 +6747,12 @@ static int xodtemplate_register_servicegroup_members(xodtemplate_servicegroup *t
 		if (!add_service_to_servicegroup(sg, s->host_name, s->service_description)) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Bad member of servicegroup '%s' (config file '%s', starting on line %d)\n", sg->group_name, xodtemplate_config_file_name(this_servicegroup->_config_file), this_servicegroup->_start_line);
 			return -1;
-			}
-		num_regs++;
 		}
+		num_regs++;
+	}
 
 	return num_regs;
-	}
+}
 
 /*
  * registers object definitions
@@ -6976,7 +6775,8 @@ static int xodtemplate_register_servicegroup_members(xodtemplate_servicegroup *t
  * objects directly rather than forcing us to fiddle with that crap
  * during runtime.
  */
-int xodtemplate_register_objects(void) {
+int xodtemplate_register_objects(void)
+{
 	unsigned int i;
 	int mcount;
 	xodtemplate_timeperiod *temp_timeperiod = NULL;
@@ -7016,7 +6816,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_timeperiod = (xodtemplate_timeperiod *)skiplist_get_first(xobject_skiplists[TIMEPERIOD_SKIPLIST], &ptr); temp_timeperiod != NULL; temp_timeperiod = (xodtemplate_timeperiod *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_timeperiod(temp_timeperiod) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u timeperiods registered\n", num_objects.timeperiods);
 
 	/* register commands */
@@ -7024,7 +6824,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_command = (xodtemplate_command *)skiplist_get_first(xobject_skiplists[COMMAND_SKIPLIST], &ptr); temp_command != NULL; temp_command = (xodtemplate_command *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_command(temp_command) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u commands registered\n", num_objects.commands);
 
 	/* register contactgroups */
@@ -7032,7 +6832,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_contactgroup = (xodtemplate_contactgroup *)skiplist_get_first(xobject_skiplists[CONTACTGROUP_SKIPLIST], &ptr); temp_contactgroup != NULL; temp_contactgroup = (xodtemplate_contactgroup *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_contactgroup(temp_contactgroup) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u contactgroups registered\n", num_objects.contactgroups);
 
 	/* register hostgroups */
@@ -7040,7 +6840,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_hostgroup = (xodtemplate_hostgroup *)skiplist_get_first(xobject_skiplists[HOSTGROUP_SKIPLIST], &ptr); temp_hostgroup != NULL; temp_hostgroup = (xodtemplate_hostgroup *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_hostgroup(temp_hostgroup) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u hostgroups registered\n", num_objects.hostgroups);
 
 	/* register servicegroups */
@@ -7048,7 +6848,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_servicegroup = (xodtemplate_servicegroup *)skiplist_get_first(xobject_skiplists[SERVICEGROUP_SKIPLIST], &ptr); temp_servicegroup != NULL; temp_servicegroup = (xodtemplate_servicegroup *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_servicegroup(temp_servicegroup) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u servicegroups registered\n", num_objects.servicegroups);
 
 	/* register contacts */
@@ -7056,7 +6856,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_contact = (xodtemplate_contact *)skiplist_get_first(xobject_skiplists[CONTACT_SKIPLIST], &ptr); temp_contact != NULL; temp_contact = (xodtemplate_contact *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_contact(temp_contact) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u contacts registered\n", num_objects.contacts);
 
 	/* register hosts */
@@ -7064,7 +6864,7 @@ int xodtemplate_register_objects(void) {
 	for(temp_host = (xodtemplate_host *)skiplist_get_first(xobject_skiplists[HOST_SKIPLIST], &ptr); temp_host != NULL; temp_host = (xodtemplate_host *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_host(temp_host) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u hosts registered\n", num_objects.hosts);
 
 	/* register services */
@@ -7072,35 +6872,38 @@ int xodtemplate_register_objects(void) {
 	for(temp_service = (xodtemplate_service *)skiplist_get_first(xobject_skiplists[SERVICE_SKIPLIST], &ptr); temp_service != NULL; temp_service = (xodtemplate_service *)skiplist_get_next(&ptr)) {
 		if(xodtemplate_register_service(temp_service) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u services registered\n", num_objects.services);
 
 	/* groups and objects are registered, so join them up */
 	/* register contactgroup members */
-	ptr = NULL; tot_members = 0;
+	ptr = NULL;
+	tot_members = 0;
 	for(temp_contactgroup = (xodtemplate_contactgroup *)skiplist_get_first(xobject_skiplists[CONTACTGROUP_SKIPLIST], &ptr); temp_contactgroup != NULL; temp_contactgroup = (xodtemplate_contactgroup *)skiplist_get_next(&ptr)) {
 		if((mcount = xodtemplate_register_contactgroup_members(temp_contactgroup)) < 0)
-			return ERROR;
+			   return ERROR;
 		tot_members += mcount;
-		}
+	}
 	timing_point("%u contactgroup memberships registered\n", tot_members);
 
 	/* register hostgroup members */
-	ptr = NULL; tot_members = 0;
+	ptr = NULL;
+	tot_members = 0;
 	for(temp_hostgroup = (xodtemplate_hostgroup *)skiplist_get_first(xobject_skiplists[HOSTGROUP_SKIPLIST], &ptr); temp_hostgroup != NULL; temp_hostgroup = (xodtemplate_hostgroup *)skiplist_get_next(&ptr)) {
 		if((mcount = xodtemplate_register_hostgroup_members(temp_hostgroup)) < 0)
-			return ERROR;
+			   return ERROR;
 		tot_members += mcount;
-		}
+	}
 	timing_point("%u hostgroup memberships registered\n", tot_members);
 
 	/* register servicegroup members */
-	ptr = NULL; tot_members = 0;
+	ptr = NULL;
+	tot_members = 0;
 	for(temp_servicegroup = (xodtemplate_servicegroup *)skiplist_get_first(xobject_skiplists[SERVICEGROUP_SKIPLIST], &ptr); temp_servicegroup != NULL; temp_servicegroup = (xodtemplate_servicegroup *)skiplist_get_next(&ptr)) {
 		if((mcount = xodtemplate_register_servicegroup_members(temp_servicegroup)) < 0)
-			return ERROR;
+			   return ERROR;
 		tot_members += mcount;
-		}
+	}
 	timing_point("%u servicegroup memberships registered\n", tot_members);
 
 	/*
@@ -7112,7 +6915,7 @@ int xodtemplate_register_objects(void) {
 		if(!parent_map) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to create parent bitmap for service dependencies\n");
 			return ERROR;
-			}
+		}
 		for(sd = xodtemplate_servicedependency_list; sd; sd = next_sd) {
 			next_sd = sd->next;
 #ifdef NSCGI
@@ -7122,18 +6925,18 @@ int xodtemplate_register_objects(void) {
 			if(xodtemplate_register_and_destroy_servicedependency(sd) == ERROR)
 				return ERROR;
 #endif
-			}
+		}
 		bitmap_destroy(parent_map);
 		parent_map = NULL;
-		}
+	}
 	timing_point("%u unique / %u total servicedependencies registered\n",
-				 num_objects.servicedependencies, xodcount.servicedependencies);
+	             num_objects.servicedependencies, xodcount.servicedependencies);
 
 	for(se = xodtemplate_serviceescalation_list; se; se = next_se) {
 		next_se = se->next;
 		if(xodtemplate_register_and_destroy_serviceescalation(se) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u serviceescalations registered\n", num_objects.serviceescalations);
 
 	for(hd = xodtemplate_hostdependency_list; hd; hd = next_hd) {
@@ -7145,24 +6948,25 @@ int xodtemplate_register_objects(void) {
 		if(xodtemplate_register_and_destroy_hostdependency(hd) == ERROR)
 			return ERROR;
 #endif
-		}
+	}
 	timing_point("%u unique / %u total hostdependencies registered\n",
-				 num_objects.hostdependencies, xodcount.hostdependencies);
+	             num_objects.hostdependencies, xodcount.hostdependencies);
 
 	for(he = xodtemplate_hostescalation_list; he; he = next_he) {
 		next_he = he->next;
 		if(xodtemplate_register_and_destroy_hostescalation(he) == ERROR)
 			return ERROR;
-		}
+	}
 	timing_point("%u hostescalations registered\n", num_objects.hostescalations);
 
 	return OK;
-	}
+}
 
 
 
 /* registers a timeperiod definition */
-int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
+int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod)
+{
 	xodtemplate_daterange *temp_daterange = NULL;
 	timeperiod *new_timeperiod = NULL;
 	daterange *new_daterange = NULL;
@@ -7189,7 +6993,7 @@ int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 	if(new_timeperiod == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register timeperiod (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* add all exceptions to timeperiod */
 	for(x = 0; x < DATERANGE_TYPES; x++) {
@@ -7204,7 +7008,7 @@ int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 			if(new_daterange == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add date exception to timeperiod (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 				return ERROR;
-				}
+			}
 
 			/* add timeranges to exception */
 			day_range_ptr = temp_daterange->timeranges;
@@ -7217,17 +7021,17 @@ int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 				if(xodtemplate_get_time_ranges(day_range_start_buffer, &range_start_time, &range_end_time) == ERROR) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not parse timerange #%d of timeperiod (config file '%s', starting on line %d)\n", range, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 					return ERROR;
-					}
+				}
 
 				/* add the new time range to the date range */
 				new_timerange = add_timerange_to_daterange(new_daterange, range_start_time, range_end_time);
 				if(new_timerange == NULL) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add timerange #%d to timeperiod (config file '%s', starting on line %d)\n", range, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 					return ERROR;
-					}
 				}
 			}
 		}
+	}
 
 	/* add all necessary timeranges to timeperiod */
 	for(day = 0; day < 7; day++) {
@@ -7246,17 +7050,17 @@ int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 			if(xodtemplate_get_time_ranges(day_range_start_buffer, &range_start_time, &range_end_time) == ERROR) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not parse timerange #%d for day %d of timeperiod (config file '%s', starting on line %d)\n", range, day, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 				return ERROR;
-				}
+			}
 
 			/* add the new time range to the time period */
 			new_timerange = add_timerange_to_timeperiod(new_timeperiod, day, range_start_time, range_end_time);
 			if(new_timerange == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add timerange #%d for day %d to timeperiod (config file '%s', starting on line %d)\n", range, day, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 				return ERROR;
-				}
 			}
-
 		}
+
+	}
 
 	/* add timeperiod exclusions */
 	if(this_timeperiod->exclusions) {
@@ -7266,17 +7070,18 @@ int xodtemplate_register_timeperiod(xodtemplate_timeperiod *this_timeperiod) {
 			if(new_timeperiodexclusion == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add excluded timeperiod '%s' to timeperiod (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(this_timeperiod->_config_file), this_timeperiod->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* parses timerange string into start and end minutes */
-int xodtemplate_get_time_ranges(char *buf, unsigned long *range_start, unsigned long *range_end) {
+int xodtemplate_get_time_ranges(char *buf, unsigned long *range_start, unsigned long *range_end)
+{
 	char *range_ptr = NULL;
 	char *range_buffer = NULL;
 	char *time_ptr = NULL;
@@ -7325,12 +7130,13 @@ int xodtemplate_get_time_ranges(char *buf, unsigned long *range_start, unsigned 
 	*range_end = (unsigned long)((minutes * 60) + (hours * 3600));
 
 	return OK;
-	}
+}
 
 
 
 /* registers a command definition */
-int xodtemplate_register_command(xodtemplate_command *this_command) {
+int xodtemplate_register_command(xodtemplate_command *this_command)
+{
 	command *new_command = NULL;
 
 	/* bail out if we shouldn't register this object */
@@ -7344,14 +7150,15 @@ int xodtemplate_register_command(xodtemplate_command *this_command) {
 	if(new_command == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register command (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_command->_config_file), this_command->_start_line);
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* registers a contactgroup definition */
-int xodtemplate_register_contactgroup(xodtemplate_contactgroup *this_contactgroup) {
+int xodtemplate_register_contactgroup(xodtemplate_contactgroup *this_contactgroup)
+{
 	contactgroup *new_contactgroup = NULL;
 
 	/* bail out if we shouldn't register this object */
@@ -7365,15 +7172,16 @@ int xodtemplate_register_contactgroup(xodtemplate_contactgroup *this_contactgrou
 	if(new_contactgroup == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register contactgroup (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_contactgroup->_config_file), this_contactgroup->_start_line);
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a hostgroup definition */
-int xodtemplate_register_hostgroup(xodtemplate_hostgroup *this_hostgroup) {
+int xodtemplate_register_hostgroup(xodtemplate_hostgroup *this_hostgroup)
+{
 	hostgroup *new_hostgroup = NULL;
 
 	/* bail out if we shouldn't register this object */
@@ -7387,13 +7195,14 @@ int xodtemplate_register_hostgroup(xodtemplate_hostgroup *this_hostgroup) {
 	if(new_hostgroup == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register hostgroup (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_hostgroup->_config_file), this_hostgroup->_start_line);
 		return ERROR;
-		}
-
-	return OK;
 	}
 
+	return OK;
+}
+
 /* registers a servicegroup definition */
-int xodtemplate_register_servicegroup(xodtemplate_servicegroup *this_servicegroup) {
+int xodtemplate_register_servicegroup(xodtemplate_servicegroup *this_servicegroup)
+{
 	servicegroup *new_servicegroup = NULL;
 
 	/* bail out if we shouldn't register this object */
@@ -7407,14 +7216,15 @@ int xodtemplate_register_servicegroup(xodtemplate_servicegroup *this_servicegrou
 	if(new_servicegroup == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register servicegroup (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_servicegroup->_config_file), this_servicegroup->_start_line);
 		return ERROR;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* registers a servicedependency definition */
-int xodtemplate_register_servicedependency(xodtemplate_servicedependency *this_servicedependency) {
+int xodtemplate_register_servicedependency(xodtemplate_servicedependency *this_servicedependency)
+{
 	servicedependency *new_servicedependency = NULL;
 
 	/* bail out if we shouldn't register this object */
@@ -7425,7 +7235,7 @@ int xodtemplate_register_servicedependency(xodtemplate_servicedependency *this_s
 	if(this_servicedependency->have_notification_failure_options == FALSE && this_servicedependency->have_execution_failure_options == FALSE) {
 		logit(NSLOG_CONFIG_WARNING, TRUE, "Warning: Ignoring lame service dependency (config file '%s', line %d)\n", xodtemplate_config_file_name(this_servicedependency->_config_file), this_servicedependency->_start_line);
 		return OK;
-		}
+	}
 
 	/* add the servicedependency */
 	if(this_servicedependency->have_execution_failure_options == TRUE) {
@@ -7437,8 +7247,8 @@ int xodtemplate_register_servicedependency(xodtemplate_servicedependency *this_s
 		if(new_servicedependency == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register service execution dependency (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_servicedependency->_config_file), this_servicedependency->_start_line);
 			return ERROR;
-			}
 		}
+	}
 	if(this_servicedependency->have_notification_failure_options == TRUE) {
 		xodcount.servicedependencies++;
 
@@ -7448,16 +7258,17 @@ int xodtemplate_register_servicedependency(xodtemplate_servicedependency *this_s
 		if(new_servicedependency == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register service notification dependency (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_servicedependency->_config_file), this_servicedependency->_start_line);
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a serviceescalation definition */
-int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation *this_serviceescalation) {
+int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation *this_serviceescalation)
+{
 	serviceescalation *new_serviceescalation = NULL;
 	contactsmember *new_contactsmember = NULL;
 	contactgroupsmember *new_contactgroupsmember = NULL;
@@ -7471,7 +7282,7 @@ int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation *this_s
 	/* default options if none specified */
 	if(this_serviceescalation->have_escalation_options == FALSE) {
 		this_serviceescalation->escalation_options = OPT_ALL;
-		}
+	}
 
 	/* add the serviceescalation */
 	new_serviceescalation = add_serviceescalation(this_serviceescalation->host_name, this_serviceescalation->service_description, this_serviceescalation->first_notification, this_serviceescalation->last_notification, this_serviceescalation->notification_interval, this_serviceescalation->escalation_period, this_serviceescalation->escalation_options);
@@ -7480,7 +7291,7 @@ int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation *this_s
 	if(new_serviceescalation == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register service escalation (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_serviceescalation->_config_file), this_serviceescalation->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* add the contact groups */
 	if(this_serviceescalation->contact_groups != NULL) {
@@ -7492,9 +7303,9 @@ int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation *this_s
 			if(new_contactgroupsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contactgroup '%s' to service escalation (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_serviceescalation->_config_file), this_serviceescalation->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add the contacts */
 	if(this_serviceescalation->contacts != NULL) {
@@ -7506,17 +7317,18 @@ int xodtemplate_register_serviceescalation(xodtemplate_serviceescalation *this_s
 			if(new_contactsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contact '%s' to service escalation (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_serviceescalation->_config_file), this_serviceescalation->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a contact definition */
-int xodtemplate_register_contact(xodtemplate_contact *this_contact) {
+int xodtemplate_register_contact(xodtemplate_contact *this_contact)
+{
 	contact *new_contact = NULL;
 	char *command_name = NULL;
 	commandsmember *new_commandsmember = NULL;
@@ -7533,7 +7345,7 @@ int xodtemplate_register_contact(xodtemplate_contact *this_contact) {
 	if(new_contact == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register contact (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_contact->_config_file), this_contact->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* add all the host notification commands */
 	if(this_contact->host_notification_commands != NULL) {
@@ -7543,9 +7355,9 @@ int xodtemplate_register_contact(xodtemplate_contact *this_contact) {
 			if(new_commandsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add host notification command '%s' to contact (config file '%s', starting on line %d)\n", command_name, xodtemplate_config_file_name(this_contact->_config_file), this_contact->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all the service notification commands */
 	if(this_contact->service_notification_commands != NULL) {
@@ -7555,25 +7367,26 @@ int xodtemplate_register_contact(xodtemplate_contact *this_contact) {
 			if(new_commandsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add service notification command '%s' to contact (config file '%s', starting on line %d)\n", command_name, xodtemplate_config_file_name(this_contact->_config_file), this_contact->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all custom variables */
 	for(temp_customvariablesmember = this_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 		if((add_custom_variable_to_contact(new_contact, temp_customvariablesmember->variable_name, temp_customvariablesmember->variable_value)) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not custom variable to contact (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_contact->_config_file), this_contact->_start_line);
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a host definition */
-int xodtemplate_register_host(xodtemplate_host *this_host) {
+int xodtemplate_register_host(xodtemplate_host *this_host)
+{
 	host *new_host = NULL;
 	char *parent_host = NULL;
 	hostsmember *new_hostsmember = NULL;
@@ -7595,7 +7408,7 @@ int xodtemplate_register_host(xodtemplate_host *this_host) {
 	if(new_host == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register host (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* add the parent hosts */
 	if(this_host->parents != NULL) {
@@ -7606,9 +7419,9 @@ int xodtemplate_register_host(xodtemplate_host *this_host) {
 			if(new_hostsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add parent host '%s' to host (config file '%s', starting on line %d)\n", parent_host, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all contact groups to the host */
 	if(this_host->contact_groups != NULL) {
@@ -7620,9 +7433,9 @@ int xodtemplate_register_host(xodtemplate_host *this_host) {
 			if(new_contactgroupsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contactgroup '%s' to host (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all contacts to the host */
 	if(this_host->contacts != NULL) {
@@ -7634,25 +7447,26 @@ int xodtemplate_register_host(xodtemplate_host *this_host) {
 			if(new_contactsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contact '%s' to host (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all custom variables */
 	for(temp_customvariablesmember = this_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 		if((add_custom_variable_to_host(new_host, temp_customvariablesmember->variable_name, temp_customvariablesmember->variable_value)) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not custom variable to host (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_host->_config_file), this_host->_start_line);
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a service definition */
-int xodtemplate_register_service(xodtemplate_service *this_service) {
+int xodtemplate_register_service(xodtemplate_service *this_service)
+{
 	service *new_service = NULL;
 	contactsmember *new_contactsmember = NULL;
 	contactgroupsmember *new_contactgroupsmember = NULL;
@@ -7671,7 +7485,7 @@ int xodtemplate_register_service(xodtemplate_service *this_service) {
 	if(new_service == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register service (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_service->_config_file), this_service->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* add all service parents */
 	if(this_service->parents != NULL) {
@@ -7682,22 +7496,21 @@ int xodtemplate_register_service(xodtemplate_service *this_service) {
 			new_servicesmember = add_parent_service_to_service(new_service, new_service->host_name, this_service->parents);
 			if(new_servicesmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add same-host service parent '%s' to service (config file '%s', starting on line %d)\n",
-					  this_service->parents,
-					  xodtemplate_config_file_name(this_service->_config_file),
-					  this_service->_start_line);
+				      this_service->parents,
+				      xodtemplate_config_file_name(this_service->_config_file),
+				      this_service->_start_line);
 				return ERROR;
-				}
 			}
-		else {
+		} else {
 			/* Multiple parents, so let's do this the hard way */
 			objectlist *list = NULL, *next;
 			bitmap_clear(service_map);
 			if(xodtemplate_expand_services(&list, service_map, NULL, this_service->parents, this_service->_config_file, this_service->_start_line) != OK) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Failed to expand service parents (config file '%s', starting at line %d)\n",
-					  xodtemplate_config_file_name(this_service->_config_file),
-					  this_service->_start_line);
+				      xodtemplate_config_file_name(this_service->_config_file),
+				      this_service->_start_line);
 				return ERROR;
-				}
+			}
 			for(; list; list = next) {
 				xodtemplate_service *parent = (xodtemplate_service *)list->object_ptr;
 				next = list->next;
@@ -7705,16 +7518,16 @@ int xodtemplate_register_service(xodtemplate_service *this_service) {
 				new_servicesmember = add_parent_service_to_service(new_service, parent->host_name, parent->service_description);
 				if(new_servicesmember == NULL) {
 					logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add service '%s' on host '%s' as parent to service '%s' on host '%s' (config file '%s', starting on line %d)\n",
-						  parent->host_name, parent->service_description,
-						  new_service->host_name, new_service->description,
-						  xodtemplate_config_file_name(this_service->_config_file),
-						  this_service->_start_line);
+					      parent->host_name, parent->service_description,
+					      new_service->host_name, new_service->description,
+					      xodtemplate_config_file_name(this_service->_config_file),
+					      this_service->_start_line);
 					free_objectlist(&next);
 					return ERROR;
-					}
 				}
 			}
 		}
+	}
 
 	/* add all contact groups to the service */
 	if(this_service->contact_groups != NULL) {
@@ -7726,9 +7539,9 @@ int xodtemplate_register_service(xodtemplate_service *this_service) {
 			if(new_contactgroupsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contactgroup '%s' to service (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_service->_config_file), this_service->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all the contacts to the service */
 	if(this_service->contacts != NULL) {
@@ -7743,25 +7556,26 @@ int xodtemplate_register_service(xodtemplate_service *this_service) {
 			if(new_contactsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contact '%s' to service (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_service->_config_file), this_service->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add all custom variables */
 	for(temp_customvariablesmember = this_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 		if((add_custom_variable_to_service(new_service, temp_customvariablesmember->variable_name, temp_customvariablesmember->variable_value)) == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not custom variable to service (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_service->_config_file), this_service->_start_line);
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a hostdependency definition */
-int xodtemplate_register_hostdependency(xodtemplate_hostdependency *this_hostdependency) {
+int xodtemplate_register_hostdependency(xodtemplate_hostdependency *this_hostdependency)
+{
 	hostdependency *new_hostdependency = NULL;
 
 	/* bail out if we shouldn't register this object */
@@ -7778,8 +7592,8 @@ int xodtemplate_register_hostdependency(xodtemplate_hostdependency *this_hostdep
 		if(new_hostdependency == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register host execution dependency (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_hostdependency->_config_file), this_hostdependency->_start_line);
 			return ERROR;
-			}
 		}
+	}
 
 	/* add the host notification dependency */
 	if(this_hostdependency->have_notification_failure_options == TRUE) {
@@ -7791,16 +7605,17 @@ int xodtemplate_register_hostdependency(xodtemplate_hostdependency *this_hostdep
 		if(new_hostdependency == NULL) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register host notification dependency (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_hostdependency->_config_file), this_hostdependency->_start_line);
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
 /* registers a hostescalation definition */
-int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostescalation) {
+int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostescalation)
+{
 	hostescalation *new_hostescalation = NULL;
 	contactsmember *new_contactsmember = NULL;
 	contactgroupsmember *new_contactgroupsmember = NULL;
@@ -7814,7 +7629,7 @@ int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostesc
 	/* default options if none specified */
 	if(this_hostescalation->have_escalation_options == FALSE) {
 		this_hostescalation->escalation_options = OPT_ALL;
-		}
+	}
 
 	/* add the hostescalation */
 	new_hostescalation = add_hostescalation(this_hostescalation->host_name, this_hostescalation->first_notification, this_hostescalation->last_notification, this_hostescalation->notification_interval, this_hostescalation->escalation_period, this_hostescalation->escalation_options);
@@ -7823,7 +7638,7 @@ int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostesc
 	if(new_hostescalation == NULL) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not register host escalation (config file '%s', starting on line %d)\n", xodtemplate_config_file_name(this_hostescalation->_config_file), this_hostescalation->_start_line);
 		return ERROR;
-		}
+	}
 
 	/* add all contact groups */
 	if(this_hostescalation->contact_groups != NULL) {
@@ -7835,9 +7650,9 @@ int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostesc
 			if(new_contactgroupsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contactgroup '%s' to host escalation (config file '%s', starting on line %d)\n", contact_group, xodtemplate_config_file_name(this_hostescalation->_config_file), this_hostescalation->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	/* add the contacts */
 	if(this_hostescalation->contacts != NULL) {
@@ -7849,12 +7664,12 @@ int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostesc
 			if(new_contactsmember == NULL) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not add contact '%s' to host escalation (config file '%s', starting on line %d)\n", contact_name, xodtemplate_config_file_name(this_hostescalation->_config_file), this_hostescalation->_start_line);
 				return ERROR;
-				}
 			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 
@@ -7866,7 +7681,8 @@ int xodtemplate_register_hostescalation(xodtemplate_hostescalation *this_hostesc
 #ifdef NSCORE
 
 /* merges a service extinfo definition */
-int xodtemplate_merge_service_extinfo_object(xodtemplate_service *this_service, xodtemplate_serviceextinfo *this_serviceextinfo) {
+int xodtemplate_merge_service_extinfo_object(xodtemplate_service *this_service, xodtemplate_serviceextinfo *this_serviceextinfo)
+{
 
 	if(this_service == NULL || this_serviceextinfo == NULL)
 		return ERROR;
@@ -7883,11 +7699,12 @@ int xodtemplate_merge_service_extinfo_object(xodtemplate_service *this_service, 
 		this_service->icon_image_alt = strdup(this_serviceextinfo->icon_image_alt);
 
 	return OK;
-	}
+}
 
 
 /* merges a host extinfo definition */
-int xodtemplate_merge_host_extinfo_object(xodtemplate_host *this_host, xodtemplate_hostextinfo *this_hostextinfo) {
+int xodtemplate_merge_host_extinfo_object(xodtemplate_host *this_host, xodtemplate_hostextinfo *this_hostextinfo)
+{
 
 	if(this_host == NULL || this_hostextinfo == NULL)
 		return ERROR;
@@ -7911,16 +7728,16 @@ int xodtemplate_merge_host_extinfo_object(xodtemplate_host *this_host, xodtempla
 		this_host->x_2d = this_hostextinfo->x_2d;
 		this_host->y_2d = this_hostextinfo->y_2d;
 		this_host->have_2d_coords = TRUE;
-		}
+	}
 	if(this_host->have_3d_coords == FALSE && this_hostextinfo->have_3d_coords == TRUE) {
 		this_host->x_3d = this_hostextinfo->x_3d;
 		this_host->y_3d = this_hostextinfo->y_3d;
 		this_host->z_3d = this_hostextinfo->z_3d;
 		this_host->have_3d_coords = TRUE;
-		}
+	}
 
 	return OK;
-	}
+}
 
 #endif
 
@@ -7929,13 +7746,14 @@ int xodtemplate_merge_host_extinfo_object(xodtemplate_host *this_host, xodtempla
 /******************** SKIPLIST FUNCTIONS **************************/
 /******************************************************************/
 
-int xodtemplate_init_xobject_skiplists(void) {
+int xodtemplate_init_xobject_skiplists(void)
+{
 	int x = 0;
 
 	for(x = 0; x < NUM_XOBJECT_SKIPLISTS; x++) {
 		xobject_template_skiplists[x] = NULL;
 		xobject_skiplists[x] = NULL;
-		}
+	}
 
 	xobject_template_skiplists[HOST_SKIPLIST] = skiplist_new(16, 0.5, FALSE, FALSE, xodtemplate_skiplist_compare_host_template);
 	xobject_template_skiplists[SERVICE_SKIPLIST] = skiplist_new(16, 0.5, FALSE, FALSE, xodtemplate_skiplist_compare_service_template);
@@ -7965,23 +7783,25 @@ int xodtemplate_init_xobject_skiplists(void) {
 	 * need to be sorted, so we avoid creating skiplists for them.
 	 */
 	return OK;
-	}
+}
 
 
 
-int xodtemplate_free_xobject_skiplists(void) {
+int xodtemplate_free_xobject_skiplists(void)
+{
 	int x = 0;
 
 	for(x = 0; x < NUM_XOBJECT_SKIPLISTS; x++) {
 		skiplist_free(&xobject_template_skiplists[x]);
 		skiplist_free(&xobject_skiplists[x]);
-		}
-
-	return OK;
 	}
 
+	return OK;
+}
 
-int xodtemplate_skiplist_compare_host_template(void *a, void *b) {
+
+int xodtemplate_skiplist_compare_host_template(void *a, void *b)
+{
 	xodtemplate_host *oa = NULL;
 	xodtemplate_host *ob = NULL;
 
@@ -7996,11 +7816,12 @@ int xodtemplate_skiplist_compare_host_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_host(void *a, void *b) {
+int xodtemplate_skiplist_compare_host(void *a, void *b)
+{
 	xodtemplate_host *oa = NULL;
 	xodtemplate_host *ob = NULL;
 
@@ -8015,11 +7836,12 @@ int xodtemplate_skiplist_compare_host(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->host_name, NULL, ob->host_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_service_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_service_template(void *a, void *b)
+{
 	xodtemplate_service *oa = NULL;
 	xodtemplate_service *ob = NULL;
 
@@ -8034,11 +7856,12 @@ int xodtemplate_skiplist_compare_service_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_service(void *a, void *b) {
+int xodtemplate_skiplist_compare_service(void *a, void *b)
+{
 	xodtemplate_service *oa = NULL;
 	xodtemplate_service *ob = NULL;
 
@@ -8053,11 +7876,12 @@ int xodtemplate_skiplist_compare_service(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->host_name, oa->service_description, ob->host_name, ob->service_description);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_timeperiod_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_timeperiod_template(void *a, void *b)
+{
 	xodtemplate_timeperiod *oa = NULL;
 	xodtemplate_timeperiod *ob = NULL;
 
@@ -8072,11 +7896,12 @@ int xodtemplate_skiplist_compare_timeperiod_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_timeperiod(void *a, void *b) {
+int xodtemplate_skiplist_compare_timeperiod(void *a, void *b)
+{
 	xodtemplate_timeperiod *oa = NULL;
 	xodtemplate_timeperiod *ob = NULL;
 
@@ -8091,11 +7916,12 @@ int xodtemplate_skiplist_compare_timeperiod(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->timeperiod_name, NULL, ob->timeperiod_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_command_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_command_template(void *a, void *b)
+{
 	xodtemplate_command *oa = NULL;
 	xodtemplate_command *ob = NULL;
 
@@ -8110,11 +7936,12 @@ int xodtemplate_skiplist_compare_command_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_command(void *a, void *b) {
+int xodtemplate_skiplist_compare_command(void *a, void *b)
+{
 	xodtemplate_command *oa = NULL;
 	xodtemplate_command *ob = NULL;
 
@@ -8129,11 +7956,12 @@ int xodtemplate_skiplist_compare_command(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->command_name, NULL, ob->command_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_contact_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_contact_template(void *a, void *b)
+{
 	xodtemplate_contact *oa = NULL;
 	xodtemplate_contact *ob = NULL;
 
@@ -8148,11 +7976,12 @@ int xodtemplate_skiplist_compare_contact_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_contact(void *a, void *b) {
+int xodtemplate_skiplist_compare_contact(void *a, void *b)
+{
 	xodtemplate_contact *oa = NULL;
 	xodtemplate_contact *ob = NULL;
 
@@ -8167,11 +7996,12 @@ int xodtemplate_skiplist_compare_contact(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->contact_name, NULL, ob->contact_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_contactgroup_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_contactgroup_template(void *a, void *b)
+{
 	xodtemplate_contactgroup *oa = NULL;
 	xodtemplate_contactgroup *ob = NULL;
 
@@ -8186,11 +8016,12 @@ int xodtemplate_skiplist_compare_contactgroup_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_contactgroup(void *a, void *b) {
+int xodtemplate_skiplist_compare_contactgroup(void *a, void *b)
+{
 	xodtemplate_contactgroup *oa = NULL;
 	xodtemplate_contactgroup *ob = NULL;
 
@@ -8205,11 +8036,12 @@ int xodtemplate_skiplist_compare_contactgroup(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->contactgroup_name, NULL, ob->contactgroup_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostgroup_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostgroup_template(void *a, void *b)
+{
 	xodtemplate_hostgroup *oa = NULL;
 	xodtemplate_hostgroup *ob = NULL;
 
@@ -8224,11 +8056,12 @@ int xodtemplate_skiplist_compare_hostgroup_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostgroup(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostgroup(void *a, void *b)
+{
 	xodtemplate_hostgroup *oa = NULL;
 	xodtemplate_hostgroup *ob = NULL;
 
@@ -8243,11 +8076,12 @@ int xodtemplate_skiplist_compare_hostgroup(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->hostgroup_name, NULL, ob->hostgroup_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_servicegroup_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_servicegroup_template(void *a, void *b)
+{
 	xodtemplate_servicegroup *oa = NULL;
 	xodtemplate_servicegroup *ob = NULL;
 
@@ -8262,11 +8096,12 @@ int xodtemplate_skiplist_compare_servicegroup_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_servicegroup(void *a, void *b) {
+int xodtemplate_skiplist_compare_servicegroup(void *a, void *b)
+{
 	xodtemplate_servicegroup *oa = NULL;
 	xodtemplate_servicegroup *ob = NULL;
 
@@ -8281,11 +8116,12 @@ int xodtemplate_skiplist_compare_servicegroup(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->servicegroup_name, NULL, ob->servicegroup_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostdependency_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostdependency_template(void *a, void *b)
+{
 	xodtemplate_hostdependency *oa = NULL;
 	xodtemplate_hostdependency *ob = NULL;
 
@@ -8300,11 +8136,12 @@ int xodtemplate_skiplist_compare_hostdependency_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostdependency(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostdependency(void *a, void *b)
+{
 	xodtemplate_hostdependency *oa = NULL;
 	xodtemplate_hostdependency *ob = NULL;
 
@@ -8319,11 +8156,12 @@ int xodtemplate_skiplist_compare_hostdependency(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->dependent_host_name, NULL, ob->dependent_host_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_servicedependency_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_servicedependency_template(void *a, void *b)
+{
 	xodtemplate_servicedependency *oa = NULL;
 	xodtemplate_servicedependency *ob = NULL;
 
@@ -8338,11 +8176,12 @@ int xodtemplate_skiplist_compare_servicedependency_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_servicedependency(void *a, void *b) {
+int xodtemplate_skiplist_compare_servicedependency(void *a, void *b)
+{
 	xodtemplate_servicedependency *oa = NULL;
 	xodtemplate_servicedependency *ob = NULL;
 
@@ -8357,11 +8196,12 @@ int xodtemplate_skiplist_compare_servicedependency(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->dependent_host_name, oa->dependent_service_description, ob->dependent_host_name, ob->dependent_service_description);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostescalation_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostescalation_template(void *a, void *b)
+{
 	xodtemplate_hostescalation *oa = NULL;
 	xodtemplate_hostescalation *ob = NULL;
 
@@ -8376,11 +8216,12 @@ int xodtemplate_skiplist_compare_hostescalation_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostescalation(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostescalation(void *a, void *b)
+{
 	xodtemplate_hostescalation *oa = NULL;
 	xodtemplate_hostescalation *ob = NULL;
 
@@ -8395,11 +8236,12 @@ int xodtemplate_skiplist_compare_hostescalation(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->host_name, NULL, ob->host_name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_serviceescalation_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_serviceescalation_template(void *a, void *b)
+{
 	xodtemplate_serviceescalation *oa = NULL;
 	xodtemplate_serviceescalation *ob = NULL;
 
@@ -8414,11 +8256,12 @@ int xodtemplate_skiplist_compare_serviceescalation_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_serviceescalation(void *a, void *b) {
+int xodtemplate_skiplist_compare_serviceescalation(void *a, void *b)
+{
 	xodtemplate_serviceescalation *oa = NULL;
 	xodtemplate_serviceescalation *ob = NULL;
 
@@ -8433,11 +8276,12 @@ int xodtemplate_skiplist_compare_serviceescalation(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->host_name, oa->service_description, ob->host_name, ob->service_description);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_hostextinfo_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_hostextinfo_template(void *a, void *b)
+{
 	xodtemplate_hostextinfo *oa = NULL;
 	xodtemplate_hostextinfo *ob = NULL;
 
@@ -8452,11 +8296,12 @@ int xodtemplate_skiplist_compare_hostextinfo_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
-int xodtemplate_skiplist_compare_serviceextinfo_template(void *a, void *b) {
+int xodtemplate_skiplist_compare_serviceextinfo_template(void *a, void *b)
+{
 	xodtemplate_serviceextinfo *oa = NULL;
 	xodtemplate_serviceextinfo *ob = NULL;
 
@@ -8471,7 +8316,7 @@ int xodtemplate_skiplist_compare_serviceextinfo_template(void *a, void *b) {
 		return -1;
 
 	return skiplist_compare_text(oa->name, NULL, ob->name, NULL);
-	}
+}
 
 
 
@@ -8481,7 +8326,8 @@ int xodtemplate_skiplist_compare_serviceextinfo_template(void *a, void *b) {
 /******************************************************************/
 
 /* frees memory */
-int xodtemplate_free_memory(void) {
+int xodtemplate_free_memory(void)
+{
 	xodtemplate_timeperiod *this_timeperiod = NULL;
 	xodtemplate_timeperiod *next_timeperiod = NULL;
 	xodtemplate_daterange *this_daterange = NULL;
@@ -8515,17 +8361,17 @@ int xodtemplate_free_memory(void) {
 			my_free(this_timeperiod->alias);
 		}
 		for(x = 0; x < 7; x++)
-			my_free(this_timeperiod->timeranges[x]);
+			    my_free(this_timeperiod->timeranges[x]);
 		for(x = 0; x < DATERANGE_TYPES; x++) {
 			for(this_daterange = this_timeperiod->exceptions[x]; this_daterange != NULL; this_daterange = next_daterange) {
 				next_daterange = this_daterange->next;
 				my_free(this_daterange->timeranges);
 				my_free(this_daterange);
-				}
 			}
+		}
 		my_free(this_timeperiod->exclusions);
 		my_free(this_timeperiod);
-		}
+	}
 	xodtemplate_timeperiod_list = NULL;
 	xodtemplate_timeperiod_list_tail = NULL;
 
@@ -8539,7 +8385,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_command->command_line);
 		}
 		my_free(this_command);
-		}
+	}
 	xodtemplate_command_list = NULL;
 	xodtemplate_command_list_tail = NULL;
 
@@ -8558,7 +8404,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_contactgroup->alias);
 		}
 		my_free(this_contactgroup);
-		}
+	}
 	xodtemplate_contactgroup_list = NULL;
 	xodtemplate_contactgroup_list_tail = NULL;
 
@@ -8580,7 +8426,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_hostgroup->action_url);
 		}
 		my_free(this_hostgroup);
-		}
+	}
 	xodtemplate_hostgroup_list = NULL;
 	xodtemplate_hostgroup_list_tail = NULL;
 
@@ -8602,7 +8448,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_servicegroup->action_url);
 		}
 		my_free(this_servicegroup);
-		}
+	}
 	xodtemplate_servicegroup_list = NULL;
 	xodtemplate_servicegroup_list_tail = NULL;
 
@@ -8617,7 +8463,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_customvariablesmember->variable_value);
 			my_free(this_customvariablesmember);
 			this_customvariablesmember = next_customvariablesmember;
-			}
+		}
 		my_free(this_contact->template);
 		my_free(this_contact->name);
 		my_free(this_contact->contact_groups);
@@ -8631,10 +8477,10 @@ int xodtemplate_free_memory(void) {
 			my_free(this_contact->email);
 			my_free(this_contact->pager);
 			for (x = 0; x < MAX_XODTEMPLATE_CONTACT_ADDRESSES; x++)
-				my_free(this_contact->address[x]);
-			}
-		my_free(this_contact);
+				     my_free(this_contact->address[x]);
 		}
+		my_free(this_contact);
+	}
 	xodtemplate_contact_list = NULL;
 	xodtemplate_contact_list_tail = NULL;
 
@@ -8649,7 +8495,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_customvariablesmember->variable_value);
 			my_free(this_customvariablesmember);
 			this_customvariablesmember = next_customvariablesmember;
-			}
+		}
 
 		my_free(this_host->template);
 		my_free(this_host->name);
@@ -8673,9 +8519,9 @@ int xodtemplate_free_memory(void) {
 			my_free(this_host->icon_image_alt);
 			my_free(this_host->statusmap_image);
 			my_free(this_host->vrml_image);
-			}
-		my_free(this_host);
 		}
+		my_free(this_host);
+	}
 	xodtemplate_host_list = NULL;
 	xodtemplate_host_list_tail = NULL;
 
@@ -8695,7 +8541,7 @@ int xodtemplate_free_memory(void) {
 				my_free(this_customvariablesmember->variable_value);
 				my_free(this_customvariablesmember);
 				this_customvariablesmember = next_customvariablesmember;
-				}
+			}
 
 			my_free(this_service->template);
 			my_free(this_service->name);
@@ -8712,9 +8558,9 @@ int xodtemplate_free_memory(void) {
 			my_free(this_service->icon_image_alt);
 			my_free(this_service->hostgroup_name);
 			my_free(this_service->service_description);
-			}
-		my_free(this_service);
 		}
+		my_free(this_service);
+	}
 	xodtemplate_service_list = NULL;
 	xodtemplate_service_list_tail = NULL;
 
@@ -8729,7 +8575,7 @@ int xodtemplate_free_memory(void) {
 
 	/* free memory for the config file names */
 	for(x = 0; x < xodtemplate_current_config_file; x++)
-		my_free(xodtemplate_config_files[x]);
+		    my_free(xodtemplate_config_files[x]);
 	my_free(xodtemplate_config_files);
 	xodtemplate_current_config_file = 0;
 
@@ -8737,13 +8583,14 @@ int xodtemplate_free_memory(void) {
 	xodtemplate_free_xobject_skiplists();
 
 	return OK;
-	}
+}
 
 
 
 
 /* adds a member to a list */
-int xodtemplate_add_member_to_memberlist(xodtemplate_memberlist **list, char *name1, char *name2) {
+int xodtemplate_add_member_to_memberlist(xodtemplate_memberlist **list, char *name1, char *name2)
+{
 	xodtemplate_memberlist *temp_item = NULL;
 	xodtemplate_memberlist *new_item = NULL;
 	int error = FALSE;
@@ -8759,11 +8606,10 @@ int xodtemplate_add_member_to_memberlist(xodtemplate_memberlist **list, char *na
 			if(temp_item->name2 == NULL) {
 				if(name2 == NULL)
 					break;
-				}
-			else if(name2 != NULL && !strcmp(temp_item->name2, name2))
+			} else if(name2 != NULL && !strcmp(temp_item->name2, name2))
 				break;
-			}
 		}
+	}
 	if(temp_item)
 		return OK;
 
@@ -8775,29 +8621,30 @@ int xodtemplate_add_member_to_memberlist(xodtemplate_memberlist **list, char *na
 	if(name1) {
 		if((new_item->name1 = (char *)strdup(name1)) == NULL)
 			error = TRUE;
-		}
+	}
 	if(name2) {
 		if((new_item->name2 = (char *)strdup(name2)) == NULL)
 			error = TRUE;
-		}
+	}
 
 	if(error == TRUE) {
 		my_free(new_item->name1);
 		my_free(new_item->name2);
 		my_free(new_item);
 		return ERROR;
-		}
+	}
 
 	/* add new item to head of list */
 	new_item->next = *list;
 	*list = new_item;
 
 	return OK;
-	}
+}
 
 
 /* frees memory allocated to a temporary member list */
-int xodtemplate_free_memberlist(xodtemplate_memberlist **temp_list) {
+int xodtemplate_free_memberlist(xodtemplate_memberlist **temp_list)
+{
 	xodtemplate_memberlist *this_memberlist = NULL;
 	xodtemplate_memberlist *next_memberlist = NULL;
 
@@ -8807,16 +8654,17 @@ int xodtemplate_free_memberlist(xodtemplate_memberlist **temp_list) {
 		my_free(this_memberlist->name1);
 		my_free(this_memberlist->name2);
 		my_free(this_memberlist);
-		}
+	}
 
 	*temp_list = NULL;
 
 	return OK;
-	}
+}
 
 
 /* remove an entry from the member list */
-void xodtemplate_remove_memberlist_item(xodtemplate_memberlist *item, xodtemplate_memberlist **list) {
+void xodtemplate_remove_memberlist_item(xodtemplate_memberlist *item, xodtemplate_memberlist **list)
+{
 	xodtemplate_memberlist *temp_item = NULL;
 
 	if(item == NULL || list == NULL)
@@ -8834,16 +8682,16 @@ void xodtemplate_remove_memberlist_item(xodtemplate_memberlist *item, xodtemplat
 			if(temp_item->next == item) {
 				temp_item->next = item->next;
 				break;
-				}
 			}
 		}
+	}
 
 	my_free(item->name1);
 	my_free(item->name2);
 	my_free(item);
 
 	return;
-	}
+}
 
 
 /******************************************************************/
@@ -8852,7 +8700,8 @@ void xodtemplate_remove_memberlist_item(xodtemplate_memberlist *item, xodtemplat
 
 
 /* expands contacts */
-int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *contacts, int _config_file, int _start_line) {
+int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *contacts, int _config_file, int _start_line)
+{
 	char *contact_names = NULL;
 	char *temp_ptr = NULL;
 	xodtemplate_contact *temp_contact = NULL;
@@ -8889,7 +8738,7 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				my_free(contact_names);
 				return ERROR;
-				}
+			}
 
 			/* test match against all contacts */
 			for(temp_contact = xodtemplate_contact_list; temp_contact != NULL; temp_contact = temp_contact->next) {
@@ -8909,11 +8758,11 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
 
 				/* add contact to list */
 				add_object_to_objectlist(ret, temp_contact);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -8934,8 +8783,8 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
 
 					/* add contact to list */
 					add_object_to_objectlist(ret, temp_contact);
-					}
 				}
+			}
 
 			/* else this is just a single contact... */
 			else {
@@ -8944,7 +8793,7 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the contact */
 				temp_contact = xodtemplate_find_real_contact(temp_ptr);
@@ -8955,19 +8804,18 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
 					/* add contact to list */
 					if(reject_item) {
 						bitmap_set(reject_map, temp_contact->id);
-						}
-					else {
+					} else {
 						add_object_to_objectlist(ret, temp_contact);
-						}
 					}
 				}
 			}
+		}
 
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any contact matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	/* free memory */
 	my_free(contact_names);
@@ -8976,7 +8824,7 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
 		return ERROR;
 
 	return OK;
-	}
+}
 
 
 #ifdef NSCORE
@@ -8986,7 +8834,8 @@ int xodtemplate_expand_contacts(objectlist **ret, bitmap *reject_map, char *cont
  * an objectlist of hosts. This cannot be called until hostgroups
  * have been recombobulated.
  */
-objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *hosts, int _config_file, int _start_line) {
+objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *hosts, int _config_file, int _start_line)
+{
 	objectlist *ret = NULL, *glist = NULL, *hlist, *list = NULL, *next;
 	bitmap *reject;
 	int result;
@@ -8995,7 +8844,7 @@ objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *host
 	if(!reject) {
 		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Unable to create reject map for expanding hosts and hostgroups\n");
 		return NULL;
-		}
+	}
 
 	/*
 	 * process host names first. If they're explicitly added we must obey
@@ -9008,8 +8857,8 @@ objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *host
 			free_objectlist(&ret);
 			bitmap_destroy(reject);
 			return NULL;
-			}
 		}
+	}
 
 	/* process list of hostgroups... */
 	if(hostgroups != NULL) {
@@ -9020,8 +8869,8 @@ objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *host
 			free_objectlist(&glist);
 			bitmap_destroy(reject);
 			return NULL;
-			}
 		}
+	}
 
 	/*
 	 * add hostgroup hosts to ret, taking care not to add any that are
@@ -9041,7 +8890,7 @@ objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *host
 	bitmap_destroy(reject);
 
 	return ret;
-	}
+}
 
 #endif
 
@@ -9053,7 +8902,8 @@ objectlist *xodtemplate_expand_hostgroups_and_hosts(char *hostgroups, char *host
  * This can only be called after hostgroups are recombobulated.
  * returns ERROR on error and OK on success.
  */
-int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *hostgroups, int _config_file, int _start_line) {
+int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *hostgroups, int _config_file, int _start_line)
+{
 	char *hostgroup_names = NULL;
 	char *temp_ptr = NULL;
 	xodtemplate_hostgroup *temp_hostgroup = NULL;
@@ -9092,7 +8942,7 @@ int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *h
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				my_free(hostgroup_names);
 				return ERROR;
-				}
+			}
 
 			/* test match against all hostgroup names */
 			for(temp_hostgroup = xodtemplate_hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
@@ -9111,11 +8961,11 @@ int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *h
 					continue;
 
 				add_object_to_objectlist(list, temp_hostgroup);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -9133,8 +8983,8 @@ int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *h
 
 					/* add hostgroup to list */
 					add_object_to_objectlist(list, temp_hostgroup);
-					}
 				}
+			}
 
 			/* else this is just a single hostgroup... */
 			else {
@@ -9143,7 +8993,7 @@ int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *h
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the hostgroup */
 				temp_hostgroup = xodtemplate_find_real_hostgroup(temp_ptr);
@@ -9152,20 +9002,19 @@ int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *h
 
 					if(reject_item) {
 						bitmap_unite(reject_map, temp_hostgroup->member_map);
-						}
-					else {
+					} else {
 						/* add hostgroup members to proper list */
 						add_object_to_objectlist(list, temp_hostgroup);
-						}
 					}
 				}
 			}
+		}
 
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any hostgroup matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	/* free memory */
 	my_free(hostgroup_names);
@@ -9174,12 +9023,13 @@ int xodtemplate_expand_hostgroups(objectlist **list, bitmap *reject_map, char *h
 		return ERROR;
 
 	return OK;
-	}
+}
 
 
 
 /* expands hosts */
-int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts, int _config_file, int _start_line) {
+int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts, int _config_file, int _start_line)
+{
 	char *temp_ptr = NULL;
 	xodtemplate_host *temp_host = NULL;
 	regex_t preg;
@@ -9209,7 +9059,7 @@ int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts,
 			/* compile regular expression */
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				return ERROR;
-				}
+			}
 
 			/* test match against all hosts */
 			for(temp_host = xodtemplate_host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -9229,11 +9079,11 @@ int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts,
 
 				/* add host to list */
 				add_object_to_objectlist(list, temp_host);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -9254,8 +9104,8 @@ int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts,
 
 					/* add host to list */
 					add_object_to_objectlist(list, temp_host);
-					}
 				}
+			}
 
 			/* else this is just a single host... */
 			else {
@@ -9264,7 +9114,7 @@ int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts,
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the host */
 				temp_host = xodtemplate_find_real_host(temp_ptr);
@@ -9275,25 +9125,24 @@ int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts,
 					/* add host to list */
 					if(!reject_item) {
 						add_object_to_objectlist(list, temp_host);
-						}
-					else {
+					} else {
 						bitmap_set(reject_map, temp_host->id);
-						}
 					}
 				}
 			}
+		}
 
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any host matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	if(found_match == FALSE)
 		return ERROR;
 
 	return OK;
-	}
+}
 
 
 /*
@@ -9302,7 +9151,8 @@ int xodtemplate_expand_hosts(objectlist **list, bitmap *reject_map, char *hosts,
  * reject will map services from all rejected servicegroups
  * This can only be called after servicegroups are recombobulated.
  */
-int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *servicegroups, int _config_file, int _start_line) {
+int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *servicegroups, int _config_file, int _start_line)
+{
 	xodtemplate_servicegroup  *temp_servicegroup = NULL;
 	regex_t preg;
 	char *servicegroup_names = NULL;
@@ -9342,7 +9192,7 @@ int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *se
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				my_free(servicegroup_names);
 				return ERROR;
-				}
+			}
 
 			/* test match against all servicegroup names */
 			for(temp_servicegroup = xodtemplate_servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next) {
@@ -9362,11 +9212,11 @@ int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *se
 
 				/* add servicegroup to list */
 				add_object_to_objectlist(list, temp_servicegroup);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -9384,8 +9234,8 @@ int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *se
 
 					/* add servicegroup to list */
 					prepend_object_to_objectlist(list, temp_servicegroup);
-					}
 				}
+			}
 
 			/* else this is just a single servicegroup... */
 			else {
@@ -9394,7 +9244,7 @@ int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *se
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the servicegroup */
 				if((temp_servicegroup = xodtemplate_find_real_servicegroup(temp_ptr)) != NULL) {
@@ -9406,16 +9256,16 @@ int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *se
 						bitmap_unite(reject, temp_servicegroup->member_map);
 					else
 						add_object_to_objectlist(list, temp_servicegroup);
-					}
 				}
 			}
+		}
 
 		/* we didn't find a matching servicegroup */
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any servicegroup matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	/* free memory */
 	my_free(servicegroup_names);
@@ -9424,10 +9274,11 @@ int xodtemplate_expand_servicegroups(objectlist **list, bitmap *reject, char *se
 		return ERROR;
 
 	return OK;
-	}
+}
 
 /* expands services (host name is not expanded) */
-int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *host_name, char *services, int _config_file, int _start_line) {
+int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *host_name, char *services, int _config_file, int _start_line)
+{
 	char *service_names = NULL;
 	char *temp_ptr = NULL;
 	xodtemplate_service *temp_service = NULL;
@@ -9456,7 +9307,7 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 			p2 = strchr(p1, ',');
 			if (!p2) {
 				logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Service description missing from list '%s' (config file '%s', starting at line %d)\n",
-					  services, xodtemplate_config_file_name(_config_file), _start_line);
+				      services, xodtemplate_config_file_name(_config_file), _start_line);
 				free(scopy);
 				return ERROR;
 			}
@@ -9475,10 +9326,10 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 			if(xodtemplate_expand_services(list, reject_map, p1, p2, _config_file, _start_line) != OK) {
 				free(scopy);
 				return ERROR;
-				}
 			}
-		free(scopy);
 		}
+		free(scopy);
+	}
 	if(host_name == NULL || services == NULL)
 		return OK;
 
@@ -9491,7 +9342,7 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 	if(use_regexp_host == TRUE) {
 		if(regcomp(&preg2, host_name, REG_EXTENDED))
 			return ERROR;
-		}
+	}
 #endif
 
 	if((service_names = (char *)strdup(services)) == NULL) {
@@ -9500,7 +9351,7 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 			regfree(&preg2);
 #endif
 		return ERROR;
-		}
+	}
 
 	/* expand each service description */
 	for(temp_ptr = strtok(service_names, ","); temp_ptr; temp_ptr = strtok(NULL, ",")) {
@@ -9525,8 +9376,8 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 					regfree(&preg2);
 				my_free(service_names);
 				return ERROR;
-				}
 			}
+		}
 
 		/* use regular expression matching */
 		if(use_regexp_host == TRUE || use_regexp_service == TRUE) {
@@ -9541,21 +9392,19 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 				if(use_regexp_host == TRUE) {
 					if(regexec(&preg2, temp_service->host_name, 0, NULL, 0))
 						continue;
-					}
-				else {
+				} else {
 					if(strcmp(temp_service->host_name, host_name))
 						continue;
-					}
+				}
 
 				/* skip this service if it doesn't match the service description expression */
 				if(use_regexp_service == TRUE) {
 					if(regexec(&preg, temp_service->service_description, 0, NULL, 0))
 						continue;
-					}
-				else {
+				} else {
 					if(strcmp(temp_service->service_description, temp_ptr))
 						continue;
-					}
+				}
 
 				found_match = TRUE;
 
@@ -9565,12 +9414,12 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 
 				/* add service to the list */
 				add_object_to_objectlist(list, temp_service);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			if(use_regexp_service == TRUE)
 				regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else if(!strcmp(temp_ptr, "*")) {
@@ -9592,8 +9441,8 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 
 				/* add service to the list */
 				add_object_to_objectlist(list, temp_service);
-				}
 			}
+		}
 
 		/* else this is just a single service... */
 		else {
@@ -9602,7 +9451,7 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 			if(temp_ptr[0] == '!') {
 				reject_item = TRUE;
 				temp_ptr++;
-				}
+			}
 
 #endif
 			/* find the service */
@@ -9622,8 +9471,8 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 		if(found_match == FALSE && reject_item == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find a service matching host name '%s' and description '%s' (config file '%s', starting on line %d)\n", host_name, temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 #ifndef NSCGI
 	if(use_regexp_host == TRUE)
 		regfree(&preg2);
@@ -9633,10 +9482,11 @@ int xodtemplate_expand_services(objectlist **list, bitmap *reject_map, char *hos
 		return ERROR;
 
 	return OK;
-	}
+}
 
 /* returns a comma-delimited list of hostgroup names */
-char * xodtemplate_process_hostgroup_names(char *hostgroups, int _config_file, int _start_line) {
+char * xodtemplate_process_hostgroup_names(char *hostgroups, int _config_file, int _start_line)
+{
 	xodtemplate_memberlist *temp_list = NULL;
 	xodtemplate_memberlist *reject_list = NULL;
 	xodtemplate_memberlist *list_ptr = NULL;
@@ -9654,7 +9504,7 @@ char * xodtemplate_process_hostgroup_names(char *hostgroups, int _config_file, i
 			xodtemplate_free_memberlist(&temp_list);
 			xodtemplate_free_memberlist(&reject_list);
 			return NULL;
-			}
+		}
 
 		/* remove rejects (if any) from the list (no duplicate entries exist in either list) */
 		for(reject_ptr = reject_list; reject_ptr != NULL; reject_ptr = reject_ptr->next) {
@@ -9662,36 +9512,36 @@ char * xodtemplate_process_hostgroup_names(char *hostgroups, int _config_file, i
 				if(!strcmp(reject_ptr->name1, list_ptr->name1)) {
 					xodtemplate_remove_memberlist_item(list_ptr, &temp_list);
 					break;
-					}
 				}
 			}
+		}
 
 		xodtemplate_free_memberlist(&reject_list);
 		reject_list = NULL;
-		}
+	}
 
 	/* generate the list of group members */
 	for(this_list = temp_list; this_list != NULL; this_list = this_list->next) {
 		if(buf == NULL) {
 			buf = (char *)malloc(strlen(this_list->name1) + 1);
 			strcpy(buf, this_list->name1);
-			}
-		else {
+		} else {
 			buf = (char *)realloc(buf, strlen(buf) + strlen(this_list->name1) + 2);
 			strcat(buf, ",");
 			strcat(buf, this_list->name1);
-			}
 		}
+	}
 
 	xodtemplate_free_memberlist(&temp_list);
 
 	return buf;
-	}
+}
 
 
 
 /* return a list of hostgroup names */
-int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_memberlist **reject_list, char *hostgroups, int _config_file, int _start_line) {
+int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_memberlist **reject_list, char *hostgroups, int _config_file, int _start_line)
+{
 	char *hostgroup_names = NULL;
 	char *temp_ptr = NULL;
 	xodtemplate_hostgroup *temp_hostgroup = NULL;
@@ -9728,7 +9578,7 @@ int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_m
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				my_free(hostgroup_names);
 				return ERROR;
-				}
+			}
 
 			/* test match against all hostgroup names */
 			for(temp_hostgroup = xodtemplate_hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
@@ -9748,11 +9598,11 @@ int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_m
 
 				/* add hostgroup to list */
 				xodtemplate_add_member_to_memberlist(list, temp_hostgroup->hostgroup_name, NULL);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -9770,8 +9620,8 @@ int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_m
 
 					/* add hostgroup to list */
 					xodtemplate_add_member_to_memberlist(list, temp_hostgroup->hostgroup_name, NULL);
-					}
 				}
+			}
 
 			/* else this is just a single hostgroup... */
 			else {
@@ -9780,7 +9630,7 @@ int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_m
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the hostgroup */
 				temp_hostgroup = xodtemplate_find_real_hostgroup(temp_ptr);
@@ -9790,15 +9640,15 @@ int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_m
 
 					/* add hostgroup to proper list */
 					xodtemplate_add_member_to_memberlist((reject_item == TRUE) ? reject_list : list, temp_hostgroup->hostgroup_name, NULL);
-					}
 				}
 			}
+		}
 
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any hostgroup matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	/* free memory */
 	my_free(hostgroup_names);
@@ -9807,12 +9657,13 @@ int xodtemplate_get_hostgroup_names(xodtemplate_memberlist **list, xodtemplate_m
 		return ERROR;
 
 	return OK;
-	}
+}
 
 
 
 /* returns a comma-delimited list of contactgroup names */
-char * xodtemplate_process_contactgroup_names(char *contactgroups, int _config_file, int _start_line) {
+char * xodtemplate_process_contactgroup_names(char *contactgroups, int _config_file, int _start_line)
+{
 	xodtemplate_memberlist *temp_list = NULL;
 	xodtemplate_memberlist *reject_list = NULL;
 	xodtemplate_memberlist *list_ptr = NULL;
@@ -9830,7 +9681,7 @@ char * xodtemplate_process_contactgroup_names(char *contactgroups, int _config_f
 			xodtemplate_free_memberlist(&temp_list);
 			xodtemplate_free_memberlist(&reject_list);
 			return NULL;
-			}
+		}
 
 		/* remove rejects (if any) from the list (no duplicate entries exist in either list) */
 		for(reject_ptr = reject_list; reject_ptr != NULL; reject_ptr = reject_ptr->next) {
@@ -9838,36 +9689,36 @@ char * xodtemplate_process_contactgroup_names(char *contactgroups, int _config_f
 				if(!strcmp(reject_ptr->name1, list_ptr->name1)) {
 					xodtemplate_remove_memberlist_item(list_ptr, &temp_list);
 					break;
-					}
 				}
 			}
+		}
 
 		xodtemplate_free_memberlist(&reject_list);
 		reject_list = NULL;
-		}
+	}
 
 	/* generate the list of group members */
 	for(this_list = temp_list; this_list != NULL; this_list = this_list->next) {
 		if(buf == NULL) {
 			buf = (char *)malloc(strlen(this_list->name1) + 1);
 			strcpy(buf, this_list->name1);
-			}
-		else {
+		} else {
 			buf = (char *)realloc(buf, strlen(buf) + strlen(this_list->name1) + 2);
 			strcat(buf, ",");
 			strcat(buf, this_list->name1);
-			}
 		}
+	}
 
 	xodtemplate_free_memberlist(&temp_list);
 
 	return buf;
-	}
+}
 
 
 
 /* return a list of contactgroup names */
-int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplate_memberlist **reject_list, char *contactgroups, int _config_file, int _start_line) {
+int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplate_memberlist **reject_list, char *contactgroups, int _config_file, int _start_line)
+{
 	char *contactgroup_names = NULL;
 	char *temp_ptr = NULL;
 	xodtemplate_contactgroup *temp_contactgroup = NULL;
@@ -9904,7 +9755,7 @@ int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplat
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				my_free(contactgroup_names);
 				return ERROR;
-				}
+			}
 
 			/* test match against all contactgroup names */
 			for(temp_contactgroup = xodtemplate_contactgroup_list; temp_contactgroup != NULL; temp_contactgroup = temp_contactgroup->next) {
@@ -9924,11 +9775,11 @@ int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplat
 
 				/* add contactgroup to list */
 				xodtemplate_add_member_to_memberlist(list, temp_contactgroup->contactgroup_name, NULL);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -9946,8 +9797,8 @@ int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplat
 
 					/* add contactgroup to list */
 					xodtemplate_add_member_to_memberlist(list, temp_contactgroup->contactgroup_name, NULL);
-					}
 				}
+			}
 
 			/* else this is just a single contactgroup... */
 			else {
@@ -9956,7 +9807,7 @@ int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplat
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the contactgroup */
 				temp_contactgroup = xodtemplate_find_real_contactgroup(temp_ptr);
@@ -9966,15 +9817,15 @@ int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplat
 
 					/* add contactgroup members to proper list */
 					xodtemplate_add_member_to_memberlist((reject_item == TRUE) ? reject_list : list, temp_contactgroup->contactgroup_name, NULL);
-					}
 				}
 			}
+		}
 
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any contactgroup matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	/* free memory */
 	my_free(contactgroup_names);
@@ -9983,12 +9834,13 @@ int xodtemplate_get_contactgroup_names(xodtemplate_memberlist **list, xodtemplat
 		return ERROR;
 
 	return OK;
-	}
+}
 
 
 
 /* returns a comma-delimited list of servicegroup names */
-char * xodtemplate_process_servicegroup_names(char *servicegroups, int _config_file, int _start_line) {
+char * xodtemplate_process_servicegroup_names(char *servicegroups, int _config_file, int _start_line)
+{
 	xodtemplate_memberlist *temp_list = NULL;
 	xodtemplate_memberlist *reject_list = NULL;
 	xodtemplate_memberlist *list_ptr = NULL;
@@ -10006,7 +9858,7 @@ char * xodtemplate_process_servicegroup_names(char *servicegroups, int _config_f
 			xodtemplate_free_memberlist(&temp_list);
 			xodtemplate_free_memberlist(&reject_list);
 			return NULL;
-			}
+		}
 
 		/* remove rejects (if any) from the list (no duplicate entries exist in either list) */
 		for(reject_ptr = reject_list; reject_ptr != NULL; reject_ptr = reject_ptr->next) {
@@ -10014,36 +9866,36 @@ char * xodtemplate_process_servicegroup_names(char *servicegroups, int _config_f
 				if(!strcmp(reject_ptr->name1, list_ptr->name1)) {
 					xodtemplate_remove_memberlist_item(list_ptr, &temp_list);
 					break;
-					}
 				}
 			}
+		}
 
 		xodtemplate_free_memberlist(&reject_list);
 		reject_list = NULL;
-		}
+	}
 
 	/* generate the list of group members */
 	for(this_list = temp_list; this_list != NULL; this_list = this_list->next) {
 		if(buf == NULL) {
 			buf = (char *)malloc(strlen(this_list->name1) + 1);
 			strcpy(buf, this_list->name1);
-			}
-		else {
+		} else {
 			buf = (char *)realloc(buf, strlen(buf) + strlen(this_list->name1) + 2);
 			strcat(buf, ",");
 			strcat(buf, this_list->name1);
-			}
 		}
+	}
 
 	xodtemplate_free_memberlist(&temp_list);
 
 	return buf;
-	}
+}
 
 
 
 /* return a list of servicegroup names */
-int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplate_memberlist **reject_list, char *servicegroups, int _config_file, int _start_line) {
+int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplate_memberlist **reject_list, char *servicegroups, int _config_file, int _start_line)
+{
 	char *servicegroup_names = NULL;
 	char *temp_ptr = NULL;
 	xodtemplate_servicegroup *temp_servicegroup = NULL;
@@ -10080,7 +9932,7 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 			if(regcomp(&preg, temp_ptr, REG_EXTENDED)) {
 				my_free(servicegroup_names);
 				return ERROR;
-				}
+			}
 
 			/* test match against all servicegroup names */
 			for(temp_servicegroup = xodtemplate_servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next) {
@@ -10100,11 +9952,11 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 
 				/* add servicegroup to list */
 				xodtemplate_add_member_to_memberlist(list, temp_servicegroup->servicegroup_name, NULL);
-				}
+			}
 
 			/* free memory allocated to compiled regexp */
 			regfree(&preg);
-			}
+		}
 
 		/* use standard matching... */
 		else {
@@ -10122,8 +9974,8 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 
 					/* add servicegroup to list */
 					xodtemplate_add_member_to_memberlist(list, temp_servicegroup->servicegroup_name, NULL);
-					}
 				}
+			}
 
 			/* else this is just a single servicegroup... */
 			else {
@@ -10132,7 +9984,7 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 				if(temp_ptr[0] == '!') {
 					reject_item = TRUE;
 					temp_ptr++;
-					}
+				}
 
 				/* find the servicegroup */
 				temp_servicegroup = xodtemplate_find_real_servicegroup(temp_ptr);
@@ -10142,15 +9994,15 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 
 					/* add servicegroup members to proper list */
 					xodtemplate_add_member_to_memberlist((reject_item == TRUE) ? reject_list : list, temp_servicegroup->servicegroup_name, NULL);
-					}
 				}
 			}
+		}
 
 		if(found_match == FALSE) {
 			logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Could not find any servicegroup matching '%s' (config file '%s', starting on line %d)\n", temp_ptr, xodtemplate_config_file_name(_config_file), _start_line);
 			break;
-			}
 		}
+	}
 
 	/* free memory */
 	my_free(servicegroup_names);
@@ -10159,7 +10011,7 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 		return ERROR;
 
 	return OK;
-	}
+}
 
 #ifndef NSCGI
 
@@ -10168,7 +10020,8 @@ int xodtemplate_get_servicegroup_names(xodtemplate_memberlist **list, xodtemplat
 /******************************************************************/
 
 /* determines the value of an inherited string */
-int xodtemplate_get_inherited_string(char *have_template_value, char **template_value, char *have_this_value, char **this_value) {
+int xodtemplate_get_inherited_string(char *have_template_value, char **template_value, char *have_this_value, char **this_value)
+{
 	char *buf = NULL;
 
 	/* template has a value we should use */
@@ -10184,8 +10037,8 @@ int xodtemplate_get_inherited_string(char *have_template_value, char **template_
 				if(*have_this_value == FALSE) {
 					/* NOTE: leave leading + sign if present, as it needed during object resolution and will get stripped later */
 					*this_value = (char *)strdup(*template_value);
-					}
 				}
+			}
 
 			/* we already have a value... */
 			else {
@@ -10197,24 +10050,25 @@ int xodtemplate_get_inherited_string(char *have_template_value, char **template_
 						strcat(buf, *this_value + 1);
 						my_free(*this_value);
 						*this_value = buf;
-						}
 					}
+				}
 
 				/* otherwise our value overrides/replaces the template value */
-				}
 			}
+		}
 
 		/* template has a NULL value.... */
 
 		*have_this_value = TRUE;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* removes leading + sign from various directives */
-int xodtemplate_clean_additive_string(char **str) {
+int xodtemplate_clean_additive_string(char **str)
+{
 	char *buf = NULL;
 
 	/* remove the additive symbol if present */
@@ -10222,15 +10076,16 @@ int xodtemplate_clean_additive_string(char **str) {
 		buf = (char *)strdup(*str + 1);
 		my_free(*str);
 		*str = buf;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* cleans strings which may contain additive inheritance directives */
 /* NOTE: this must be done after objects are resolved */
-int xodtemplate_clean_additive_strings(void) {
+int xodtemplate_clean_additive_strings(void)
+{
 	xodtemplate_contactgroup *temp_contactgroup = NULL;
 	xodtemplate_hostgroup *temp_hostgroup = NULL;
 	xodtemplate_servicegroup *temp_servicegroup = NULL;
@@ -10246,19 +10101,19 @@ int xodtemplate_clean_additive_strings(void) {
 	for(temp_contactgroup = xodtemplate_contactgroup_list; temp_contactgroup != NULL; temp_contactgroup = temp_contactgroup->next) {
 		xodtemplate_clean_additive_string(&temp_contactgroup->members);
 		xodtemplate_clean_additive_string(&temp_contactgroup->contactgroup_members);
-		}
+	}
 
 	/* resolve all hostgroup objects */
 	for(temp_hostgroup = xodtemplate_hostgroup_list; temp_hostgroup != NULL; temp_hostgroup = temp_hostgroup->next) {
 		xodtemplate_clean_additive_string(&temp_hostgroup->members);
 		xodtemplate_clean_additive_string(&temp_hostgroup->hostgroup_members);
-		}
+	}
 
 	/* resolve all servicegroup objects */
 	for(temp_servicegroup = xodtemplate_servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next) {
 		xodtemplate_clean_additive_string(&temp_servicegroup->members);
 		xodtemplate_clean_additive_string(&temp_servicegroup->servicegroup_members);
-		}
+	}
 
 	/* resolve all servicedependency objects */
 	for(temp_servicedependency = xodtemplate_servicedependency_list; temp_servicedependency != NULL; temp_servicedependency = temp_servicedependency->next) {
@@ -10270,7 +10125,7 @@ int xodtemplate_clean_additive_strings(void) {
 		xodtemplate_clean_additive_string(&temp_servicedependency->dependent_hostgroup_name);
 		xodtemplate_clean_additive_string(&temp_servicedependency->dependent_host_name);
 		xodtemplate_clean_additive_string(&temp_servicedependency->dependent_service_description);
-		}
+	}
 
 	/* resolve all serviceescalation objects */
 	for(temp_serviceescalation = xodtemplate_serviceescalation_list; temp_serviceescalation != NULL; temp_serviceescalation = temp_serviceescalation->next) {
@@ -10283,14 +10138,14 @@ int xodtemplate_clean_additive_strings(void) {
 		xodtemplate_clean_additive_string(&temp_serviceescalation->hostgroup_name);
 		xodtemplate_clean_additive_string(&temp_serviceescalation->host_name);
 		xodtemplate_clean_additive_string(&temp_serviceescalation->service_description);
-		}
+	}
 
 	/* resolve all contact objects */
 	for(temp_contact = xodtemplate_contact_list; temp_contact != NULL; temp_contact = temp_contact->next) {
 		xodtemplate_clean_additive_string(&temp_contact->contact_groups);
 		xodtemplate_clean_additive_string(&temp_contact->host_notification_commands);
 		xodtemplate_clean_additive_string(&temp_contact->service_notification_commands);
-		}
+	}
 
 	/* clean all host objects */
 	for(temp_host = xodtemplate_host_list; temp_host != NULL; temp_host = temp_host->next) {
@@ -10298,7 +10153,7 @@ int xodtemplate_clean_additive_strings(void) {
 		xodtemplate_clean_additive_string(&temp_host->contacts);
 		xodtemplate_clean_additive_string(&temp_host->parents);
 		xodtemplate_clean_additive_string(&temp_host->host_groups);
-		}
+	}
 
 	/* clean all service objects */
 	for(temp_service = xodtemplate_service_list; temp_service != NULL; temp_service = temp_service->next) {
@@ -10307,7 +10162,7 @@ int xodtemplate_clean_additive_strings(void) {
 		xodtemplate_clean_additive_string(&temp_service->host_name);
 		xodtemplate_clean_additive_string(&temp_service->hostgroup_name);
 		xodtemplate_clean_additive_string(&temp_service->service_groups);
-		}
+	}
 
 	/* resolve all hostdependency objects */
 	for(temp_hostdependency = xodtemplate_hostdependency_list; temp_hostdependency != NULL; temp_hostdependency = temp_hostdependency->next) {
@@ -10315,7 +10170,7 @@ int xodtemplate_clean_additive_strings(void) {
 		xodtemplate_clean_additive_string(&temp_hostdependency->dependent_host_name);
 		xodtemplate_clean_additive_string(&temp_hostdependency->hostgroup_name);
 		xodtemplate_clean_additive_string(&temp_hostdependency->dependent_hostgroup_name);
-		}
+	}
 
 	/* resolve all hostescalation objects */
 	for(temp_hostescalation = xodtemplate_hostescalation_list; temp_hostescalation != NULL; temp_hostescalation = temp_hostescalation->next) {
@@ -10326,9 +10181,9 @@ int xodtemplate_clean_additive_strings(void) {
 		*/
 		xodtemplate_clean_additive_string(&temp_hostescalation->host_name);
 		xodtemplate_clean_additive_string(&temp_hostescalation->hostgroup_name);
-		}
+	}
 
 	return OK;
-	}
+}
 
 #endif

--- a/xdata/xpddefault.c
+++ b/xdata/xpddefault.c
@@ -47,7 +47,8 @@ static int     service_perfdata_fd = -1;
 /******************************************************************/
 
 /* initializes performance data */
-int xpddefault_initialize_performance_data(const char *cfgfile) {
+int xpddefault_initialize_performance_data(const char *cfgfile)
+{
 	char *buffer = NULL;
 	char *temp_buffer = NULL;
 	char *temp_command_name = NULL;
@@ -91,13 +92,13 @@ int xpddefault_initialize_performance_data(const char *cfgfile) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Host performance command '%s' was not found - host performance data will not be processed!\n", temp_command_name);
 
 			my_free(host_perfdata_command);
-			}
+		}
 
 		my_free(temp_buffer);
 
 		/* save the command pointer for later */
 		host_perfdata_command_ptr = temp_command;
-		}
+	}
 	if(service_perfdata_command != NULL) {
 
 		temp_buffer = (char *)strdup(service_perfdata_command);
@@ -110,14 +111,14 @@ int xpddefault_initialize_performance_data(const char *cfgfile) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Service performance command '%s' was not found - service performance data will not be processed!\n", temp_command_name);
 
 			my_free(service_perfdata_command);
-			}
+		}
 
 		/* free memory */
 		my_free(temp_buffer);
 
 		/* save the command pointer for later */
 		service_perfdata_command_ptr = temp_command;
-		}
+	}
 	if(host_perfdata_file_processing_command != NULL) {
 
 		temp_buffer = (char *)strdup(host_perfdata_file_processing_command);
@@ -130,14 +131,14 @@ int xpddefault_initialize_performance_data(const char *cfgfile) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Host performance file processing command '%s' was not found - host performance data file will not be processed!\n", temp_command_name);
 
 			my_free(host_perfdata_file_processing_command);
-			}
+		}
 
 		/* free memory */
 		my_free(temp_buffer);
 
 		/* save the command pointer for later */
 		host_perfdata_file_processing_command_ptr = temp_command;
-		}
+	}
 	if(service_perfdata_file_processing_command != NULL) {
 
 		temp_buffer = (char *)strdup(service_perfdata_file_processing_command);
@@ -150,11 +151,11 @@ int xpddefault_initialize_performance_data(const char *cfgfile) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Service performance file processing command '%s' was not found - service performance data file will not be processed!\n", temp_command_name);
 
 			my_free(service_perfdata_file_processing_command);
-			}
+		}
 
 		/* save the command pointer for later */
 		service_perfdata_file_processing_command_ptr = temp_command;
-		}
+	}
 
 	/* periodically process the host perfdata file */
 	if(host_perfdata_file_processing_interval > 0 && host_perfdata_file_processing_command != NULL)
@@ -169,26 +170,27 @@ int xpddefault_initialize_performance_data(const char *cfgfile) {
 	if(host_perfdata_file != NULL) {
 		if((mac->x[MACRO_HOSTPERFDATAFILE] = (char *)strdup(host_perfdata_file)))
 			strip(mac->x[MACRO_HOSTPERFDATAFILE]);
-		}
+	}
 
 	/* save the service perf data file macro */
 	my_free(mac->x[MACRO_SERVICEPERFDATAFILE]);
 	if(service_perfdata_file != NULL) {
 		if((mac->x[MACRO_SERVICEPERFDATAFILE] = (char *)strdup(service_perfdata_file)))
 			strip(mac->x[MACRO_SERVICEPERFDATAFILE]);
-		}
+	}
 
 	/* free memory */
 	my_free(temp_buffer);
 	my_free(buffer);
 
 	return OK;
-	}
+}
 
 
 
 /* cleans up performance data */
-int xpddefault_cleanup_performance_data(void) {
+int xpddefault_cleanup_performance_data(void)
+{
 
 	/* free memory */
 	my_free(host_perfdata_command);
@@ -205,7 +207,7 @@ int xpddefault_cleanup_performance_data(void) {
 	xpddefault_close_service_perfdata_file();
 
 	return OK;
-	}
+}
 
 
 
@@ -215,7 +217,8 @@ int xpddefault_cleanup_performance_data(void) {
 
 
 /* updates service performance data */
-int xpddefault_update_service_performance_data(service *svc) {
+int xpddefault_update_service_performance_data(service *svc)
+{
 	nagios_macros mac;
 	host *hst;
 
@@ -225,12 +228,12 @@ int xpddefault_update_service_performance_data(service *svc) {
 	 * on distributed setups, empty perfdata results are required, so
 	 * only drop out if demanded via configs.
 	*/
-	if(service_perfdata_process_empty_results==FALSE){
-	        if(!svc || !svc->perf_data || !*svc->perf_data) {
-		       return OK;
+	if(service_perfdata_process_empty_results==FALSE) {
+		if(!svc || !svc->perf_data || !*svc->perf_data) {
+			return OK;
 		}
-	        if((!service_perfdata_fp || !service_perfdata_file_template) && !service_perfdata_command) {
-		       return OK;
+		if((!service_perfdata_fp || !service_perfdata_file_template) && !service_perfdata_command) {
+			return OK;
 		}
 
 	}
@@ -256,11 +259,12 @@ int xpddefault_update_service_performance_data(service *svc) {
 	clear_volatile_macros_r(&mac);
 
 	return OK;
-	}
+}
 
 
 /* updates host performance data */
-int xpddefault_update_host_performance_data(host *hst) {
+int xpddefault_update_host_performance_data(host *hst)
+{
 	nagios_macros mac;
 
 
@@ -270,14 +274,14 @@ int xpddefault_update_host_performance_data(host *hst) {
 	 * on distributed setups, empty perfdata results are required, so
 	 * only drop out if demanded via configs.
 	 */
-	if(host_perfdata_process_empty_results==FALSE){
+	if(host_perfdata_process_empty_results==FALSE) {
 		if(!hst || !hst->perf_data || !*hst->perf_data) {
 			return OK;
-			}
+		}
 		if((!host_perfdata_fp || !host_perfdata_file_template) && !host_perfdata_command) {
 			return OK;
-			}
 		}
+	}
 
 	/* set up macros and get to work */
 	memset(&mac, 0, sizeof(mac));
@@ -296,7 +300,7 @@ int xpddefault_update_host_performance_data(host *hst) {
 	clear_volatile_macros_r(&mac);
 
 	return OK;
-	}
+}
 
 
 
@@ -307,7 +311,8 @@ int xpddefault_update_host_performance_data(host *hst) {
 
 
 /* runs the service performance data command */
-int xpddefault_run_service_performance_data_command(nagios_macros *mac, service *svc) {
+int xpddefault_run_service_performance_data_command(nagios_macros *mac, service *svc)
+{
 	char *raw_command_line = NULL;
 	char *processed_command_line = NULL;
 	int result = OK;
@@ -344,11 +349,12 @@ int xpddefault_run_service_performance_data_command(nagios_macros *mac, service 
 	my_free(processed_command_line);
 
 	return result;
-	}
+}
 
 
 /* runs the host performance data command */
-int xpddefault_run_host_performance_data_command(nagios_macros *mac, host *hst) {
+int xpddefault_run_host_performance_data_command(nagios_macros *mac, host *hst)
+{
 	char *raw_command_line = NULL;
 	char *processed_command_line = NULL;
 	int result = OK;
@@ -385,7 +391,7 @@ int xpddefault_run_host_performance_data_command(nagios_macros *mac, host *hst) 
 	my_free(processed_command_line);
 
 	return result;
-	}
+}
 
 
 
@@ -394,7 +400,8 @@ int xpddefault_run_host_performance_data_command(nagios_macros *mac, host *hst) 
 /******************************************************************/
 
 /* open the host performance data file for writing */
-int xpddefault_open_host_perfdata_file(void) {
+int xpddefault_open_host_perfdata_file(void)
+{
 
 	if(host_perfdata_file != NULL) {
 
@@ -402,8 +409,7 @@ int xpddefault_open_host_perfdata_file(void) {
 			/* must open read-write to avoid failure if the other end isn't ready yet */
 			host_perfdata_fd = open(host_perfdata_file, O_NONBLOCK | O_RDWR | O_CREAT, 0644);
 			host_perfdata_fp = fdopen(host_perfdata_fd, "w");
-			}
-		else
+		} else
 			host_perfdata_fp = fopen(host_perfdata_file, (host_perfdata_file_append == TRUE) ? "a" : "w");
 
 		if(host_perfdata_fp == NULL) {
@@ -411,23 +417,23 @@ int xpddefault_open_host_perfdata_file(void) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: File '%s' could not be opened - host performance data will not be written to file!\n", host_perfdata_file);
 
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* open the service performance data file for writing */
-int xpddefault_open_service_perfdata_file(void) {
+int xpddefault_open_service_perfdata_file(void)
+{
 
 	if(service_perfdata_file != NULL) {
 		if(service_perfdata_file_pipe == TRUE) {
 			/* must open read-write to avoid failure if the other end isn't ready yet */
 			service_perfdata_fd = open(service_perfdata_file, O_NONBLOCK | O_RDWR);
 			service_perfdata_fp = fdopen(service_perfdata_fd, "w");
-			}
-		else
+		} else
 			service_perfdata_fp = fopen(service_perfdata_file, (service_perfdata_file_append == TRUE) ? "a" : "w");
 
 		if(service_perfdata_fp == NULL) {
@@ -435,43 +441,46 @@ int xpddefault_open_service_perfdata_file(void) {
 			logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: File '%s' could not be opened - service performance data will not be written to file!\n", service_perfdata_file);
 
 			return ERROR;
-			}
 		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* close the host performance data file */
-int xpddefault_close_host_perfdata_file(void) {
+int xpddefault_close_host_perfdata_file(void)
+{
 
 	if(host_perfdata_fp != NULL)
 		fclose(host_perfdata_fp);
 	if(host_perfdata_fd >= 0) {
 		close(host_perfdata_fd);
 		host_perfdata_fd = -1;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* close the service performance data file */
-int xpddefault_close_service_perfdata_file(void) {
+int xpddefault_close_service_perfdata_file(void)
+{
 
 	if(service_perfdata_fp != NULL)
 		fclose(service_perfdata_fp);
 	if(service_perfdata_fd >= 0) {
 		close(service_perfdata_fd);
 		service_perfdata_fd = -1;
-		}
+	}
 
 	return OK;
-	}
+}
 
 
 /* processes delimiter characters in templates */
-int xpddefault_preprocess_file_templates(char *template) {
+int xpddefault_preprocess_file_templates(char *template)
+{
 	char *tempbuf;
 	unsigned int x, y;
 
@@ -489,32 +498,29 @@ int xpddefault_preprocess_file_templates(char *template) {
 			if(template[x + 1] == 't') {
 				tempbuf[y] = '\t';
 				x++;
-				}
-			else if(template[x + 1] == 'r') {
+			} else if(template[x + 1] == 'r') {
 				tempbuf[y] = '\r';
 				x++;
-				}
-			else if(template[x + 1] == 'n') {
+			} else if(template[x + 1] == 'n') {
 				tempbuf[y] = '\n';
 				x++;
-				}
-			else
+			} else
 				tempbuf[y] = template[x];
-			}
-		else
+		} else
 			tempbuf[y] = template[x];
-		}
+	}
 	tempbuf[y] = '\x0';
 
 	strcpy(template, tempbuf);
 	my_free(tempbuf);
 
 	return OK;
-	}
+}
 
 
 /* updates service performance data file */
-int xpddefault_update_service_performance_data_file(nagios_macros *mac, service *svc) {
+int xpddefault_update_service_performance_data_file(nagios_macros *mac, service *svc)
+{
 	char *raw_output = NULL;
 	char *processed_output = NULL;
 	int result = OK;
@@ -550,11 +556,12 @@ int xpddefault_update_service_performance_data_file(nagios_macros *mac, service 
 	my_free(processed_output);
 
 	return result;
-	}
+}
 
 
 /* updates host performance data file */
-int xpddefault_update_host_performance_data_file(nagios_macros *mac, host *hst) {
+int xpddefault_update_host_performance_data_file(nagios_macros *mac, host *hst)
+{
 	char *raw_output = NULL;
 	char *processed_output = NULL;
 	int result = OK;
@@ -590,11 +597,12 @@ int xpddefault_update_host_performance_data_file(nagios_macros *mac, host *hst) 
 	my_free(processed_output);
 
 	return result;
-	}
+}
 
 
 /* periodically process the host perf data file */
-int xpddefault_process_host_perfdata_file(void) {
+int xpddefault_process_host_perfdata_file(void)
+{
 	char *raw_command_line = NULL;
 	char *processed_command_line = NULL;
 	int early_timeout = FALSE;
@@ -617,7 +625,7 @@ int xpddefault_process_host_perfdata_file(void) {
 	if(raw_command_line == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_PERFDATA, 2, "Raw host performance data file processing command line: %s\n", raw_command_line);
 
@@ -627,7 +635,7 @@ int xpddefault_process_host_perfdata_file(void) {
 	if(processed_command_line == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_PERFDATA, 2, "Processed host performance data file processing command line: %s\n", processed_command_line);
 
@@ -650,11 +658,12 @@ int xpddefault_process_host_perfdata_file(void) {
 	my_free(processed_command_line);
 
 	return result;
-	}
+}
 
 
 /* periodically process the service perf data file */
-int xpddefault_process_service_perfdata_file(void) {
+int xpddefault_process_service_perfdata_file(void)
+{
 	char *raw_command_line = NULL;
 	char *processed_command_line = NULL;
 	int early_timeout = FALSE;
@@ -677,7 +686,7 @@ int xpddefault_process_service_perfdata_file(void) {
 	if(raw_command_line == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_PERFDATA, 2, "Raw service performance data file processing command line: %s\n", raw_command_line);
 
@@ -687,7 +696,7 @@ int xpddefault_process_service_perfdata_file(void) {
 	if(processed_command_line == NULL) {
 		clear_volatile_macros_r(&mac);
 		return ERROR;
-		}
+	}
 
 	log_debug_info(DEBUGL_PERFDATA, 2, "Processed service performance data file processing command line: %s\n", processed_command_line);
 
@@ -710,4 +719,4 @@ int xpddefault_process_service_perfdata_file(void) {
 	my_free(processed_command_line);
 
 	return result;
-	}
+}

--- a/xdata/xrddefault.c
+++ b/xdata/xrddefault.c
@@ -41,7 +41,8 @@
 
 
 /* initialize retention data */
-int xrddefault_initialize_retention_data(const char *cfgfile) {
+int xrddefault_initialize_retention_data(const char *cfgfile)
+{
 	nagios_macros *mac;
 
 	/* initialize locations if necessary  */
@@ -61,24 +62,26 @@ int xrddefault_initialize_retention_data(const char *cfgfile) {
 		strip(mac->x[MACRO_RETENTIONDATAFILE]);
 
 	return OK;
-	}
+}
 
 
 /* cleanup retention data before terminating */
-int xrddefault_cleanup_retention_data(void) {
+int xrddefault_cleanup_retention_data(void)
+{
 
 	/* free memory */
 	my_free(retention_file);
 
 	return OK;
-	}
+}
 
 
 /******************************************************************/
 /**************** DEFAULT STATE OUTPUT FUNCTION *******************/
 /******************************************************************/
 
-int xrddefault_save_state_information(void) {
+int xrddefault_save_state_information(void)
+{
 	char *tmp_file = NULL;
 	customvariablesmember *temp_customvariablesmember = NULL;
 	time_t current_time = 0L;
@@ -106,7 +109,7 @@ int xrddefault_save_state_information(void) {
 	if(retention_file == NULL || temp_file == NULL) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: We don't have the required file names to store retention data!\n");
 		return ERROR;
-		}
+	}
 
 	/* open a safe temp file for output */
 	asprintf(&tmp_file, "%sXXXXXX", temp_file);
@@ -128,7 +131,7 @@ int xrddefault_save_state_information(void) {
 		my_free(tmp_file);
 
 		return ERROR;
-		}
+	}
 
 	/* what attributes should be masked out? */
 	/* NOTE: host/service/contact-specific values may be added in the future, but for now we only have global masks */
@@ -249,10 +252,10 @@ int xrddefault_save_state_information(void) {
 		for(temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if(temp_customvariablesmember->variable_name)
 				fprintf(fp, "_%s=%d;%s\n", temp_customvariablesmember->variable_name, temp_customvariablesmember->has_been_modified, (temp_customvariablesmember->variable_value == NULL) ? "" : temp_customvariablesmember->variable_value);
-			}
+		}
 
 		fprintf(fp, "}\n");
-		}
+	}
 
 	/* save service state information */
 	for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
@@ -321,10 +324,10 @@ int xrddefault_save_state_information(void) {
 		for(temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if(temp_customvariablesmember->variable_name)
 				fprintf(fp, "_%s=%d;%s\n", temp_customvariablesmember->variable_name, temp_customvariablesmember->has_been_modified, (temp_customvariablesmember->variable_value == NULL) ? "" : temp_customvariablesmember->variable_value);
-			}
+		}
 
 		fprintf(fp, "}\n");
-		}
+	}
 
 	/* save contact state information */
 	for(temp_contact = contact_list; temp_contact != NULL; temp_contact = temp_contact->next) {
@@ -345,10 +348,10 @@ int xrddefault_save_state_information(void) {
 		for(temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if(temp_customvariablesmember->variable_name)
 				fprintf(fp, "_%s=%d;%s\n", temp_customvariablesmember->variable_name, temp_customvariablesmember->has_been_modified, (temp_customvariablesmember->variable_value == NULL) ? "" : temp_customvariablesmember->variable_value);
-			}
+		}
 
 		fprintf(fp, "}\n");
-		}
+	}
 
 	/* save all comments */
 	for(temp_comment = comment_list; temp_comment != NULL; temp_comment = temp_comment->next) {
@@ -370,7 +373,7 @@ int xrddefault_save_state_information(void) {
 		fprintf(fp, "author=%s\n", temp_comment->author);
 		fprintf(fp, "comment_data=%s\n", temp_comment->comment_data);
 		fprintf(fp, "}\n");
-		}
+	}
 
 	/* save all downtime */
 	for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; temp_downtime = temp_downtime->next) {
@@ -396,7 +399,7 @@ int xrddefault_save_state_information(void) {
 		fprintf(fp, "author=%s\n", temp_downtime->author);
 		fprintf(fp, "comment=%s\n", temp_downtime->comment);
 		fprintf(fp, "}\n");
-		}
+	}
 
 	fflush(fp);
 	fsync(fd);
@@ -412,8 +415,8 @@ int xrddefault_save_state_information(void) {
 			unlink(tmp_file);
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to update retention file '%s': %s", retention_file, strerror(errno));
 			result = ERROR;
-			}
 		}
+	}
 
 	/* a problem occurred saving the file */
 	else {
@@ -423,13 +426,13 @@ int xrddefault_save_state_information(void) {
 		/* remove temp file and log an error */
 		unlink(tmp_file);
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to save retention file: %s", strerror(errno));
-		}
+	}
 
 	/* free memory */
 	my_free(tmp_file);
 
 	return result;
-	}
+}
 
 
 
@@ -438,7 +441,8 @@ int xrddefault_save_state_information(void) {
 /***************** DEFAULT STATE INPUT FUNCTION *******************/
 /******************************************************************/
 
-int xrddefault_read_state_information(void) {
+int xrddefault_read_state_information(void)
+{
 	char *input = NULL;
 	char *inputbuf = NULL;
 	char *temp_ptr = NULL;
@@ -504,7 +508,7 @@ int xrddefault_read_state_information(void) {
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: We don't have a filename for retention data!\n");
 
 		return ERROR;
-		}
+	}
 
 	if(test_scheduling == TRUE)
 		gettimeofday(&tv[0], NULL);
@@ -567,268 +571,268 @@ int xrddefault_read_state_information(void) {
 
 			switch(data_type) {
 
-				case XRDDEFAULT_INFO_DATA:
-					break;
+			case XRDDEFAULT_INFO_DATA:
+				break;
 
-				case XRDDEFAULT_PROGRAMSTATUS_DATA:
+			case XRDDEFAULT_PROGRAMSTATUS_DATA:
+
+				/* adjust modified attributes if necessary */
+				if(use_retained_program_state == FALSE) {
+					modified_host_process_attributes = MODATTR_NONE;
+					modified_service_process_attributes = MODATTR_NONE;
+				}
+				break;
+
+			case XRDDEFAULT_HOSTSTATUS_DATA:
+
+				if(temp_host != NULL) {
 
 					/* adjust modified attributes if necessary */
-					if(use_retained_program_state == FALSE) {
-						modified_host_process_attributes = MODATTR_NONE;
-						modified_service_process_attributes = MODATTR_NONE;
+					if(temp_host->retain_nonstatus_information == FALSE)
+						temp_host->modified_attributes = MODATTR_NONE;
+
+					/* adjust modified attributes if no custom variables have been changed */
+					if(temp_host->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
+						for(temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+							if(temp_customvariablesmember->has_been_modified == TRUE)
+								break;
+
 						}
-					break;
+						if(temp_customvariablesmember == NULL)
+							temp_host->modified_attributes -= MODATTR_CUSTOM_VARIABLE;
+					}
 
-				case XRDDEFAULT_HOSTSTATUS_DATA:
+					/* calculate next possible notification time */
+					if(temp_host->current_state != HOST_UP && temp_host->last_notification != (time_t)0)
+						temp_host->next_notification = get_next_host_notification_time(temp_host, temp_host->last_notification);
 
-					if(temp_host != NULL) {
-
-						/* adjust modified attributes if necessary */
-						if(temp_host->retain_nonstatus_information == FALSE)
-							temp_host->modified_attributes = MODATTR_NONE;
-
-						/* adjust modified attributes if no custom variables have been changed */
-						if(temp_host->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
-							for(temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-								if(temp_customvariablesmember->has_been_modified == TRUE)
-									break;
-
-								}
-							if(temp_customvariablesmember == NULL)
-								temp_host->modified_attributes -= MODATTR_CUSTOM_VARIABLE;
-							}
-
-						/* calculate next possible notification time */
-						if(temp_host->current_state != HOST_UP && temp_host->last_notification != (time_t)0)
-							temp_host->next_notification = get_next_host_notification_time(temp_host, temp_host->last_notification);
-
-						/* ADDED 01/23/2009 adjust current check attempts if host in hard problem state (max attempts may have changed in config since restart) */
-						if(temp_host->current_state != HOST_UP && temp_host->state_type == HARD_STATE)
-							temp_host->current_attempt = temp_host->max_attempts;
+					/* ADDED 01/23/2009 adjust current check attempts if host in hard problem state (max attempts may have changed in config since restart) */
+					if(temp_host->current_state != HOST_UP && temp_host->state_type == HARD_STATE)
+						temp_host->current_attempt = temp_host->max_attempts;
 
 
-						/* ADDED 02/20/08 assume same flapping state if large install tweaks enabled */
-						if(use_large_installation_tweaks == TRUE) {
-							temp_host->is_flapping = was_flapping;
-							}
-						/* else use normal startup flap detection logic */
-						else {
-							/* host was flapping before program started */
-							/* 11/10/07 don't allow flapping notifications to go out */
-							if(was_flapping == TRUE)
-								allow_flapstart_notification = FALSE;
-							else
-								/* flapstart notifications are okay */
-								allow_flapstart_notification = TRUE;
-
-							/* check for flapping */
-							check_for_host_flapping(temp_host, FALSE, FALSE, allow_flapstart_notification);
-
-							/* host was flapping before and isn't now, so clear recovery check variable if host isn't flapping now */
-							if(was_flapping == TRUE && temp_host->is_flapping == FALSE)
-								temp_host->check_flapping_recovery_notification = FALSE;
-							}
-
-						/* handle new vars added in 2.x */
-						if(temp_host->last_hard_state_change == (time_t)0)
-							temp_host->last_hard_state_change = temp_host->last_state_change;
-
-						/* update host status */
-						update_host_status(temp_host, FALSE);
-						}
-
-					/* reset vars */
-					was_flapping = FALSE;
-					allow_flapstart_notification = TRUE;
-
-					my_free(host_name);
-					host_name = NULL;
-					temp_host = NULL;
-					break;
-
-				case XRDDEFAULT_SERVICESTATUS_DATA:
-
-					if(temp_service != NULL) {
-
-						/* adjust modified attributes if necessary */
-						if(temp_service->retain_nonstatus_information == FALSE)
-							temp_service->modified_attributes = MODATTR_NONE;
-
-						/* adjust modified attributes if no custom variables have been changed */
-						if(temp_service->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
-							for(temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-								if(temp_customvariablesmember->has_been_modified == TRUE)
-									break;
-
-								}
-							if(temp_customvariablesmember == NULL)
-								temp_service->modified_attributes -= MODATTR_CUSTOM_VARIABLE;
-							}
-
-						/* calculate next possible notification time */
-						if(temp_service->current_state != STATE_OK && temp_service->last_notification != (time_t)0)
-							temp_service->next_notification = get_next_service_notification_time(temp_service, temp_service->last_notification);
-
-						/* fix old vars */
-						if(temp_service->has_been_checked == FALSE && temp_service->state_type == SOFT_STATE)
-							temp_service->state_type = HARD_STATE;
-
-						/* ADDED 01/23/2009 adjust current check attempt if service is in hard problem state (max attempts may have changed in config since restart) */
-						if(temp_service->current_state != STATE_OK && temp_service->state_type == HARD_STATE)
-							temp_service->current_attempt = temp_service->max_attempts;
-
-
-						/* ADDED 02/20/08 assume same flapping state if large install tweaks enabled */
-						if(use_large_installation_tweaks == TRUE) {
-							temp_service->is_flapping = was_flapping;
-							}
-						/* else use normal startup flap detection logic */
-						else {
-							/* service was flapping before program started */
-							/* 11/10/07 don't allow flapping notifications to go out */
-							if(was_flapping == TRUE)
-								allow_flapstart_notification = FALSE;
-							else
-								/* flapstart notifications are okay */
-								allow_flapstart_notification = TRUE;
-
-							/* check for flapping */
-							check_for_service_flapping(temp_service, FALSE, allow_flapstart_notification);
-
-							/* service was flapping before and isn't now, so clear recovery check variable if service isn't flapping now */
-							if(was_flapping == TRUE && temp_service->is_flapping == FALSE)
-								temp_service->check_flapping_recovery_notification = FALSE;
-							}
-
-						/* handle new vars added in 2.x */
-						if(temp_service->last_hard_state_change == (time_t)0)
-							temp_service->last_hard_state_change = temp_service->last_state_change;
-
-						/* update service status */
-						update_service_status(temp_service, FALSE);
-						}
-
-					/* reset vars */
-					was_flapping = FALSE;
-					allow_flapstart_notification = TRUE;
-
-					my_free(host_name);
-					my_free(service_description);
-					temp_service = NULL;
-					break;
-
-				case XRDDEFAULT_CONTACTSTATUS_DATA:
-
-					if(temp_contact != NULL) {
-
-						/* adjust modified attributes if necessary */
-						if(temp_contact->retain_nonstatus_information == FALSE)
-							temp_contact->modified_attributes = MODATTR_NONE;
-
-						/* adjust modified attributes if no custom variables have been changed */
-						if(temp_contact->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
-							for(temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-								if(temp_customvariablesmember->has_been_modified == TRUE)
-									break;
-
-								}
-							if(temp_customvariablesmember == NULL)
-								temp_contact->modified_attributes -= MODATTR_CUSTOM_VARIABLE;
-							}
-
-						/* update contact status */
-						update_contact_status(temp_contact, FALSE);
-						}
-
-					my_free(contact_name);
-					temp_contact = NULL;
-					break;
-
-				case XRDDEFAULT_HOSTCOMMENT_DATA:
-				case XRDDEFAULT_SERVICECOMMENT_DATA:
-
-					/* add the comment */
-					add_comment((data_type == XRDDEFAULT_HOSTCOMMENT_DATA) ? HOST_COMMENT : SERVICE_COMMENT, entry_type, host_name, service_description, entry_time, author, comment_data, comment_id, persistent, expires, expire_time, source);
-
-					/* delete the comment if necessary */
-					/* it seems a bit backwards to add and then immediately delete the comment, but its necessary to track comment deletions in the event broker */
-					remove_comment = FALSE;
-					/* host no longer exists */
-					if((temp_host = find_host(host_name)) == NULL)
-						remove_comment = TRUE;
-					/* service no longer exists */
-					else if(data_type == XRDDEFAULT_SERVICECOMMENT_DATA && (temp_service = find_service(host_name, service_description)) == NULL)
-						remove_comment = TRUE;
-					/* acknowledgement comments get deleted if they're not persistent and the original problem is no longer acknowledged */
-					else if(entry_type == ACKNOWLEDGEMENT_COMMENT) {
-						ack = FALSE;
-						if(data_type == XRDDEFAULT_HOSTCOMMENT_DATA)
-							ack = temp_host->problem_has_been_acknowledged;
+					/* ADDED 02/20/08 assume same flapping state if large install tweaks enabled */
+					if(use_large_installation_tweaks == TRUE) {
+						temp_host->is_flapping = was_flapping;
+					}
+					/* else use normal startup flap detection logic */
+					else {
+						/* host was flapping before program started */
+						/* 11/10/07 don't allow flapping notifications to go out */
+						if(was_flapping == TRUE)
+							allow_flapstart_notification = FALSE;
 						else
-							ack = temp_service->problem_has_been_acknowledged;
-						if(ack == FALSE && persistent == FALSE)
-							remove_comment = TRUE;
-						}
-					/* non-persistent comments don't last past restarts UNLESS they're acks (see above) */
-					else if(persistent == FALSE)
-						remove_comment = TRUE;
+							/* flapstart notifications are okay */
+							allow_flapstart_notification = TRUE;
 
-					if(remove_comment == TRUE)
-						delete_comment((data_type == XRDDEFAULT_HOSTCOMMENT_DATA) ? HOST_COMMENT : SERVICE_COMMENT, comment_id);
+						/* check for flapping */
+						check_for_host_flapping(temp_host, FALSE, FALSE, allow_flapstart_notification);
 
-					/* free temp memory */
-					my_free(host_name);
-					my_free(service_description);
-					my_free(author);
-					my_free(comment_data);
+						/* host was flapping before and isn't now, so clear recovery check variable if host isn't flapping now */
+						if(was_flapping == TRUE && temp_host->is_flapping == FALSE)
+							temp_host->check_flapping_recovery_notification = FALSE;
+					}
 
-					/* reset defaults */
-					entry_type = USER_COMMENT;
-					comment_id = 0;
-					source = COMMENTSOURCE_INTERNAL;
-					persistent = FALSE;
-					entry_time = 0L;
-					expires = FALSE;
-					expire_time = 0L;
+					/* handle new vars added in 2.x */
+					if(temp_host->last_hard_state_change == (time_t)0)
+						temp_host->last_hard_state_change = temp_host->last_state_change;
 
-					break;
-
-				case XRDDEFAULT_HOSTDOWNTIME_DATA:
-				case XRDDEFAULT_SERVICEDOWNTIME_DATA:
-
-					/* add the downtime */
-					if(data_type == XRDDEFAULT_HOSTDOWNTIME_DATA)
-						add_host_downtime(host_name, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
-					else
-						add_service_downtime(host_name, service_description, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
-
-					/* must register the downtime with Nagios so it can schedule it, add comments, etc. */
-					register_downtime((data_type == XRDDEFAULT_HOSTDOWNTIME_DATA) ? HOST_DOWNTIME : SERVICE_DOWNTIME, downtime_id);
-
-					/* free temp memory */
-					my_free(host_name);
-					my_free(service_description);
-					my_free(author);
-					my_free(comment_data);
-
-					/* reset defaults */
-					downtime_id = 0;
-					entry_time = 0L;
-					start_time = 0L;
-					flex_downtime_start = ( time_t)0;
-					end_time = 0L;
-					fixed = FALSE;
-					triggered_by = 0;
-					duration = 0L;
-
-					break;
-
-				default:
-					break;
+					/* update host status */
+					update_host_status(temp_host, FALSE);
 				}
 
-			data_type = XRDDEFAULT_NO_DATA;
+				/* reset vars */
+				was_flapping = FALSE;
+				allow_flapstart_notification = TRUE;
+
+				my_free(host_name);
+				host_name = NULL;
+				temp_host = NULL;
+				break;
+
+			case XRDDEFAULT_SERVICESTATUS_DATA:
+
+				if(temp_service != NULL) {
+
+					/* adjust modified attributes if necessary */
+					if(temp_service->retain_nonstatus_information == FALSE)
+						temp_service->modified_attributes = MODATTR_NONE;
+
+					/* adjust modified attributes if no custom variables have been changed */
+					if(temp_service->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
+						for(temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+							if(temp_customvariablesmember->has_been_modified == TRUE)
+								break;
+
+						}
+						if(temp_customvariablesmember == NULL)
+							temp_service->modified_attributes -= MODATTR_CUSTOM_VARIABLE;
+					}
+
+					/* calculate next possible notification time */
+					if(temp_service->current_state != STATE_OK && temp_service->last_notification != (time_t)0)
+						temp_service->next_notification = get_next_service_notification_time(temp_service, temp_service->last_notification);
+
+					/* fix old vars */
+					if(temp_service->has_been_checked == FALSE && temp_service->state_type == SOFT_STATE)
+						temp_service->state_type = HARD_STATE;
+
+					/* ADDED 01/23/2009 adjust current check attempt if service is in hard problem state (max attempts may have changed in config since restart) */
+					if(temp_service->current_state != STATE_OK && temp_service->state_type == HARD_STATE)
+						temp_service->current_attempt = temp_service->max_attempts;
+
+
+					/* ADDED 02/20/08 assume same flapping state if large install tweaks enabled */
+					if(use_large_installation_tweaks == TRUE) {
+						temp_service->is_flapping = was_flapping;
+					}
+					/* else use normal startup flap detection logic */
+					else {
+						/* service was flapping before program started */
+						/* 11/10/07 don't allow flapping notifications to go out */
+						if(was_flapping == TRUE)
+							allow_flapstart_notification = FALSE;
+						else
+							/* flapstart notifications are okay */
+							allow_flapstart_notification = TRUE;
+
+						/* check for flapping */
+						check_for_service_flapping(temp_service, FALSE, allow_flapstart_notification);
+
+						/* service was flapping before and isn't now, so clear recovery check variable if service isn't flapping now */
+						if(was_flapping == TRUE && temp_service->is_flapping == FALSE)
+							temp_service->check_flapping_recovery_notification = FALSE;
+					}
+
+					/* handle new vars added in 2.x */
+					if(temp_service->last_hard_state_change == (time_t)0)
+						temp_service->last_hard_state_change = temp_service->last_state_change;
+
+					/* update service status */
+					update_service_status(temp_service, FALSE);
+				}
+
+				/* reset vars */
+				was_flapping = FALSE;
+				allow_flapstart_notification = TRUE;
+
+				my_free(host_name);
+				my_free(service_description);
+				temp_service = NULL;
+				break;
+
+			case XRDDEFAULT_CONTACTSTATUS_DATA:
+
+				if(temp_contact != NULL) {
+
+					/* adjust modified attributes if necessary */
+					if(temp_contact->retain_nonstatus_information == FALSE)
+						temp_contact->modified_attributes = MODATTR_NONE;
+
+					/* adjust modified attributes if no custom variables have been changed */
+					if(temp_contact->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
+						for(temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+							if(temp_customvariablesmember->has_been_modified == TRUE)
+								break;
+
+						}
+						if(temp_customvariablesmember == NULL)
+							temp_contact->modified_attributes -= MODATTR_CUSTOM_VARIABLE;
+					}
+
+					/* update contact status */
+					update_contact_status(temp_contact, FALSE);
+				}
+
+				my_free(contact_name);
+				temp_contact = NULL;
+				break;
+
+			case XRDDEFAULT_HOSTCOMMENT_DATA:
+			case XRDDEFAULT_SERVICECOMMENT_DATA:
+
+				/* add the comment */
+				add_comment((data_type == XRDDEFAULT_HOSTCOMMENT_DATA) ? HOST_COMMENT : SERVICE_COMMENT, entry_type, host_name, service_description, entry_time, author, comment_data, comment_id, persistent, expires, expire_time, source);
+
+				/* delete the comment if necessary */
+				/* it seems a bit backwards to add and then immediately delete the comment, but its necessary to track comment deletions in the event broker */
+				remove_comment = FALSE;
+				/* host no longer exists */
+				if((temp_host = find_host(host_name)) == NULL)
+					remove_comment = TRUE;
+				/* service no longer exists */
+				else if(data_type == XRDDEFAULT_SERVICECOMMENT_DATA && (temp_service = find_service(host_name, service_description)) == NULL)
+					remove_comment = TRUE;
+				/* acknowledgement comments get deleted if they're not persistent and the original problem is no longer acknowledged */
+				else if(entry_type == ACKNOWLEDGEMENT_COMMENT) {
+					ack = FALSE;
+					if(data_type == XRDDEFAULT_HOSTCOMMENT_DATA)
+						ack = temp_host->problem_has_been_acknowledged;
+					else
+						ack = temp_service->problem_has_been_acknowledged;
+					if(ack == FALSE && persistent == FALSE)
+						remove_comment = TRUE;
+				}
+				/* non-persistent comments don't last past restarts UNLESS they're acks (see above) */
+				else if(persistent == FALSE)
+					remove_comment = TRUE;
+
+				if(remove_comment == TRUE)
+					delete_comment((data_type == XRDDEFAULT_HOSTCOMMENT_DATA) ? HOST_COMMENT : SERVICE_COMMENT, comment_id);
+
+				/* free temp memory */
+				my_free(host_name);
+				my_free(service_description);
+				my_free(author);
+				my_free(comment_data);
+
+				/* reset defaults */
+				entry_type = USER_COMMENT;
+				comment_id = 0;
+				source = COMMENTSOURCE_INTERNAL;
+				persistent = FALSE;
+				entry_time = 0L;
+				expires = FALSE;
+				expire_time = 0L;
+
+				break;
+
+			case XRDDEFAULT_HOSTDOWNTIME_DATA:
+			case XRDDEFAULT_SERVICEDOWNTIME_DATA:
+
+				/* add the downtime */
+				if(data_type == XRDDEFAULT_HOSTDOWNTIME_DATA)
+					add_host_downtime(host_name, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
+				else
+					add_service_downtime(host_name, service_description, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
+
+				/* must register the downtime with Nagios so it can schedule it, add comments, etc. */
+				register_downtime((data_type == XRDDEFAULT_HOSTDOWNTIME_DATA) ? HOST_DOWNTIME : SERVICE_DOWNTIME, downtime_id);
+
+				/* free temp memory */
+				my_free(host_name);
+				my_free(service_description);
+				my_free(author);
+				my_free(comment_data);
+
+				/* reset defaults */
+				downtime_id = 0;
+				entry_time = 0L;
+				start_time = 0L;
+				flex_downtime_start = ( time_t)0;
+				end_time = 0L;
+				fixed = FALSE;
+				triggered_by = 0;
+				duration = 0L;
+
+				break;
+
+			default:
+				break;
 			}
+
+			data_type = XRDDEFAULT_NO_DATA;
+		}
 
 		else if(data_type != XRDDEFAULT_NO_DATA) {
 
@@ -843,845 +847,769 @@ int xrddefault_read_state_information(void) {
 
 			switch(data_type) {
 
-				case XRDDEFAULT_INFO_DATA:
-					if(!strcmp(var, "created")) {
-						creation_time = strtoul(val, NULL, 10);
-						time(&current_time);
-						if(current_time - creation_time < retention_scheduling_horizon)
-							scheduling_info_is_ok = TRUE;
-						else
-							scheduling_info_is_ok = FALSE;
-						last_program_stop = creation_time;
-						}
-					else if(!strcmp(var, "version")) {
-						/* initialize last version in case we're reading a pre-3.1.0 retention file */
-						if(last_program_version == NULL)
-							last_program_version = (char *)strdup(val);
-						}
-					else if(!strcmp(var, "last_update_check"))
-						last_update_check = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "update_available"))
-						update_available = atoi(val);
-					else if(!strcmp(var, "update_uid"))
-						update_uid = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "last_version")) {
-						if(last_program_version)
-							my_free(last_program_version);
+			case XRDDEFAULT_INFO_DATA:
+				if(!strcmp(var, "created")) {
+					creation_time = strtoul(val, NULL, 10);
+					time(&current_time);
+					if(current_time - creation_time < retention_scheduling_horizon)
+						scheduling_info_is_ok = TRUE;
+					else
+						scheduling_info_is_ok = FALSE;
+					last_program_stop = creation_time;
+				} else if(!strcmp(var, "version")) {
+					/* initialize last version in case we're reading a pre-3.1.0 retention file */
+					if(last_program_version == NULL)
 						last_program_version = (char *)strdup(val);
-						}
-					else if(!strcmp(var, "new_version"))
-						new_program_version = (char *)strdup(val);
-					break;
-
-				case XRDDEFAULT_PROGRAMSTATUS_DATA:
-					if(!strcmp(var, "modified_host_attributes")) {
-
-						modified_host_process_attributes = strtoul(val, NULL, 10);
-
-						/* mask out attributes we don't want to retain */
-						modified_host_process_attributes &= ~process_host_attribute_mask;
-						}
-					else if(!strcmp(var, "modified_service_attributes")) {
-
-						modified_service_process_attributes = strtoul(val, NULL, 10);
-
-						/* mask out attributes we don't want to retain */
-						modified_service_process_attributes &= ~process_service_attribute_mask;
-						}
-					if(use_retained_program_state == TRUE) {
-						if(!strcmp(var, "enable_notifications")) {
-							if(modified_host_process_attributes & MODATTR_NOTIFICATIONS_ENABLED)
-								enable_notifications = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "active_service_checks_enabled")) {
-							if(modified_service_process_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
-								execute_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "passive_service_checks_enabled")) {
-							if(modified_service_process_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
-								accept_passive_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "active_host_checks_enabled")) {
-							if(modified_host_process_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
-								execute_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "passive_host_checks_enabled")) {
-							if(modified_host_process_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
-								accept_passive_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "enable_event_handlers")) {
-							if(modified_host_process_attributes & MODATTR_EVENT_HANDLER_ENABLED)
-								enable_event_handlers = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "obsess_over_services")) {
-							if(modified_service_process_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
-								obsess_over_services = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "obsess_over_hosts")) {
-							if(modified_host_process_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
-								obsess_over_hosts = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "check_service_freshness")) {
-							if(modified_service_process_attributes & MODATTR_FRESHNESS_CHECKS_ENABLED)
-								check_service_freshness = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "check_host_freshness")) {
-							if(modified_host_process_attributes & MODATTR_FRESHNESS_CHECKS_ENABLED)
-								check_host_freshness = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "enable_flap_detection")) {
-							if(modified_host_process_attributes & MODATTR_FLAP_DETECTION_ENABLED)
-								enable_flap_detection = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "process_performance_data")) {
-							if(modified_host_process_attributes & MODATTR_PERFORMANCE_DATA_ENABLED)
-								process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
-							}
-						else if(!strcmp(var, "global_host_event_handler")) {
-							if(modified_host_process_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
-
-								/* make sure the check command still exists... */
-								tempval = (char *)strdup(val);
-								temp_ptr = my_strtok(tempval, "!");
-								temp_command = find_command(temp_ptr);
-								temp_ptr = (char *)strdup(val);
-								my_free(tempval);
-
-								if(temp_command != NULL && temp_ptr != NULL) {
-									my_free(global_host_event_handler);
-									global_host_event_handler = temp_ptr;
-									}
-								}
-							}
-						else if(!strcmp(var, "global_service_event_handler")) {
-							if(modified_service_process_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
-
-								/* make sure the check command still exists... */
-								tempval = (char *)strdup(val);
-								temp_ptr = my_strtok(tempval, "!");
-								temp_command = find_command(temp_ptr);
-								temp_ptr = (char *)strdup(val);
-								my_free(tempval);
-
-								if(temp_command != NULL && temp_ptr != NULL) {
-									my_free(global_service_event_handler);
-									global_service_event_handler = temp_ptr;
-									}
-								}
-							}
-						else if(!strcmp(var, "next_comment_id"))
-							next_comment_id = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_downtime_id"))
-							next_downtime_id = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_event_id"))
-							next_event_id = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_problem_id"))
-							next_problem_id = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_notification_id"))
-							next_notification_id = strtoul(val, NULL, 10);
-						}
-					break;
-
-				case XRDDEFAULT_HOSTSTATUS_DATA:
-
-					if(temp_host == NULL) {
-						if(!strcmp(var, "host_name")) {
-							host_name = (char *)strdup(val);
-							temp_host = find_host(host_name);
-							}
-						}
-					else {
-						if(!strcmp(var, "modified_attributes")) {
-
-							temp_host->modified_attributes = strtoul(val, NULL, 10);
-
-							/* mask out attributes we don't want to retain */
-							temp_host->modified_attributes &= ~host_attribute_mask;
-
-							/* break out */
-							break;
-							}
-						if(temp_host->retain_status_information == TRUE) {
-							if(!strcmp(var, "has_been_checked"))
-								temp_host->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
-							else if(!strcmp(var, "check_execution_time"))
-								temp_host->execution_time = strtod(val, NULL);
-							else if(!strcmp(var, "check_latency"))
-								temp_host->latency = strtod(val, NULL);
-							else if(!strcmp(var, "check_type"))
-								temp_host->check_type = atoi(val);
-							else if(!strcmp(var, "current_state"))
-								temp_host->current_state = atoi(val);
-							else if(!strcmp(var, "last_state"))
-								temp_host->last_state = atoi(val);
-							else if(!strcmp(var, "last_hard_state"))
-								temp_host->last_hard_state = atoi(val);
-							else if(!strcmp(var, "plugin_output")) {
-								my_free(temp_host->plugin_output);
-								temp_host->plugin_output = (char *)strdup(val);
-								}
-							else if(!strcmp(var, "long_plugin_output")) {
-								my_free(temp_host->long_plugin_output);
-								temp_host->long_plugin_output = (char *)strdup(val);
-								}
-							else if(!strcmp(var, "performance_data")) {
-								my_free(temp_host->perf_data);
-								temp_host->perf_data = (char *)strdup(val);
-								}
-							else if(!strcmp(var, "last_check"))
-								temp_host->last_check = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "next_check")) {
-								if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
-									temp_host->next_check = strtoul(val, NULL, 10);
-								}
-							else if(!strcmp(var, "check_options")) {
-								if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
-									temp_host->check_options = atoi(val);
-								}
-							else if(!strcmp(var, "current_attempt"))
-								temp_host->current_attempt = (atoi(val) > 0) ? TRUE : FALSE;
-							else if(!strcmp(var, "current_event_id"))
-								temp_host->current_event_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_event_id"))
-								temp_host->last_event_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "current_problem_id"))
-								temp_host->current_problem_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_problem_id"))
-								temp_host->last_problem_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "state_type"))
-								temp_host->state_type = atoi(val);
-							else if(!strcmp(var, "last_state_change"))
-								temp_host->last_state_change = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_hard_state_change"))
-								temp_host->last_hard_state_change = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_up"))
-								temp_host->last_time_up = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_down"))
-								temp_host->last_time_down = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_unreachable"))
-								temp_host->last_time_unreachable = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "notified_on_down"))
-								temp_host->notified_on |= (atoi(val) > 0 ? OPT_DOWN : 0);
-							else if(!strcmp(var, "notified_on_unreachable"))
-								temp_host->notified_on |= (atoi(val) > 0 ? OPT_UNREACHABLE : 0);
-							else if(!strcmp(var, "last_notification"))
-								temp_host->last_notification = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "current_notification_number"))
-								temp_host->current_notification_number = atoi(val);
-							else if(!strcmp(var, "current_notification_id"))
-								temp_host->current_notification_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "is_flapping"))
-								was_flapping = atoi(val);
-							else if(!strcmp(var, "percent_state_change"))
-								temp_host->percent_state_change = strtod(val, NULL);
-							else if(!strcmp(var, "check_flapping_recovery_notification"))
-								temp_host->check_flapping_recovery_notification = atoi(val);
-							else if(!strcmp(var, "state_history")) {
-								temp_ptr = val;
-								for(x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++) {
-									if((ch = my_strsep(&temp_ptr, ",")) != NULL)
-										temp_host->state_history[x] = atoi(ch);
-									else
-										break;
-									}
-								temp_host->state_history_index = 0;
-								}
-							else
-								found_directive = FALSE;
-							}
-						if(temp_host->retain_nonstatus_information == TRUE) {
-							/* null-op speeds up logic */
-							if(found_directive == TRUE);
-
-							else if(!strcmp(var, "problem_has_been_acknowledged"))
-								temp_host->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
-							else if(!strcmp(var, "acknowledgement_type"))
-								temp_host->acknowledgement_type = atoi(val);
-							else if(!strcmp(var, "notifications_enabled")) {
-								if(temp_host->modified_attributes & MODATTR_NOTIFICATIONS_ENABLED)
-									temp_host->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "active_checks_enabled")) {
-								if(temp_host->modified_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
-									temp_host->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "passive_checks_enabled")) {
-								if(temp_host->modified_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
-									temp_host->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "event_handler_enabled")) {
-								if(temp_host->modified_attributes & MODATTR_EVENT_HANDLER_ENABLED)
-									temp_host->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "flap_detection_enabled")) {
-								if(temp_host->modified_attributes & MODATTR_FLAP_DETECTION_ENABLED)
-									temp_host->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "process_performance_data")) {
-								if(temp_host->modified_attributes & MODATTR_PERFORMANCE_DATA_ENABLED)
-									temp_host->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "obsess_over_host") || !strcmp(var, "obsess")) {
-								if(temp_host->modified_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
-									temp_host->obsess = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "check_command")) {
-								if(temp_host->modified_attributes & MODATTR_CHECK_COMMAND) {
-
-									/* make sure the check command still exists... */
-									tempval = (char *)strdup(val);
-									temp_ptr = my_strtok(tempval, "!");
-									temp_command = find_command(temp_ptr);
-									temp_ptr = (char *)strdup(val);
-									my_free(tempval);
-
-									if(temp_command != NULL && temp_ptr != NULL) {
-										my_free(temp_host->check_command);
-										temp_host->check_command = temp_ptr;
-										}
-									else
-										temp_host->modified_attributes -= MODATTR_CHECK_COMMAND;
-									}
-								}
-							else if(!strcmp(var, "check_period")) {
-								if(temp_host->modified_attributes & MODATTR_CHECK_TIMEPERIOD) {
-
-									/* make sure the timeperiod still exists... */
-									temp_timeperiod = find_timeperiod(val);
-									temp_ptr = (char *)strdup(val);
-
-									if(temp_timeperiod != NULL && temp_ptr != NULL) {
-										my_free(temp_host->check_period);
-										temp_host->check_period = temp_ptr;
-										}
-									else
-										temp_host->modified_attributes -= MODATTR_CHECK_TIMEPERIOD;
-									}
-								}
-							else if(!strcmp(var, "notification_period")) {
-								if(temp_host->modified_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
-
-									/* make sure the timeperiod still exists... */
-									temp_timeperiod = find_timeperiod(val);
-									temp_ptr = (char *)strdup(val);
-
-									if(temp_timeperiod != NULL && temp_ptr != NULL) {
-										my_free(temp_host->notification_period);
-										temp_host->notification_period = temp_ptr;
-										}
-									else
-										temp_host->modified_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
-									}
-								}
-							else if(!strcmp(var, "event_handler")) {
-								if(temp_host->modified_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
-
-									/* make sure the check command still exists... */
-									tempval = (char *)strdup(val);
-									temp_ptr = my_strtok(tempval, "!");
-									temp_command = find_command(temp_ptr);
-									temp_ptr = (char *)strdup(val);
-									my_free(tempval);
-
-									if(temp_command != NULL && temp_ptr != NULL) {
-										my_free(temp_host->event_handler);
-										temp_host->event_handler = temp_ptr;
-										}
-									else
-										temp_host->modified_attributes -= MODATTR_EVENT_HANDLER_COMMAND;
-									}
-								}
-							else if(!strcmp(var, "normal_check_interval")) {
-								if(temp_host->modified_attributes & MODATTR_NORMAL_CHECK_INTERVAL && strtod(val, NULL) >= 0)
-									temp_host->check_interval = strtod(val, NULL);
-								}
-							else if(!strcmp(var, "retry_check_interval")) {
-								if(temp_host->modified_attributes & MODATTR_RETRY_CHECK_INTERVAL && strtod(val, NULL) >= 0)
-									temp_host->retry_interval = strtod(val, NULL);
-								}
-							else if(!strcmp(var, "max_attempts")) {
-								if(temp_host->modified_attributes & MODATTR_MAX_CHECK_ATTEMPTS && atoi(val) >= 1) {
-
-									temp_host->max_attempts = atoi(val);
-
-									/* adjust current attempt number if in a hard state */
-									if(temp_host->state_type == HARD_STATE && temp_host->current_state != HOST_UP && temp_host->current_attempt > 1)
-										temp_host->current_attempt = temp_host->max_attempts;
-									}
-								}
-
-							/* custom variables */
-							else if(var[0] == '_') {
-
-								if(temp_host->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
-
-									/* get the variable name */
-									if((customvarname = (char *)strdup(var + 1))) {
-
-										for(temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-											if(!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
-												if((x = atoi(val)) > 0 && strlen(val) > 3) {
-													my_free(temp_customvariablesmember->variable_value);
-													temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
-													temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
-													}
-												break;
-												}
-											}
-
-										/* free memory */
-										my_free(customvarname);
-										}
-									}
-
-								}
-							}
-
-						}
-
-					break;
-
-				case XRDDEFAULT_SERVICESTATUS_DATA:
-
-					if(temp_service == NULL) {
-						if(!strcmp(var, "host_name")) {
-							host_name = (char *)strdup(val);
-
-							/*temp_service=find_service(host_name,service_description);*/
-
-							/* break out */
-							break;
-							}
-						else if(!strcmp(var, "service_description")) {
-							service_description = (char *)strdup(val);
-							temp_service = find_service(host_name, service_description);
-
-							/* break out */
-							break;
-							}
-						}
-					else {
-						if(!strcmp(var, "modified_attributes")) {
-
-							temp_service->modified_attributes = strtoul(val, NULL, 10);
-
-							/* mask out attributes we don't want to retain */
-							temp_service->modified_attributes &= ~service_attribute_mask;
-							}
-						if(temp_service->retain_status_information == TRUE) {
-							if(!strcmp(var, "has_been_checked"))
-								temp_service->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
-							else if(!strcmp(var, "check_execution_time"))
-								temp_service->execution_time = strtod(val, NULL);
-							else if(!strcmp(var, "check_latency"))
-								temp_service->latency = strtod(val, NULL);
-							else if(!strcmp(var, "check_type"))
-								temp_service->check_type = atoi(val);
-							else if(!strcmp(var, "current_state"))
-								temp_service->current_state = atoi(val);
-							else if(!strcmp(var, "last_state"))
-								temp_service->last_state = atoi(val);
-							else if(!strcmp(var, "last_hard_state"))
-								temp_service->last_hard_state = atoi(val);
-							else if(!strcmp(var, "current_attempt"))
-								temp_service->current_attempt = atoi(val);
-							else if(!strcmp(var, "current_event_id"))
-								temp_service->current_event_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_event_id"))
-								temp_service->last_event_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "current_problem_id"))
-								temp_service->current_problem_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_problem_id"))
-								temp_service->last_problem_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "state_type"))
-								temp_service->state_type = atoi(val);
-							else if(!strcmp(var, "last_state_change"))
-								temp_service->last_state_change = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_hard_state_change"))
-								temp_service->last_hard_state_change = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_ok"))
-								temp_service->last_time_ok = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_warning"))
-								temp_service->last_time_warning = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_unknown"))
-								temp_service->last_time_unknown = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_time_critical"))
-								temp_service->last_time_critical = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "plugin_output")) {
-								my_free(temp_service->plugin_output);
-								temp_service->plugin_output = (char *)strdup(val);
-								}
-							else if(!strcmp(var, "long_plugin_output")) {
-								my_free(temp_service->long_plugin_output);
-								temp_service->long_plugin_output = (char *)strdup(val);
-								}
-							else if(!strcmp(var, "performance_data")) {
-								my_free(temp_service->perf_data);
-								temp_service->perf_data = (char *)strdup(val);
-								}
-							else if(!strcmp(var, "last_check"))
-								temp_service->last_check = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "next_check")) {
-								if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
-									temp_service->next_check = strtoul(val, NULL, 10);
-								}
-							else if(!strcmp(var, "check_options")) {
-								if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
-									temp_service->check_options = atoi(val);
-								}
-							else if(!strcmp(var, "notified_on_unknown"))
-								temp_service->notified_on |= ((atoi(val) > 0) ? OPT_UNKNOWN : 0);
-							else if(!strcmp(var, "notified_on_warning"))
-								temp_service->notified_on |= ((atoi(val) > 0) ? OPT_WARNING : 0);
-							else if(!strcmp(var, "notified_on_critical"))
-								temp_service->notified_on |= ((atoi(val) > 0) ? OPT_CRITICAL : 0);
-							else if(!strcmp(var, "current_notification_number"))
-								temp_service->current_notification_number = atoi(val);
-							else if(!strcmp(var, "current_notification_id"))
-								temp_service->current_notification_id = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_notification"))
-								temp_service->last_notification = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "is_flapping"))
-								was_flapping = atoi(val);
-							else if(!strcmp(var, "percent_state_change"))
-								temp_service->percent_state_change = strtod(val, NULL);
-							else if(!strcmp(var, "check_flapping_recovery_notification"))
-								temp_service->check_flapping_recovery_notification = atoi(val);
-							else if(!strcmp(var, "state_history")) {
-								temp_ptr = val;
-								for(x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++) {
-									if((ch = my_strsep(&temp_ptr, ",")) != NULL)
-										temp_service->state_history[x] = atoi(ch);
-									else
-										break;
-									}
-								temp_service->state_history_index = 0;
-								}
-							else
-								found_directive = FALSE;
-							}
-						if(temp_service->retain_nonstatus_information == TRUE) {
-							/* null-op speeds up logic */
-							if(found_directive == TRUE);
-
-							else if(!strcmp(var, "problem_has_been_acknowledged"))
-								temp_service->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
-							else if(!strcmp(var, "acknowledgement_type"))
-								temp_service->acknowledgement_type = atoi(val);
-							else if(!strcmp(var, "notifications_enabled")) {
-								if(temp_service->modified_attributes & MODATTR_NOTIFICATIONS_ENABLED)
-									temp_service->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "active_checks_enabled")) {
-								if(temp_service->modified_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
-									temp_service->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "passive_checks_enabled")) {
-								if(temp_service->modified_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
-									temp_service->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "event_handler_enabled")) {
-								if(temp_service->modified_attributes & MODATTR_EVENT_HANDLER_ENABLED)
-									temp_service->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "flap_detection_enabled")) {
-								if(temp_service->modified_attributes & MODATTR_FLAP_DETECTION_ENABLED)
-									temp_service->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "process_performance_data")) {
-								if(temp_service->modified_attributes & MODATTR_PERFORMANCE_DATA_ENABLED)
-									temp_service->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "obsess_over_service") || !strcmp(var, "obsess")) {
-								if(temp_service->modified_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
-									temp_service->obsess = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "check_command")) {
-								if(temp_service->modified_attributes & MODATTR_CHECK_COMMAND) {
-
-									/* make sure the check command still exists... */
-									tempval = (char *)strdup(val);
-									temp_ptr = my_strtok(tempval, "!");
-									temp_command = find_command(temp_ptr);
-									temp_ptr = (char *)strdup(val);
-									my_free(tempval);
-
-									if(temp_command != NULL && temp_ptr != NULL) {
-										my_free(temp_service->check_command);
-										temp_service->check_command = temp_ptr;
-										}
-									else
-										temp_service->modified_attributes -= MODATTR_CHECK_COMMAND;
-									}
-								}
-							else if(!strcmp(var, "check_period")) {
-								if(temp_service->modified_attributes & MODATTR_CHECK_TIMEPERIOD) {
-
-									/* make sure the timeperiod still exists... */
-									temp_timeperiod = find_timeperiod(val);
-									temp_ptr = (char *)strdup(val);
-
-									if(temp_timeperiod != NULL && temp_ptr != NULL) {
-										my_free(temp_service->check_period);
-										temp_service->check_period = temp_ptr;
-										}
-									else
-										temp_service->modified_attributes -= MODATTR_CHECK_TIMEPERIOD;
-									}
-								}
-							else if(!strcmp(var, "notification_period")) {
-								if(temp_service->modified_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
-
-									/* make sure the timeperiod still exists... */
-									temp_timeperiod = find_timeperiod(val);
-									temp_ptr = (char *)strdup(val);
-
-									if(temp_timeperiod != NULL && temp_ptr != NULL) {
-										my_free(temp_service->notification_period);
-										temp_service->notification_period = temp_ptr;
-										}
-									else
-										temp_service->modified_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
-									}
-								}
-							else if(!strcmp(var, "event_handler")) {
-								if(temp_service->modified_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
-
-									/* make sure the check command still exists... */
-									tempval = (char *)strdup(val);
-									temp_ptr = my_strtok(tempval, "!");
-									temp_command = find_command(temp_ptr);
-									temp_ptr = (char *)strdup(val);
-									my_free(tempval);
-
-									if(temp_command != NULL && temp_ptr != NULL) {
-										my_free(temp_service->event_handler);
-										temp_service->event_handler = temp_ptr;
-										}
-									else
-										temp_service->modified_attributes -= MODATTR_EVENT_HANDLER_COMMAND;
-									}
-								}
-							else if(!strcmp(var, "normal_check_interval")) {
-								if(temp_service->modified_attributes & MODATTR_NORMAL_CHECK_INTERVAL && strtod(val, NULL) >= 0)
-									temp_service->check_interval = strtod(val, NULL);
-								}
-							else if(!strcmp(var, "retry_check_interval")) {
-								if(temp_service->modified_attributes & MODATTR_RETRY_CHECK_INTERVAL && strtod(val, NULL) >= 0)
-									temp_service->retry_interval = strtod(val, NULL);
-								}
-							else if(!strcmp(var, "max_attempts")) {
-								if(temp_service->modified_attributes & MODATTR_MAX_CHECK_ATTEMPTS && atoi(val) >= 1) {
-
-									temp_service->max_attempts = atoi(val);
-
-									/* adjust current attempt number if in a hard state */
-									if(temp_service->state_type == HARD_STATE && temp_service->current_state != STATE_OK && temp_service->current_attempt > 1)
-										temp_service->current_attempt = temp_service->max_attempts;
-									}
-								}
-
-							/* custom variables */
-							else if(var[0] == '_') {
-
-								if(temp_service->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
-
-									/* get the variable name */
-									if((customvarname = (char *)strdup(var + 1))) {
-
-										for(temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-											if(!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
-												if((x = atoi(val)) > 0 && strlen(val) > 3) {
-													my_free(temp_customvariablesmember->variable_value);
-													temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
-													temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
-													}
-												break;
-												}
-											}
-
-										/* free memory */
-										my_free(customvarname);
-										}
-									}
-
-								}
-							}
-						}
-
-					break;
-
-				case XRDDEFAULT_CONTACTSTATUS_DATA:
-					if(temp_contact == NULL) {
-						if(!strcmp(var, "contact_name")) {
-							contact_name = (char *)strdup(val);
-							temp_contact = find_contact(contact_name);
-							}
-						}
-					else {
-						if(!strcmp(var, "modified_attributes")) {
-
-							temp_contact->modified_attributes = strtoul(val, NULL, 10);
-
-							/* mask out attributes we don't want to retain */
-							temp_contact->modified_attributes &= ~contact_attribute_mask;
-							}
-						else if(!strcmp(var, "modified_host_attributes")) {
-
-							temp_contact->modified_host_attributes = strtoul(val, NULL, 10);
-
-							/* mask out attributes we don't want to retain */
-							temp_contact->modified_host_attributes &= ~contact_host_attribute_mask;
-							}
-						else if(!strcmp(var, "modified_service_attributes")) {
-							temp_contact->modified_service_attributes = strtoul(val, NULL, 10);
-
-							/* mask out attributes we don't want to retain */
-							temp_contact->modified_service_attributes &= ~contact_service_attribute_mask;
-							}
-						else if(temp_contact->retain_status_information == TRUE) {
-							if(!strcmp(var, "last_host_notification"))
-								temp_contact->last_host_notification = strtoul(val, NULL, 10);
-							else if(!strcmp(var, "last_service_notification"))
-								temp_contact->last_service_notification = strtoul(val, NULL, 10);
-							else
-								found_directive = FALSE;
-							}
-						if(temp_contact->retain_nonstatus_information == TRUE) {
-							/* null-op speeds up logic */
-							if(found_directive == TRUE);
-
-							else if(!strcmp(var, "host_notification_period")) {
-								if(temp_contact->modified_host_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
-
-									/* make sure the timeperiod still exists... */
-									temp_timeperiod = find_timeperiod(val);
-									temp_ptr = (char *)strdup(val);
-
-									if(temp_timeperiod != NULL && temp_ptr != NULL) {
-										my_free(temp_contact->host_notification_period);
-										temp_contact->host_notification_period = temp_ptr;
-										}
-									else
-										temp_contact->modified_host_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
-									}
-								}
-							else if(!strcmp(var, "service_notification_period")) {
-								if(temp_contact->modified_service_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
-
-									/* make sure the timeperiod still exists... */
-									temp_timeperiod = find_timeperiod(val);
-									temp_ptr = (char *)strdup(val);
-
-									if(temp_timeperiod != NULL && temp_ptr != NULL) {
-										my_free(temp_contact->service_notification_period);
-										temp_contact->service_notification_period = temp_ptr;
-										}
-									else
-										temp_contact->modified_service_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
-									}
-								}
-							else if(!strcmp(var, "host_notifications_enabled")) {
-								if(temp_contact->modified_host_attributes & MODATTR_NOTIFICATIONS_ENABLED)
-									temp_contact->host_notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							else if(!strcmp(var, "service_notifications_enabled")) {
-								if(temp_contact->modified_service_attributes & MODATTR_NOTIFICATIONS_ENABLED)
-									temp_contact->service_notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-								}
-							/* custom variables */
-							else if(var[0] == '_') {
-
-								if(temp_contact->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
-
-									/* get the variable name */
-									if((customvarname = (char *)strdup(var + 1))) {
-
-										for(temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
-											if(!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
-												if((x = atoi(val)) > 0 && strlen(val) > 3) {
-													my_free(temp_customvariablesmember->variable_value);
-													temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
-													temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
-													}
-												break;
-												}
-											}
-
-										/* free memory */
-										my_free(customvarname);
-										}
-									}
-								}
-							}
-						}
-					break;
-
-				case XRDDEFAULT_HOSTCOMMENT_DATA:
-				case XRDDEFAULT_SERVICECOMMENT_DATA:
-					if(!strcmp(var, "host_name"))
-						host_name = (char *)strdup(val);
-					else if(!strcmp(var, "service_description"))
-						service_description = (char *)strdup(val);
-					else if(!strcmp(var, "entry_type"))
-						entry_type = atoi(val);
-					else if(!strcmp(var, "comment_id"))
-						comment_id = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "source"))
-						source = atoi(val);
-					else if(!strcmp(var, "persistent"))
-						persistent = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "entry_time"))
-						entry_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "expires"))
-						expires = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "expire_time"))
-						expire_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "author"))
-						author = (char *)strdup(val);
-					else if(!strcmp(var, "comment_data"))
-						comment_data = (char *)strdup(val);
-					break;
-
-				case XRDDEFAULT_HOSTDOWNTIME_DATA:
-				case XRDDEFAULT_SERVICEDOWNTIME_DATA:
-					if(!strcmp(var, "host_name"))
-						host_name = (char *)strdup(val);
-					else if(!strcmp(var, "service_description"))
-						service_description = (char *)strdup(val);
-					else if(!strcmp(var, "downtime_id"))
-						downtime_id = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "comment_id"))
-						comment_id = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "entry_time"))
-						entry_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "start_time"))
-						start_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "flex_downtime_start"))
-						flex_downtime_start = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "end_time"))
-						end_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "fixed"))
-						fixed = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "triggered_by"))
-						triggered_by = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "is_in_effect"))
-						is_in_effect = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "start_notification_sent"))
-						start_notification_sent = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "duration"))
-						duration = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "author"))
-						author = (char *)strdup(val);
-					else if(!strcmp(var, "comment"))
-						comment_data = (char *)strdup(val);
-					break;
-
-				default:
-					break;
+				} else if(!strcmp(var, "last_update_check"))
+					last_update_check = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "update_available"))
+					update_available = atoi(val);
+				else if(!strcmp(var, "update_uid"))
+					update_uid = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "last_version")) {
+					if(last_program_version)
+						my_free(last_program_version);
+					last_program_version = (char *)strdup(val);
+				} else if(!strcmp(var, "new_version"))
+					new_program_version = (char *)strdup(val);
+				break;
+
+			case XRDDEFAULT_PROGRAMSTATUS_DATA:
+				if(!strcmp(var, "modified_host_attributes")) {
+
+					modified_host_process_attributes = strtoul(val, NULL, 10);
+
+					/* mask out attributes we don't want to retain */
+					modified_host_process_attributes &= ~process_host_attribute_mask;
+				} else if(!strcmp(var, "modified_service_attributes")) {
+
+					modified_service_process_attributes = strtoul(val, NULL, 10);
+
+					/* mask out attributes we don't want to retain */
+					modified_service_process_attributes &= ~process_service_attribute_mask;
 				}
+				if(use_retained_program_state == TRUE) {
+					if(!strcmp(var, "enable_notifications")) {
+						if(modified_host_process_attributes & MODATTR_NOTIFICATIONS_ENABLED)
+							enable_notifications = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "active_service_checks_enabled")) {
+						if(modified_service_process_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
+							execute_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "passive_service_checks_enabled")) {
+						if(modified_service_process_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
+							accept_passive_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "active_host_checks_enabled")) {
+						if(modified_host_process_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
+							execute_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "passive_host_checks_enabled")) {
+						if(modified_host_process_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
+							accept_passive_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "enable_event_handlers")) {
+						if(modified_host_process_attributes & MODATTR_EVENT_HANDLER_ENABLED)
+							enable_event_handlers = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "obsess_over_services")) {
+						if(modified_service_process_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
+							obsess_over_services = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "obsess_over_hosts")) {
+						if(modified_host_process_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
+							obsess_over_hosts = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "check_service_freshness")) {
+						if(modified_service_process_attributes & MODATTR_FRESHNESS_CHECKS_ENABLED)
+							check_service_freshness = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "check_host_freshness")) {
+						if(modified_host_process_attributes & MODATTR_FRESHNESS_CHECKS_ENABLED)
+							check_host_freshness = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "enable_flap_detection")) {
+						if(modified_host_process_attributes & MODATTR_FLAP_DETECTION_ENABLED)
+							enable_flap_detection = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "process_performance_data")) {
+						if(modified_host_process_attributes & MODATTR_PERFORMANCE_DATA_ENABLED)
+							process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
+					} else if(!strcmp(var, "global_host_event_handler")) {
+						if(modified_host_process_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
+
+							/* make sure the check command still exists... */
+							tempval = (char *)strdup(val);
+							temp_ptr = my_strtok(tempval, "!");
+							temp_command = find_command(temp_ptr);
+							temp_ptr = (char *)strdup(val);
+							my_free(tempval);
+
+							if(temp_command != NULL && temp_ptr != NULL) {
+								my_free(global_host_event_handler);
+								global_host_event_handler = temp_ptr;
+							}
+						}
+					} else if(!strcmp(var, "global_service_event_handler")) {
+						if(modified_service_process_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
+
+							/* make sure the check command still exists... */
+							tempval = (char *)strdup(val);
+							temp_ptr = my_strtok(tempval, "!");
+							temp_command = find_command(temp_ptr);
+							temp_ptr = (char *)strdup(val);
+							my_free(tempval);
+
+							if(temp_command != NULL && temp_ptr != NULL) {
+								my_free(global_service_event_handler);
+								global_service_event_handler = temp_ptr;
+							}
+						}
+					} else if(!strcmp(var, "next_comment_id"))
+						next_comment_id = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_downtime_id"))
+						next_downtime_id = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_event_id"))
+						next_event_id = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_problem_id"))
+						next_problem_id = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_notification_id"))
+						next_notification_id = strtoul(val, NULL, 10);
+				}
+				break;
+
+			case XRDDEFAULT_HOSTSTATUS_DATA:
+
+				if(temp_host == NULL) {
+					if(!strcmp(var, "host_name")) {
+						host_name = (char *)strdup(val);
+						temp_host = find_host(host_name);
+					}
+				} else {
+					if(!strcmp(var, "modified_attributes")) {
+
+						temp_host->modified_attributes = strtoul(val, NULL, 10);
+
+						/* mask out attributes we don't want to retain */
+						temp_host->modified_attributes &= ~host_attribute_mask;
+
+						/* break out */
+						break;
+					}
+					if(temp_host->retain_status_information == TRUE) {
+						if(!strcmp(var, "has_been_checked"))
+							temp_host->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
+						else if(!strcmp(var, "check_execution_time"))
+							temp_host->execution_time = strtod(val, NULL);
+						else if(!strcmp(var, "check_latency"))
+							temp_host->latency = strtod(val, NULL);
+						else if(!strcmp(var, "check_type"))
+							temp_host->check_type = atoi(val);
+						else if(!strcmp(var, "current_state"))
+							temp_host->current_state = atoi(val);
+						else if(!strcmp(var, "last_state"))
+							temp_host->last_state = atoi(val);
+						else if(!strcmp(var, "last_hard_state"))
+							temp_host->last_hard_state = atoi(val);
+						else if(!strcmp(var, "plugin_output")) {
+							my_free(temp_host->plugin_output);
+							temp_host->plugin_output = (char *)strdup(val);
+						} else if(!strcmp(var, "long_plugin_output")) {
+							my_free(temp_host->long_plugin_output);
+							temp_host->long_plugin_output = (char *)strdup(val);
+						} else if(!strcmp(var, "performance_data")) {
+							my_free(temp_host->perf_data);
+							temp_host->perf_data = (char *)strdup(val);
+						} else if(!strcmp(var, "last_check"))
+							temp_host->last_check = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "next_check")) {
+							if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
+								temp_host->next_check = strtoul(val, NULL, 10);
+						} else if(!strcmp(var, "check_options")) {
+							if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
+								temp_host->check_options = atoi(val);
+						} else if(!strcmp(var, "current_attempt"))
+							temp_host->current_attempt = (atoi(val) > 0) ? TRUE : FALSE;
+						else if(!strcmp(var, "current_event_id"))
+							temp_host->current_event_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_event_id"))
+							temp_host->last_event_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "current_problem_id"))
+							temp_host->current_problem_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_problem_id"))
+							temp_host->last_problem_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "state_type"))
+							temp_host->state_type = atoi(val);
+						else if(!strcmp(var, "last_state_change"))
+							temp_host->last_state_change = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_hard_state_change"))
+							temp_host->last_hard_state_change = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_up"))
+							temp_host->last_time_up = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_down"))
+							temp_host->last_time_down = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_unreachable"))
+							temp_host->last_time_unreachable = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "notified_on_down"))
+							temp_host->notified_on |= (atoi(val) > 0 ? OPT_DOWN : 0);
+						else if(!strcmp(var, "notified_on_unreachable"))
+							temp_host->notified_on |= (atoi(val) > 0 ? OPT_UNREACHABLE : 0);
+						else if(!strcmp(var, "last_notification"))
+							temp_host->last_notification = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "current_notification_number"))
+							temp_host->current_notification_number = atoi(val);
+						else if(!strcmp(var, "current_notification_id"))
+							temp_host->current_notification_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "is_flapping"))
+							was_flapping = atoi(val);
+						else if(!strcmp(var, "percent_state_change"))
+							temp_host->percent_state_change = strtod(val, NULL);
+						else if(!strcmp(var, "check_flapping_recovery_notification"))
+							temp_host->check_flapping_recovery_notification = atoi(val);
+						else if(!strcmp(var, "state_history")) {
+							temp_ptr = val;
+							for(x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++) {
+								if((ch = my_strsep(&temp_ptr, ",")) != NULL)
+									temp_host->state_history[x] = atoi(ch);
+								else
+									break;
+							}
+							temp_host->state_history_index = 0;
+						} else
+							found_directive = FALSE;
+					}
+					if(temp_host->retain_nonstatus_information == TRUE) {
+						/* null-op speeds up logic */
+						if(found_directive == TRUE);
+
+						else if(!strcmp(var, "problem_has_been_acknowledged"))
+							temp_host->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
+						else if(!strcmp(var, "acknowledgement_type"))
+							temp_host->acknowledgement_type = atoi(val);
+						else if(!strcmp(var, "notifications_enabled")) {
+							if(temp_host->modified_attributes & MODATTR_NOTIFICATIONS_ENABLED)
+								temp_host->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "active_checks_enabled")) {
+							if(temp_host->modified_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
+								temp_host->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "passive_checks_enabled")) {
+							if(temp_host->modified_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
+								temp_host->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "event_handler_enabled")) {
+							if(temp_host->modified_attributes & MODATTR_EVENT_HANDLER_ENABLED)
+								temp_host->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "flap_detection_enabled")) {
+							if(temp_host->modified_attributes & MODATTR_FLAP_DETECTION_ENABLED)
+								temp_host->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "process_performance_data")) {
+							if(temp_host->modified_attributes & MODATTR_PERFORMANCE_DATA_ENABLED)
+								temp_host->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "obsess_over_host") || !strcmp(var, "obsess")) {
+							if(temp_host->modified_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
+								temp_host->obsess = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "check_command")) {
+							if(temp_host->modified_attributes & MODATTR_CHECK_COMMAND) {
+
+								/* make sure the check command still exists... */
+								tempval = (char *)strdup(val);
+								temp_ptr = my_strtok(tempval, "!");
+								temp_command = find_command(temp_ptr);
+								temp_ptr = (char *)strdup(val);
+								my_free(tempval);
+
+								if(temp_command != NULL && temp_ptr != NULL) {
+									my_free(temp_host->check_command);
+									temp_host->check_command = temp_ptr;
+								} else
+									temp_host->modified_attributes -= MODATTR_CHECK_COMMAND;
+							}
+						} else if(!strcmp(var, "check_period")) {
+							if(temp_host->modified_attributes & MODATTR_CHECK_TIMEPERIOD) {
+
+								/* make sure the timeperiod still exists... */
+								temp_timeperiod = find_timeperiod(val);
+								temp_ptr = (char *)strdup(val);
+
+								if(temp_timeperiod != NULL && temp_ptr != NULL) {
+									my_free(temp_host->check_period);
+									temp_host->check_period = temp_ptr;
+								} else
+									temp_host->modified_attributes -= MODATTR_CHECK_TIMEPERIOD;
+							}
+						} else if(!strcmp(var, "notification_period")) {
+							if(temp_host->modified_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
+
+								/* make sure the timeperiod still exists... */
+								temp_timeperiod = find_timeperiod(val);
+								temp_ptr = (char *)strdup(val);
+
+								if(temp_timeperiod != NULL && temp_ptr != NULL) {
+									my_free(temp_host->notification_period);
+									temp_host->notification_period = temp_ptr;
+								} else
+									temp_host->modified_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
+							}
+						} else if(!strcmp(var, "event_handler")) {
+							if(temp_host->modified_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
+
+								/* make sure the check command still exists... */
+								tempval = (char *)strdup(val);
+								temp_ptr = my_strtok(tempval, "!");
+								temp_command = find_command(temp_ptr);
+								temp_ptr = (char *)strdup(val);
+								my_free(tempval);
+
+								if(temp_command != NULL && temp_ptr != NULL) {
+									my_free(temp_host->event_handler);
+									temp_host->event_handler = temp_ptr;
+								} else
+									temp_host->modified_attributes -= MODATTR_EVENT_HANDLER_COMMAND;
+							}
+						} else if(!strcmp(var, "normal_check_interval")) {
+							if(temp_host->modified_attributes & MODATTR_NORMAL_CHECK_INTERVAL && strtod(val, NULL) >= 0)
+								temp_host->check_interval = strtod(val, NULL);
+						} else if(!strcmp(var, "retry_check_interval")) {
+							if(temp_host->modified_attributes & MODATTR_RETRY_CHECK_INTERVAL && strtod(val, NULL) >= 0)
+								temp_host->retry_interval = strtod(val, NULL);
+						} else if(!strcmp(var, "max_attempts")) {
+							if(temp_host->modified_attributes & MODATTR_MAX_CHECK_ATTEMPTS && atoi(val) >= 1) {
+
+								temp_host->max_attempts = atoi(val);
+
+								/* adjust current attempt number if in a hard state */
+								if(temp_host->state_type == HARD_STATE && temp_host->current_state != HOST_UP && temp_host->current_attempt > 1)
+									temp_host->current_attempt = temp_host->max_attempts;
+							}
+						}
+
+						/* custom variables */
+						else if(var[0] == '_') {
+
+							if(temp_host->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
+
+								/* get the variable name */
+								if((customvarname = (char *)strdup(var + 1))) {
+
+									for(temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+										if(!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
+											if((x = atoi(val)) > 0 && strlen(val) > 3) {
+												my_free(temp_customvariablesmember->variable_value);
+												temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
+												temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
+											}
+											break;
+										}
+									}
+
+									/* free memory */
+									my_free(customvarname);
+								}
+							}
+
+						}
+					}
+
+				}
+
+				break;
+
+			case XRDDEFAULT_SERVICESTATUS_DATA:
+
+				if(temp_service == NULL) {
+					if(!strcmp(var, "host_name")) {
+						host_name = (char *)strdup(val);
+
+						/*temp_service=find_service(host_name,service_description);*/
+
+						/* break out */
+						break;
+					} else if(!strcmp(var, "service_description")) {
+						service_description = (char *)strdup(val);
+						temp_service = find_service(host_name, service_description);
+
+						/* break out */
+						break;
+					}
+				} else {
+					if(!strcmp(var, "modified_attributes")) {
+
+						temp_service->modified_attributes = strtoul(val, NULL, 10);
+
+						/* mask out attributes we don't want to retain */
+						temp_service->modified_attributes &= ~service_attribute_mask;
+					}
+					if(temp_service->retain_status_information == TRUE) {
+						if(!strcmp(var, "has_been_checked"))
+							temp_service->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
+						else if(!strcmp(var, "check_execution_time"))
+							temp_service->execution_time = strtod(val, NULL);
+						else if(!strcmp(var, "check_latency"))
+							temp_service->latency = strtod(val, NULL);
+						else if(!strcmp(var, "check_type"))
+							temp_service->check_type = atoi(val);
+						else if(!strcmp(var, "current_state"))
+							temp_service->current_state = atoi(val);
+						else if(!strcmp(var, "last_state"))
+							temp_service->last_state = atoi(val);
+						else if(!strcmp(var, "last_hard_state"))
+							temp_service->last_hard_state = atoi(val);
+						else if(!strcmp(var, "current_attempt"))
+							temp_service->current_attempt = atoi(val);
+						else if(!strcmp(var, "current_event_id"))
+							temp_service->current_event_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_event_id"))
+							temp_service->last_event_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "current_problem_id"))
+							temp_service->current_problem_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_problem_id"))
+							temp_service->last_problem_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "state_type"))
+							temp_service->state_type = atoi(val);
+						else if(!strcmp(var, "last_state_change"))
+							temp_service->last_state_change = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_hard_state_change"))
+							temp_service->last_hard_state_change = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_ok"))
+							temp_service->last_time_ok = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_warning"))
+							temp_service->last_time_warning = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_unknown"))
+							temp_service->last_time_unknown = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_time_critical"))
+							temp_service->last_time_critical = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "plugin_output")) {
+							my_free(temp_service->plugin_output);
+							temp_service->plugin_output = (char *)strdup(val);
+						} else if(!strcmp(var, "long_plugin_output")) {
+							my_free(temp_service->long_plugin_output);
+							temp_service->long_plugin_output = (char *)strdup(val);
+						} else if(!strcmp(var, "performance_data")) {
+							my_free(temp_service->perf_data);
+							temp_service->perf_data = (char *)strdup(val);
+						} else if(!strcmp(var, "last_check"))
+							temp_service->last_check = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "next_check")) {
+							if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
+								temp_service->next_check = strtoul(val, NULL, 10);
+						} else if(!strcmp(var, "check_options")) {
+							if(use_retained_scheduling_info == TRUE && scheduling_info_is_ok == TRUE)
+								temp_service->check_options = atoi(val);
+						} else if(!strcmp(var, "notified_on_unknown"))
+							temp_service->notified_on |= ((atoi(val) > 0) ? OPT_UNKNOWN : 0);
+						else if(!strcmp(var, "notified_on_warning"))
+							temp_service->notified_on |= ((atoi(val) > 0) ? OPT_WARNING : 0);
+						else if(!strcmp(var, "notified_on_critical"))
+							temp_service->notified_on |= ((atoi(val) > 0) ? OPT_CRITICAL : 0);
+						else if(!strcmp(var, "current_notification_number"))
+							temp_service->current_notification_number = atoi(val);
+						else if(!strcmp(var, "current_notification_id"))
+							temp_service->current_notification_id = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_notification"))
+							temp_service->last_notification = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "is_flapping"))
+							was_flapping = atoi(val);
+						else if(!strcmp(var, "percent_state_change"))
+							temp_service->percent_state_change = strtod(val, NULL);
+						else if(!strcmp(var, "check_flapping_recovery_notification"))
+							temp_service->check_flapping_recovery_notification = atoi(val);
+						else if(!strcmp(var, "state_history")) {
+							temp_ptr = val;
+							for(x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++) {
+								if((ch = my_strsep(&temp_ptr, ",")) != NULL)
+									temp_service->state_history[x] = atoi(ch);
+								else
+									break;
+							}
+							temp_service->state_history_index = 0;
+						} else
+							found_directive = FALSE;
+					}
+					if(temp_service->retain_nonstatus_information == TRUE) {
+						/* null-op speeds up logic */
+						if(found_directive == TRUE);
+
+						else if(!strcmp(var, "problem_has_been_acknowledged"))
+							temp_service->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
+						else if(!strcmp(var, "acknowledgement_type"))
+							temp_service->acknowledgement_type = atoi(val);
+						else if(!strcmp(var, "notifications_enabled")) {
+							if(temp_service->modified_attributes & MODATTR_NOTIFICATIONS_ENABLED)
+								temp_service->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "active_checks_enabled")) {
+							if(temp_service->modified_attributes & MODATTR_ACTIVE_CHECKS_ENABLED)
+								temp_service->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "passive_checks_enabled")) {
+							if(temp_service->modified_attributes & MODATTR_PASSIVE_CHECKS_ENABLED)
+								temp_service->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "event_handler_enabled")) {
+							if(temp_service->modified_attributes & MODATTR_EVENT_HANDLER_ENABLED)
+								temp_service->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "flap_detection_enabled")) {
+							if(temp_service->modified_attributes & MODATTR_FLAP_DETECTION_ENABLED)
+								temp_service->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "process_performance_data")) {
+							if(temp_service->modified_attributes & MODATTR_PERFORMANCE_DATA_ENABLED)
+								temp_service->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "obsess_over_service") || !strcmp(var, "obsess")) {
+							if(temp_service->modified_attributes & MODATTR_OBSESSIVE_HANDLER_ENABLED)
+								temp_service->obsess = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "check_command")) {
+							if(temp_service->modified_attributes & MODATTR_CHECK_COMMAND) {
+
+								/* make sure the check command still exists... */
+								tempval = (char *)strdup(val);
+								temp_ptr = my_strtok(tempval, "!");
+								temp_command = find_command(temp_ptr);
+								temp_ptr = (char *)strdup(val);
+								my_free(tempval);
+
+								if(temp_command != NULL && temp_ptr != NULL) {
+									my_free(temp_service->check_command);
+									temp_service->check_command = temp_ptr;
+								} else
+									temp_service->modified_attributes -= MODATTR_CHECK_COMMAND;
+							}
+						} else if(!strcmp(var, "check_period")) {
+							if(temp_service->modified_attributes & MODATTR_CHECK_TIMEPERIOD) {
+
+								/* make sure the timeperiod still exists... */
+								temp_timeperiod = find_timeperiod(val);
+								temp_ptr = (char *)strdup(val);
+
+								if(temp_timeperiod != NULL && temp_ptr != NULL) {
+									my_free(temp_service->check_period);
+									temp_service->check_period = temp_ptr;
+								} else
+									temp_service->modified_attributes -= MODATTR_CHECK_TIMEPERIOD;
+							}
+						} else if(!strcmp(var, "notification_period")) {
+							if(temp_service->modified_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
+
+								/* make sure the timeperiod still exists... */
+								temp_timeperiod = find_timeperiod(val);
+								temp_ptr = (char *)strdup(val);
+
+								if(temp_timeperiod != NULL && temp_ptr != NULL) {
+									my_free(temp_service->notification_period);
+									temp_service->notification_period = temp_ptr;
+								} else
+									temp_service->modified_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
+							}
+						} else if(!strcmp(var, "event_handler")) {
+							if(temp_service->modified_attributes & MODATTR_EVENT_HANDLER_COMMAND) {
+
+								/* make sure the check command still exists... */
+								tempval = (char *)strdup(val);
+								temp_ptr = my_strtok(tempval, "!");
+								temp_command = find_command(temp_ptr);
+								temp_ptr = (char *)strdup(val);
+								my_free(tempval);
+
+								if(temp_command != NULL && temp_ptr != NULL) {
+									my_free(temp_service->event_handler);
+									temp_service->event_handler = temp_ptr;
+								} else
+									temp_service->modified_attributes -= MODATTR_EVENT_HANDLER_COMMAND;
+							}
+						} else if(!strcmp(var, "normal_check_interval")) {
+							if(temp_service->modified_attributes & MODATTR_NORMAL_CHECK_INTERVAL && strtod(val, NULL) >= 0)
+								temp_service->check_interval = strtod(val, NULL);
+						} else if(!strcmp(var, "retry_check_interval")) {
+							if(temp_service->modified_attributes & MODATTR_RETRY_CHECK_INTERVAL && strtod(val, NULL) >= 0)
+								temp_service->retry_interval = strtod(val, NULL);
+						} else if(!strcmp(var, "max_attempts")) {
+							if(temp_service->modified_attributes & MODATTR_MAX_CHECK_ATTEMPTS && atoi(val) >= 1) {
+
+								temp_service->max_attempts = atoi(val);
+
+								/* adjust current attempt number if in a hard state */
+								if(temp_service->state_type == HARD_STATE && temp_service->current_state != STATE_OK && temp_service->current_attempt > 1)
+									temp_service->current_attempt = temp_service->max_attempts;
+							}
+						}
+
+						/* custom variables */
+						else if(var[0] == '_') {
+
+							if(temp_service->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
+
+								/* get the variable name */
+								if((customvarname = (char *)strdup(var + 1))) {
+
+									for(temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+										if(!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
+											if((x = atoi(val)) > 0 && strlen(val) > 3) {
+												my_free(temp_customvariablesmember->variable_value);
+												temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
+												temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
+											}
+											break;
+										}
+									}
+
+									/* free memory */
+									my_free(customvarname);
+								}
+							}
+
+						}
+					}
+				}
+
+				break;
+
+			case XRDDEFAULT_CONTACTSTATUS_DATA:
+				if(temp_contact == NULL) {
+					if(!strcmp(var, "contact_name")) {
+						contact_name = (char *)strdup(val);
+						temp_contact = find_contact(contact_name);
+					}
+				} else {
+					if(!strcmp(var, "modified_attributes")) {
+
+						temp_contact->modified_attributes = strtoul(val, NULL, 10);
+
+						/* mask out attributes we don't want to retain */
+						temp_contact->modified_attributes &= ~contact_attribute_mask;
+					} else if(!strcmp(var, "modified_host_attributes")) {
+
+						temp_contact->modified_host_attributes = strtoul(val, NULL, 10);
+
+						/* mask out attributes we don't want to retain */
+						temp_contact->modified_host_attributes &= ~contact_host_attribute_mask;
+					} else if(!strcmp(var, "modified_service_attributes")) {
+						temp_contact->modified_service_attributes = strtoul(val, NULL, 10);
+
+						/* mask out attributes we don't want to retain */
+						temp_contact->modified_service_attributes &= ~contact_service_attribute_mask;
+					} else if(temp_contact->retain_status_information == TRUE) {
+						if(!strcmp(var, "last_host_notification"))
+							temp_contact->last_host_notification = strtoul(val, NULL, 10);
+						else if(!strcmp(var, "last_service_notification"))
+							temp_contact->last_service_notification = strtoul(val, NULL, 10);
+						else
+							found_directive = FALSE;
+					}
+					if(temp_contact->retain_nonstatus_information == TRUE) {
+						/* null-op speeds up logic */
+						if(found_directive == TRUE);
+
+						else if(!strcmp(var, "host_notification_period")) {
+							if(temp_contact->modified_host_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
+
+								/* make sure the timeperiod still exists... */
+								temp_timeperiod = find_timeperiod(val);
+								temp_ptr = (char *)strdup(val);
+
+								if(temp_timeperiod != NULL && temp_ptr != NULL) {
+									my_free(temp_contact->host_notification_period);
+									temp_contact->host_notification_period = temp_ptr;
+								} else
+									temp_contact->modified_host_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
+							}
+						} else if(!strcmp(var, "service_notification_period")) {
+							if(temp_contact->modified_service_attributes & MODATTR_NOTIFICATION_TIMEPERIOD) {
+
+								/* make sure the timeperiod still exists... */
+								temp_timeperiod = find_timeperiod(val);
+								temp_ptr = (char *)strdup(val);
+
+								if(temp_timeperiod != NULL && temp_ptr != NULL) {
+									my_free(temp_contact->service_notification_period);
+									temp_contact->service_notification_period = temp_ptr;
+								} else
+									temp_contact->modified_service_attributes -= MODATTR_NOTIFICATION_TIMEPERIOD;
+							}
+						} else if(!strcmp(var, "host_notifications_enabled")) {
+							if(temp_contact->modified_host_attributes & MODATTR_NOTIFICATIONS_ENABLED)
+								temp_contact->host_notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						} else if(!strcmp(var, "service_notifications_enabled")) {
+							if(temp_contact->modified_service_attributes & MODATTR_NOTIFICATIONS_ENABLED)
+								temp_contact->service_notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+						}
+						/* custom variables */
+						else if(var[0] == '_') {
+
+							if(temp_contact->modified_attributes & MODATTR_CUSTOM_VARIABLE) {
+
+								/* get the variable name */
+								if((customvarname = (char *)strdup(var + 1))) {
+
+									for(temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
+										if(!strcmp(customvarname, temp_customvariablesmember->variable_name)) {
+											if((x = atoi(val)) > 0 && strlen(val) > 3) {
+												my_free(temp_customvariablesmember->variable_value);
+												temp_customvariablesmember->variable_value = (char *)strdup(val + 2);
+												temp_customvariablesmember->has_been_modified = (x > 0) ? TRUE : FALSE;
+											}
+											break;
+										}
+									}
+
+									/* free memory */
+									my_free(customvarname);
+								}
+							}
+						}
+					}
+				}
+				break;
+
+			case XRDDEFAULT_HOSTCOMMENT_DATA:
+			case XRDDEFAULT_SERVICECOMMENT_DATA:
+				if(!strcmp(var, "host_name"))
+					host_name = (char *)strdup(val);
+				else if(!strcmp(var, "service_description"))
+					service_description = (char *)strdup(val);
+				else if(!strcmp(var, "entry_type"))
+					entry_type = atoi(val);
+				else if(!strcmp(var, "comment_id"))
+					comment_id = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "source"))
+					source = atoi(val);
+				else if(!strcmp(var, "persistent"))
+					persistent = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "entry_time"))
+					entry_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "expires"))
+					expires = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "expire_time"))
+					expire_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "author"))
+					author = (char *)strdup(val);
+				else if(!strcmp(var, "comment_data"))
+					comment_data = (char *)strdup(val);
+				break;
+
+			case XRDDEFAULT_HOSTDOWNTIME_DATA:
+			case XRDDEFAULT_SERVICEDOWNTIME_DATA:
+				if(!strcmp(var, "host_name"))
+					host_name = (char *)strdup(val);
+				else if(!strcmp(var, "service_description"))
+					service_description = (char *)strdup(val);
+				else if(!strcmp(var, "downtime_id"))
+					downtime_id = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "comment_id"))
+					comment_id = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "entry_time"))
+					entry_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "start_time"))
+					start_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "flex_downtime_start"))
+					flex_downtime_start = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "end_time"))
+					end_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "fixed"))
+					fixed = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "triggered_by"))
+					triggered_by = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "is_in_effect"))
+					is_in_effect = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "start_notification_sent"))
+					start_notification_sent = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "duration"))
+					duration = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "author"))
+					author = (char *)strdup(val);
+				else if(!strcmp(var, "comment"))
+					comment_data = (char *)strdup(val);
+				break;
+
+			default:
+				break;
 			}
 		}
+	}
 
 	/* free memory and close the file */
 	my_free(inputbuf);
@@ -1706,7 +1634,7 @@ int xrddefault_read_state_information(void) {
 		printf("                      ============\n");
 		printf("TOTAL:                %.6lf sec\n", runtime[1]);
 		printf("\n\n");
-		}
+	}
 
 	return OK;
-	}
+}

--- a/xdata/xsddefault.c
+++ b/xdata/xsddefault.c
@@ -66,7 +66,8 @@ int program_stats[MAX_CHECK_STATS_TYPES][3];
 
 
 /* initialize status data */
-int xsddefault_initialize_status_data(const char *cfgfile) {
+int xsddefault_initialize_status_data(const char *cfgfile)
+{
 	nagios_macros *mac;
 
 	/* initialize locations if necessary */
@@ -88,23 +89,24 @@ int xsddefault_initialize_status_data(const char *cfgfile) {
 		unlink(status_file);
 
 	return OK;
-	}
+}
 
 
 /* cleanup status data before terminating */
-int xsddefault_cleanup_status_data(int delete_status_data) {
+int xsddefault_cleanup_status_data(int delete_status_data)
+{
 
 	/* delete the status log */
 	if(delete_status_data == TRUE && status_file) {
 		if(unlink(status_file))
 			return ERROR;
-		}
+	}
 
 	/* free memory */
 	my_free(status_file);
 
 	return OK;
-	}
+}
 
 
 /******************************************************************/
@@ -112,7 +114,8 @@ int xsddefault_cleanup_status_data(int delete_status_data) {
 /******************************************************************/
 
 /* write all status data to file */
-int xsddefault_save_status_data(void) {
+int xsddefault_save_status_data(void)
+{
 	char *tmp_log = NULL;
 	customvariablesmember *temp_customvariablesmember = NULL;
 	host *temp_host = NULL;
@@ -146,7 +149,7 @@ int xsddefault_save_status_data(void) {
 		my_free(tmp_log);
 
 		return ERROR;
-		}
+	}
 	fp = (FILE *)fdopen(fd, "w");
 	if(fp == NULL) {
 
@@ -160,7 +163,7 @@ int xsddefault_save_status_data(void) {
 		my_free(tmp_log);
 
 		return ERROR;
-		}
+	}
 
 	/* generate check statistics */
 	generate_check_stats();
@@ -288,9 +291,9 @@ int xsddefault_save_status_data(void) {
 		for(temp_customvariablesmember = temp_host->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if(temp_customvariablesmember->variable_name)
 				fprintf(fp, "\t_%s=%d;%s\n", temp_customvariablesmember->variable_name, temp_customvariablesmember->has_been_modified, (temp_customvariablesmember->variable_value == NULL) ? "" : temp_customvariablesmember->variable_value);
-			}
-		fprintf(fp, "\t}\n\n");
 		}
+		fprintf(fp, "\t}\n\n");
+	}
 
 	/* save service status data */
 	for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next) {
@@ -355,9 +358,9 @@ int xsddefault_save_status_data(void) {
 		for(temp_customvariablesmember = temp_service->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if(temp_customvariablesmember->variable_name)
 				fprintf(fp, "\t_%s=%d;%s\n", temp_customvariablesmember->variable_name, temp_customvariablesmember->has_been_modified, (temp_customvariablesmember->variable_value == NULL) ? "" : temp_customvariablesmember->variable_value);
-			}
-		fprintf(fp, "\t}\n\n");
 		}
+		fprintf(fp, "\t}\n\n");
+	}
 
 	/* save contact status data */
 	for(temp_contact = contact_list; temp_contact != NULL; temp_contact = temp_contact->next) {
@@ -379,9 +382,9 @@ int xsddefault_save_status_data(void) {
 		for(temp_customvariablesmember = temp_contact->custom_variables; temp_customvariablesmember != NULL; temp_customvariablesmember = temp_customvariablesmember->next) {
 			if(temp_customvariablesmember->variable_name)
 				fprintf(fp, "\t_%s=%d;%s\n", temp_customvariablesmember->variable_name, temp_customvariablesmember->has_been_modified, (temp_customvariablesmember->variable_value == NULL) ? "" : temp_customvariablesmember->variable_value);
-			}
-		fprintf(fp, "\t}\n\n");
 		}
+		fprintf(fp, "\t}\n\n");
+	}
 
 	/* save all comments */
 	for(temp_comment = comment_list; temp_comment != NULL; temp_comment = temp_comment->next) {
@@ -403,7 +406,7 @@ int xsddefault_save_status_data(void) {
 		fprintf(fp, "\tauthor=%s\n", temp_comment->author);
 		fprintf(fp, "\tcomment_data=%s\n", temp_comment->comment_data);
 		fprintf(fp, "\t}\n\n");
-		}
+	}
 
 	/* save all downtime */
 	for(temp_downtime = scheduled_downtime_list; temp_downtime != NULL; temp_downtime = temp_downtime->next) {
@@ -429,7 +432,7 @@ int xsddefault_save_status_data(void) {
 		fprintf(fp, "\tauthor=%s\n", temp_downtime->author);
 		fprintf(fp, "\tcomment=%s\n", temp_downtime->comment);
 		fprintf(fp, "\t}\n\n");
-		}
+	}
 
 
 	/* reset file permissions */
@@ -454,8 +457,8 @@ int xsddefault_save_status_data(void) {
 			unlink(tmp_log);
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to update status data file '%s': %s", status_file, strerror(errno));
 			result = ERROR;
-			}
 		}
+	}
 
 	/* a problem occurred saving the file */
 	else {
@@ -465,13 +468,13 @@ int xsddefault_save_status_data(void) {
 		/* remove temp file and log an error */
 		unlink(tmp_log);
 		logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: Unable to save status file: %s", strerror(errno));
-		}
+	}
 
 	/* free memory */
 	my_free(tmp_log);
 
 	return result;
-	}
+}
 
 #endif
 
@@ -484,7 +487,8 @@ int xsddefault_save_status_data(void) {
 /******************************************************************/
 
 /* read all program, host, and service status information */
-int xsddefault_read_status_data(const char *cfgfile, int options) {
+int xsddefault_read_status_data(const char *cfgfile, int options)
+{
 #ifdef NO_MMAP
 	char input[MAX_PLUGIN_OUTPUT_LENGTH] = "";
 	FILE *fp = NULL;
@@ -527,7 +531,7 @@ int xsddefault_read_status_data(const char *cfgfile, int options) {
 		program_stats[x][0] = 0;
 		program_stats[x][1] = 0;
 		program_stats[x][2] = 0;
-		}
+	}
 
 	/* open the status file for reading */
 #ifdef NO_MMAP
@@ -571,16 +575,13 @@ int xsddefault_read_status_data(const char *cfgfile, int options) {
 		else if(!strcmp(input, "hoststatus {")) {
 			data_type = XSDDEFAULT_HOSTSTATUS_DATA;
 			temp_hoststatus = (hoststatus *)calloc(1, sizeof(hoststatus));
-			}
-		else if(!strcmp(input, "servicestatus {")) {
+		} else if(!strcmp(input, "servicestatus {")) {
 			data_type = XSDDEFAULT_SERVICESTATUS_DATA;
 			temp_servicestatus = (servicestatus *)calloc(1, sizeof(servicestatus));
-			}
-		else if(!strcmp(input, "contactstatus {")) {
+		} else if(!strcmp(input, "contactstatus {")) {
 			data_type = XSDDEFAULT_CONTACTSTATUS_DATA;
 			/* unimplemented */
-			}
-		else if(!strcmp(input, "hostcomment {"))
+		} else if(!strcmp(input, "hostcomment {"))
 			data_type = XSDDEFAULT_HOSTCOMMENT_DATA;
 		else if(!strcmp(input, "servicecomment {"))
 			data_type = XSDDEFAULT_SERVICECOMMENT_DATA;
@@ -593,83 +594,83 @@ int xsddefault_read_status_data(const char *cfgfile, int options) {
 
 			switch(data_type) {
 
-				case XSDDEFAULT_INFO_DATA:
-					break;
+			case XSDDEFAULT_INFO_DATA:
+				break;
 
-				case XSDDEFAULT_PROGRAMSTATUS_DATA:
-					break;
+			case XSDDEFAULT_PROGRAMSTATUS_DATA:
+				break;
 
-				case XSDDEFAULT_HOSTSTATUS_DATA:
-					add_host_status(temp_hoststatus);
-					temp_hoststatus = NULL;
-					break;
+			case XSDDEFAULT_HOSTSTATUS_DATA:
+				add_host_status(temp_hoststatus);
+				temp_hoststatus = NULL;
+				break;
 
-				case XSDDEFAULT_SERVICESTATUS_DATA:
-					add_service_status(temp_servicestatus);
-					temp_servicestatus = NULL;
-					break;
+			case XSDDEFAULT_SERVICESTATUS_DATA:
+				add_service_status(temp_servicestatus);
+				temp_servicestatus = NULL;
+				break;
 
-				case XSDDEFAULT_CONTACTSTATUS_DATA:
-					/* unimplemented */
-					break;
+			case XSDDEFAULT_CONTACTSTATUS_DATA:
+				/* unimplemented */
+				break;
 
-				case XSDDEFAULT_HOSTCOMMENT_DATA:
-				case XSDDEFAULT_SERVICECOMMENT_DATA:
+			case XSDDEFAULT_HOSTCOMMENT_DATA:
+			case XSDDEFAULT_SERVICECOMMENT_DATA:
 
-					/* add the comment */
-					add_comment((data_type == XSDDEFAULT_HOSTCOMMENT_DATA) ? HOST_COMMENT : SERVICE_COMMENT, entry_type, host_name, service_description, entry_time, author, comment_data, comment_id, persistent, expires, expire_time, source);
+				/* add the comment */
+				add_comment((data_type == XSDDEFAULT_HOSTCOMMENT_DATA) ? HOST_COMMENT : SERVICE_COMMENT, entry_type, host_name, service_description, entry_time, author, comment_data, comment_id, persistent, expires, expire_time, source);
 
-					/* free temp memory */
-					my_free(host_name);
-					my_free(service_description);
-					my_free(author);
-					my_free(comment_data);
+				/* free temp memory */
+				my_free(host_name);
+				my_free(service_description);
+				my_free(author);
+				my_free(comment_data);
 
-					/* reset defaults */
-					entry_type = USER_COMMENT;
-					comment_id = 0;
-					source = COMMENTSOURCE_INTERNAL;
-					persistent = FALSE;
-					entry_time = 0L;
-					expires = FALSE;
-					expire_time = 0L;
+				/* reset defaults */
+				entry_type = USER_COMMENT;
+				comment_id = 0;
+				source = COMMENTSOURCE_INTERNAL;
+				persistent = FALSE;
+				entry_time = 0L;
+				expires = FALSE;
+				expire_time = 0L;
 
-					break;
+				break;
 
-				case XSDDEFAULT_HOSTDOWNTIME_DATA:
-				case XSDDEFAULT_SERVICEDOWNTIME_DATA:
+			case XSDDEFAULT_HOSTDOWNTIME_DATA:
+			case XSDDEFAULT_SERVICEDOWNTIME_DATA:
 
-					/* add the downtime */
-					if(data_type == XSDDEFAULT_HOSTDOWNTIME_DATA)
-						add_host_downtime(host_name, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
-					else
-						add_service_downtime(host_name, service_description, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
+				/* add the downtime */
+				if(data_type == XSDDEFAULT_HOSTDOWNTIME_DATA)
+					add_host_downtime(host_name, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
+				else
+					add_service_downtime(host_name, service_description, entry_time, author, comment_data, start_time, flex_downtime_start, end_time, fixed, triggered_by, duration, downtime_id, is_in_effect, start_notification_sent);
 
-					/* free temp memory */
-					my_free(host_name);
-					my_free(service_description);
-					my_free(author);
-					my_free(comment_data);
+				/* free temp memory */
+				my_free(host_name);
+				my_free(service_description);
+				my_free(author);
+				my_free(comment_data);
 
-					/* reset defaults */
-					downtime_id = 0;
-					entry_time = 0L;
-					start_time = 0L;
-					end_time = 0L;
-					fixed = FALSE;
-					triggered_by = 0;
-					duration = 0L;
-					is_in_effect = FALSE;
-					start_notification_sent = FALSE;
+				/* reset defaults */
+				downtime_id = 0;
+				entry_time = 0L;
+				start_time = 0L;
+				end_time = 0L;
+				fixed = FALSE;
+				triggered_by = 0;
+				duration = 0L;
+				is_in_effect = FALSE;
+				start_notification_sent = FALSE;
 
-					break;
+				break;
 
-				default:
-					break;
-				}
+			default:
+				break;
+			}
 
 			data_type = XSDDEFAULT_NO_DATA;
-			}
+		}
 
 		else if(data_type != XSDDEFAULT_NO_DATA) {
 
@@ -680,341 +681,337 @@ int xsddefault_read_status_data(const char *cfgfile, int options) {
 
 			switch(data_type) {
 
-				case XSDDEFAULT_INFO_DATA:
-					break;
+			case XSDDEFAULT_INFO_DATA:
+				break;
 
-				case XSDDEFAULT_PROGRAMSTATUS_DATA:
-					/* NOTE: some vars are not read, as they are not used by the CGIs (modified attributes, event handler commands, etc.) */
-					if(!strcmp(var, "nagios_pid"))
-						nagios_pid = atoi(val);
-					else if(!strcmp(var, "daemon_mode"))
-						daemon_mode = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "program_start"))
-						program_start = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "last_log_rotation"))
-						last_log_rotation = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "enable_notifications"))
-						enable_notifications = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "active_service_checks_enabled"))
-						execute_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "passive_service_checks_enabled"))
-						accept_passive_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "active_host_checks_enabled"))
-						execute_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "passive_host_checks_enabled"))
-						accept_passive_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "enable_event_handlers"))
-						enable_event_handlers = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "obsess_over_services"))
-						obsess_over_services = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "obsess_over_hosts"))
-						obsess_over_hosts = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "check_service_freshness"))
-						check_service_freshness = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "check_host_freshness"))
-						check_host_freshness = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "enable_flap_detection"))
-						enable_flap_detection = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "process_performance_data"))
-						process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
+			case XSDDEFAULT_PROGRAMSTATUS_DATA:
+				/* NOTE: some vars are not read, as they are not used by the CGIs (modified attributes, event handler commands, etc.) */
+				if(!strcmp(var, "nagios_pid"))
+					nagios_pid = atoi(val);
+				else if(!strcmp(var, "daemon_mode"))
+					daemon_mode = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "program_start"))
+					program_start = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "last_log_rotation"))
+					last_log_rotation = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "enable_notifications"))
+					enable_notifications = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "active_service_checks_enabled"))
+					execute_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "passive_service_checks_enabled"))
+					accept_passive_service_checks = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "active_host_checks_enabled"))
+					execute_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "passive_host_checks_enabled"))
+					accept_passive_host_checks = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "enable_event_handlers"))
+					enable_event_handlers = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "obsess_over_services"))
+					obsess_over_services = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "obsess_over_hosts"))
+					obsess_over_hosts = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "check_service_freshness"))
+					check_service_freshness = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "check_host_freshness"))
+					check_host_freshness = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "enable_flap_detection"))
+					enable_flap_detection = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "process_performance_data"))
+					process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
 
-					else if(strstr(var, "_stats")) {
+				else if(strstr(var, "_stats")) {
 
-						x = -1;
-						if(!strcmp(var, "active_scheduled_host_check_stats"))
-							x = ACTIVE_SCHEDULED_HOST_CHECK_STATS;
-						if(!strcmp(var, "active_ondemand_host_check_stats"))
-							x = ACTIVE_ONDEMAND_HOST_CHECK_STATS;
-						if(!strcmp(var, "passive_host_check_stats"))
-							x = PASSIVE_HOST_CHECK_STATS;
-						if(!strcmp(var, "active_scheduled_service_check_stats"))
-							x = ACTIVE_SCHEDULED_SERVICE_CHECK_STATS;
-						if(!strcmp(var, "active_ondemand_service_check_stats"))
-							x = ACTIVE_ONDEMAND_SERVICE_CHECK_STATS;
-						if(!strcmp(var, "passive_service_check_stats"))
-							x = PASSIVE_SERVICE_CHECK_STATS;
-						if(!strcmp(var, "cached_host_check_stats"))
-							x = ACTIVE_CACHED_HOST_CHECK_STATS;
-						if(!strcmp(var, "cached_service_check_stats"))
-							x = ACTIVE_CACHED_SERVICE_CHECK_STATS;
-						if(!strcmp(var, "external_command_stats"))
-							x = EXTERNAL_COMMAND_STATS;
-						if(!strcmp(var, "parallel_host_check_stats"))
-							x = PARALLEL_HOST_CHECK_STATS;
-						if(!strcmp(var, "serial_host_check_stats"))
-							x = SERIAL_HOST_CHECK_STATS;
+					x = -1;
+					if(!strcmp(var, "active_scheduled_host_check_stats"))
+						x = ACTIVE_SCHEDULED_HOST_CHECK_STATS;
+					if(!strcmp(var, "active_ondemand_host_check_stats"))
+						x = ACTIVE_ONDEMAND_HOST_CHECK_STATS;
+					if(!strcmp(var, "passive_host_check_stats"))
+						x = PASSIVE_HOST_CHECK_STATS;
+					if(!strcmp(var, "active_scheduled_service_check_stats"))
+						x = ACTIVE_SCHEDULED_SERVICE_CHECK_STATS;
+					if(!strcmp(var, "active_ondemand_service_check_stats"))
+						x = ACTIVE_ONDEMAND_SERVICE_CHECK_STATS;
+					if(!strcmp(var, "passive_service_check_stats"))
+						x = PASSIVE_SERVICE_CHECK_STATS;
+					if(!strcmp(var, "cached_host_check_stats"))
+						x = ACTIVE_CACHED_HOST_CHECK_STATS;
+					if(!strcmp(var, "cached_service_check_stats"))
+						x = ACTIVE_CACHED_SERVICE_CHECK_STATS;
+					if(!strcmp(var, "external_command_stats"))
+						x = EXTERNAL_COMMAND_STATS;
+					if(!strcmp(var, "parallel_host_check_stats"))
+						x = PARALLEL_HOST_CHECK_STATS;
+					if(!strcmp(var, "serial_host_check_stats"))
+						x = SERIAL_HOST_CHECK_STATS;
 
-						if(x >= 0) {
-							if((ptr = strtok(val, ","))) {
-								program_stats[x][0] = atoi(ptr);
-								if((ptr = strtok(NULL, ","))) {
-									program_stats[x][1] = atoi(ptr);
-									if((ptr = strtok(NULL, "\n")))
-										program_stats[x][2] = atoi(ptr);
-									}
-								}
+					if(x >= 0) {
+						if((ptr = strtok(val, ","))) {
+							program_stats[x][0] = atoi(ptr);
+							if((ptr = strtok(NULL, ","))) {
+								program_stats[x][1] = atoi(ptr);
+								if((ptr = strtok(NULL, "\n")))
+									program_stats[x][2] = atoi(ptr);
 							}
 						}
-					break;
-
-				case XSDDEFAULT_HOSTSTATUS_DATA:
-					/* NOTE: some vars are not read, as they are not used by the CGIs (modified attributes, event handler commands, etc.) */
-					if(temp_hoststatus != NULL) {
-						if(!strcmp(var, "host_name"))
-							temp_hoststatus->host_name = (char *)strdup(val);
-						else if(!strcmp(var, "has_been_checked"))
-							temp_hoststatus->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "should_be_scheduled"))
-							temp_hoststatus->should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "check_execution_time"))
-							temp_hoststatus->execution_time = strtod(val, NULL);
-						else if(!strcmp(var, "check_latency"))
-							temp_hoststatus->latency = strtod(val, NULL);
-						else if(!strcmp(var, "check_type"))
-							temp_hoststatus->check_type = atoi(val);
-						else if(!strcmp(var, "current_state"))
-							temp_hoststatus->status = atoi(val);
-						else if(!strcmp(var, "last_hard_state"))
-							temp_hoststatus->last_hard_state = atoi(val);
-						else if(!strcmp(var, "plugin_output")) {
-							temp_hoststatus->plugin_output = (char *)strdup(val);
-							unescape_newlines(temp_hoststatus->plugin_output);
-							}
-						else if(!strcmp(var, "long_plugin_output")) {
-							temp_hoststatus->long_plugin_output = (char *)strdup(val);
-							unescape_newlines(temp_hoststatus->long_plugin_output);
-							}
-						else if(!strcmp(var, "performance_data"))
-							temp_hoststatus->perf_data = (char *)strdup(val);
-						else if(!strcmp(var, "current_attempt"))
-							temp_hoststatus->current_attempt = atoi(val);
-						else if(!strcmp(var, "max_attempts"))
-							temp_hoststatus->max_attempts = atoi(val);
-						else if(!strcmp(var, "last_check"))
-							temp_hoststatus->last_check = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_check"))
-							temp_hoststatus->next_check = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "check_options"))
-							temp_hoststatus->check_options = atoi(val);
-						else if(!strcmp(var, "current_attempt"))
-							temp_hoststatus->current_attempt = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "state_type"))
-							temp_hoststatus->state_type = atoi(val);
-						else if(!strcmp(var, "last_state_change"))
-							temp_hoststatus->last_state_change = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_hard_state_change"))
-							temp_hoststatus->last_hard_state_change = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_up"))
-							temp_hoststatus->last_time_up = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_down"))
-							temp_hoststatus->last_time_down = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_unreachable"))
-							temp_hoststatus->last_time_unreachable = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_notification"))
-							temp_hoststatus->last_notification = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_notification"))
-							temp_hoststatus->next_notification = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "no_more_notifications"))
-							temp_hoststatus->no_more_notifications = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "current_notification_number"))
-							temp_hoststatus->current_notification_number = atoi(val);
-						else if(!strcmp(var, "notifications_enabled"))
-							temp_hoststatus->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "problem_has_been_acknowledged"))
-							temp_hoststatus->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "acknowledgement_type"))
-							temp_hoststatus->acknowledgement_type = atoi(val);
-						else if(!strcmp(var, "active_checks_enabled"))
-							temp_hoststatus->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "passive_checks_enabled"))
-							temp_hoststatus->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "event_handler_enabled"))
-							temp_hoststatus->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "flap_detection_enabled"))
-							temp_hoststatus->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "process_performance_data"))
-							temp_hoststatus->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "obsess_over_host") || !strcmp(var, "obsess"))
-							temp_hoststatus->obsess = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "last_update"))
-							temp_hoststatus->last_update = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "is_flapping"))
-							temp_hoststatus->is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "percent_state_change"))
-							temp_hoststatus->percent_state_change = strtod(val, NULL);
-						else if(!strcmp(var, "scheduled_downtime_depth")) {
-							temp_hoststatus->scheduled_downtime_depth = atoi(val);
-							if (temp_hoststatus->scheduled_downtime_depth < 0)
-								temp_hoststatus->scheduled_downtime_depth = 0;
-							}
-						}
-					break;
-
-				case XSDDEFAULT_SERVICESTATUS_DATA:
-					/* NOTE: some vars are not read, as they are not used by the CGIs (modified attributes, event handler commands, etc.) */
-					if(temp_servicestatus != NULL) {
-						if(!strcmp(var, "host_name"))
-							temp_servicestatus->host_name = (char *)strdup(val);
-						else if(!strcmp(var, "service_description"))
-							temp_servicestatus->description = (char *)strdup(val);
-						else if(!strcmp(var, "has_been_checked"))
-							temp_servicestatus->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "should_be_scheduled"))
-							temp_servicestatus->should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "check_execution_time"))
-							temp_servicestatus->execution_time = strtod(val, NULL);
-						else if(!strcmp(var, "check_latency"))
-							temp_servicestatus->latency = strtod(val, NULL);
-						else if(!strcmp(var, "check_type"))
-							temp_servicestatus->check_type = atoi(val);
-						else if(!strcmp(var, "current_state"))
-							temp_servicestatus->status = atoi(val);
-						else if(!strcmp(var, "last_hard_state"))
-							temp_servicestatus->last_hard_state = atoi(val);
-						else if(!strcmp(var, "current_attempt"))
-							temp_servicestatus->current_attempt = atoi(val);
-						else if(!strcmp(var, "max_attempts"))
-							temp_servicestatus->max_attempts = atoi(val);
-						else if(!strcmp(var, "state_type"))
-							temp_servicestatus->state_type = atoi(val);
-						else if(!strcmp(var, "last_state_change"))
-							temp_servicestatus->last_state_change = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_hard_state_change"))
-							temp_servicestatus->last_hard_state_change = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_ok"))
-							temp_servicestatus->last_time_ok = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_warning"))
-							temp_servicestatus->last_time_warning = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_unknown"))
-							temp_servicestatus->last_time_unknown = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "last_time_critical"))
-							temp_servicestatus->last_time_critical = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "plugin_output")) {
-							temp_servicestatus->plugin_output = (char *)strdup(val);
-							unescape_newlines(temp_servicestatus->plugin_output);
-							}
-						else if(!strcmp(var, "long_plugin_output")) {
-							temp_servicestatus->long_plugin_output = (char *)strdup(val);
-							unescape_newlines(temp_servicestatus->long_plugin_output);
-							}
-						else if(!strcmp(var, "performance_data"))
-							temp_servicestatus->perf_data = (char *)strdup(val);
-						else if(!strcmp(var, "last_check"))
-							temp_servicestatus->last_check = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_check"))
-							temp_servicestatus->next_check = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "check_options"))
-							temp_servicestatus->check_options = atoi(val);
-						else if(!strcmp(var, "current_notification_number"))
-							temp_servicestatus->current_notification_number = atoi(val);
-						else if(!strcmp(var, "last_notification"))
-							temp_servicestatus->last_notification = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "next_notification"))
-							temp_servicestatus->next_notification = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "no_more_notifications"))
-							temp_servicestatus->no_more_notifications = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "notifications_enabled"))
-							temp_servicestatus->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "active_checks_enabled"))
-							temp_servicestatus->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "passive_checks_enabled"))
-							temp_servicestatus->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "event_handler_enabled"))
-							temp_servicestatus->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "problem_has_been_acknowledged"))
-							temp_servicestatus->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "acknowledgement_type"))
-							temp_servicestatus->acknowledgement_type = atoi(val);
-						else if(!strcmp(var, "flap_detection_enabled"))
-							temp_servicestatus->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "process_performance_data"))
-							temp_servicestatus->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "obsess_over_service") || !strcmp(var, "obsess"))
-							temp_servicestatus->obsess = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "last_update"))
-							temp_servicestatus->last_update = strtoul(val, NULL, 10);
-						else if(!strcmp(var, "is_flapping"))
-							temp_servicestatus->is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
-						else if(!strcmp(var, "percent_state_change"))
-							temp_servicestatus->percent_state_change = strtod(val, NULL);
-						else if(!strcmp(var, "scheduled_downtime_depth")) {
-							temp_servicestatus->scheduled_downtime_depth = atoi(val);
-							if (temp_servicestatus->scheduled_downtime_depth < 0)
-								temp_servicestatus->scheduled_downtime_depth = 0;
-							}
-						}
-					break;
-
-				case XSDDEFAULT_CONTACTSTATUS_DATA:
-					/* unimplemented */
-					break;
-
-				case XSDDEFAULT_HOSTCOMMENT_DATA:
-				case XSDDEFAULT_SERVICECOMMENT_DATA:
-					if(!strcmp(var, "host_name"))
-						host_name = (char *)strdup(val);
-					else if(!strcmp(var, "service_description"))
-						service_description = (char *)strdup(val);
-					else if(!strcmp(var, "entry_type"))
-						entry_type = atoi(val);
-					else if(!strcmp(var, "comment_id"))
-						comment_id = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "source"))
-						source = atoi(val);
-					else if(!strcmp(var, "persistent"))
-						persistent = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "entry_time"))
-						entry_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "expires"))
-						expires = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "expire_time"))
-						expire_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "author"))
-						author = (char *)strdup(val);
-					else if(!strcmp(var, "comment_data"))
-						comment_data = (char *)strdup(val);
-					break;
-
-				case XSDDEFAULT_HOSTDOWNTIME_DATA:
-				case XSDDEFAULT_SERVICEDOWNTIME_DATA:
-					if(!strcmp(var, "host_name"))
-						host_name = (char *)strdup(val);
-					else if(!strcmp(var, "service_description"))
-						service_description = (char *)strdup(val);
-					else if(!strcmp(var, "downtime_id"))
-						downtime_id = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "comment_id"))
-						comment_id = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "entry_time"))
-						entry_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "start_time"))
-						start_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "flex_downtime_start"))
-						flex_downtime_start = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "end_time"))
-						end_time = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "fixed"))
-						fixed = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "triggered_by"))
-						triggered_by = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "duration"))
-						duration = strtoul(val, NULL, 10);
-					else if(!strcmp(var, "is_in_effect"))
-						is_in_effect = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "start_notification_sent"))
-						start_notification_sent = (atoi(val) > 0) ? TRUE : FALSE;
-					else if(!strcmp(var, "author"))
-						author = (char *)strdup(val);
-					else if(!strcmp(var, "comment"))
-						comment_data = (char *)strdup(val);
-					break;
-
-				default:
-					break;
+					}
 				}
+				break;
 
+			case XSDDEFAULT_HOSTSTATUS_DATA:
+				/* NOTE: some vars are not read, as they are not used by the CGIs (modified attributes, event handler commands, etc.) */
+				if(temp_hoststatus != NULL) {
+					if(!strcmp(var, "host_name"))
+						temp_hoststatus->host_name = (char *)strdup(val);
+					else if(!strcmp(var, "has_been_checked"))
+						temp_hoststatus->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "should_be_scheduled"))
+						temp_hoststatus->should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "check_execution_time"))
+						temp_hoststatus->execution_time = strtod(val, NULL);
+					else if(!strcmp(var, "check_latency"))
+						temp_hoststatus->latency = strtod(val, NULL);
+					else if(!strcmp(var, "check_type"))
+						temp_hoststatus->check_type = atoi(val);
+					else if(!strcmp(var, "current_state"))
+						temp_hoststatus->status = atoi(val);
+					else if(!strcmp(var, "last_hard_state"))
+						temp_hoststatus->last_hard_state = atoi(val);
+					else if(!strcmp(var, "plugin_output")) {
+						temp_hoststatus->plugin_output = (char *)strdup(val);
+						unescape_newlines(temp_hoststatus->plugin_output);
+					} else if(!strcmp(var, "long_plugin_output")) {
+						temp_hoststatus->long_plugin_output = (char *)strdup(val);
+						unescape_newlines(temp_hoststatus->long_plugin_output);
+					} else if(!strcmp(var, "performance_data"))
+						temp_hoststatus->perf_data = (char *)strdup(val);
+					else if(!strcmp(var, "current_attempt"))
+						temp_hoststatus->current_attempt = atoi(val);
+					else if(!strcmp(var, "max_attempts"))
+						temp_hoststatus->max_attempts = atoi(val);
+					else if(!strcmp(var, "last_check"))
+						temp_hoststatus->last_check = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_check"))
+						temp_hoststatus->next_check = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "check_options"))
+						temp_hoststatus->check_options = atoi(val);
+					else if(!strcmp(var, "current_attempt"))
+						temp_hoststatus->current_attempt = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "state_type"))
+						temp_hoststatus->state_type = atoi(val);
+					else if(!strcmp(var, "last_state_change"))
+						temp_hoststatus->last_state_change = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_hard_state_change"))
+						temp_hoststatus->last_hard_state_change = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_up"))
+						temp_hoststatus->last_time_up = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_down"))
+						temp_hoststatus->last_time_down = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_unreachable"))
+						temp_hoststatus->last_time_unreachable = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_notification"))
+						temp_hoststatus->last_notification = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_notification"))
+						temp_hoststatus->next_notification = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "no_more_notifications"))
+						temp_hoststatus->no_more_notifications = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "current_notification_number"))
+						temp_hoststatus->current_notification_number = atoi(val);
+					else if(!strcmp(var, "notifications_enabled"))
+						temp_hoststatus->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "problem_has_been_acknowledged"))
+						temp_hoststatus->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "acknowledgement_type"))
+						temp_hoststatus->acknowledgement_type = atoi(val);
+					else if(!strcmp(var, "active_checks_enabled"))
+						temp_hoststatus->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "passive_checks_enabled"))
+						temp_hoststatus->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "event_handler_enabled"))
+						temp_hoststatus->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "flap_detection_enabled"))
+						temp_hoststatus->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "process_performance_data"))
+						temp_hoststatus->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "obsess_over_host") || !strcmp(var, "obsess"))
+						temp_hoststatus->obsess = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "last_update"))
+						temp_hoststatus->last_update = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "is_flapping"))
+						temp_hoststatus->is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "percent_state_change"))
+						temp_hoststatus->percent_state_change = strtod(val, NULL);
+					else if(!strcmp(var, "scheduled_downtime_depth")) {
+						temp_hoststatus->scheduled_downtime_depth = atoi(val);
+						if (temp_hoststatus->scheduled_downtime_depth < 0)
+							temp_hoststatus->scheduled_downtime_depth = 0;
+					}
+				}
+				break;
+
+			case XSDDEFAULT_SERVICESTATUS_DATA:
+				/* NOTE: some vars are not read, as they are not used by the CGIs (modified attributes, event handler commands, etc.) */
+				if(temp_servicestatus != NULL) {
+					if(!strcmp(var, "host_name"))
+						temp_servicestatus->host_name = (char *)strdup(val);
+					else if(!strcmp(var, "service_description"))
+						temp_servicestatus->description = (char *)strdup(val);
+					else if(!strcmp(var, "has_been_checked"))
+						temp_servicestatus->has_been_checked = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "should_be_scheduled"))
+						temp_servicestatus->should_be_scheduled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "check_execution_time"))
+						temp_servicestatus->execution_time = strtod(val, NULL);
+					else if(!strcmp(var, "check_latency"))
+						temp_servicestatus->latency = strtod(val, NULL);
+					else if(!strcmp(var, "check_type"))
+						temp_servicestatus->check_type = atoi(val);
+					else if(!strcmp(var, "current_state"))
+						temp_servicestatus->status = atoi(val);
+					else if(!strcmp(var, "last_hard_state"))
+						temp_servicestatus->last_hard_state = atoi(val);
+					else if(!strcmp(var, "current_attempt"))
+						temp_servicestatus->current_attempt = atoi(val);
+					else if(!strcmp(var, "max_attempts"))
+						temp_servicestatus->max_attempts = atoi(val);
+					else if(!strcmp(var, "state_type"))
+						temp_servicestatus->state_type = atoi(val);
+					else if(!strcmp(var, "last_state_change"))
+						temp_servicestatus->last_state_change = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_hard_state_change"))
+						temp_servicestatus->last_hard_state_change = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_ok"))
+						temp_servicestatus->last_time_ok = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_warning"))
+						temp_servicestatus->last_time_warning = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_unknown"))
+						temp_servicestatus->last_time_unknown = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "last_time_critical"))
+						temp_servicestatus->last_time_critical = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "plugin_output")) {
+						temp_servicestatus->plugin_output = (char *)strdup(val);
+						unescape_newlines(temp_servicestatus->plugin_output);
+					} else if(!strcmp(var, "long_plugin_output")) {
+						temp_servicestatus->long_plugin_output = (char *)strdup(val);
+						unescape_newlines(temp_servicestatus->long_plugin_output);
+					} else if(!strcmp(var, "performance_data"))
+						temp_servicestatus->perf_data = (char *)strdup(val);
+					else if(!strcmp(var, "last_check"))
+						temp_servicestatus->last_check = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_check"))
+						temp_servicestatus->next_check = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "check_options"))
+						temp_servicestatus->check_options = atoi(val);
+					else if(!strcmp(var, "current_notification_number"))
+						temp_servicestatus->current_notification_number = atoi(val);
+					else if(!strcmp(var, "last_notification"))
+						temp_servicestatus->last_notification = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "next_notification"))
+						temp_servicestatus->next_notification = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "no_more_notifications"))
+						temp_servicestatus->no_more_notifications = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "notifications_enabled"))
+						temp_servicestatus->notifications_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "active_checks_enabled"))
+						temp_servicestatus->checks_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "passive_checks_enabled"))
+						temp_servicestatus->accept_passive_checks = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "event_handler_enabled"))
+						temp_servicestatus->event_handler_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "problem_has_been_acknowledged"))
+						temp_servicestatus->problem_has_been_acknowledged = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "acknowledgement_type"))
+						temp_servicestatus->acknowledgement_type = atoi(val);
+					else if(!strcmp(var, "flap_detection_enabled"))
+						temp_servicestatus->flap_detection_enabled = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "process_performance_data"))
+						temp_servicestatus->process_performance_data = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "obsess_over_service") || !strcmp(var, "obsess"))
+						temp_servicestatus->obsess = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "last_update"))
+						temp_servicestatus->last_update = strtoul(val, NULL, 10);
+					else if(!strcmp(var, "is_flapping"))
+						temp_servicestatus->is_flapping = (atoi(val) > 0) ? TRUE : FALSE;
+					else if(!strcmp(var, "percent_state_change"))
+						temp_servicestatus->percent_state_change = strtod(val, NULL);
+					else if(!strcmp(var, "scheduled_downtime_depth")) {
+						temp_servicestatus->scheduled_downtime_depth = atoi(val);
+						if (temp_servicestatus->scheduled_downtime_depth < 0)
+							temp_servicestatus->scheduled_downtime_depth = 0;
+					}
+				}
+				break;
+
+			case XSDDEFAULT_CONTACTSTATUS_DATA:
+				/* unimplemented */
+				break;
+
+			case XSDDEFAULT_HOSTCOMMENT_DATA:
+			case XSDDEFAULT_SERVICECOMMENT_DATA:
+				if(!strcmp(var, "host_name"))
+					host_name = (char *)strdup(val);
+				else if(!strcmp(var, "service_description"))
+					service_description = (char *)strdup(val);
+				else if(!strcmp(var, "entry_type"))
+					entry_type = atoi(val);
+				else if(!strcmp(var, "comment_id"))
+					comment_id = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "source"))
+					source = atoi(val);
+				else if(!strcmp(var, "persistent"))
+					persistent = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "entry_time"))
+					entry_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "expires"))
+					expires = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "expire_time"))
+					expire_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "author"))
+					author = (char *)strdup(val);
+				else if(!strcmp(var, "comment_data"))
+					comment_data = (char *)strdup(val);
+				break;
+
+			case XSDDEFAULT_HOSTDOWNTIME_DATA:
+			case XSDDEFAULT_SERVICEDOWNTIME_DATA:
+				if(!strcmp(var, "host_name"))
+					host_name = (char *)strdup(val);
+				else if(!strcmp(var, "service_description"))
+					service_description = (char *)strdup(val);
+				else if(!strcmp(var, "downtime_id"))
+					downtime_id = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "comment_id"))
+					comment_id = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "entry_time"))
+					entry_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "start_time"))
+					start_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "flex_downtime_start"))
+					flex_downtime_start = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "end_time"))
+					end_time = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "fixed"))
+					fixed = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "triggered_by"))
+					triggered_by = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "duration"))
+					duration = strtoul(val, NULL, 10);
+				else if(!strcmp(var, "is_in_effect"))
+					is_in_effect = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "start_notification_sent"))
+					start_notification_sent = (atoi(val) > 0) ? TRUE : FALSE;
+				else if(!strcmp(var, "author"))
+					author = (char *)strdup(val);
+				else if(!strcmp(var, "comment"))
+					comment_data = (char *)strdup(val);
+				break;
+
+			default:
+				break;
 			}
+
 		}
+	}
 
 	/* free memory and close the file */
 #ifdef NO_MMAP
@@ -1033,6 +1030,6 @@ int xsddefault_read_status_data(const char *cfgfile, int options) {
 		return ERROR;
 
 	return OK;
-	}
+}
 
 #endif


### PR DESCRIPTION
Change style to KNF for readability.

I'd rather not debate about the superiority of indent styles. Here's the hard truth: Running the original banner-style `indent-all.sh` against e3d8eb3 produces a bunch of changes. This leads me to believe that there isn't a serious attachment to a particular indent style (if there was, it wasn't enforced well). In fact, indenting using the `--style=knf` argument leaves a number of source files untouched!
## Tests Before e3d8eb3

```
Test Summary Report
-------------------
615cgierror.t                 (Wstat: 768 Tests: 17 Failed: 3)
  Failed tests:  1, 9, 13
  Non-zero exit status: 3
618cgisecurity.t              (Wstat: 256 Tests: 3 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
900-configparsing.t           (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
Files=14, Tests=481,  6 wallclock secs ( 0.11 usr  0.04 sys +  4.31 cusr  0.22 csys =  4.68 CPU)
Result: FAIL
Makefile:6: recipe for target 'test' failed
make: *** [test] Error 1
```
## Tests After e67e21e

```
Test Summary Report
-------------------
615cgierror.t                 (Wstat: 768 Tests: 17 Failed: 3)
  Failed tests:  1, 9, 13
  Non-zero exit status: 3
618cgisecurity.t              (Wstat: 256 Tests: 3 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
900-configparsing.t           (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
Files=14, Tests=481,  5 wallclock secs ( 0.10 usr  0.05 sys +  4.21 cusr  0.29 csys =  4.65 CPU)
Result: FAIL
Makefile:6: recipe for target 'test' failed
make: *** [test] Error 1
```
