### PR TITLE
Fix for bug #0000582 - Incorrect parsing of valid shell commands 

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -132,7 +132,7 @@ int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv)
 	int arg = 0, a = 0;
 	unsigned int i;
 	int state, ret = 0;
-	int seen_space = 0;
+	int seen_space = 0, seen_equals = 0;
 	size_t len;
 	char *argz;
 


### PR DESCRIPTION
Valid nagios shell commands of the form

command_line VAR='VALUE' /bin/something

were not properly parsed by runcmd.c.

This caused issues with check_mk's flexible notifications.

This patch fixes the issue by detecting an '=' character before the first space in a command and forcing the use of a command shell to execute the command
