### PR TITLE
Fixed a bug calling killproc_nagios() from stop

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -201,7 +201,7 @@ case "$1" in
 		echo -n "Stopping nagios: "
 
 		pid_nagios
-		killproc_nagios nagios -SIGTERM
+		killproc_nagios nagios -TERM
 
  		# now we have to wait for nagios to exit and remove its
  		# own NagiosRunFile, otherwise a following "start" could


### PR DESCRIPTION
running /etc/init.d/nagios stop produces an error because the stop case calls killproc_stop with only one argument, but the fn. expects the signal to be the second arg.
