### PR TITLE
off-by-one error in bounds check

### DIFF
--- a/lib/iobroker.c
+++ b/lib/iobroker.c
@@ -179,7 +179,7 @@ static int reg_one(iobroker_set *iobs, int fd, int events, void *arg, int (*hand
 	if (!iobs) {
 		return IOBROKER_ENOSET;
 	}
-	if (fd < 0 || fd > iobs->max_fds)
+	if (fd < 0 || fd >= iobs->max_fds)
 		return IOBROKER_EINVAL;
 
 	/*


### PR DESCRIPTION
leads to segfault when fd==max_fds as iobs->iobroker_fds array bounds are exceeded

Seen due to leaking FDs with external queryhandlers - see #10 