### PR TITLE
Add host_down_disable_service_checks directive to nagios.cfg

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -409,4 +409,4 @@ dist: distclean
 	rm -f nagios-$(VERSION)
 
 # Targets that always get built
-.PHONY:	indent clean clean distclean dox test
+.PHONY:	indent clean clean distclean dox test html

--- a/base/checks.c
+++ b/base/checks.c
@@ -1183,6 +1183,7 @@ int check_service_check_viability(service *svc, int check_options, int *time_is_
 	time_t current_time = 0L;
 	time_t preferred_time = 0L;
 	int check_interval = 0;
+	host *temp_host = NULL;
 
 	log_debug_info(DEBUGL_FUNCTIONS, 0, "check_service_check_viability()\n");
 
@@ -1229,6 +1230,19 @@ int check_service_check_viability(service *svc, int check_options, int *time_is_
 			perform_check = FALSE;
 
 			log_debug_info(DEBUGL_CHECKS, 2, "Execution dependencies for this service failed, so it will not be actively checked.\n");
+			}
+		}
+
+		/* check if host is up - if not, do not perform check */
+		if(host_down_disable_service_checks) {
+			if((temp_host = svc->host_ptr) == NULL) {
+				log_debug_info(DEBUGL_CHECKS, 2, "Host pointer NULL in check_service_check_viability().\n");
+				return ERROR;
+			} else {
+				if(temp_host->current_state != HOST_UP) {
+					log_debug_info(DEBUGL_CHECKS, 2, "Host state not UP, so service check will not be performed - will be rescheduled as normal.\n");
+					perform_check = FALSE;
+				}
 			}
 		}
 

--- a/base/config.c
+++ b/base/config.c
@@ -1169,6 +1169,9 @@ int read_main_config_file(char *main_config_file) {
 		else if(strstr(input, "x") == input)
 			continue;
 
+		else if(!strcmp(variable,"host_down_disable_service_checks")) {
+			host_down_disable_service_checks = strtoul(value, NULL, 0);
+		}
 		/* we don't know what this variable is... */
 		else {
 			asprintf(&error_message, "UNKNOWN VARIABLE");

--- a/base/utils.c
+++ b/base/utils.c
@@ -192,6 +192,8 @@ char *use_timezone;
 
 int allow_empty_hostgroup_assignment;
 
+int host_down_disable_service_checks;
+
 /*** perfdata variables ***/
 int     perfdata_timeout;
 char    *host_perfdata_command;
@@ -371,6 +373,7 @@ void init_main_cfg_vars(int first_time) {
 		use_timezone = NULL;
 		allow_empty_hostgroup_assignment =
 				DEFAULT_ALLOW_EMPTY_HOSTGROUP_ASSIGNMENT;
+		host_down_disable_service_checks = FALSE;
 		perfdata_timeout = 0;
 		host_perfdata_command = NULL;
 		service_perfdata_command = NULL;
@@ -2126,6 +2129,10 @@ int process_check_result(check_result *cr)
 	return ERROR;
 	}
 
+/* Unescapes newlines in a string. Declared here for now as it's not used
+ * elsewhere. */
+static char *unescape_check_result_file_output(char*);
+
 /* reads check result(s) from a file */
 int process_check_result_file(char *fname) {
 	mmapfile *thefile = NULL;
@@ -2248,7 +2255,7 @@ int process_check_result_file(char *fname) {
 				 * newline delimited format we use internally. By converting as
 				 * soon as possible after reading from the file we don't have
 				 * to worry about two different representations later. */
-				cr.output = unescape_check_result_output(val);
+				cr.output = unescape_check_result_file_output(val);
 			}
 		}
 
@@ -2438,8 +2445,11 @@ char *escape_newlines(char *rawbuf) {
 	return newbuf;
 	}
 
-/* Unescapes newlines (and backslashes) in a string. */
-char *unescape_check_result_output(const char *rawbuf) {
+/* Unescapes newlines (and backslashes) in a string.
+ * @note: There is an unescape_newlines() in cgi/cgiutils.c:845 that unescapes
+ * more than '\\' and '\n'. Since this function isn't used elsewhere, we'll
+ * give it a more specific name to avoid confusion and conflicts. */
+static char *unescape_check_result_file_output(char *rawbuf) {
 	char *newbuf = NULL;
 	int x;
 	int y;

--- a/base/utils.c
+++ b/base/utils.c
@@ -2255,7 +2255,7 @@ int process_check_result_file(char *fname) {
 				 * newline delimited format we use internally. By converting as
 				 * soon as possible after reading from the file we don't have
 				 * to worry about two different representations later. */
-				cr.output = unescape_check_result_file_output(val);
+				cr.output = unescape_check_result_output(val);
 			}
 		}
 
@@ -2445,11 +2445,8 @@ char *escape_newlines(char *rawbuf) {
 	return newbuf;
 	}
 
-/* Unescapes newlines (and backslashes) in a string.
- * @note: There is an unescape_newlines() in cgi/cgiutils.c:845 that unescapes
- * more than '\\' and '\n'. Since this function isn't used elsewhere, we'll
- * give it a more specific name to avoid confusion and conflicts. */
-static char *unescape_check_result_file_output(char *rawbuf) {
+/* Unescapes newlines (and backslashes) in a string. */
+char *unescape_check_result_output(const char *rawbuf) {
 	char *newbuf = NULL;
 	int x;
 	int y;

--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -70,6 +70,9 @@ int             lock_author_names = TRUE;
 int             navbar_search_addresses = TRUE;
 int             navbar_search_aliases = TRUE;
 
+int		ack_no_sticky  = FALSE;
+int		ack_no_send    = FALSE;
+
 time_t          this_scheduled_log_rotation = 0L;
 time_t          last_scheduled_log_rotation = 0L;
 time_t          next_scheduled_log_rotation = 0L;
@@ -440,6 +443,10 @@ int read_cgi_config_file(const char *filename) {
 
 		else if(!strcmp(var, "navbar_search_aliases"))
 			navbar_search_aliases = (atoi(val) > 0) ? TRUE : FALSE;
+		else if(!strcmp(var, "ack_no_sticky"))
+			ack_no_sticky = (atoi(val) > 0) ? TRUE : FALSE;
+		else if(!strcmp(var, "ack_no_send"))
+			ack_no_send = (atoi(val) > 0) ? TRUE : FALSE;
 		}
 
 	for(p = illegal_output_chars; p && *p; p++)

--- a/cgi/cmd.c
+++ b/cgi/cmd.c
@@ -44,6 +44,8 @@ extern int  use_authentication;
 
 extern int  lock_author_names;
 
+extern int ack_no_sticky;
+extern int ack_no_send;
 
 #define MAX_AUTHOR_LENGTH	64
 #define MAX_COMMENT_LENGTH	1024
@@ -950,10 +952,10 @@ void request_command_data(int cmd) {
 			printf("</b></td></tr>\n");
 			if(cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) {
 				printf("<tr><td CLASS='optBoxItem'>Sticky Acknowledgement:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='sticky_ack' CHECKED>");
+				printf("<INPUT TYPE='checkbox' NAME='sticky_ack' %s>", (ack_no_sticky == TRUE) ? "" : "CHECKED");
 				printf("</b></td></tr>\n");
 				printf("<tr><td CLASS='optBoxItem'>Send Notification:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='send_notification' CHECKED>");
+				printf("<INPUT TYPE='checkbox' NAME='send_notification' %s>", (ack_no_send == TRUE) ? "" : "CHECKED");
 				printf("</b></td></tr>\n");
 				}
 			printf("<tr><td CLASS='optBoxItem'>Persistent%s:</td><td><b>", (cmd == CMD_ACKNOWLEDGE_HOST_PROBLEM) ? " Comment" : "");
@@ -976,10 +978,10 @@ void request_command_data(int cmd) {
 			printf("<INPUT TYPE='TEXT' NAME='service' VALUE='%s'>", escape_string(service_desc));
 			if(cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) {
 				printf("<tr><td CLASS='optBoxItem'>Sticky Acknowledgement:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='sticky_ack' CHECKED>");
+				printf("<INPUT TYPE='checkbox' NAME='sticky_ack' %s>", (ack_no_sticky == TRUE) ? "" : "CHECKED");
 				printf("</b></td></tr>\n");
 				printf("<tr><td CLASS='optBoxItem'>Send Notification:</td><td><b>");
-				printf("<INPUT TYPE='checkbox' NAME='send_notification' CHECKED>");
+				printf("<INPUT TYPE='checkbox' NAME='send_notification' %s>", (ack_no_send == TRUE) ? "" : "CHECKED");
 				printf("</b></td></tr>\n");
 				}
 			printf("<tr><td CLASS='optBoxItem'>Persistent%s:</td><td><b>", (cmd == CMD_ACKNOWLEDGE_SVC_PROBLEM) ? " Comment" : "");

--- a/cgi/statusjson.c
+++ b/cgi/statusjson.c
@@ -3482,7 +3482,7 @@ void json_status_service_details(json_object *json_details,
 			&percent_escapes, temp_servicestatus->long_plugin_output);
 	json_object_append_string(json_details, "perf_data", &percent_escapes,
 			temp_servicestatus->perf_data);
-	json_object_append_integer(json_details, "max_attemps", 
+	json_object_append_integer(json_details, "max_attempts", 
 			temp_servicestatus->max_attempts);
 	json_object_append_integer(json_details, "current_attempt", 
 			temp_servicestatus->current_attempt);

--- a/include/nagios.h
+++ b/include/nagios.h
@@ -622,6 +622,20 @@ void my_system_sighandler(int);				/* handles timeouts when executing commands v
 char *get_next_string_from_buf(char *buf, int *start_index, int bufsize);
 int compare_strings(char *, char *);                    /* compares two strings for equality */
 char *escape_newlines(char *);
+/**
+ * Unescapes newlines and backslashes in a check result output string read from
+ * a source that uses newlines as a delimiter (e.g., files in the checkresults
+ * spool dir, or the command pipe).
+ * @note: There is an unescape_newlines() in cgi/cgiutils.c that unescapes more
+ * than '\\' and '\n' in place. Since this function is specifically intended
+ * for processing escaped plugin output, we'll use a more specific name to
+ * avoid confusion and conflicts.
+ * @param rawbuf Input string tp unescape.
+ * @return An unescaped copy of rawbuf in a newly allocated string, or NULL if
+ * rawbuf is NULL or no memory could be allocated for the new string.
+ */
+char *unescape_check_result_output(const char *rawbuf);
+
 int contains_illegal_object_chars(char *);		/* tests whether or not an object name (host, service, etc.) contains illegal characters */
 int my_rename(char *, char *);                          /* renames a file - works across filesystems */
 int my_fcopy(char *, char *);                           /* copies a file - works across filesystems */

--- a/include/nagios.h
+++ b/include/nagios.h
@@ -187,6 +187,8 @@ extern unsigned long max_debug_file_size;
 
 extern int allow_empty_hostgroup_assignment;
 
+extern int host_down_disable_service_checks;
+
 extern time_t last_program_stop;
 extern time_t event_start;
 
@@ -620,20 +622,6 @@ void my_system_sighandler(int);				/* handles timeouts when executing commands v
 char *get_next_string_from_buf(char *buf, int *start_index, int bufsize);
 int compare_strings(char *, char *);                    /* compares two strings for equality */
 char *escape_newlines(char *);
-/**
- * Unescapes newlines and backslashes in a check result output string read from
- * a source that uses newlines as a delimiter (e.g., files in the checkresults
- * spool dir, or the command pipe).
- * @note: There is an unescape_newlines() in cgi/cgiutils.c that unescapes more
- * than '\\' and '\n' in place. Since this function is specifically intended
- * for processing escaped plugin output, we'll use a more specific name to
- * avoid confusion and conflicts.
- * @param rawbuf Input string tp unescape.
- * @return An unescaped copy of rawbuf in a newly allocated string, or NULL if
- * rawbuf is NULL or no memory could be allocated for the new string.
- */
-char *unescape_check_result_output(const char *rawbuf);
-
 int contains_illegal_object_chars(char *);		/* tests whether or not an object name (host, service, etc.) contains illegal characters */
 int my_rename(char *, char *);                          /* renames a file - works across filesystems */
 int my_fcopy(char *, char *);                           /* copies a file - works across filesystems */

--- a/lib/fanout.h
+++ b/lib/fanout.h
@@ -64,7 +64,7 @@ extern int fanout_add(fanout_table *t, unsigned long key, void *data);
  * Remove an entry from the fanout table and return its data.
  *
  * @param[in] t fanout table to look in
- * @param[key] The key whose data we should locate
+ * @param[in] key The key whose data we should locate
  * @return Pointer to the data stored on success; NULL on errors
  */
 extern void *fanout_remove(fanout_table *t, unsigned long key);

--- a/lib/runcmd.h
+++ b/lib/runcmd.h
@@ -67,7 +67,7 @@ extern const char *runcmd_strerror(int code);
 
 /**
  * Start a command from a command string
- * @param[in] cmdstring The command to launch
+ * @param[in] cmd The command to launch
  * @param[out] pfd Child's stdout filedescriptor
  * @param[out] pfderr Child's stderr filedescriptor
  * @param[in] env Currently ignored for portability

--- a/lib/squeue.h
+++ b/lib/squeue.h
@@ -118,7 +118,7 @@ extern squeue_event *squeue_add_msec(squeue_t *q, time_t when, time_t msec, void
  *
  * @param q The scheduling queue holding the event.
  * @param evt The event to reschedule.
- * @param when When the event should be rescheduled to.
+ * @param tv When the event should be rescheduled to.
  */
 extern void squeue_change_priority_tv(squeue_t *q, squeue_event *evt, struct timeval *tv);
 


### PR DESCRIPTION
Adding the option to disable checks on services if the associated host is in a non-UP state.  Uses the same logic as active check enabled/disabled, time period valid, and dependencies in OK states.