### PR TITLE
Fix for two bugs/problems: Replace use of %zd in base/utils.c & incorrect va_start() in cgi/jsonutils.c

### DIFF
--- a/base/utils.c
+++ b/base/utils.c
@@ -3117,9 +3117,13 @@ int query_update_api(void) {
 	         "POST %s HTTP/1.0\r\nUser-Agent: Nagios/%s\r\n"
 	         "Connection: close\r\nHost: %s\r\n"
 	         "Content-Type: application/x-www-form-urlencoded\r\n"
-	         "Content-Length: %zd\r\n\r\n%s",
+	         "Content-Length: %lu\r\n\r\n%s",
 	         api_path, PROGRAM_VERSION, api_server,
-	         strlen(api_query), api_query);
+	         (unsigned long) strlen(api_query), api_query);
+
+	if (buf == NULL) {
+	  abort();
+	}
 
 	my_tcp_connect(api_server, 80, &sd, 2);
 	if(sd > 0) {

--- a/cgi/jsonutils.c
+++ b/cgi/jsonutils.c
@@ -522,7 +522,7 @@ void json_object_append_string(json_object *obj, char *key,
 		escaped_format = format;
 		}
 	if(NULL != escaped_format) {
-		va_start(a_list, escaped_format);
+	        va_start(a_list, format);
 		result = vasprintf(&buf, escaped_format, a_list);
 		va_end(a_list);
 		if(result >= 0) {


### PR DESCRIPTION
The usage of %zd in base/&utils crashes automatic Nagios update check on systems that doesn't support %z in printf() - causing a coredump.

The incorrect va_start() call in cgi/jsonutils.c (uses the wrong variable) casues another coredump.