### PR TITLE
Fix for #23 - Hosts now go to DOWN HARD immediately when max_check_atttempts=1

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -2529,7 +2529,12 @@ int process_host_check_result(host *hst, int new_state, char *old_plugin_output,
 			if(hst->check_type == CHECK_TYPE_ACTIVE || passive_host_checks_are_soft == TRUE) {
 
 				/* set the state type */
-				hst->state_type = SOFT_STATE;
+				/* we've maxed out on the retries */
+				if(hst->current_attempt == hst->max_attempts)
+					hst->state_type = HARD_STATE;
+				/* the host is in a soft state and the check will be retried */
+				else
+					hst->state_type = SOFT_STATE;
 				}
 
 			/* by default, passive check results are treated as HARD states */


### PR DESCRIPTION
*Feel free to close if I have not created the PR properly*

This fix is for the 4.1 branch of Core.  It fixes #23, properly setting the host state to DOWN HARD when mac_check_attempts=1, as I believe this is the intended behavior.  Currently the behavior is that the host will first go to a SOFT DOWN and then a HARD DOWN when max_check_attempts=1, which causes two checks to be performed instead of one.