### PR TITLE
ISSUE_125 avoid rendering a page from a different host and restrict t…

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -7,9 +7,12 @@ if (isset($_GET['corewindow'])) {
 	// Parse the URL and remove permalink option from base.
 	$a = parse_url($_GET['corewindow']);
 
-	// Build the base url.
-	$url = htmlentities($a['path']).'?';
-	$url = (isset($a['host'])) ? $a['scheme'].'://'.$a['host'].$url : '/'.$url;
+	// ignore host and build base url using just the path to avoid malicious host redirect.
+	if(isset($a['path']) && $a['path'] != '/'){
+		$url = htmlentities($a['path']).'?';
+	}else{
+		$url = '/main.php?';
+	}
 
 	$query = isset($a['query']) ? $a['query'] : '';
 	$pairs = explode('&', $query);


### PR DESCRIPTION
A malicious page can be displayed on nagios using "corewindow" parameter. This change tries to avoid rendering pages from anything but the nagios host. More information about this has been listed at https://github.com/NagiosEnterprises/nagioscore/issues/125