### PR TITLE
Update incorrect word in comments

### DIFF
--- a/sample-config/template-object/localhost.cfg.in
+++ b/sample-config/template-object/localhost.cfg.in
@@ -96,7 +96,7 @@ define service{
 
 # Define a service to check the number of currently running procs
 # on the local machine.  Warning if > 250 processes, critical if
-# > 400 users.
+# > 400 processes.
 
 define service{
         use                             local-service         ; Name of service template to use


### PR DESCRIPTION
Comments for the Total Processes service had "> 400 users" when it should be "> 400 processes".