### PR TITLE
Update runcmd

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -626,3 +626,14 @@ int update_environment(char *name, char *value, int set) {
 
 	return 0;
 }
+
+/**
+ * This will free pids if non-null
+ * Useful for external applications that rely on libnagios to
+ * keep a lid on potential memory leaks
+ */
+void runcmd_free_pids(void) {
+	if (pids)
+		free(pids);
+}
+

--- a/lib/runcmd.h
+++ b/lib/runcmd.h
@@ -104,6 +104,14 @@ extern int runcmd_close(int fd);
  */
 extern int runcmd_cmd2strv(const char *str, int *out_argc, char **out_argv);
 
+/**
+ * If you're using libnagios to execute a remote command, the 
+ * static pid_t pids is not freed after runcmd_open
+ * You can call this function when you're sure pids is no longer
+ * in use, to keep down memory leaks
+ */
+extern void runcmd_free_pids(void);
+
 /** @} */
 /* INCLUDE_runcmd_h__ */
 #endif


### PR DESCRIPTION
When using runcmd_open from an external application, static pid_t pids is never free()'d.

This functionality allows external applications access to free(pids);