### PR TITLE
Nagios init script exit codes do not comply with the LSB exit codes

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -146,7 +146,7 @@ pid_nagios ()
 {
 	if test ! -f $NagiosRunFile; then
 		echo "No lock file found in $NagiosRunFile"
-		exit 1
+		return 1
 	fi
 
 	NagiosPID=`head -n 1 $NagiosRunFile`
@@ -199,6 +199,9 @@ case "$1" in
 		echo -n "Stopping nagios:"
 
 		pid_nagios
+		if [ $? -eq 1 ]; then
+			exit 0
+		fi
 		killproc_nagios TERM
 
 		# now we have to wait for nagios to exit and remove its
@@ -228,6 +231,9 @@ case "$1" in
 
 	status)
 		pid_nagios
+		if [ $? -eq 1 ]; then
+			exit 3
+		fi
 		printstatus_nagios
 		;;
 


### PR DESCRIPTION
Nagios' exit codes do not comply with the Linux Standard Base: https://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/iniscrptact.html

Issues:
- status case returns "1" when Nagios is stopped; should return 3.
- stop case returns "1" when Nagios is stopped; should return 0.

This prevents Pacemaker (resource manager for Linux HA Cluster Stack) from using the LSB script to control Nagios properly.
