### PR TITLE
checkresults .ok file accumulation bugfix + added debug messages

### DIFF
--- a/base/utils.c
+++ b/base/utils.c
@@ -2200,7 +2200,7 @@ int process_check_result_file(char *fname) {
 	if((thefile = mmap_fopen(fname)) == NULL) {
 
 		/* try removing the file - zero length files can't be mmap()'ed, so it might exist */
-		unlink(fname);
+		delete_check_result_file(fname);
 
 		return ERROR;
 		}

--- a/base/utils.c
+++ b/base/utils.c
@@ -2200,6 +2200,7 @@ int process_check_result_file(char *fname) {
 	if((thefile = mmap_fopen(fname)) == NULL) {
 
 		/* try removing the file - zero length files can't be mmap()'ed, so it might exist */
+		log_debug_info(DEBUGL_CHECKS, 1, "Failed to open check result file for reading: '%s'\n", fname);
 		delete_check_result_file(fname);
 
 		return ERROR;
@@ -2307,8 +2308,11 @@ int process_check_result_file(char *fname) {
 
 		/* process check result */
 		process_check_result(&cr);
-		}
-
+	}
+	else {
+		/* log a debug message */
+		log_debug_info(DEBUGL_CHECKS, 1, "Minimum amount of data not present; Skipped check result file: '%s'\n", fname);
+	}
 	free_check_result(&cr);
 
 	/* free memory and close file */


### PR DESCRIPTION
The Debug messages are really just a bi-product of trying to figure out why I couldn't create custom passive-checks.  They were being swallowed up but nothing in the debug logs (Even with full debugging verbosity set). Turns out it was a simple permission issue.

However a second bug was uncovered as a result of this permission issue causing the **.ok** files (in the _checkresults_ directory) to accumulate and not be cleaned up.

The bugfix for this is included as well (a simple one-liner).