### PR TITLE
Vent command pipe before deleting it in daemon-init.in to avoid deadlock on writing end

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -192,7 +192,9 @@ case "$1" in
 		fi
 
 		touch $NagiosVarDir/nagios.log $NagiosRetentionFile
-		rm -f $NagiosCommandFile
+		# must vent stalled pipe to allow blocked writers to escape a deadlock in blocking open() syscall
+		# see http://unix.stackexchange.com/questions/335406/opening-named-pipe-blocks-forever-if-pipe-is-deleted-without-being-connected
+		mv -f $NagiosCommandFile $NagiosCommandFile~ &>/dev/null && dd if=$NagiosCommandFile~ count=0 &>/dev/null && rm -f $NagiosCommandFile~ || true
 		touch $NagiosRunFile
 		chown -h $NagiosUser:$NagiosGroup $NagiosRunFile $NagiosVarDir/nagios.log $NagiosRetentionFile
 		$NagiosBin -d $NagiosCfgFile


### PR DESCRIPTION
If a stalled command pipe gets deleted, while there are processes trying/waiting to open it for writing, those processes get deadlocked in a blocking open() system call. In order to avoid such situations, or rather to give such processes a chance to die on a broken pipe, a pre-existing named pipe should shortly be _opened for reading_ (without actually reading from it) before discarding it. To avoid the chicken-egg-problem, the inode should be relabeled beforehand.

see http://unix.stackexchange.com/questions/335406/opening-named-pipe-blocks-forever-if-pipe-is-deleted-without-being-connected

A better solution would be, of course, to avoid the deletion of the pipe all together. I'm not quite sure why the that would be necessary anyway.