### PR TITLE
Change log file format to nagios-yyyy-mm-dd-hh.log

### DIFF
--- a/base/logging.c
+++ b/base/logging.c
@@ -406,8 +406,7 @@ int rotate_log_file(time_t rotation_time) {
 	close_log_file();
 
 	/* get the archived filename to use */
-	asprintf(&log_archive, "%s%snagios-%02d-%02d-%d-%02d.log", log_archive_path, (log_archive_path[strlen(log_archive_path) - 1] == '/') ? "" : "/", t->tm_mon + 1, t->tm_mday, t->tm_year + 1900, t->tm_hour);
-
+        asprintf(&log_archive, "%s%snagios-%d-%02d-%02d-%02d.log", log_archive_path, (log_archive_path[strlen(log_archive_path) - 1] == '/') ? "" : "/", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday, t->tm_hour);
 	/* HACK: If the archive exists, don't overwrite it. This is a hack
 		because the real problem is that some log rotations are executed
 		early and as a result the next log rotation is scheduled for 


### PR DESCRIPTION
Minor change to convert the log file names to ISO8601 yyyy-mm-dd-hh format so it sorts properly and doesn't cause confusion with non-US countries who use dd/mm rather than mm/dd