### PR TITLE
Improve config file parsing.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -187,6 +187,7 @@ wrong, please let me know.
 * Marcus Fleige
 * Marcus Hildenbrand
 * Mark DeTrano
+* Mark Felder
 * Mark Frost
 * Mark Goldfinch
 * Mark Schenker

--- a/base/config.c
+++ b/base/config.c
@@ -107,7 +107,7 @@ int read_main_config_file(char *main_config_file) {
 
 	/* open the config file for reading */
 	if((thefile = mmap_fopen(main_config_file)) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open main configuration file '%s' for reading!\n", main_config_file);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open main configuration file '%s' for reading!", main_config_file);
 		exit(ERROR);
 		}
 
@@ -1269,7 +1269,7 @@ int read_main_config_file(char *main_config_file) {
 
 	/* make sure a log file has been specified */
 	if(log_file == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Log file is not specified anywhere in main config file '%s'!\n", main_config_file);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Log file is not specified anywhere in main config file '%s'!", main_config_file);
 		exit(ERROR);
 		}
 	strip(log_file);
@@ -1291,7 +1291,7 @@ int read_resource_file(char *resource_file) {
 	int user_index = 0;
 
 	if((thefile = mmap_fopen(resource_file)) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open resource file '%s' for reading!\n", resource_file);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open resource file '%s' for reading!", resource_file);
 		return ERROR;
 		}
 

--- a/base/config.c
+++ b/base/config.c
@@ -100,7 +100,6 @@ int read_main_config_file(char *main_config_file) {
 	DIR *tmpdir = NULL;
 	nagios_macros *mac;
 	objectlist *list;
-	char *log_file = NULL;
 
 	mac = get_global_macros();
 

--- a/base/config.c
+++ b/base/config.c
@@ -107,7 +107,7 @@ int read_main_config_file(char *main_config_file) {
 
 	/* open the config file for reading */
 	if((thefile = mmap_fopen(main_config_file)) == NULL) {
-		printf("Error: Cannot open main configuration file '%s' for reading!", main_config_file);
+		printf("Error: Cannot open main configuration file '%s' for reading!\n", main_config_file);
 		exit(ERROR);
 		}
 
@@ -1291,7 +1291,7 @@ int read_resource_file(char *resource_file) {
 	int user_index = 0;
 
 	if((thefile = mmap_fopen(resource_file)) == NULL) {
-		printf("Error: Cannot open resource file '%s' for reading!", resource_file);
+		printf("Error: Cannot open resource file '%s' for reading!\n", resource_file);
 		exit(ERROR);
 		}
 

--- a/base/config.c
+++ b/base/config.c
@@ -107,7 +107,7 @@ int read_main_config_file(char *main_config_file) {
 
 	/* open the config file for reading */
 	if((thefile = mmap_fopen(main_config_file)) == NULL) {
-		printf("Error: Cannot open main configuration file '%s' for reading!\n", main_config_file);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open main configuration file '%s' for reading!\n", main_config_file);
 		exit(ERROR);
 		}
 
@@ -1269,7 +1269,7 @@ int read_main_config_file(char *main_config_file) {
 
 	/* make sure a log file has been specified */
 	if(log_file == NULL) {
-		printf("Error: Log file is not specified anywhere in main config file '%s'!\n", main_config_file);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Log file is not specified anywhere in main config file '%s'!\n", main_config_file);
 		exit(ERROR);
 		}
 	strip(log_file);
@@ -1291,8 +1291,8 @@ int read_resource_file(char *resource_file) {
 	int user_index = 0;
 
 	if((thefile = mmap_fopen(resource_file)) == NULL) {
-		printf("Error: Cannot open resource file '%s' for reading!\n", resource_file);
-		exit(ERROR);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open resource file '%s' for reading!\n", resource_file);
+		return ERROR;
 		}
 
 	/* process all lines in the resource file */

--- a/base/config.c
+++ b/base/config.c
@@ -100,14 +100,15 @@ int read_main_config_file(char *main_config_file) {
 	DIR *tmpdir = NULL;
 	nagios_macros *mac;
 	objectlist *list;
+	char *log_file = NULL;
 
 	mac = get_global_macros();
 
 
 	/* open the config file for reading */
 	if((thefile = mmap_fopen(main_config_file)) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open main configuration file '%s' for reading!", main_config_file);
-		return ERROR;
+		printf("Error: Cannot open main configuration file '%s' for reading!", main_config_file);
+		exit(ERROR);
 		}
 
 	/* save the main config file macro */
@@ -1267,12 +1268,11 @@ int read_main_config_file(char *main_config_file) {
 	my_free(value);
 
 	/* make sure a log file has been specified */
-	strip(log_file);
-	if(!strcmp(log_file, "")) {
-		if(daemon_mode == FALSE)
-			printf("Error: Log file is not specified anywhere in main config file '%s'!\n", main_config_file);
-		return ERROR;
+	if(log_file == NULL) {
+		printf("Error: Log file is not specified anywhere in main config file '%s'!\n", main_config_file);
+		exit(ERROR);
 		}
+	strip(log_file);
 
 	return OK;
 	}
@@ -1291,8 +1291,8 @@ int read_resource_file(char *resource_file) {
 	int user_index = 0;
 
 	if((thefile = mmap_fopen(resource_file)) == NULL) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Cannot open resource file '%s' for reading!", resource_file);
-		return ERROR;
+		printf("Error: Cannot open resource file '%s' for reading!", resource_file);
+		exit(ERROR);
 		}
 
 	/* process all lines in the resource file */


### PR DESCRIPTION
Properly exit with an error and print if important conditions arise:

- Cannot read main config file
- Cannot read resources.cfg
- No log file defined in main config file

This was born out of the frustration of an accidental permisisons change
to resources.cfg and the pain required to track down why thousands of
Nagios checks suddenly started failing.

The poor sap who did a "restart" was confused when the system blew up
and nobody could identify what was happening until we dug into debug
logs and found that the macro parsing had gone awry.

Simply logging that resources.cfg is not readable is unacceptable. It
needs to be an obvious and showstopping error. Nagios should not attempt
to fly with one wing.

These changes will surely improve troubleshooting for admins everywhere.