### PR TITLE
Ship an OpenRC init script

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,7 @@ Nagios Core 4 Change Log
 * Fix minor map issues (Troy Lea)
 * Fix lockfile issues (Bryan Heden)
 * Switch order of daemon_init and drop_priveleges (Bryan Heden)
+* Add an OpenRC init script (Michael Orlitzky)
 
 
 4.3.2 - 2017-05-09

--- a/Makefile.in
+++ b/Makefile.in
@@ -197,7 +197,7 @@ distclean: clean
 	cd $(SRC_TTAP) && $(MAKE) $@
 	cd $(SRC_WORKERS) && $(MAKE) $@
 	rm -f sample-config/*.cfg  sample-config/*.conf sample-config/template-object/*.cfg
-	rm -f daemon-init pkginfo
+	rm -f daemon-init openrc-init pkginfo
 	rm -f Makefile subst
 	rm -f config.log config.status config.cache
 	rm -f tags

--- a/THANKS
+++ b/THANKS
@@ -219,6 +219,7 @@ wrong, please let me know.
 * Michael Lubben
 * Michael Marineau
 * Michael O'Reilly
+* Michael Orlitzky
 * Michael Smedius
 * Michal Zimen
 * Michelle Craft

--- a/configure.ac
+++ b/configure.ac
@@ -793,7 +793,7 @@ if test -z "$UNZIP"; then
 	AC_MSG_ERROR([Cannot continue without unzip!])
 fi
 
-AC_OUTPUT(Makefile lib/Makefile subst pkginfo base/Makefile common/Makefile contrib/Makefile cgi/Makefile html/Makefile module/Makefile worker/Makefile worker/ping/Makefile xdata/Makefile daemon-init t/Makefile t-tap/Makefile)
+AC_OUTPUT(Makefile lib/Makefile subst pkginfo base/Makefile common/Makefile contrib/Makefile cgi/Makefile html/Makefile module/Makefile worker/Makefile worker/ping/Makefile xdata/Makefile daemon-init openrc-init t/Makefile t-tap/Makefile)
 
 
 perl subst include/locations.h

--- a/configure.ac
+++ b/configure.ac
@@ -267,9 +267,9 @@ AC_SUBST(init_dir)
 dnl User can override lock file location
 AC_ARG_WITH(lockfile,
 	AC_HELP_STRING([--with-lockfile=<path>],
-		[sets path and file name for lock file]),
+		[sets path for lock file (default: /run/nagios.lock)]),
 	lockfile=$withval,
-	lockfile=$localstatedir/nagios.lock
+	lockfile=/run/nagios.lock
 )
 AC_SUBST(lockfile)
 

--- a/openrc-init.in
+++ b/openrc-init.in
@@ -1,0 +1,66 @@
+#!/sbin/openrc-run
+
+# This is a custom variable, and has the following default value if a
+# specific config file is not defined by the user.
+: ${NAGIOS_CONFIG:="@sysconfdir@/nagios.cfg"}
+
+# These two facilitate the bindir variable substitution below.
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+
+# The rest are OpenRC variables.
+extra_commands="checkconfig"
+extra_started_commands="reload"
+
+# We put "--daemon" in command_args and not command_args_background
+# because the latter interacts weirdly with the config file argument.
+command="@bindir@/nagios"
+command_args="--daemon ${NAGIOS_CONFIG}"
+pidfile="@lockfile@"
+
+depend(){
+  # Most daemons don't really *need* the network; they're happy with
+  # the loopback interface. However, nagios might start generating
+  # "EVERYTHING IS DOWN" alerts if it starts before the real live
+  # network comes up.
+  need net
+  use logger
+  after mysql postgresql
+}
+
+reload(){
+  checkconfig || return $?
+  ebegin "Reloading configuration"
+  start-stop-daemon --signal HUP --pidfile "${pidfile}"
+  eend $?
+}
+
+checkconfig(){
+  ebegin "Verifying config files"
+
+  # Save the output in case verification fails and errors are printed.
+  OUTPUT=$( ${command} --verify-config "${NAGIOS_CONFIG}" )
+
+  # Save the exit code from the verification so that `echo` doesn't
+  # clobber it. Then, if verification failed, show its
+  # output. Otherwise, succeed quietly.
+  local exit_code=$?
+  [ $exit_code -ne 0 ] && echo "${OUTPUT}" >&2
+  eend $exit_code
+}
+
+start_pre() {
+  # Without this, the "start" action will appear to succeed even if
+  # the config file contains errors, and the daemon fails to start.
+  # Another approach would be to wait for the PID file to appear, but
+  # this is fast enough and feels cleaner.
+  checkconfig || return $?
+}
+
+stop_pre() {
+  # If this is a restart, check to make sure the user's config
+  # isn't busted before we stop the running daemon.
+  if [ "${RC_CMD}" = "restart" ] ; then
+    checkconfig || return $?
+  fi
+}


### PR DESCRIPTION
This finishes up issue #404 and addresses issue #378. I just tested the init script with our Gentoo package and after one last-minute bugfix, it works. The commit messages go into further detail.

I have one open question: should the `--with-lockfile` default involve `$prefix` or something similar?
