### PR TITLE
Use absolute paths when deleting in checkresults directory

### DIFF
--- a/base/utils.c
+++ b/base/utils.c
@@ -2133,7 +2133,7 @@ int process_check_result_queue(char *dirname) {
 
 			/* if the file is too old, we delete it */
 			if (stat_buf.st_mtime + max_check_result_file_age < time(NULL)) {
-				delete_check_result_file(dirfile->d_name);
+				delete_check_result_file(file);
 				continue;
 				}
 


### PR DESCRIPTION
Once nagios is done with a file in the checkresults directory,
it deletes it. This was done with a relative file path, causing
failures if nagios working directory is not the checkresults
directory. As a consequence, old result file remained intact,
causing system slowdowns as the directory grew and nagios spent
more and more time attempting to clean it up.

The fix is just to use an absolute path, so that it works
regardeless of current directory setting.