### PR TITLE
With the echo as a background call the race condition is averted

### DIFF
--- a/daemon-init.in
+++ b/daemon-init.in
@@ -169,7 +169,7 @@ remove_commandfile ()
 	
 	if [ -p $NagiosCommandFile ]; then
 		mv -f $NagiosCommandFile $NagiosCommandFile~
-		(dd if=$NagiosCommandFile~ count=0 2>/dev/null & echo -n "" >$NagiosCommandFile~)
+		(dd if=$NagiosCommandFile~ count=0 2>/dev/null & echo -n "" >$NagiosCommandFile~ &)
 	fi
 	
 	rm -f $NagiosCommandFile $NagiosCommandFile~


### PR DESCRIPTION
I was developing a devops driven install from source and ran into https://github.com/NagiosEnterprises/nagioscore/issues/443

I have a basic test that reproduces a stuck nagios shutdown or start that is hung on the NagiosCommandFile pipe.   Using this test, I can usually reproduce the hanging problem within five iterations.

With my fix, the test completes hundreds of rounds.  Its the first time I've ever seen the time warning.  
Starting nagios: done.
Stopping nagios:..........................................................................................
Warning - nagios did not exit in a timely manner - Killing it!

This is the test:
R=0
while :;do 
    R=$[ $R + 1 ]
    echo "Round: $R"
    /etc/init.d/nagios start
    sleep $[ $RANDOM % 3 ]
   /etc/init.d/nagios stop
done