### PR TITLE
Fixing issue #443

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,12 +2,18 @@
 Nagios Core 4 Change Log
 ########################
 
+Future Version - 
+----------------
+* Fixed a lockup condition sometimes encountered on shutdown or restart (Aaron Beck)
+
+
 4.3.4 - 2017-08-24
 ------------------
 * Improved config file parsing (Mark Felder)
 * Fixed configure script to check for existence of /run for lock file (in regards to CVE-2017-12847, Bryan Heden)
 * Use absolute paths when deleting check results files (Emmanuel Dreyfus)
 * Add sanity checking in reassign_worker (sq5bpf)
+
 
 4.3.3 - 2017-08-12
 ------------------

--- a/THANKS
+++ b/THANKS
@@ -8,6 +8,7 @@ few of the many members that have contributed to Nagios in various ways
 since 1999.  If I missed your name, misspelled it or otherwise got it
 wrong, please let me know.
 
+* Aaron Beck
 * Adam Bowen
 * Ahmon Dancy
 * Alain Radix

--- a/daemon-init.in
+++ b/daemon-init.in
@@ -162,14 +162,15 @@ remove_commandfile ()
 	# will deadlock those processes in a blocking open() system call. To allow such processes to
 	# die on a broken pipe, the pipe must be opened for reading without actually reading from it,
 	# which is what dd does here. To avoid a chicken-egg problem, the pipe is renamed beforehand.
-	# In order for the dd to not deadlock when there is no writing process, it is executed in the
-	# background in a subshell together with an empty echo to have at least one writing process.
+	# In order for the dd to not deadlock when there is no writing process, it is executed in a
+	# subshell together with an empty echo to have at least one writing process.  Both are called
+	# in the background to avoid stalling the subshell from closure (see NagiosCore issue #443)
 	
 	# see http://unix.stackexchange.com/questions/335406/opening-named-pipe-blocks-forever-if-pipe-is-deleted-without-being-connected
 	
 	if [ -p $NagiosCommandFile ]; then
 		mv -f $NagiosCommandFile $NagiosCommandFile~
-		(dd if=$NagiosCommandFile~ count=0 2>/dev/null & echo -n "" >$NagiosCommandFile~)
+		(dd if=$NagiosCommandFile~ count=0 2>/dev/null & echo -n "" >$NagiosCommandFile~ &)
 	fi
 	
 	rm -f $NagiosCommandFile $NagiosCommandFile~


### PR DESCRIPTION
Analysis of the nagios init script showed the echo call in a subshell was occasionally causing a hang condition on shutdown or restart.   Placing the echo call in the background fixes the issue.

Testing was done with the following script of 1000 rounds:
MaxRounds=1000
M=1000
while [ $M -gt 0 ];do echo Round $[ $MaxRounds + 1 - $M ] - $( date );/etc/init.d/nagios restart;M=$[ $M -1 ];done


Sometimes issue 443 will show repeatedly rapidly (Nagios is a VM on a busy hypervisor scenario), other times the issue might take a large number of rounds to manifest.   I suspect folks seeing this issue are not seeing it after they reboot, so they go about their way.

I have a devops system that can produce a VM that will encounter the failure and hang approximately 25% of the deployments with stock nagios-4.3.4.  With my fix present zero hangs are encountered.


Failure:

This is what a failure looks like on Centos 6.9 with stock 4.3.4 compiled, where the output sits on "Stopping nagios:. done." until intervention occurs.
Round 1 - Wed Nov 1 21:40:07 PDT 2017
Running configuration check...
Stopping nagios: done.
Starting nagios: done.
...
Round 207 - Wed Nov 1 21:40:39 PDT 2017
Running configuration check...
Stopping nagios:. done.
^C/etc/init.d/nagios: line 172: /usr/local/nagios/var/rw/nagios.cmd~: Interrupted system call  <-- I waited ten minutes before pressing ctrl-c a few times to stop the script from being hung up.




Fixed:
This is what a 1000 round test with the proposed change usually** looks like, nice n' smooth:
Round 1 - Wed Nov 1 21:47:22 PDT 2017
Running configuration check...
Stopping nagios: done.
Starting nagios: done.
...
Round 1000 - Wed Nov 1 21:50:02 PDT 2017
Running configuration check...
Stopping nagios: done.
Starting nagios: done.


** one time I was able to get some other subsystem in the script to cause a different kind of lockup in nagios that is outside the scope of issue #443 and this pull request
