### PR TITLE
Fixes to make install-init

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -349,12 +349,12 @@ install-daemoninit:
 	$(INSTALL) -m 755 $(INIT_OPTS) startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE)
 	if [ x$(INIT_TYPE) = xsystemd ]; then \
 		if which systemctl >/dev/null 2>&1; then \
-			systemctl daemon-reload \
+			systemctl daemon-reload; \
 		fi \
 	fi
 	if [ x$(INIT_TYPE) = xupstart ]; then \
 		if which initctl >/dev/null 2>&1; then \
-			initctl reload-configuration \
+			initctl reload-configuration; \
 		fi \
 	fi
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -42,7 +42,9 @@ LN_HTTPD_SITES_ENABLED=@LN_HTTPD_SITES_ENABLED@
 INIT_DIR=@initdir@
 INIT_OPTS=@INIT_OPTS@
 CGICFGDIR=$(CGIDIR)
-
+NAGIOS_USER=@nagios_user@
+NAGIOS_GRP=@nagios_grp@
+DIST=@dist_type@
 
 SRC_INIT=@src_init@
 INIT_FILE=@initname@
@@ -95,6 +97,9 @@ all:
 	@echo ""
 	@echo "  make install-init"
 	@echo "     - This installs the init script in $(DESTDIR)$(INIT_DIR)"
+	@echo ""
+	@echo "  make install-groups-users"
+	@echo "     - This adds the users and groups if they do not exist"
 	@echo ""
 	@echo "  make install-commandmode"
 	@echo "     - This installs and configures permissions on the"
@@ -275,7 +280,6 @@ install-basic:
 	@echo "     - This installs sample config files in $(DESTDIR)$(CFGDIR)"
 	@echo ""
 
-
 install-config:
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)
 	$(INSTALL) -m 775 $(INSTALL_OPTS) -d $(DESTDIR)$(CFGDIR)/objects
@@ -298,6 +302,9 @@ install-config:
 	@echo "the documentation for more information on how to actually define"
 	@echo "services, hosts, etc. to fit your particular needs."
 	@echo ""
+
+install-groups-users:
+	@autoconf-macros/add_group_user $(DIST) $(NAGIOS_USER) $(NAGIOS_GRP)
 
 install-webconf:
 	$(INSTALL) -m 644 sample-config/httpd.conf $(DESTDIR)$(HTTPD_CONF)/nagios.conf

--- a/Makefile.in
+++ b/Makefile.in
@@ -46,7 +46,7 @@ CGICFGDIR=$(CGIDIR)
 
 SRC_INIT=@src_init@
 INIT_FILE=@initname@
-#INIT_TYPE=@init_type@
+INIT_TYPE=@init_type@
 
 USE_EVENTBROKER=@USE_EVENTBROKER@
 USE_LIBTAP=@USE_LIBTAP@
@@ -347,14 +347,27 @@ install-init: install-daemoninit
 
 install-daemoninit:
 	$(INSTALL) -m 755 $(INIT_OPTS) startup/$(SRC_INIT) $(INIT_DIR)/$(INIT_FILE)
+	if [ x$(INIT_TYPE) = xsysv ]; then \
+		if which chkconfig >/dev/null 2>&1; then \
+			chkconfig --add nagios; \
+		elif which update-rc.d >/dev/null 2>&1; then \
+			update-rc.d nagios defaults; \
+		fi \
+	fi
 	if [ x$(INIT_TYPE) = xsystemd ]; then \
 		if which systemctl >/dev/null 2>&1; then \
 			systemctl daemon-reload; \
+			systemctl enable nagios.service; \
 		fi \
 	fi
 	if [ x$(INIT_TYPE) = xupstart ]; then \
 		if which initctl >/dev/null 2>&1; then \
 			initctl reload-configuration; \
+		fi \
+	fi
+	if [ x$(INIT_TYPE) = xopenrc ]; then \
+		if which rc-update >/dev/null 2>&1; then \
+			rc-update add nagios default; \
 		fi \
 	fi
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -304,7 +304,7 @@ install-config:
 	@echo ""
 
 install-groups-users:
-	@autoconf-macros/add_group_user $(DIST) $(NAGIOS_USER) $(NAGIOS_GRP)
+	@autoconf-macros/add_group_user $(DIST) $(NAGIOS_USER) $(NAGIOS_GRP) 1
 
 install-webconf:
 	$(INSTALL) -m 644 sample-config/httpd.conf $(DESTDIR)$(HTTPD_CONF)/nagios.conf

--- a/autoconf-macros/add_group_user
+++ b/autoconf-macros/add_group_user
@@ -8,6 +8,18 @@ uid="$2"
 gid="$3"
 rc=0
 
+#------------------------------------------------------------------
+# Determine if the user should be created with a shell environment
+# 0 = no shell (more secure)
+# 1 = shell (less secure but sometimes required)
+#------------------------------------------------------------------
+shell=0
+if [ $# -eq 4 ]; then
+	if [ x$4 = x1 ]; then
+		shell=1
+	fi
+fi
+
 #-------------------------------------
 # Check if the specified group exists
 #-------------------------------------
@@ -56,8 +68,10 @@ add_user(){
 			dscl . -create /Users/$uid
 			echo dscl . -create /Users/$uid UniqueID $newid > /dev/stderr
 			dscl . -create /Users/$uid UniqueID $newid
-			echo dscl . -create /Users/$uid UserShell /usr/bin/false > /dev/stderr
-			dscl . -create /Users/$uid UserShell /usr/bin/false
+			if [ $shell = 0 ]; then
+				echo dscl . -create /Users/$uid UserShell /usr/bin/false > /dev/stderr
+				dscl . -create /Users/$uid UserShell /usr/bin/false
+			fi
 			echo dscl . -create /Users/$uid PrimaryGroupID 20 > /dev/stderr
 			dscl . -create /Users/$uid PrimaryGroupID 20
 			echo dscl . -append /Groups/$gid GroupMembership $uid > /dev/stderr
@@ -65,8 +79,13 @@ add_user(){
 			;;
 
 		freebsd)
-			echo pw add user $uid -g $gid -s /usr/bin/false > /dev/stderr
-			rc=`pw add user $uid -g $gid -s /usr/bin/false; echo $?`
+			if [ $shell = 0 ]; then
+				echo pw add user $uid -g $gid -s /usr/bin/false > /dev/stderr
+				rc=`pw add user $uid -g $gid -s /usr/bin/false; echo $?`
+			else
+				echo pw add user $uid -g $gid > /dev/stderr
+				rc=`pw add user $uid -g $gid; echo $?`
+			fi
 			;;
 
 		netbsd|openbsd)
@@ -75,8 +94,13 @@ add_user(){
 			;;
 
 		*)
-			echo useradd -r -g $gid $uid > /dev/stderr
-			rc=`useradd -r -g $gid $uid; echo $?`
+			if [ $shell = 0 ]; then
+				echo useradd -r -g $gid $uid > /dev/stderr
+				rc=`useradd -r -g $gid $uid; echo $?`
+			else
+				echo useradd -g $gid $uid > /dev/stderr
+				rc=`useradd -g $gid $uid; echo $?`
+			fi
 			;;
 	esac
 

--- a/configure
+++ b/configure
@@ -745,6 +745,8 @@ datarootdir
 libexecdir
 sbindir
 bindir
+bin_rm
+bin_kill
 program_transform_name
 prefix
 exec_prefix
@@ -5174,7 +5176,7 @@ if test ! -d "$subsyslockdir"; then
 	subsyslockdir="N/A"
 	subsyslockfile="N/A"
 else
-	subsyslockfile="$subsyslockdir/$INIT_PROG"
+	subsyslockfile="$subsyslockdir/nagios.lock"
 fi
 if test "$need_loc" = no; then
 	localedir="N/A"
@@ -5705,7 +5707,7 @@ fi
 if test $subsyslockdir = "N/A"; then
 	if test -d "/var/run"; then
 		subsyslockdir="/var/run"
-		subsyslockfile="/var/run/nagios"
+		subsyslockfile="/var/run/nagios.lock"
 	else
 		subsyslockdir="/usr/local/nagios/var/"
 		subsyslockfile="/usr/local/nagios/var/nagios.lock"
@@ -6240,6 +6242,22 @@ if test x$MAIL_PROG = x; then
 	else
 		MAIL_PROG="/bin/mail"
 	fi
+fi
+
+
+# Determine location of rm binary
+if test $dist_type = freebsd; then
+	bin_rm=`which rm`
+else
+	bin_rm=`type -P rm`
+fi
+
+
+# Determine location of kill binary
+if test $dist_type = freebsd; then
+	bin_kill=`which kill`
+else
+	bin_kill=`type -P kill`
 fi
 
 

--- a/configure
+++ b/configure
@@ -5528,7 +5528,7 @@ case $init_type in #(
 			initname=${initname="rc.$INIT_PROG"}
 		fi ;; #(
   newbsd) :
-    initdir=${initdir="/etc/rc.d"}
+    initdir=${initdir="/usr/local/etc/rc.d"}
 		initname=${initname="$INIT_PROG"} ;; #(
   gentoo) :
     initdir=${initdir="/etc/init.d"}
@@ -5634,7 +5634,7 @@ case $init_type in #(
   newbsd) :
     if test $dist_type = freebsd ; then
 			bsd_enable="_enable"
-			src_init=newbsd-init
+			src_init=default-init
 		elif test $dist_type = openbsd ; then
 			bsd_enable="_flags"
 			src_init=openbsd-init
@@ -5696,6 +5696,8 @@ $as_echo "$src_inetd" >&6; }
 if test $src_init != "default-init" -a \
         $src_init != "default-service" -a \
         $src_init != "openrc-init" -a \
+        $src_init != "newbsd-init" -a \
+        $src_init != "openbsd-init" -a \
         $src_init != "upstart-init"; then
 
 	src_init="default-init"

--- a/startup/default-init.in
+++ b/startup/default-init.in
@@ -96,7 +96,7 @@ check_config ()
 
 	echo -n "Running configuration check... "
 
-	rm -f "$NagiosCfgtestFile";
+	@bin_rm@ -f "$NagiosCfgtestFile";
 	if test -e "$NagiosCfgtestFile"; then
 		echo "ERROR: Could not delete '$NagiosCfgtestFile'"
 		exit 8
@@ -113,13 +113,13 @@ check_config ()
 
 	if test "$WARN" = "0" && test "${ERR}" = "0"; then
 		echo "OK - Configuration check verified" > $NagiosCfgtestFile
-		/bin/rm "$TMPFILE"
+		@bin_rm@ "$TMPFILE"
 		return 0
 	elif test "${ERR}" = "0"; then
 		# Write the errors to a file we can have a script watching for.
 		echo "WARNING: Warnings in config files - see log for details: $NagiosCfgtestFile" > $NagiosCfgtestFile
 		egrep -i "(^warning|^error)" "$TMPFILE" >> $NagiosCfgtestFile
-		/bin/rm "$TMPFILE"
+		@bin_rm@ "$TMPFILE"
 		return 0
 	else
 		# Write the errors to a file we can have a script watching for.
@@ -153,7 +153,7 @@ printstatus_nagios ()
 
 killproc_nagios ()
 {
-	kill -s "$1" $NagiosPID
+	@bin_kill@ -s "$1" $NagiosPID
 }
 
 pid_nagios ()
@@ -183,7 +183,7 @@ remove_commandfile ()
 		(dd if=$NagiosCommandFile~ count=0 2>/dev/null & echo -n "" >$NagiosCommandFile~ &)
 	fi
 	
-	rm -f $NagiosCommandFile $NagiosCommandFile~
+	@bin_rm@ -f $NagiosCommandFile $NagiosCommandFile~
 }
 
 
@@ -255,7 +255,7 @@ case "$1" in
 		fi
 
 		remove_commandfile
-		rm -f $NagiosStatusFile $NagiosRunFile
+		@bin_rm@ -f $NagiosStatusFile $NagiosRunFile
 		;;
 
 	status)

--- a/startup/default-init.in
+++ b/startup/default-init.in
@@ -46,7 +46,6 @@ NagiosStatusFile=@localstatedir@/status.dat
 NagiosRetentionFile=@localstatedir@/retention.dat
 NagiosCommandFile=@localstatedir@/rw/nagios.cmd
 NagiosVarDir=@localstatedir@
-NagiosRunFile=@subsyslockfile@
 NagiosCGIDir=@sbindir@
 NagiosUser=@nagios_user@
 NagiosGroup=@nagios_grp@
@@ -197,6 +196,13 @@ fi
 if [ ! -f $NagiosCfgFile ]; then
     echo "Configuration file $NagiosCfgFile not found. Exiting."
     exit 1
+fi
+
+# Get the lock_file from nagios.cfg
+NagiosRunFile=`sed -n -e 's/^lock_file=*//p' $NagiosCfgFile`
+if [ $? -ne 0 ]; then
+	# If there was a problem the use the value from when Core was compiled
+	NagiosRunFile=@subsyslockfile@
 fi
 
 # See how we were called.

--- a/startup/default-service.in
+++ b/startup/default-service.in
@@ -8,9 +8,9 @@ Type=forking
 PIDFile=@subsyslockfile@
 ExecStartPre=@bindir@/nagios -v @sysconfdir@/nagios.cfg
 ExecStart=@bindir@/nagios -d @sysconfdir@/nagios.cfg
-ExecStop=/bin/kill -s TERM ${MAINPID}
-ExecStopPost=/usr/bin/rm -f @localstatedir@/rw/nagios.cmd
-ExecReload=/bin/kill -s HUP ${MAINPID}
+ExecStop=@bin_kill@ -s TERM ${MAINPID}
+ExecStopPost=@bin_rm@ -f @localstatedir@/rw/nagios.cmd
+ExecReload=@bin_kill@ -s HUP ${MAINPID}
 
 [Install]
 WantedBy=multi-user.target

--- a/startup/default-service.in
+++ b/startup/default-service.in
@@ -5,7 +5,6 @@ After=network.target local-fs.target
 
 [Service]
 Type=forking
-PIDFile=@subsyslockfile@
 ExecStartPre=@bindir@/nagios -v @sysconfdir@/nagios.cfg
 ExecStart=@bindir@/nagios -d @sysconfdir@/nagios.cfg
 ExecStop=@bin_kill@ -s TERM ${MAINPID}


### PR DESCRIPTION
Missing some semicolons, fixes this error when running `make install-init':
```
/usr/bin/install -c -m 755 -o root -g root startup/default-service /usr/lib/systemd/system/nagios.service
if [ x = xsystemd ]; then \
	if which systemctl >/dev/null 2>&1; then \
		systemctl daemon-reload \
	fi \
fi
/bin/sh: -c: line 5: syntax error: unexpected end of file
make: *** [install-daemoninit] Error 1
```