### PR TITLE
contrib/Makefile.in: Use uname instead of arch command

### DIFF
--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -88,7 +88,7 @@ $(CGI_O): $(CGI_C)
 ##############################################################################
 # rpm making automation for CentOS/RHEL.
 
-ARCH ?= $(shell arch)
+ARCH ?= $(shell uname -m)
 ifeq ($(ARCH),x86_64)
 RPM_ARCH := x86_64
 else


### PR DESCRIPTION
Hi,

I found that the `arch` command is only available at some distros. I am replacing it with the more widespread tool `uname -m`.

