### PR TITLE
Fix typo in comments.h

### DIFF
--- a/include/comments.h
+++ b/include/comments.h
@@ -113,6 +113,6 @@ int add_comment_to_hashlist(struct nagios_comment *);
 
 void free_comment_data(void);                                             /* frees memory allocated to the comment list */
 
-NAGIOS_BEGIN_DECL
+NAGIOS_END_DECL
 
 #endif


### PR DESCRIPTION
I can't build my c++ broker, because of a typo in the comments.h.