### PR TITLE
Fix the cgivars memory leak in free_cgivars()

### DIFF
--- a/cgi/getcgi.c
+++ b/cgi/getcgi.c
@@ -547,5 +547,6 @@ void free_cgivars(char **cgivars) {
 	for(x = 0; cgivars[x] != '\x0'; x++)
 		free(cgivars[x]);
 
+	free(cgivars);
 	return;
 	}


### PR DESCRIPTION
The following memory allocation in `getcgivars()` was never freed:
``` c
    /* extract the names and values from the pairlist */
    cgivars = (char **)malloc((paircount * 2 + 1) * sizeof(char *));
```