### PR TITLE
workers.h: remove extra ';' after NAGIOS_*_DECL macros

### DIFF
--- a/include/workers.h
+++ b/include/workers.h
@@ -19,7 +19,7 @@
 
 #define WPROC_FORCE  (1 << 0)
 
-NAGIOS_BEGIN_DECL;
+NAGIOS_BEGIN_DECL
 
 typedef struct wproc_result {
 	unsigned int job_id;
@@ -58,5 +58,5 @@ extern int wproc_run_service_job(int jtype, int timeout, service *svc, char *cmd
 extern int wproc_run_host_job(int jtype, int timeout, host *hst, char *cmd, nagios_macros *mac);
 extern int wproc_run_callback(char *cmt, int timeout, void (*cb)(struct wproc_result *, void *, int), void *data, nagios_macros *mac);
 
-NAGIOS_END_DECL;
+NAGIOS_END_DECL
 #endif


### PR DESCRIPTION
This fixes the following compiler error reported by gcc-8.1.0:
```
In file included from nagios.c:48:
../include/workers.h: At top level:
../include/workers.h:22:18: error: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 NAGIOS_BEGIN_DECL;
                  ^
In file included from nagios.c:48:
../include/workers.h:61:16: error: ISO C does not allow extra ‘;’ outside of a function [-Wpedantic]
 NAGIOS_END_DECL;
                ^
```