### PR TITLE
nwrite() compiler warnings and cleanups

### DIFF
--- a/lib/nwrite.h
+++ b/lib/nwrite.h
@@ -32,7 +32,7 @@ static inline ssize_t nwrite(int fd, const void *buf, size_t count, ssize_t *wri
 		return 0;
 
 	while (tot < count) {
-		out = write(fd, buf + tot, count - tot);
+		out = write(fd, (const char *) buf + tot, count - tot);
 		if (out > 0)
 			tot += out;
 		else if(errno == EAGAIN || errno == EINTR)

--- a/lib/nwrite.h
+++ b/lib/nwrite.h
@@ -26,12 +26,17 @@
  */
 static inline ssize_t nwrite(int fd, const void *buf, size_t count, ssize_t *written)
 {
+	/*
+	 * Given the API we have to assume (unsigned) size_t 'count' fits into
+	 * a (signed) ssize_t because we can't return a larger value.
+	 * https://stackoverflow.com/questions/29722999/will-write2-always-write-less-than-or-equal-to-ssize-max
+	 */
 	ssize_t	out, tot = 0;
 
 	if (!buf || count == 0)
 		return 0;
 
-	while (tot < count) {
+	while ((size_t) tot < count) {
 		out = write(fd, (const char *) buf + tot, count - tot);
 		if (out > 0)
 			tot += out;

--- a/lib/worker.c
+++ b/lib/worker.c
@@ -181,7 +181,7 @@ int worker_send_kvvec(int sd, struct kvvec *kvv)
 
 	/* bufsize, not buflen, as it gets us the delimiter */
 	/* ret = write(sd, kvvb->buf, kvvb->bufsize); */
-    ret = nwrite(sd, kvvb->buf, kvvb->bufsize,NULL);
+	ret = nwrite(sd, kvvb->buf, kvvb->bufsize, NULL);
 	free(kvvb->buf);
 	free(kvvb);
 

--- a/lib/worker.c
+++ b/lib/worker.c
@@ -180,7 +180,6 @@ int worker_send_kvvec(int sd, struct kvvec *kvv)
 		return -1;
 
 	/* bufsize, not buflen, as it gets us the delimiter */
-	/* ret = write(sd, kvvb->buf, kvvb->bufsize); */
 	ret = nwrite(sd, kvvb->buf, kvvb->bufsize, NULL);
 	free(kvvb->buf);
 	free(kvvb);


### PR DESCRIPTION
Fix `nwrite()` related gcc 8.1.0 compiler warnings. Cleanups.