### PR TITLE
travis.yml: add gcc-8 and clang-5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ matrix:
       addons:
         apt:
           packages:
-            - build-essential
             - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - lcov
+            - libgd-dev
             - php5
             - php5-gd
-            - libgd-dev
             - unzip
-            - lcov
-            - gperf
-            - gcovr
       env:
-        - MATRIX_EVAL="CC=gcc"
+        - MATRIX_EVAL="CC=gcc && CXX=g++"
 
     - os: linux
       dist: trusty
@@ -28,18 +28,18 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - build-essential
             - apache2
-            - php5
-            - php5-gd
-            - libgd-dev
-            - unzip
-            - lcov
-            - gperf
+            - build-essential
             - gcovr
+            - gperf
             - g++-5
+            - lcov
+            - libgd-dev
+            - php5
+            - php5-gd
+            - unzip
       env:
-        - MATRIX_EVAL="CC=gcc-5"
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
     - os: linux
       dist: trusty
@@ -48,18 +48,18 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - build-essential
             - apache2
-            - php5
-            - php5-gd
-            - libgd-dev
-            - unzip
-            - lcov
-            - gperf
+            - build-essential
             - gcovr
+            - gperf
             - g++-6
+            - lcov
+            - libgd-dev
+            - php5
+            - php5-gd
+            - unzip
       env:
-        - MATRIX_EVAL="CC=gcc-6"
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
     - os: linux
       dist: trusty
@@ -68,18 +68,58 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - build-essential
             - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - g++-7
+            - lcov
+            - libgd-dev
             - php5
             - php5-gd
-            - libgd-dev
             - unzip
-            - lcov
-            - gperf
-            - gcovr
-            - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-7"
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - g++-8
+            - lcov
+            - libgd-dev
+            - php5
+            - php5-gd
+            - unzip
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+
+   - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - apache2
+            - build-essential
+            - clang-5.0
+            - gcovr
+            - gperf
+            - lcov
+            - libgd-dev
+            - php5
+            - php5-gd
+            - unzip
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
 before_install:
   - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
Hi @hedenface,

I added **gcc-8.x** and **clang-5.0** to TravisCI, sorted the package list, and defined `CXX` explicitly.

I tried **clang-3.9** too, but it does not want to compile. You can also that a look at the **gcc-8** and **clang-5.0** new warnings.

Thanks!  