### PR TITLE
Add clang-6.0 and fix a trivial warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,28 @@ matrix:
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 
+    - os: linux
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - clang-6.0
+            - gcovr
+            - gperf
+            - g++-4.9
+            - lcov
+            - libgd-dev
+            - php5
+            - php5-gd
+            - unzip
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+
 before_install:
   - eval "${MATRIX_EVAL}"
 

--- a/worker/ping/worker-ping.c
+++ b/worker/ping/worker-ping.c
@@ -47,7 +47,7 @@ void		parse_worker_command_line( int, char **, char **, int *, char **,
 static int	worker( const char *);
 
 /* Everything starts here */
-main( int argc, char **argv, char **env) {
+int main( int argc, char **argv, char **env) {
 	int daemon_mode = FALSE;
 	char *worker_socket;
 	char *worker_user = ( char *)0;


### PR DESCRIPTION
Hi @hedenface,

I just figured out how to get **clang-6.0** working.

OTOH, this function seems to be unused,
```
checks.c:1084:20: warning: unused function 'service_propagate_dependency_checks' 
```

Thanks!