### PR TITLE
Fix for CVE-2018-13441 null pointer dereference

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,7 @@ Nagios Core 4 Change Log
 * Fix for duplicate comments on reload (Bryan Heden)
 * Fix for check_interval/retry_interval bug (Scott Wilkerson)
 * Fix passive checks sending recovery email when host was previously up (Scott Wilkerson)
+* Fix for CVE-2018-13441 null pointer dereference (Trevor McDonald)
 
 4.4.1 - 2018-06-25
 ------------------

--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,12 @@
 Nagios Core 4 Change Log
 ########################
 
+4.4.2 - 2018-07-??
+------------------
+* Fix for duplicate comments on reload (Bryan Heden)
+* Fix for check_interval/retry_interval bug (Scott Wilkerson)
+* Fix passive checks sending recovery email when host was previously up (Scott Wilkerson)
+
 4.4.1 - 2018-06-25
 ------------------
 FIXES

--- a/base/query-handler.c
+++ b/base/query-handler.c
@@ -26,7 +26,7 @@ static int qh_echo(int sd, char *buf, unsigned int len)
 {
 	int result = 0;
 
-	if (!strcmp(buf, "help")) {
+	if (buf == NULL || !strcmp(buf, "help")) {
 
 		nsock_printf_nul(sd,
 			"Query handler that simply echoes back what you send it.");
@@ -371,7 +371,7 @@ static int qh_help(int sd, char *buf, unsigned int len)
 {
 	struct query_handler *qh = NULL;
 
-	if (!*buf || !strcmp(buf, "help")) {
+	if (buf == NULL || !strcmp(buf, "help")) {
 		nsock_printf_nul(sd,
 			"  help <name>   show help for handler <name>\n"
 			"  help list     list registered handlers\n");
@@ -405,7 +405,7 @@ static int qh_core(int sd, char *buf, unsigned int len)
 {
 	char *space;
 
-	if (*buf == 0 || !strcmp(buf, "help")) {
+	if (buf == NULL || !strcmp(buf, "help")) {
 
 		nsock_printf_nul(sd, 
 			"Query handler for manipulating nagios core.\n"


### PR DESCRIPTION
Explicit pointer comparison to NULL, default to "help" output if so