### PR TITLE
fix for duplicated flapping comments across Nagios reloads

### DIFF
--- a/base/flapping.c
+++ b/base/flapping.c
@@ -308,10 +308,12 @@ void set_service_flap(service *svc, double percent_change, double high_threshold
 	/* log a notice - this one is parsed by the history CGI */
 	logit(NSLOG_RUNTIME_WARNING, FALSE, "SERVICE FLAPPING ALERT: %s;%s;STARTED; Service appears to have started flapping (%2.1f%% change >= %2.1f%% threshold)\n", svc->host_name, svc->description, percent_change, high_threshold);
 
-	/* add a non-persistent comment to the service */
-	asprintf(&temp_buffer, "Notifications for this service are being suppressed because it was detected as having been flapping between different states (%2.1f%% change >= %2.1f%% threshold).  When the service state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
-	add_new_service_comment(FLAPPING_COMMENT, svc->host_name, svc->description, time(NULL), "(Nagios Process)", temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(svc->flapping_comment_id));
-	my_free(temp_buffer);
+	if (svc->flapping_comment_id == 0) {
+		/* add a non-persistent comment to the service */
+		asprintf(&temp_buffer, "Notifications for this service are being suppressed because it was detected as having been flapping between different states (%2.1f%% change >= %2.1f%% threshold).  When the service state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
+		add_new_service_comment(FLAPPING_COMMENT, svc->host_name, svc->description, time(NULL), "(Nagios Process)", temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(svc->flapping_comment_id));
+		my_free(temp_buffer);
+		}
 
 	/* set the flapping indicator */
 	svc->is_flapping = TRUE;
@@ -396,10 +398,12 @@ void set_host_flap(host *hst, double percent_change, double high_threshold, doub
 	/* log a notice - this one is parsed by the history CGI */
 	logit(NSLOG_RUNTIME_WARNING, FALSE, "HOST FLAPPING ALERT: %s;STARTED; Host appears to have started flapping (%2.1f%% change > %2.1f%% threshold)\n", hst->name, percent_change, high_threshold);
 
-	/* add a non-persistent comment to the host */
-	asprintf(&temp_buffer, "Notifications for this host are being suppressed because it was detected as having been flapping between different states (%2.1f%% change > %2.1f%% threshold).  When the host state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
-	add_new_host_comment(FLAPPING_COMMENT, hst->name, time(NULL), "(Nagios Process)", temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(hst->flapping_comment_id));
-	my_free(temp_buffer);
+	if (hst->flapping_comment_id == 0) {
+		/* add a non-persistent comment to the host */
+		asprintf(&temp_buffer, "Notifications for this host are being suppressed because it was detected as having been flapping between different states (%2.1f%% change > %2.1f%% threshold).  When the host state stabilizes and the flapping stops, notifications will be re-enabled.", percent_change, high_threshold);
+		add_new_host_comment(FLAPPING_COMMENT, hst->name, time(NULL), "(Nagios Process)", temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(hst->flapping_comment_id));
+		my_free(temp_buffer);
+	}
 
 	/* set the flapping indicator */
 	hst->is_flapping = TRUE;

--- a/xdata/xrddefault.c
+++ b/xdata/xrddefault.c
@@ -239,6 +239,7 @@ int xrddefault_save_state_information(void) {
 		fprintf(fp, "is_flapping=%d\n", temp_host->is_flapping);
 		fprintf(fp, "percent_state_change=%.2f\n", temp_host->percent_state_change);
 		fprintf(fp, "check_flapping_recovery_notification=%d\n", temp_host->check_flapping_recovery_notification);
+		fprintf(fp, "flapping_comment_id=%lu\n", temp_host->flapping_comment_id);
 
 		fprintf(fp, "state_history=");
 		for(x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++)
@@ -311,6 +312,7 @@ int xrddefault_save_state_information(void) {
 		fprintf(fp, "is_flapping=%d\n", temp_service->is_flapping);
 		fprintf(fp, "percent_state_change=%.2f\n", temp_service->percent_state_change);
 		fprintf(fp, "check_flapping_recovery_notification=%d\n", temp_service->check_flapping_recovery_notification);
+		fprintf(fp, "flapping_comment_id=%lu\n", temp_service->flapping_comment_id);
 
 		fprintf(fp, "state_history=");
 		for(x = 0; x < MAX_STATE_HISTORY_ENTRIES; x++)
@@ -1086,6 +1088,8 @@ int xrddefault_read_state_information(void) {
 									}
 								temp_host->state_history_index = 0;
 								}
+							else if(!strcmp(var, "flapping_comment_id") && sigrestart == TRUE)
+								temp_host->flapping_comment_id = strtoul(val, NULL, 10);
 							else
 								found_directive = FALSE;
 							}
@@ -1357,6 +1361,8 @@ int xrddefault_read_state_information(void) {
 									}
 								temp_service->state_history_index = 0;
 								}
+							else if(!strcmp(var, "flapping_comment_id") && sigrestart == TRUE)
+								temp_service->flapping_comment_id = strtoul(val, NULL, 10);
 							else
 								found_directive = FALSE;
 							}


### PR DESCRIPTION
Version 4.4.1 duplicates the flapping comments when reloading the Nagios process. This happens because the main process stores the current state to the retention data file, reinitializes by reading the previously safed retention data and then recheck the flapping state of all hosts and services (this is only done with large installation tweaks disabled).
Rechecking for flapping hosts and services leads to an new flapping comment. This overwrites the flapping_comment_id of the host or service object and breaks the link between the object and its comment.
The old flapping comment is not deleted.
The changes of this pull request store the flapping_comment_id to the retention data file (to keep the link between the object and the flapping comment) and prevent the creation of a new flapping comment if there is already one.