### PR TITLE
Avoid a make error when building on the aarch64 architecture.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Nagios Core 4 Change Log
 ------------------
 FIXES
 * Fixed services sending recovery emails when they recover if host in down state (#572) (Scott Wilkerson)
+* Avoid a make error when building on the aarch64 architecture.
 
 4.4.2 - 2018-08-16
 ------------------

--- a/THANKS
+++ b/THANKS
@@ -97,6 +97,7 @@ wrong, please let me know.
 * Franky Van Liedekerke
 * Frederic Schaer
 * Frederic Van Espen 
+* Gareth Randall
 * Garry Cook
 * Gary Berger
 * Gary Miller

--- a/contrib/Makefile.in
+++ b/contrib/Makefile.in
@@ -95,7 +95,11 @@ else
     ifeq ($(ARCH),i686)
 RPM_ARCH := i386
     else
+        ifeq ($(ARCH),aarch64)
+RPM_ARCH := aarch64
+        else
 $(error Unknown arch "$(ARCH)".)
+        endif
     endif
 endif
 


### PR DESCRIPTION
This resolves an error triggered by running 'make clean' as part of the build of nagioscore, when building on the aarch64 architecture.