### PR TITLE
Add missing semi-colon to &nbsp element.

### DIFF
--- a/cgi/status.c
+++ b/cgi/status.c
@@ -3230,7 +3230,7 @@ void show_servicegroup_service_totals_summary(servicegroup *temp_servicegroup) {
 		printf("<td class='miniStatusCRITICAL'><table border='0'>\n");
 		printf("<tr>\n");
 
-		printf("<td class='miniStatusCRITICAL'><a href='%s?servicegroup=%s&style=detail&servicestatustypes=%d&hoststatustypes=%d&serviceprops=%lu&hostprops=%lu'>%d CRITICAL</a>&nbsp:</td>\n", STATUS_CGI, url_encode(temp_servicegroup->group_name), SERVICE_CRITICAL, host_status_types, service_properties, host_properties, services_critical);
+		printf("<td class='miniStatusCRITICAL'><a href='%s?servicegroup=%s&style=detail&servicestatustypes=%d&hoststatustypes=%d&serviceprops=%lu&hostprops=%lu'>%d CRITICAL</a>&nbsp;:</td>\n", STATUS_CGI, url_encode(temp_servicegroup->group_name), SERVICE_CRITICAL, host_status_types, service_properties, host_properties, services_critical);
 
 		printf("<td><table border='0'>\n");
 


### PR DESCRIPTION
The Critical status message found in the Service Status Summary column
of the Status Summary For all Service Groups is malformed. An &nbsp
element within cgi/status.c is missing the ending semi-colon causing the display to print
'&nbsp:' instead of ' :'.

This behaviour is exhibited on Nagios 4.0.8 with Linux 2.6.32-696.23.1.el6.x86_64 CentOS6.
