### PR TITLE
Prevent log rotation to be repeatedly scheduled to the same time on a DST change.

### DIFF
--- a/base/utils.c
+++ b/base/utils.c
@@ -1561,6 +1561,7 @@ time_t get_next_log_rotation_time(void) {
 	struct tm *t, tm_s;
 	int is_dst_now = FALSE;
 	time_t run_time;
+	int expected_mday;
 
 	time(&current_time);
 	t = localtime_r(&current_time, &tm_s);
@@ -1594,8 +1595,15 @@ time_t get_next_log_rotation_time(void) {
 
 	if(is_dst_now == TRUE && t->tm_isdst == 0)
 		run_time += 3600;
-	else if(is_dst_now == FALSE && t->tm_isdst > 0)
+	else if(is_dst_now == FALSE && t->tm_isdst > 0) {
+		expected_mday = t->tm_mday;
 		run_time -= 3600;
+		t = localtime(&run_time);
+		/* add an hour back if we would end up in the */
+		/* day before */
+		if (t->tm_mday < expected_mday)
+			run_time += 3600;
+		}
 
 	return run_time;
 	}


### PR DESCRIPTION
Several states in Brazil have a DST change on 4th of November at midnight. This causes nagios to schedule log rotations to 11pm repeatedly until the next day. This is caused by the following logic:

        1) Get current UNIX time.
        2) Convert it to local time.
        3) Reset seconds and minutes and store the DST flag.
        4) If rotation type is LOG_ROTATION_DAILY:
                5) Increment day.
                6) Reset hour to 0.
                7) Convert localtime to UNIX time.
        8) If DST changed from 0 to 1:
                9) Subtract one hour.

In states that have the DST change on midnight (I used Sao Paulo for my testing), the day before the DST change occurs:

        5) Increment day to 4.
        6) Reset hour to 0.
        8) Evaluates to true, because 'on midnight' it is DST.
        9) Subtract hour, making the time 3rd of November, 11pm.

This means that the rotation will hapen on 3rd of November once at midnight (proper time) and then again at 11pm. The next rotation scheduling will do the following:

        5) Increment day to 4.
        6) Reset hour to 0 (from 23).
        8) Again evaluates to true.
        9) Subtract hour, again making it 11pm.

This will then repeat until it is the next day in local time. The reason for this problem is, that if we add one second to 23:59:59, we get 01:00:00 of the following day, so the hour does not really exist (i.e.
the hour we try to subtract). This commit catches this situation and does not subtract the one hour in such cases.