### PR TITLE
Fix negative numbers and wrong scheduled downtime numbers in Availability Report

### DIFF
--- a/cgi/avail.c
+++ b/cgi/avail.c
@@ -2073,6 +2073,9 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 		}
 	}
 
+	/* save "processed state" info */
+	as->processed_state = subject->last_known_state;
+
 	/* special case if first entry was program start */
 	if (first_state == AS_PROGRAM_START) {
 
@@ -2089,6 +2092,9 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 					start_state = AS_SVC_OK;
 				}
 			}
+
+			/* save "processed state" info */
+			as->processed_state = start_state;
 		}
 		else {
 			return;
@@ -2099,8 +2105,7 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 		subject->last_known_state = first_state;
 	}
 
-	/* save "processed state" info */
-	as->processed_state = start_state;
+	
 
 #ifdef DEBUG
 	printf("PASSED TIME CHECKS, CLIPPED VALUES: START=%lu, END=%lu\n", start_time, end_time);
@@ -2386,13 +2391,8 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 		compute_subject_downtime_part_times(start_time, end_time, part_subject_state, subject);
 	}
 	else {
-		/* is outside scheduled time, use end schdule downtime */
-		if (last->time_stamp > end_time) {
-			compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
-		}
-		else {
-			compute_subject_downtime_part_times(saved_stamp, last->time_stamp, saved_status, subject);
-		}
+		/* is outside scheduled time, or at the end of the log, so fake the end of scheduled downtime */
+		compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
 	}
 }
 
@@ -4340,7 +4340,7 @@ void display_host_availability(void)
 			printf("<td CLASS='hostUP' rowspan=3>UP</td>");
 			printf("<td CLASS='dataEven'>Unscheduled</td>");
 			printf("<td CLASS='dataEven'>%s</td>", time_up_unscheduled_string);
-			printf("<td CLASS='dataEven'>%2.3f%%</td>", percent_time_up);
+			printf("<td CLASS='dataEven'>%2.3f%%</td>", percent_time_up_unscheduled);
 			printf("<td class='dataEven'>%2.3f%%</td></tr>\n", percent_time_up_known);
 			printf("<tr CLASS='dataEven'>");
 			printf("<td CLASS='dataEven'>Scheduled</td>");

--- a/cgi/avail.c
+++ b/cgi/avail.c
@@ -2107,7 +2107,10 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 
 	/* save "processed state" info */
 	as->processed_state = start_state;
+
+#ifdef DEBUG2
 	printf("PROCESSED_STATE: %d\n", start_state);
+#endif
 
 #ifdef DEBUG
 	printf("PASSED TIME CHECKS, CLIPPED VALUES: START=%lu, END=%lu\n", start_time, end_time);
@@ -2365,6 +2368,11 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 
 		/* if status changed, we have to calculate */
 		if (saved_status != temp_as->entry_type) {
+
+			/* accommodate status for program start/end */
+			if (saved_status == AS_PROGRAM_START || saved_status == AS_PROGRAM_END) {
+				saved_status = temp_as->processed_state;
+			}
 
 			/* is outside schedule time, use end schdule downtime */
 			if (temp_as->time_stamp > end_time) {

--- a/cgi/avail.c
+++ b/cgi/avail.c
@@ -2400,7 +2400,9 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 	}
 	else {
 		/* is outside scheduled time, or at the end of the log, so fake the end of scheduled downtime */
+#ifdef DEBUG2
 		printf("<b>LAST ENTRY TYPE: %d</b>\n", last->entry_type);
+#endif
 		if (last->entry_type == AS_PROGRAM_START || last->entry_type == AS_PROGRAM_END) {
 			compute_subject_downtime_part_times(saved_stamp, end_time, part_subject_state, subject);
 		} else {

--- a/cgi/avail.c
+++ b/cgi/avail.c
@@ -1834,6 +1834,9 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 #ifdef DEBUG
 	printf("--- BEGINNING/MIDDLE SECTION ---<BR>\n");
 #endif
+#ifdef DEBUG2
+	printf("<pre>");
+#endif
 
 	/**********************************/
 	/*    BEGINNING/MIDDLE SECTION    */
@@ -1941,6 +1944,9 @@ void compute_subject_availability(avail_subject *subject, time_t current_time) {
 			}
 		}
 
+#ifdef DEBUG2
+	printf("</pre>");
+#endif
 
 	return;
 	}
@@ -1961,15 +1967,15 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 	unsigned long start          = 0L;
 	unsigned long end            = 0L;
 
-#ifdef DEBUG
+#ifdef DEBUG2
 	if (subject->type == HOST_SUBJECT) {
-		printf("HOST '%s'...\n", subject->host_name);
+		printf("\nHOST '%s'...\n", subject->host_name);
 	}
 	else {
-		printf("SERVICE '%s' ON HOST '%s'...\n", subject->service_description, subject->host_name);
+		printf("\nSERVICE '%s' ON HOST '%s'...\n", subject->service_description, subject->host_name);
 	}
 
-	printf("COMPUTING %d->%d FROM %lu to %lu (%lu seconds) FOR %s<br>\n", first_state, last_state, start_time, end_time, (end_time - start_time), (subject->type == HOST_SUBJECT) ? "HOST" : "SERVICE");
+	printf("COMPUTING %d->%d FROM %lu to %lu (%lu seconds) FOR %s\n", first_state, last_state, start_time, end_time, (end_time - start_time), (subject->type == HOST_SUBJECT) ? "HOST" : "SERVICE");
 #endif
 
 	/* clip times if necessary */
@@ -2073,9 +2079,6 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 		}
 	}
 
-	/* save "processed state" info */
-	as->processed_state = subject->last_known_state;
-
 	/* special case if first entry was program start */
 	if (first_state == AS_PROGRAM_START) {
 
@@ -2092,9 +2095,6 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 					start_state = AS_SVC_OK;
 				}
 			}
-
-			/* save "processed state" info */
-			as->processed_state = start_state;
 		}
 		else {
 			return;
@@ -2105,7 +2105,9 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 		subject->last_known_state = first_state;
 	}
 
-	
+	/* save "processed state" info */
+	as->processed_state = start_state;
+	printf("PROCESSED_STATE: %d\n", start_state);
 
 #ifdef DEBUG
 	printf("PASSED TIME CHECKS, CLIPPED VALUES: START=%lu, END=%lu\n", start_time, end_time);
@@ -2160,6 +2162,7 @@ void compute_subject_downtime(avail_subject *subject, time_t current_time)
 	int process_chunk          = FALSE;
 
 #ifdef DEBUG2
+	printf("<pre>");
 	printf("COMPUTE_SUBJECT_DOWNTIME\n");
 #endif
 
@@ -2253,6 +2256,10 @@ void compute_subject_downtime(avail_subject *subject, time_t current_time)
 			compute_subject_downtime_times(start_time, end_time, subject, temp_sd);
 		}
 	}
+
+#ifdef DEBUG2
+	printf("</pre>");
+#endif
 }
 
 
@@ -2269,7 +2276,7 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 	archived_state *last        = NULL;
 
 #ifdef DEBUG2
-	printf("<P><b>ENTERING COMPUTE_SUBJECT_DOWNTIME_TIMES: start=%lu, end=%lu, t1=%lu, t2=%lu </b></P>", start_time, end_time, t1, t2);
+	printf("\n<b>ENTERING COMPUTE_SUBJECT_DOWNTIME_TIMES: start=%lu, end=%lu, t1=%lu, t2=%lu </b>\n\n", start_time, end_time, t1, t2);
 #endif
 
 	/* times are weird, so bail out... */
@@ -2283,25 +2290,25 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 	/* find starting point in archived state list */
 	if (sd == NULL) {
 #ifdef DEBUG2
-		printf("<P>TEMP_AS=SUBJECT->AS_LIST </P>");
+		printf("TEMP_AS=SUBJECT->AS_LIST\n");
 #endif
 		temp_as = subject->as_list;
 	}
 	else if (sd->misc_ptr == NULL) {
 #ifdef DEBUG2
-		printf("<P>TEMP_AS=SUBJECT->AS_LIST</P>");
+		printf("TEMP_AS=SUBJECT->AS_LIST\n");
 #endif
 		temp_as = subject->as_list;
 	}
 	else if (sd->misc_ptr->next == NULL) {
 #ifdef DEBUG2
-		printf("<P>TEMP_AS=SD->MISC_PTR</P>");
+		printf("TEMP_AS=SD->MISC_PTR\n");
 #endif
 		temp_as = sd->misc_ptr;
 	}
 	else {
 #ifdef DEBUG2
-		printf("<P>TEMP_AS=SD->MISC_PTR->NEXT</P>");
+		printf("TEMP_AS=SD->MISC_PTR->NEXT\n");
 #endif
 		temp_as = sd->misc_ptr->next;
 	}
@@ -2312,20 +2319,21 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 	}
 	else if (temp_as->processed_state == AS_PROGRAM_START || temp_as->processed_state == AS_PROGRAM_END || temp_as->processed_state == AS_NO_DATA) {
 #ifdef DEBUG2
-		printf("<P>ENTRY TYPE #1: %d</P>", temp_as->entry_type);
+		printf("ENTRY TYPE #1: %d\n", temp_as->entry_type);
 #endif
 		part_subject_state = AS_NO_DATA;
 	}
 	else {
 #ifdef DEBUG2
-		printf("<P>ENTRY TYPE #2: %d</P>", temp_as->entry_type);
+		printf("ENTRY TYPE #2: %d\n", temp_as->entry_type);
+		printf("STATE: %d\n", temp_as->processed_state);
 #endif
 		part_subject_state = temp_as->processed_state;
 	}
 
 #ifdef DEBUG2
-	printf("<P>TEMP_AS=%s</P>", (temp_as == NULL) ? "NULL" : "Not NULL");
-	printf("<P>SD=%s</P>", (sd == NULL) ? "NULL" : "Not NULL");
+	printf("TEMP_AS=%s\n", (temp_as == NULL) ? "NULL" : "Not NULL");
+	printf("SD=%s\n\n", (sd == NULL) ? "NULL" : "Not NULL");
 #endif
 
 	/* temp_as now points to first event to possibly "break" this chunk */
@@ -2392,7 +2400,12 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 	}
 	else {
 		/* is outside scheduled time, or at the end of the log, so fake the end of scheduled downtime */
-		compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
+		printf("<b>LAST ENTRY TYPE: %d</b>\n", last->entry_type);
+		if (last->entry_type == AS_PROGRAM_START || last->entry_type == AS_PROGRAM_END) {
+			compute_subject_downtime_part_times(saved_stamp, end_time, part_subject_state, subject);
+		} else {
+			compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
+		}
 	}
 }
 
@@ -3511,7 +3524,13 @@ void write_log_entries(avail_subject *subject)
 		if (temp_as->next == NULL) {
 			get_time_string(&t2, end_date_time, sizeof(end_date_time) - 1, SHORT_DATE_TIME);
 			get_time_breakdown((time_t)(t2 - temp_as->time_stamp), &days, &hours, &minutes, &seconds);
-			snprintf(duration, sizeof(duration) - 1, "%dd %dh %dm %ds+", days, hours, minutes, seconds);
+
+			/* show blank event duration if the end time is past the start time */
+			if ((t2 - temp_as->time_stamp) > end_date_time) {
+				snprintf(duration, sizeof(duration), "");
+			} else {
+				snprintf(duration, sizeof(duration) - 1, "%dd %dh %dm %ds+", days, hours, minutes, seconds);
+			}
 		}
 		else {
 			get_time_string(&(temp_as->next->time_stamp), end_date_time, sizeof(end_date_time) - 1, SHORT_DATE_TIME);

--- a/cgi/avail.c
+++ b/cgi/avail.c
@@ -2097,6 +2097,7 @@ void compute_subject_availability_times(int first_state, int last_state, time_t 
 			}
 		}
 		else {
+			as->processed_state = AS_NO_DATA;
 			return;
 		}
 	}
@@ -2412,6 +2413,10 @@ void compute_subject_downtime_times(time_t start_time, time_t end_time, avail_su
 		printf("<b>LAST ENTRY TYPE: %d</b>\n", last->entry_type);
 #endif
 		if (last->entry_type == AS_PROGRAM_START || last->entry_type == AS_PROGRAM_END) {
+			/* if we are NOT assuming initial states, then we do not want to add this data into the downtime */
+			if (last->entry_type == AS_PROGRAM_START && assume_initial_states == FALSE) {
+				return;
+			}
 			compute_subject_downtime_part_times(saved_stamp, end_time, part_subject_state, subject);
 		} else {
 			compute_subject_downtime_part_times(saved_stamp, end_time, saved_status, subject);
@@ -4370,7 +4375,7 @@ void display_host_availability(void)
 			printf("<td CLASS='dataEven'>Unscheduled</td>");
 			printf("<td CLASS='dataEven'>%s</td>", time_up_unscheduled_string);
 			printf("<td CLASS='dataEven'>%2.3f%%</td>", percent_time_up_unscheduled);
-			printf("<td class='dataEven'>%2.3f%%</td></tr>\n", percent_time_up_known);
+			printf("<td class='dataEven'>%2.3f%%</td></tr>\n", percent_time_up_unscheduled_known);
 			printf("<tr CLASS='dataEven'>");
 			printf("<td CLASS='dataEven'>Scheduled</td>");
 			printf("<td CLASS='dataEven'>%s</td>", time_up_scheduled_string);


### PR DESCRIPTION
This patch fixes #384.
Also fixes issues with % values not set to the proper variables.