### PR TITLE
Fix #621 - Service Problem ID and Last Service Problem ID not set properly after check

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -1601,10 +1601,12 @@ int handle_async_service_check_result(service *svc, check_result *cr)
 	   switch into a HARD state and reset the attempts */
 	if (svc->current_state == STATE_OK && state_change == TRUE) {
 
-		/* Reset attempts and problem state */
+		/*  Problem state starts regardless of SOFT/HARD status. */
+		svc->last_problem_id = svc->current_problem_id;
+		svc->current_problem_id = 0L;
+
+		/* Reset attempts */
 		if (hard_state_change == TRUE) {
-			svc->last_problem_id = svc->current_problem_id;
-			svc->current_problem_id = 0L;
 			svc->current_notification_number = 0;
 			svc->host_problem_at_last_check = FALSE;
 		}


### PR DESCRIPTION
The bug mentioned in #621 was also impacting the $LASTSERVICEPROBLEMID$ macro - the value would remain at zero for the life of the nagios process, unless it was restarted, in which case both macros would be set to the 'correct' values on startup.

After the change listed here, both macros change in the same manner as the $HOSTPROBLEMID$ and $LASTHOSTPROBLEMID$ macros. 

Refer to bug-621-data.pdf below for the expected vs. actual output. 

Note that the plugin output shows the most recent available data, with each change occurring after plugin execution, so they should be 'off-by-1' from the STATUS column, which is the 'incoming' exit code produced by each execution of the plugin.

[bug-621-data.pdf](https://github.com/NagiosEnterprises/nagioscore/files/3209119/bug-621-data.pdf)

