### PR TITLE
Don't roll back the clock when entering daylight saving time and scheduling log rotation

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,8 @@ Nagios Core 4 Change Log
 * Fixed $SERVICEPROBLEMID$ to be reset after service recovery (#621) (Sebastian Wolf)
 * Fixed main nagios thread to release nagios.qh on a closed connection (#635) (Sebastian Wolf)
 * Fixed semicolon escaping to remove prepended backslash (\) (#643) (Sebastian Wolf)
+* Fixed 'Checks of this host have been disabled' message showing on passive-only hosts (#632) (Vojtěch Širůček & Sebastian Wolf)
+* Fixed last_hard_state showing the current hard state when service status is brokered (#633) (Sebastian Wolf)
 
 
 4.4.3 - 2019-01-15

--- a/Changelog
+++ b/Changelog
@@ -5,7 +5,7 @@ Nagios Core 4 Change Log
 
 4.4.4 - 2019-??-??
 ------------------
-* Fixed log rotation logic to not repeatedly schedule rotation on a DST change (#610) (Jaroslav Jindrak)
+* Fixed log rotation logic to not repeatedly schedule rotation on a DST change (#610, #626) (Jaroslav Jindrak & Sebastian Wolf)
 * Fixed $SERVICEPROBLEMID$ to be reset after service recovery (#621) (Sebastian Wolf)
 * Fixed main nagios thread to release nagios.qh on a closed connection (#635) (Sebastian Wolf)
 * Fixed semicolon escaping to remove prepended backslash (\) (#643) (Sebastian Wolf)

--- a/THANKS
+++ b/THANKS
@@ -290,6 +290,7 @@ wrong, please let me know.
 * Sam Howard
 * Sean Finney
 * Sebastian Guarino
+* Sebastian Wolf
 * Sebastien Barbereau
 * Sergio Guzman
 * Shad Lords
@@ -337,6 +338,7 @@ wrong, please let me know.
 * Uwe Knop
 * Uwe Knop
 * Vadim Okun
+* Vojtěch Širůček
 * Volkan Yazici
 * Volker Aust
 * William Leibzon

--- a/base/utils.c
+++ b/base/utils.c
@@ -1595,15 +1595,6 @@ time_t get_next_log_rotation_time(void) {
 
 	if(is_dst_now == TRUE && t->tm_isdst == 0)
 		run_time += 3600;
-	else if(is_dst_now == FALSE && t->tm_isdst > 0) {
-		expected_mday = t->tm_mday;
-		run_time -= 3600;
-		t = localtime(&run_time);
-		/* add an hour back if we would end up in the */
-		/* day before */
-		if (t->tm_mday < expected_mday)
-			run_time += 3600;
-		}
 
 	return run_time;
 	}


### PR DESCRIPTION
Fixes #610, #626 