### PR TITLE
Fix #647 - multiple issues related to short timeperiods

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -1542,7 +1542,7 @@ int handle_async_service_check_result(service *svc, check_result *cr)
 		   constraints. Add a random amount so we don't get all checks
 		   subject to that timeperiod constraint scheduled at the same time */
 		if (next_valid_time > preferred_time) {
-			svc->next_check += ranged_urand(0, check_window(svc));
+			svc->next_check = reschedule_within_timeperiod(next_valid_time, svc->check_period_ptr, check_window(svc));
 		}
 
 		schedule_service_check(svc, svc->next_check, CHECK_OPTION_NONE);
@@ -2425,7 +2425,7 @@ int handle_async_host_check_result(host *hst, check_result *cr)
 		   constraints. Add a random amount so we don't get all checks
 		   subject to that timeperiod constraint scheduled at the same time */
 		if (next_valid_time > preferred_time) {
-			hst->next_check += ranged_urand(0, check_window(hst));
+			hst->next_check = reschedule_within_timeperiod(next_valid_time, hst->check_period_ptr, check_window(hst));
 		}
 
 		schedule_host_check(hst, hst->next_check, CHECK_OPTION_NONE);
@@ -3000,7 +3000,7 @@ int run_scheduled_host_check(host *hst, int check_options, double latency)
 			if ((time_is_valid == FALSE) 
 				&& (check_time_against_period(next_valid_time, hst->check_period_ptr) == ERROR)) {
 
-				hst->next_check = preferred_time + ranged_urand(0, check_window(hst));
+				hst->next_check = reschedule_within_timeperiod(next_valid_time, hst->check_period_ptr, check_window(hst));
 
 				logit(NSLOG_RUNTIME_WARNING, TRUE, "Warning: Check of host '%s' could not be rescheduled properly.  Scheduling check for %s...\n", hst->name, ctime(&preferred_time));
 
@@ -3016,7 +3016,7 @@ int run_scheduled_host_check(host *hst, int check_options, double latency)
 					 * don't get all checks subject to that timeperiod
 					 * constraint scheduled at the same time
 					 */
-					hst->next_check += ranged_urand(0, check_window(hst));
+					hst->next_check = reschedule_within_timeperiod(next_valid_time, hst->check_period_ptr, check_window(hst));
 				}
 				hst->should_be_scheduled = TRUE;
 

--- a/base/checks.c
+++ b/base/checks.c
@@ -134,7 +134,7 @@ int run_scheduled_service_check(service *svc, int check_options, double latency)
 					 * don't get all checks subject to that timeperiod
 					 * constraint scheduled at the same time
 					 */
-					svc->next_check += ranged_urand(0, check_window(svc));
+					svc->next_check = reschedule_within_timeperiod(next_valid_time, svc->check_period_ptr, check_window(svc));
 				}
 				svc->should_be_scheduled = TRUE;
 

--- a/base/events.c
+++ b/base/events.c
@@ -356,7 +356,7 @@ void init_timing_loop(void) {
 						"  Fixing check time %lu secs too far away\n",
 						check_delay - check_window(temp_service));
 				fixed_services++;
-				check_delay = ranged_urand(0, check_window(temp_service));
+				check_delay = reschedule_within_timeperiod(next_valid_time, temp_service->check_period_ptr, check_window(temp_service));
 				log_debug_info(DEBUGL_EVENTS, 0, "  New check offset: %d\n",
 						check_delay);
 			}
@@ -509,7 +509,7 @@ void init_timing_loop(void) {
 			log_debug_info(DEBUGL_EVENTS, 1, "Fixing check time (off by %lu)\n",
 					check_delay - check_window(temp_host));
 			fixed_hosts++;
-			check_delay = ranged_urand(0, check_window(temp_host));
+			check_delay = reschedule_within_timeperiod(next_valid_time, temp_host->check_period_ptr, check_window(temp_host));
 			}
 		temp_host->next_check = (time_t)(current_time + check_delay);
 

--- a/base/utils.c
+++ b/base/utils.c
@@ -1377,6 +1377,28 @@ void get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperi
 	_get_next_valid_time(pref_time, valid_time, tperiod);
 	}
 
+/* Given the next valid time in a timeperiod, the timeperiod itself, and the normal rescheduling window, */
+/* return the next check time */
+time_t reschedule_within_timeperiod(time_t starting_valid_time, timeperiod* check_period_ptr, time_t check_window) {
+
+	/* First, find the next time that is outside the timeperiod */
+	time_t next_invalid_time;
+	_get_next_invalid_time(starting_valid_time, &next_invalid_time, check_period_ptr);
+
+	/* Determine whether the next invalid time or the outside of the check_window is closer */
+	time_t max;
+	if (next_invalid_time - starting_valid_time > check_window) {
+		max = check_window;
+		}
+	else {
+		max = next_invalid_time - starting_valid_time;
+		}
+
+	/* Reschedule within the smaller range */
+
+	return starting_valid_time + ranged_urand(0, max);
+	}
+
 
 /* tests if a date range covers just a single day */
 int is_daterange_single_day(daterange *dr) {

--- a/base/utils.c
+++ b/base/utils.c
@@ -1381,6 +1381,8 @@ void get_next_valid_time(time_t pref_time, time_t *valid_time, timeperiod *tperi
 /* return the next check time */
 time_t reschedule_within_timeperiod(time_t starting_valid_time, timeperiod* check_period_ptr, time_t check_window) {
 
+	log_debug_info(DEBUGL_FUNCTIONS, 0, "reschedule_within_timeperiod");
+
 	/* First, find the next time that is outside the timeperiod */
 	time_t ending_valid_time;
 	_get_next_invalid_time(starting_valid_time, &ending_valid_time, check_period_ptr);
@@ -1388,13 +1390,13 @@ time_t reschedule_within_timeperiod(time_t starting_valid_time, timeperiod* chec
 	/* _get_next_invalid_time returns the first invalid minute. The maximum allowable should be a minute earlier */
 	ending_valid_time -= 60;
 
-	log_debug_info(DEBUGL_CHECKS, 0, "reschedule: The starting time is %s \n", ctime(&starting_valid_time));
-	log_debug_info(DEBUGL_CHECKS, 0, "reschedule: The next invalid time is %s \n", ctime(&ending_valid_time));
-
 	/* Determine whether the next invalid time or the outside of the check_window is closer */
 	time_t max_nudge = ending_valid_time - starting_valid_time;
+
+	/* max_nudge will be less than zero when there's no 'invalid' time */
+	/* Otherwise, use the closest of the two times to reschedule the check */
 	if (max_nudge <= 0 || max_nudge > check_window) {
-		log_debug_info(DEBUGL_CHECKS, 0, "reschedule: using check_window, check_window %d is smaller than %d\n", check_window, max_nudge);
+		log_debug_info(DEBUGL_CHECKS, 0, "Using raw check_window instead of timeperiod for scheduling \n");
 		max_nudge = check_window;
 		}
 

--- a/include/nagios.h
+++ b/include/nagios.h
@@ -669,6 +669,7 @@ int is_daterange_single_day(daterange *);
 time_t calculate_time_from_weekday_of_month(int, int, int, int);	/* calculates midnight time of specific (3rd, last, etc.) weekday of a particular month */
 time_t calculate_time_from_day_of_month(int, int, int);	/* calculates midnight time of specific (1st, last, etc.) day of a particular month */
 void get_next_valid_time(time_t, time_t *, timeperiod *);	/* get the next valid time in a time period */
+time_t reschedule_within_timeperiod(time_t, timeperiod*, time_t);
 time_t get_next_log_rotation_time(void);	     	/* determine the next time to schedule a log rotation */
 int dbuf_init(dbuf *, int);
 int dbuf_free(dbuf *);


### PR DESCRIPTION
In addition to the issue found in #647, this also addresses an issue with automatic check rescheduling - checks would often be rescheduled outside of their check_period, causing the check to be skipped and rescheduled for the next period in perpetuity. 