### PR TITLE
Resolve #651. Fix current_attempt not being set for a SOFT CRITICAL service whose host is HARD DOWN

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,7 @@ Nagios Core 4 Change Log
 * Fixed semicolon escaping to remove prepended backslash (\) (#643) (Sebastian Wolf)
 * Fixed 'Checks of this host have been disabled' message showing on passive-only hosts (#632) (Vojtěch Širůček & Sebastian Wolf)
 * Fixed last_hard_state showing the current hard state when service status is brokered (#633) (Sebastian Wolf)
+* Fixed SOFT recoveries sending when services had HARD recovery some time after host recovery (#651) (Sebastian Wolf)
 
 
 4.4.3 - 2019-01-15

--- a/base/checks.c
+++ b/base/checks.c
@@ -1350,6 +1350,7 @@ int handle_async_service_check_result(service *svc, check_result *cr)
 		hard_state_change = TRUE;
 		svc->state_type = HARD_STATE;
 		new_last_hard_state = svc->current_state;
+		svc->current_attempt = svc->max_attempts;
     }
 
 	if (check_host == TRUE) {


### PR DESCRIPTION
#651 for background & explanation of fix
