### PR TITLE
Superglobal 'REMOTE_USER' susceptible to XSS

### DIFF
--- a/html/map.php
+++ b/html/map.php
@@ -78,7 +78,7 @@
 				var vboxText = "<a href=https://www.nagios.com/tours target=_blank>" +
 							"Click here to watch the entire Nagios Core 4 Tour!</a>";
 				$(document).ready(function() {
-					var user = "<?php echo $_SERVER['REMOTE_USER']; ?>";
+					var user = "<?php echo htmlspecialchars($_SERVER['REMOTE_USER']); ?>";
 
 					vBoxId += ";" + user;
 					vbox = new vidbox({pos:'lr',vidurl:'https://www.youtube.com/embed/leaRdb3BElI',


### PR DESCRIPTION
The $_SERVER['REMOTE_USER'] isn't sanitized prior to being echoed out which results in a XSS (though this would be difficult for an attacker to reproduce due to needing access to the users file).
 
To reproduce, add new user to: /usr/local/nagiosxi/etc/htpasswd.users
with username: <script>alert(document.cookie)</script> and reload the page resulting in the cookie being displayed.