### PR TITLE
Fix service validate max_check_attempts directive

### DIFF
--- a/common/objects.c
+++ b/common/objects.c
@@ -1454,7 +1454,7 @@ service *add_service(char *host_name, char *description, char *display_name, cha
 
 	/* check values */
 	if(max_attempts <= 0 || check_interval < 0 || retry_interval <= 0 || notification_interval < 0) {
-		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid max_attempts, check_interval, retry_interval, or notification_interval value for service '%s' on host '%s'\n", description, host_name);
+		logit(NSLOG_CONFIG_ERROR, TRUE, "Error: Invalid max_check_attempts, check_interval, retry_interval, or notification_interval value for service '%s' on host '%s'\n", description, host_name);
 		return NULL;
 		}
 


### PR DESCRIPTION
Validating a configuration with at least one service with an invalid value for the `max_check_attempts`, `check_interval`, `retry_interval`, or `notification_interval` directives raised the following error: 

    Error: Invalid max_attempts, check_interval, retry_interval, or notification_interval value for service 'BAR' on host 'foo'

The name given here for `max_check_attempts` is given incorrectly, and could confuse users trying to fix their configurations.  This commit corrects the error message.