### PR TITLE
Check nagios conf before reloading

### DIFF
--- a/startup/default-service.in
+++ b/startup/default-service.in
@@ -9,6 +9,7 @@ ExecStartPre=@bindir@/nagios -v @sysconfdir@/nagios.cfg
 ExecStart=@bindir@/nagios -d @sysconfdir@/nagios.cfg
 ExecStop=@BIN_KILL@ -s TERM ${MAINPID}
 ExecStopPost=@BIN_RM@ -f @localstatedir@/rw/nagios.cmd
+ExecReload=@bindir@/nagios -v @sysconfdir@/nagios.cfg
 ExecReload=@BIN_KILL@ -s HUP ${MAINPID}
 
 [Install]


### PR DESCRIPTION
See doc at https://www.freedesktop.org/software/systemd/man/systemd.service.html:
"If more than one command is specified, the commands are invoked sequentially in the order they appear in the unit file. If one of the commands fails (and is not prefixed with "-"), other lines are not executed, and the unit is considered failed."

This will check nagios conf before attemping a restart, it's the same as "ExecStartPre"