### PR TITLE
Resolve #723. Nagios Event Radio Dispatch should be usable if --enable-nerd is used

### DIFF
--- a/base/nerd.c
+++ b/base/nerd.c
@@ -1,4 +1,3 @@
-#ifdef ENABLE_NERD
 /*
  * Nagios Event Radio Dispatcher
  *
@@ -26,6 +25,8 @@
 #include "include/nebmods.h"
 #include "include/nebmodules.h"
 #include "include/nebstructs.h"
+
+#ifdef ENABLE_NERD
 
 struct nerd_channel {
 	const char *name; /* name of this channel */

--- a/configure.ac
+++ b/configure.ac
@@ -459,7 +459,7 @@ AC_ARG_ENABLE(nerd,
 	NERD=yes
 )
 if test "x$NERD" = "xyes"; then
-	AC_DEFINE_UNQUOTED(ENABLE_NERD,,[defined if user enabled NERD (radio dispatcher)])
+	AC_DEFINE(ENABLE_NERD,1,[defined if user enabled NERD (radio dispatcher)])
 	NERD_O="nerd.o"
 fi
 AC_SUBST(NERD_O)


### PR DESCRIPTION
Resolve #723 (iirc references don't work from PR titles)

NERD seems to be broken starting in 4.4.0, when it was moved to a ./configure option.
This commit changes the preprocessor code to check whether ENABLE_NERD has been defined
only after the #include for config.h, where the symbol would be defined.