### PR TITLE
Added validation that each line of configuration file is a string

### DIFF
--- a/html/includes/utils.inc.php
+++ b/html/includes/utils.inc.php
@@ -150,6 +150,9 @@ function read_main_config_file($thefile=""){
 			while(!feof($fh)){
 				$s=fgets($fh);
 				
+				// ensure that $s is a string
+				if (is_string($s) === false) continue;
+
 				// skip comments
 				if($s[0]=='#')
 					continue;
@@ -212,6 +215,9 @@ function read_cgi_config_file($thefile=""){
 			// read all lines in the config file
 			while(!feof($fh)){
 				$s=fgets($fh);
+
+				// ensure that $s is a string
+				if (is_string($s) === false) continue;
 				
 				// skip comments
 				if($s[0]=='#')


### PR DESCRIPTION
Fixes #745 
Prevents from displaying PHP warning messages on a home page. Adds extra validation if each line of a configuration's file is really a string. Which could be not true on the last iteration of a cycle which reads configuration file line by line.