### PR TITLE
Fixed broken condition to assert whether checkbox input is checked

### DIFF
--- a/html/js/jsonquery.js
+++ b/html/js/jsonquery.js
@@ -337,7 +337,7 @@ $( document).ready( function() {
 				else if( option.valid_values instanceof Object) {
 					for( var key in option.valid_values) {
 						if( $( '#' + name + 'row input[value=' + key + 
-								']').attr( 'checked') == 'checked') {
+								']').is(":checked")) {
 							output.push( key);
 						};
 					}


### PR DESCRIPTION
Line 340 of jsonquery.html has `undefined ` result while querying checkbox object for the "checked" attribute.