### PR TITLE
Fix typos: consecutive occurrences of 'the'

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -164,6 +164,7 @@ wrong, please let me know.
 * Jonathan Kamens
 * Jonathan Saggau
 * Jorge Sanchez
+* Jorge Vallecillo
 * Joseph Maiorana
 * Josh Soref
 * Josh Thorstad

--- a/base/config.c
+++ b/base/config.c
@@ -2037,7 +2037,7 @@ int pre_flight_object_check(int *w, int *e) {
  * parents.
  */
 /*
- * same as dfs_host_path, but we flip the the tree and traverse it
+ * same as dfs_host_path, but we flip the tree and traverse it
  * backwards, since core Nagios doesn't need the child pointer at
  * later stages.
  */

--- a/cgi/archivejson.c
+++ b/cgi/archivejson.c
@@ -3399,7 +3399,7 @@ unsigned long calculate_window_duration(time_t start_time, time_t end_time,
 	unsigned long start;
 	unsigned long end;
 
-	/* MickeM - attempt to handle the the report time_period (if any) */
+	/* MickeM - attempt to handle the report time_period (if any) */
 	if(report_timeperiod != NULL) {
 		t = localtime((time_t *)&start_time);
 		state_duration = 0;

--- a/cgi/archiveutils.c
+++ b/cgi/archiveutils.c
@@ -266,7 +266,7 @@ int read_archived_data(time_t start_time, time_t end_time,
 		printf("Archive name: '%s'\n", filename);
 #endif
 
-		/* Record the last modification time of the the archive file */
+		/* Record the last modification time of the archive file */
 		if(stat(filename, &adstat) < 0) {
 			/* ENOENT is OK because Nagios may have been down when the 
 				logs were being rotated */

--- a/cgi/trends.c
+++ b/cgi/trends.c
@@ -2217,7 +2217,7 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 	else {
 
 
-		/* figure out the the state string to use */
+		/* figure out the state string to use */
 		switch(start_state) {
 			case AS_HOST_UP:
 				strcpy(state_string, "UP");

--- a/lib/squeue.h
+++ b/lib/squeue.h
@@ -62,7 +62,7 @@ extern squeue_t *squeue_create(unsigned int size);
 /**
  * Destroys a scheduling queue completely
  * @param[in] q The doomed queue
- * @param[in] flags Flags determining the the level of destruction
+ * @param[in] flags Flags determining the level of destruction
  */
 extern void squeue_destroy(squeue_t *q, int flags);
 


### PR DESCRIPTION
Minor fix: remove duplicated or consecutive 'the' occurrences
`s/the the /the /g`