### PR TITLE
Add support for ARM64 platform in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,24 @@ matrix:
         - MATRIX_EVAL="CC=gcc && CXX=g++"
 
     - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - lcov
+            - php5.6
+            - libgd-dev
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=gcc && CXX=g++"
+
+    - os: linux
       dist: trusty
       addons:
         apt:
@@ -38,6 +56,27 @@ matrix:
             - libgd-dev
             - php5
             - php5-gd
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - g++-5
+            - lcov
+            - libgd-dev
+            - php5.6
             - unzip
             - valgrind
       env:
@@ -65,6 +104,27 @@ matrix:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
 
     - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - g++-6
+            - lcov
+            - libgd-dev
+            - php5.6
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+
+    - os: linux
       dist: trusty
       addons:
         apt:
@@ -80,6 +140,27 @@ matrix:
             - libgd-dev
             - php5
             - php5-gd
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - g++-7
+            - lcov
+            - libgd-dev
+            - php5.6
             - unzip
             - valgrind
       env:
@@ -107,6 +188,27 @@ matrix:
         - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
 
     - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - gcovr
+            - gperf
+            - g++-8
+            - lcov
+            - libgd-dev
+            - php5.6
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
+
+    - os: linux
       dist: trusty
       addons:
         apt:
@@ -122,6 +224,27 @@ matrix:
             - libgd-dev
             - php5
             - php5-gd
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
+
+    - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - apache2
+            - build-essential
+            - clang-5.0
+            - gcovr
+            - gperf
+            - lcov
+            - libgd-dev
+            - php5.6
             - unzip
             - valgrind
       env:
@@ -145,6 +268,27 @@ matrix:
             - libgd-dev
             - php5
             - php5-gd
+            - unzip
+            - valgrind
+      env:
+        - MATRIX_EVAL="CC=clang-6.0 && CXX=clang++-6.0"
+    - os: linux
+      arch: arm64
+      dist: trusty
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
+          packages:
+            - apache2
+            - build-essential
+            - clang-6.0
+            - gcovr
+            - gperf
+            - lcov
+            - libgd-dev
+            - php5.6
             - unzip
             - valgrind
       env:

--- a/lib/t-utils.c
+++ b/lib/t-utils.c
@@ -89,7 +89,7 @@ int t_ok(int success, const char *fmt, ...)
 		va_end(ap);
 	}
 	else
-		t_okv(success, NULL, NULL);
+		t_okv(success, NULL, ap);
 
 	return success;
 }

--- a/tap/config.guess
+++ b/tap/config.guess
@@ -900,6 +900,9 @@ EOF
     x86_64:Linux:*:*)
 	echo x86_64-unknown-linux-gnu
 	exit 0 ;;
+    aarch64:Linux:*:*)
+        echo aarch64-unknown-linux-gnu
+        exit 0 ;;
     i*86:Linux:*:*)
 	# The BFD linker knows what the default object file format is, so
 	# first see if it will tell us. cd to the root directory to prevent


### PR DESCRIPTION
Added support for arm64 architecture in Travis-CI. Here are the details:

- Added arm64 jobs in ".travis.yml"
- Modified "tap/config.guess" file to add arm64 architecture.
- Passing "NULL" for type "va_list" produces error in arm64 platform, replaced "NULL" with "ap"