### PR TITLE
cgi: fix truncation of pairlist when no query parameters are provided

### DIFF
--- a/cgi/getcgi.c
+++ b/cgi/getcgi.c
@@ -245,7 +245,9 @@ char **getcgivars(void) {
 		formid = strstr(cookies, "NagFormId=");
 		if (formid) {
 			if(!(paircount % 256)) {
-				pairlist = (char **)realloc(pairlist, (paircount + 1) * sizeof(char *));
+				/* if no query parameters were provided, paircount can begin as zero, resulting in */
+				/* truncation of the pairlist array if we do not reserve at least two elements. */
+				pairlist = (char **)realloc(pairlist, (paircount + 2) * sizeof(char *));
 				if(pairlist == NULL) {
 					printf("getcgivars(): Could not re-allocate memory for name-value pairlist.\n");
 					exit(1);


### PR DESCRIPTION
If no query parameters are provided, paircount will be 0, and the pairlist will be
allocated to a single element array which does not provide sufficient space for its
null terminator.

Signed-off-by: Ariadne Conill <ariadne@dereferenced.org>