### PR TITLE
fix a mem-leak issue

### DIFF
--- a/xdata/xodtemplate.c
+++ b/xdata/xodtemplate.c
@@ -8967,6 +8967,7 @@ int xodtemplate_free_memory(void) {
 			my_free(this_service->icon_image_alt);
 			my_free(this_service->hostgroup_name);
 			my_free(this_service->service_description);
+			my_free(this_service->host_name);
 			}
 		my_free(this_service);
 		}


### PR DESCRIPTION
Dear Maintainer,
      I guess there is a mem-leak issue
      Which mem-block is malloced at xodtemplate_add_object_property function, but there is no my_free function called to free the  mem-block.
      Could U please to review it? Thanks