### PR TITLE
Misc fixes

### DIFF
--- a/base/query-handler.c
+++ b/base/query-handler.c
@@ -268,7 +268,7 @@ int qh_deregister_handler(const char *name)
 	struct query_handler *prev = NULL;
 
 	qh = dkhash_remove(qh_table, name, NULL);
-	if (qh != NULL) {
+	if (qh == NULL) {
 		return 0;
 	}
 
@@ -282,7 +282,8 @@ int qh_deregister_handler(const char *name)
 	if (prev != NULL) {
 		prev->next_qh = next;
 	}
-	else {
+
+	if (qh == qhandlers) {
 		qhandlers = next;
 	}
 
@@ -349,11 +350,8 @@ int qh_register_handler(const char *name, const char *description, unsigned int 
 
 void qh_deinit(const char *path)
 {
-	struct query_handler *qh   = NULL;
-
-	for (qh = qhandlers; qh != NULL; qh = qh->next_qh) {
-
-		qh_deregister_handler(qh->name);
+	while (qhandlers) {
+		qh_deregister_handler(qhandlers->name);
 	}
 
 	dkhash_destroy(qh_table);

--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -1154,7 +1154,7 @@ char * html_encode(char *input, int escape_newlines) {
 	/* we need up to six times the space to do the conversion */
 	len = (int)strlen(input);
 	output_max = len * 6;
-	if(( outcp = encoded_html_string = (char *)malloc(output_max + 1)) == NULL)
+	if(len == 0 || ( outcp = encoded_html_string = (char *)malloc(output_max + 1)) == NULL)
 		return "";
 
 	strcpy(encoded_html_string, "");
@@ -1390,7 +1390,7 @@ char *escape_string(const char *input) {
 	/* We need up to six times the space to do the conversion */
 	len = (int)strlen(input);
 	output_max = len * 6;
-	if(( stp = encoded_html_string = (char *)malloc(output_max + 1)) == NULL)
+	if(len == 0 || ( stp = encoded_html_string = (char *)malloc(output_max + 1)) == NULL)
 		return "";
 
 	strcpy(encoded_html_string, "");

--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -1254,12 +1254,12 @@ char * html_encode(char *input, int escape_newlines) {
 
 		/* newlines turn to <BR> tags */
 		else if(escape_newlines == TRUE && *incp == '\n') {
-			strncpy( outcp, "<BR>", 4);
+			memcpy( outcp, "<BR>", 4);
 			outcp += 4;
 		}
 
 		else if(escape_newlines == TRUE && *incp == '\\' && *(incp + 1) == '\n') {
-			strncpy( outcp, "<BR>", 4);
+			memcpy( outcp, "<BR>", 4);
 			outcp += 4;
 			incp++; /* needed so loop skips two characters */
 		}
@@ -1430,11 +1430,12 @@ char *escape_string(const char *input) {
 
 		/* Encode everything else (this may be excessive) */
 		else {
+			len = strlen( temp_expansion);
 			sprintf( temp_expansion, "&#%u;", ( unsigned int)wctemp[ 0]);
-			if((( stp - encoded_html_string) + strlen( temp_expansion)) <
+			if((( stp - encoded_html_string) + len) <
 					(unsigned int)output_max) {
-				strncpy( stp, temp_expansion, strlen( temp_expansion));
-				stp += strlen( temp_expansion);
+				memcpy( stp, temp_expansion, len);
+				stp += len;
 				}
 			input += mbtowc_result;
 			}

--- a/html/includes/utils.inc.php
+++ b/html/includes/utils.inc.php
@@ -147,9 +147,7 @@ function read_main_config_file($thefile=""){
 		// open main config file for reading...
 		if(($fh=@fopen($fname,'r'))!=FALSE){
 			// read all lines in the config file
-			while(!feof($fh)){
-				$s=fgets($fh);
-				
+			while( ($s=fgets($fh)) !== false){
 				// skip comments
 				if($s[0]=='#')
 					continue;
@@ -210,9 +208,7 @@ function read_cgi_config_file($thefile=""){
 		// open cgi config file for reading...
 		if(($fh=@fopen($fname,'r'))!=FALSE){
 			// read all lines in the config file
-			while(!feof($fh)){
-				$s=fgets($fh);
-				
+			while( ($s=fgets($fh)) !== false){
 				// skip comments
 				if($s[0]=='#')
 					continue;


### PR DESCRIPTION
Cleans up a few items from valgrind, a few compile warnings and a runtime warning.

+ Fix freeing of query handlers
+ PHP: Use fgets() to detect EOF
+ Use memcpy if exact length is known
+ Don't encode/escape string if empty
