### PR TITLE
Fix Schedule Service Check

### DIFF
--- a/base/events.c
+++ b/base/events.c
@@ -356,7 +356,7 @@ void init_timing_loop(void) {
 						"  Fixing check time %lu secs too far away\n",
 						check_delay - check_window(temp_service));
 				fixed_services++;
-				check_delay = check_window(temp_service);
+				check_delay = ranged_urand(0, check_window(temp_service));
 				log_debug_info(DEBUGL_EVENTS, 0, "  New check offset: %d\n",
 						check_delay);
 			}


### PR DESCRIPTION
Fixed a case where check_delay would have the same value for all service monitoring.