### PR TITLE
configure.ac: fix -Wimplicit-int, -Wimplicit-function-declaration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,10 @@ AC_CACHE_CHECK([for C99 vsnprintf],ac_cv_HAVE_C99_VSNPRINTF,[
 AC_TRY_RUN([
 #include <sys/types.h>
 #include <stdarg.h>
-void foo(const char *format, ...) { 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+void foo(const char *format, ...) {
        va_list ap;
        int len;
        char buf[5];
@@ -144,7 +147,7 @@ void foo(const char *format, ...) {
 
        exit(0);
 }
-main() { foo("hello"); }
+int main(void) { foo("hello"); }
 ],
 ac_cv_HAVE_C99_VSNPRINTF=yes,ac_cv_HAVE_C99_VSNPRINTF=no,ac_cv_HAVE_C99_VSNPRINTF=cross)])
 if test "x$ac_cv_HAVE_C99_VSNPRINTF" = "xyes"; then


### PR DESCRIPTION
Clang 16 makes -Wimplicit-int and -Wimplicit-function-declaration error by default.

Unfortunately, this can lead to misconfiguration or miscompilation of software as configure tests may then return the wrong result.

We also fix -Wstrict-prototypes while here as it's easy to do and it prepares us for C23.

For more information, see LWN.net [0] or LLVM's Discourse [1], the Gentoo wiki [2], or the (new) c-std-porting mailing list [3].

[0] https://lwn.net/Articles/913505/
[1] https://discourse.llvm.org/t/configure-script-breakage-with-the-new-werror-implicit-function-declaration/65213 [2] https://wiki.gentoo.org/wiki/Modern_C_porting
[3] hosted at lists.linux.dev.

Signed-off-by: Sam James <sam@gentoo.org>