### PR TITLE
configure: Fix C99 vsnprintf check for stricter C99 compilers

### DIFF
--- a/configure
+++ b/configure
@@ -5920,6 +5920,9 @@ else
 
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 void foo(const char *format, ...) {
        va_list ap;
        int len;
@@ -5939,7 +5942,7 @@ void foo(const char *format, ...) {
 
        exit(0);
 }
-main() { foo("hello"); }
+int main() { foo("hello"); }
 
 _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :

--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,9 @@ AC_CACHE_CHECK([for C99 vsnprintf],ac_cv_HAVE_C99_VSNPRINTF,[
 AC_TRY_RUN([
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 void foo(const char *format, ...) { 
        va_list ap;
        int len;
@@ -144,7 +147,7 @@ void foo(const char *format, ...) {
 
        exit(0);
 }
-main() { foo("hello"); }
+int main() { foo("hello"); }
 ],
 ac_cv_HAVE_C99_VSNPRINTF=yes,ac_cv_HAVE_C99_VSNPRINTF=no,ac_cv_HAVE_C99_VSNPRINTF=cross)])
 if test "x$ac_cv_HAVE_C99_VSNPRINTF" = "xyes"; then


### PR DESCRIPTION
Add additional header includes for more function prototypes, and declare int as returning main.  This avoids implicit function declarations and implicit int types, language features not actually part of C99.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
