### PR TITLE
Add space after comma

### DIFF
--- a/cgi/cmd.c
+++ b/cgi/cmd.c
@@ -1846,7 +1846,7 @@ void commit_command_data(int cmd) {
 			printf("<DIV CLASS='errorMessage'>Sorry Dave, I can't let you do that...</DIV><br>");
 			printf("<DIV CLASS='errorDescription'>");
 			printf("It seems that you have chosen to not use the authentication functionality of the CGIs.<br><br>");
-			printf("I don't want to be personally responsible for what may happen as a result of allowing unauthorized users to issue commands to Nagios,");
+			printf("I don't want to be personally responsible for what may happen as a result of allowing unauthorized users to issue commands to Nagios, ");
 			printf("so you'll have to disable this safeguard if you are really stubborn and want to invite trouble.<br><br>");
 			printf("<strong>Read the section on CGI authentication in the HTML documentation to learn how you can enable authentication and why you should want to.</strong>\n");
 			printf("</DIV>\n");


### PR DESCRIPTION
Before
<img width="531" alt="image" src="https://user-images.githubusercontent.com/2119212/219231246-5fc5347c-b4c6-48a4-8e6f-378ea18fa877.png">

After there should be a space after the comma...