### PR TITLE
Cleanup warnings

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -1091,44 +1091,6 @@ static inline void host_propagate_checks_to_immediate_children(host * hst, int c
 /******************************************************************************
  ******* Logic chunks propagating dependency checks
  *****************************************************************************/
-static inline void service_propagate_dependency_checks(service * svc, time_t current_time)
-{
-	if (svc->current_attempt == (svc->max_attempts - 1) 
-		&& execute_service_checks == TRUE
-		&& enable_predictive_service_dependency_checks == TRUE) {
-
-		servicedependency *temp_dependency = NULL;
-		service *master_service = NULL;
-		objectlist *list;
-
-		log_debug_info(DEBUGL_CHECKS, 1, "Propagating predictive dependency checks to services this one depends on...\n");
-
-		/* check services that THIS ONE depends on for notification AND execution */
-		/* we do this because we might be sending out a notification soon and we want the dependency logic to be accurate */
-		for(list = svc->exec_deps; list; list = list->next) {
-			temp_dependency = (servicedependency *)list->object_ptr;
-			if (temp_dependency->dependent_service_ptr == svc && temp_dependency->master_service_ptr != NULL) {
-
-				master_service = (service *)temp_dependency->master_service_ptr;
-
-				log_debug_info(DEBUGL_CHECKS, 2, "Predictive check of service '%s' on host '%s' queued.\n", master_service->description, master_service->host_name);
-				schedule_service_check(master_service, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-			}
-		}
-
-		for(list = svc->notify_deps; list; list = list->next) {
-			temp_dependency = (servicedependency *)list->object_ptr;
-			if (temp_dependency->dependent_service_ptr == svc && temp_dependency->master_service_ptr != NULL) {
-
-				master_service = (service *)temp_dependency->master_service_ptr;
-
-				log_debug_info(DEBUGL_CHECKS, 2, "Predictive check of service '%s' on host '%s' queued.\n", master_service->description, master_service->host_name);
-				schedule_service_check(master_service, current_time, CHECK_OPTION_DEPENDENCY_CHECK);
-			}
-		}
-	}
-}
-/*****************************************************************************/
 static inline void host_propagate_dependency_checks(host * hst, time_t current_time)
 {
 	/* we do to help ensure that the dependency checks are accurate before it comes time to notify */

--- a/base/nagiostats.c
+++ b/base/nagiostats.c
@@ -38,7 +38,7 @@
 static char *main_config_file = NULL;
 char *status_file = NULL;
 static char *mrtg_variables = NULL;
-static const char *mrtg_delimiter = NULL;
+static char *mrtg_delimiter = NULL;
 
 static int mrtg_mode = FALSE;
 

--- a/base/utils.c
+++ b/base/utils.c
@@ -3294,7 +3294,7 @@ int check_for_nagios_updates(int force, int reschedule) {
 		/* we didn't do an update, so calculate next possible update time */
 		if(do_check == FALSE) {
 			next_check = last_update_check + BASE_UPDATE_CHECK_INTERVAL;
-			next_check = next_check + (unsigned long)(((float)randnum / RAND_MAX) * UPDATE_CHECK_INTERVAL_WOBBLE);
+			next_check = next_check + (unsigned long)(((float)randnum / (float)RAND_MAX) * UPDATE_CHECK_INTERVAL_WOBBLE);
 			}
 
 		/* we tried to check for an update */
@@ -3303,13 +3303,13 @@ int check_for_nagios_updates(int force, int reschedule) {
 			/* api query was okay */
 			if(api_result == OK) {
 				next_check = current_time + BASE_UPDATE_CHECK_INTERVAL;
-				next_check += (unsigned long)(((float)randnum / RAND_MAX) * UPDATE_CHECK_INTERVAL_WOBBLE);
+				next_check += (unsigned long)(((float)randnum / (float)RAND_MAX) * UPDATE_CHECK_INTERVAL_WOBBLE);
 				}
 
 			/* query resulted in an error - retry at a shorter interval */
 			else {
 				next_check = current_time + BASE_UPDATE_CHECK_RETRY_INTERVAL;
-				next_check += (unsigned long)(((float)randnum / RAND_MAX) * UPDATE_CHECK_RETRY_INTERVAL_WOBBLE);
+				next_check += (unsigned long)(((float)randnum / (float)RAND_MAX) * UPDATE_CHECK_RETRY_INTERVAL_WOBBLE);
 				}
 			}
 

--- a/base/utils.c
+++ b/base/utils.c
@@ -2806,7 +2806,7 @@ int my_rename(char *source, char *dest) {
  */
 int my_fdcopy(char *source, char *dest, int dest_fd) {
 	int source_fd, rd_result = 0, wr_result = 0;
-	int tot_written = 0, tot_read = 0, buf_size = 0;
+	int tot_written = 0, buf_size = 0;
 	struct stat st;
 	char *buf;
 
@@ -2853,7 +2853,6 @@ int my_fdcopy(char *source, char *dest, int dest_fd) {
 			logit(NSLOG_RUNTIME_ERROR, TRUE, "Error: my_fcopy() failed to read from '%s': %s\n", source, strerror(errno));
 			break;
 			}
-		tot_read += rd_result;
 
 		while(loop_wr < rd_result) {
 			wr_result = write(dest_fd, buf + loop_wr, rd_result - loop_wr);
@@ -3339,7 +3338,6 @@ int query_update_api(void) {
 	char recv_buf[1024];
 	int report_install = FALSE;
 	char *ptr = NULL;
-	int current_line = 0;
 	int buf_index = 0;
 	int in_header = TRUE;
 	char *var = NULL;
@@ -3428,7 +3426,6 @@ int query_update_api(void) {
 		while((ptr = get_next_string_from_buf(recv_buf, &buf_index, sizeof(recv_buf)))) {
 
 			strip(ptr);
-			current_line++;
 
 			if(!strcmp(ptr, "")) {
 				in_header = FALSE;

--- a/base/wpres-phash.h
+++ b/base/wpres-phash.h
@@ -1,4 +1,4 @@
-/* C code produced by gperf version 3.0.3 */
+/* ANSI-C code produced by gperf version 3.1 */
 /* Command-line: gperf -S 1 -t -H wpres_key_phash -N wpres_get_key wpres.gperf  */
 /* Computed positions: -k'4-5,7' */
 
@@ -26,7 +26,7 @@
       && ('w' == 119) && ('x' == 120) && ('y' == 121) && ('z' == 122) \
       && ('{' == 123) && ('|' == 124) && ('}' == 125) && ('~' == 126))
 /* The character set is not based on ISO-646.  */
-error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+#error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gperf@gnu.org>."
 #endif
 
 #line 1 "wpres.gperf"
@@ -84,9 +84,7 @@ inline
 #endif
 #endif
 static unsigned int
-wpres_key_phash (str, len)
-     register const char *str;
-     register unsigned int len;
+wpres_key_phash (register const char *str, register size_t len)
 {
   static unsigned char asso_values[] =
     {
@@ -117,7 +115,7 @@ wpres_key_phash (str, len)
       65, 65, 65, 65, 65, 65, 65, 65, 65, 65,
       65, 65, 65, 65, 65, 65
     };
-  register int hval = len;
+  register unsigned int hval = len;
 
   switch (hval)
     {
@@ -135,16 +133,8 @@ wpres_key_phash (str, len)
   return hval;
 }
 
-#ifdef __GNUC__
-__inline
-#ifdef __GNUC_STDC_INLINE__
-__attribute__ ((__gnu_inline__))
-#endif
-#endif
 struct wpres_key *
-wpres_get_key (str, len)
-     register const char *str;
-     register unsigned int len;
+wpres_get_key (register const char *str, register size_t len)
 {
   static struct wpres_key wordlist[] =
     {
@@ -210,7 +200,7 @@ wpres_get_key (str, len)
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = wpres_key_phash (str, len);
+      register unsigned int key = wpres_key_phash (str, len);
 
       if (key <= MAX_HASH_VALUE && key >= MIN_HASH_VALUE)
         {

--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -150,7 +150,21 @@ static command *find_bang_command(char *name)
 	return cmd;
 }
 
+/*
+ * build path with prefix (must already be / terminated) and a subdir
+ */
+void build_subdir_path(char* path, size_t size, const char* prefix, const char* subdir)
+{
+	const size_t prefix_len = strlen(prefix);
+	const size_t subdir_len = strlen(subdir);
 
+	if (prefix_len + subdir_len >= size)
+		return;
+
+	memcpy(path, prefix, prefix_len);
+	memcpy(path + prefix_len, subdir, subdir_len);
+	path[prefix_len + subdir_len] = '\0';
+}
 
 /**********************************************************
  ***************** CLEANUP FUNCTIONS **********************
@@ -329,14 +343,10 @@ int read_cgi_config_file(const char *filename, read_config_callback callback) {
 			strncpy(physical_html_path, val, sizeof(physical_html_path));
 			physical_html_path[sizeof(physical_html_path) - 1] = '\x0';
 			strip(physical_html_path);
-			if(physical_html_path[strlen(physical_html_path) - 1] != '/' && (strlen(physical_html_path) < sizeof(physical_html_path) - 1))
-				strcat(physical_html_path, "/");
+			ensure_path_separator(physical_html_path, sizeof(physical_html_path));
 
-			snprintf(physical_images_path, sizeof(physical_images_path), "%simages/", physical_html_path);
-			physical_images_path[sizeof(physical_images_path) - 1] = '\x0';
-
-			snprintf(physical_ssi_path, sizeof(physical_images_path), "%sssi/", physical_html_path);
-			physical_ssi_path[sizeof(physical_ssi_path) - 1] = '\x0';
+			build_subdir_path(physical_images_path, sizeof(physical_images_path), physical_html_path, "images/");
+			build_subdir_path(physical_ssi_path, sizeof(physical_ssi_path), physical_html_path, "ssi/");
 			}
 
 		else if(!strcmp(var, "url_html_path")) {
@@ -345,31 +355,15 @@ int read_cgi_config_file(const char *filename, read_config_callback callback) {
 			url_html_path[sizeof(url_html_path) - 1] = '\x0';
 
 			strip(url_html_path);
-			if(url_html_path[strlen(url_html_path) - 1] != '/' && (strlen(url_html_path) < sizeof(url_html_path) - 1))
-				strcat(url_html_path, "/");
+			ensure_path_separator(url_html_path, sizeof(url_html_path));
 
-			snprintf(url_docs_path, sizeof(url_docs_path), "%sdocs/", url_html_path);
-			url_docs_path[sizeof(url_docs_path) - 1] = '\x0';
-
-			snprintf(url_context_help_path, sizeof(url_context_help_path), "%scontexthelp/", url_html_path);
-			url_context_help_path[sizeof(url_context_help_path) - 1] = '\x0';
-
-			snprintf(url_images_path, sizeof(url_images_path), "%simages/", url_html_path);
-			url_images_path[sizeof(url_images_path) - 1] = '\x0';
-
-			snprintf(url_logo_images_path, sizeof(url_logo_images_path), "%slogos/", url_images_path);
-			url_logo_images_path[sizeof(url_logo_images_path) - 1] = '\x0';
-
-			snprintf(url_stylesheets_path, sizeof(url_stylesheets_path), "%sstylesheets/", url_html_path);
-			url_stylesheets_path[sizeof(url_stylesheets_path) - 1] = '\x0';
-
-			snprintf(url_media_path, sizeof(url_media_path), "%smedia/", url_html_path);
-			url_media_path[sizeof(url_media_path) - 1] = '\x0';
-
-			/* added JS directory 2/1/2012 -MG */
-			snprintf(url_js_path, sizeof(url_js_path), "%sjs/", url_html_path);
-			url_js_path[sizeof(url_js_path) - 1] = '\x0';
-
+			build_subdir_path(url_docs_path, sizeof(url_docs_path), url_html_path, "docs/");
+			build_subdir_path(url_context_help_path, sizeof(url_context_help_path), url_html_path, "contexthelp/");
+			build_subdir_path(url_images_path, sizeof(url_images_path), url_html_path, "images/");
+			build_subdir_path(url_logo_images_path, sizeof(url_logo_images_path), url_html_path, "logos/");
+			build_subdir_path(url_stylesheets_path, sizeof(url_stylesheets_path), url_html_path, "stylesheets/");
+			build_subdir_path(url_media_path, sizeof(url_media_path), url_html_path, "media/");
+			build_subdir_path(url_js_path, sizeof(url_js_path), url_html_path, "js/");
 			}
 
 		else if(!strcmp(var, "service_critical_sound"))

--- a/cgi/config.c
+++ b/cgi/config.c
@@ -1476,7 +1476,7 @@ void display_timeperiods(void) {
 	int day = 0;
 	int x = 0;
 	const char *bg_class = "";
-	char timestring[10];
+	char timestring[32];
 	int hours = 0;
 	int minutes = 0;
 	int seconds = 0;

--- a/cgi/extinfo.c
+++ b/cgi/extinfo.c
@@ -1963,13 +1963,11 @@ void show_performance_data(void) {
 	int active_service_checks_15min = 0;
 	int active_service_checks_1hour = 0;
 	int active_service_checks_start = 0;
-	int active_service_checks_ever = 0;
 	int passive_service_checks_1min = 0;
 	int passive_service_checks_5min = 0;
 	int passive_service_checks_15min = 0;
 	int passive_service_checks_1hour = 0;
 	int passive_service_checks_start = 0;
-	int passive_service_checks_ever = 0;
 	int total_active_host_checks = 0;
 	int total_passive_host_checks = 0;
 	double min_host_execution_time = 0.0;
@@ -1992,13 +1990,11 @@ void show_performance_data(void) {
 	int active_host_checks_15min = 0;
 	int active_host_checks_1hour = 0;
 	int active_host_checks_start = 0;
-	int active_host_checks_ever = 0;
 	int passive_host_checks_1min = 0;
 	int passive_host_checks_5min = 0;
 	int passive_host_checks_15min = 0;
 	int passive_host_checks_1hour = 0;
 	int passive_host_checks_start = 0;
-	int passive_host_checks_ever = 0;
 	time_t current_time;
 
 
@@ -2059,8 +2055,6 @@ void show_performance_data(void) {
 				active_service_checks_1hour++;
 			if(temp_servicestatus->last_check >= program_start)
 				active_service_checks_start++;
-			if(temp_servicestatus->last_check != (time_t)0)
-				active_service_checks_ever++;
 			}
 
 		else {
@@ -2086,8 +2080,6 @@ void show_performance_data(void) {
 				passive_service_checks_1hour++;
 			if(temp_servicestatus->last_check >= program_start)
 				passive_service_checks_start++;
-			if(temp_servicestatus->last_check != (time_t)0)
-				passive_service_checks_ever++;
 			}
 		}
 
@@ -2146,8 +2138,6 @@ void show_performance_data(void) {
 				active_host_checks_1hour++;
 			if(temp_hoststatus->last_check >= program_start)
 				active_host_checks_start++;
-			if(temp_hoststatus->last_check != (time_t)0)
-				active_host_checks_ever++;
 			}
 
 		else {
@@ -2173,8 +2163,6 @@ void show_performance_data(void) {
 				passive_host_checks_1hour++;
 			if(temp_hoststatus->last_check >= program_start)
 				passive_host_checks_start++;
-			if(temp_hoststatus->last_check != (time_t)0)
-				passive_host_checks_ever++;
 			}
 		}
 

--- a/cgi/histogram.c
+++ b/cgi/histogram.c
@@ -1548,8 +1548,8 @@ void graph_all_histogram_data(void) {
 	int string_height;
 	char *days[7] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 	char *months[12] = {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
-	char start_time[MAX_INPUT_BUFFER];
-	char end_time[MAX_INPUT_BUFFER];
+	char start_time[32]; // ctime
+	char end_time[32]; // ctime
 
 	unsigned long state1_max = 0L;
 	unsigned long state1_min = 0L;

--- a/cgi/outages.c
+++ b/cgi/outages.c
@@ -262,8 +262,6 @@ int process_cgivars(void) {
 /* shows all hosts that are causing network outages */
 void display_network_outages(void) {
 	char temp_buffer[MAX_INPUT_BUFFER];
-	int number_of_problem_hosts = 0;
-	int number_of_blocking_problem_hosts = 0;
 	hostoutagesort *temp_hostoutagesort;
 	hostoutage *temp_hostoutage;
 	hoststatus *temp_hoststatus;
@@ -300,13 +298,6 @@ void display_network_outages(void) {
 
 	/* sort the outage list by severity */
 	sort_hostoutages();
-
-	/* count the number of top-level hosts that are down and the ones that are actually blocking children hosts */
-	for(temp_hostoutage = hostoutage_list; temp_hostoutage != NULL; temp_hostoutage = temp_hostoutage->next) {
-		number_of_problem_hosts++;
-		if(temp_hostoutage->affected_child_hosts > 1)
-			number_of_blocking_problem_hosts++;
-		}
 
 	/* display the problem hosts... */
 	printf("<P><DIV ALIGN=CENTER>\n");

--- a/cgi/status.c
+++ b/cgi/status.c
@@ -2077,7 +2077,6 @@ void show_host_detail(void) {
 	int seconds;
 	int duration_error = FALSE;
 	int total_entries = 0;
-	int visible_entries = 0;
 	regex_t preg_hostname;
 //	int show_host = FALSE;
 
@@ -2291,9 +2290,6 @@ void show_host_detail(void) {
 		if( (limit_results == TRUE) && ( (total_entries < page_start) || (total_entries > (page_start + result_limit)) )  ) {
 			continue;
 			}
-
-		visible_entries++;
-
 
 		/* grab macros */
 		grab_host_macros_r(mac, temp_host);

--- a/cgi/statusjson.c
+++ b/cgi/statusjson.c
@@ -4380,13 +4380,11 @@ json_object *json_status_performance(void) {
 	int active_service_checks_15min = 0;
 	int active_service_checks_1hour = 0;
 	int active_service_checks_start = 0;
-	int active_service_checks_ever = 0;
 	int passive_service_checks_1min = 0;
 	int passive_service_checks_5min = 0;
 	int passive_service_checks_15min = 0;
 	int passive_service_checks_1hour = 0;
 	int passive_service_checks_start = 0;
-	int passive_service_checks_ever = 0;
 	int total_active_host_checks = 0;
 	int total_passive_host_checks = 0;
 	double min_host_execution_time = 0.0;
@@ -4409,13 +4407,11 @@ json_object *json_status_performance(void) {
 	int active_host_checks_15min = 0;
 	int active_host_checks_1hour = 0;
 	int active_host_checks_start = 0;
-	int active_host_checks_ever = 0;
 	int passive_host_checks_1min = 0;
 	int passive_host_checks_5min = 0;
 	int passive_host_checks_15min = 0;
 	int passive_host_checks_1hour = 0;
 	int passive_host_checks_start = 0;
-	int passive_host_checks_ever = 0;
 	time_t current_time;
 
 	json_object *json_data;
@@ -4507,8 +4503,6 @@ json_object *json_status_performance(void) {
 				active_service_checks_1hour++;
 			if(temp_servicestatus->last_check >= program_start)
 				active_service_checks_start++;
-			if(temp_servicestatus->last_check != (time_t)0)
-				active_service_checks_ever++;
 			}
 
 		else {
@@ -4541,8 +4535,6 @@ json_object *json_status_performance(void) {
 				passive_service_checks_1hour++;
 			if(temp_servicestatus->last_check >= program_start)
 				passive_service_checks_start++;
-			if(temp_servicestatus->last_check != (time_t)0)
-				passive_service_checks_ever++;
 			}
 		}
 
@@ -4617,8 +4609,6 @@ json_object *json_status_performance(void) {
 				active_host_checks_1hour++;
 			if(temp_hoststatus->last_check >= program_start)
 				active_host_checks_start++;
-			if(temp_hoststatus->last_check != (time_t)0)
-				active_host_checks_ever++;
 			}
 
 		else {
@@ -4650,8 +4640,6 @@ json_object *json_status_performance(void) {
 				passive_host_checks_1hour++;
 			if(temp_hoststatus->last_check >= program_start)
 				passive_host_checks_start++;
-			if(temp_hoststatus->last_check != (time_t)0)
-				passive_host_checks_ever++;
 			}
 		}
 

--- a/cgi/statusmap.c
+++ b/cgi/statusmap.c
@@ -1342,7 +1342,6 @@ void calculate_scaling_factor(void) {
 
 /* finds hosts that can be drawn in the canvas area */
 void find_eligible_hosts(void) {
-	int total_eligible_hosts = 0;
 	host *temp_host;
 
 	/* check all extended host information entries... */
@@ -1371,7 +1370,6 @@ void find_eligible_hosts(void) {
 		/* all checks passed, so we can draw the host! */
 		else {
 			temp_host->should_be_drawn = TRUE;
-			total_eligible_hosts++;
 			}
 		}
 

--- a/cgi/statusmap.c
+++ b/cgi/statusmap.c
@@ -2170,8 +2170,7 @@ int initialize_graphics(void) {
 	gdImageInterlace(map_image, 1);
 
 	/* get the path where we will be reading logo images from (GD2 format)... */
-	snprintf(physical_logo_images_path, sizeof(physical_logo_images_path) - 1, "%slogos/", physical_images_path);
-	physical_logo_images_path[sizeof(physical_logo_images_path) - 1] = '\x0';
+	build_subdir_path(physical_logo_images_path, sizeof(physical_logo_images_path), physical_images_path, "logos/");
 
 	/* load the unknown icon to use for hosts that don't have pretty images associated with them... */
 	snprintf(image_input_file, sizeof(image_input_file) - 1, "%s%s", physical_logo_images_path, UNKNOWN_GD2_ICON);

--- a/cgi/statuswrl.c
+++ b/cgi/statuswrl.c
@@ -309,8 +309,7 @@ void display_world(void) {
 	host *temp_host = NULL;
 
 	/* get the url we will use to grab the logo images... */
-	snprintf(url_logo_images_path, sizeof(url_logo_images_path), "%slogos/", url_images_path);
-	url_logo_images_path[sizeof(url_logo_images_path) - 1] = '\x0';
+	build_subdir_path(url_logo_images_path, sizeof(url_logo_images_path), url_images_path, "logos/");
 
 	/* calculate host drawing coordinates */
 	calculate_host_coords();

--- a/cgi/trends.c
+++ b/cgi/trends.c
@@ -244,8 +244,8 @@ int main(int argc, char **argv) {
 	int result = OK;
 	char temp_buffer[MAX_INPUT_BUFFER];
 	char image_template[MAX_INPUT_BUFFER];
-	char start_time[MAX_INPUT_BUFFER];
-	char end_time[MAX_INPUT_BUFFER];
+	char start_time[32]; // ctime
+	char end_time[32]; // ctime
 	int string_width;
 	int string_height;
 	char start_timestring[MAX_INPUT_BUFFER];
@@ -2075,9 +2075,9 @@ void graph_trend_data(int first_state, int last_state, time_t real_start_time, t
 	double start_pixel_ratio;
 	double end_pixel_ratio;
 	char temp_buffer[MAX_INPUT_BUFFER];
-	char state_string[MAX_INPUT_BUFFER];
-	char end_timestring[MAX_INPUT_BUFFER];
-	char start_timestring[MAX_INPUT_BUFFER];
+	char state_string[32];
+	char end_timestring[32]; // ctime
+	char start_timestring[32]; // ctime
 	time_t center_time;
 	time_t next_start_time;
 	time_t next_end_time;

--- a/common/objects.c
+++ b/common/objects.c
@@ -2987,7 +2987,7 @@ int free_object_data(void) {
 #ifndef NSCGI
 static const char *timerange2str(const timerange *tr)
 {
-	static char str[12];
+	static char str[32];
 	int sh, sm, eh, em;
 
 	if(!tr)

--- a/common/shared.c
+++ b/common/shared.c
@@ -639,3 +639,17 @@ void get_time_breakdown(unsigned long raw_time, int *days, int *hours,
 	*minutes = temp_minutes;
 	*seconds = temp_seconds;
 	}
+
+/*
+ * ensure last character of path is the path separator '/'
+ */
+void ensure_path_separator(char *path, size_t size)
+{
+	const size_t len = strlen(path);
+	if (len > 0 && len < size - 1) {
+		if (path[len - 1] != '/') {
+			path[len] = '/';
+			path[len + 1] = '\0';
+		}
+	}
+}

--- a/include/cgiutils.h
+++ b/include/cgiutils.h
@@ -507,5 +507,7 @@ struct nagios_extcmd* extcmd_get_command_id(int);
 struct nagios_extcmd* extcmd_get_command_name(const char *);
 const char *extcmd_get_name(int);
 
+void build_subdir_path(char* path, size_t size, const char* prefix, const char* subdir);
+
 NAGIOS_END_DECL
 #endif

--- a/include/nagios.h
+++ b/include/nagios.h
@@ -513,10 +513,10 @@ void adjust_timestamp_for_time_change(time_t, time_t, unsigned long, time_t *); 
 
 
 /**** IPC Functions ****/
-int process_check_result_queue(char *);
-int process_check_result_file(char *);
+int process_check_result_queue(const char *);
+int process_check_result_file(const char *);
 int process_check_result(check_result *);
-int delete_check_result_file(char *);
+int delete_check_result_file(const char *);
 int init_check_result(check_result *);
 int free_check_result(check_result *);                  	/* frees memory associated with a host/service check result */
 int parse_check_output(char *, char **, char **, char **, int, int);

--- a/include/objects.h
+++ b/include/objects.h
@@ -163,7 +163,7 @@ typedef struct check_result {
 	int check_options;
 	int scheduled_check;                            /* was this a scheduled or an on-demand check? */
 	int reschedule_check;                           /* should we reschedule the next check */
-	char *output_file;                              /* what file is the output stored in? */
+	const char *output_file;                        /* what file is the output stored in? */
 	FILE *output_file_fp;
 	double latency;
 	struct timeval start_time;			/* time the service check was initiated */

--- a/include/shared.h
+++ b/include/shared.h
@@ -53,5 +53,7 @@ extern void get_datetime_string(time_t *raw_time, char *buffer,
 extern void get_time_breakdown(unsigned long raw_time, int *days, int *hours,
                                int *minutes, int *seconds);
 
+extern void ensure_path_separator(char *path, size_t size);
+
 NAGIOS_END_DECL
 #endif

--- a/lib/worker.c
+++ b/lib/worker.c
@@ -515,7 +515,6 @@ static void sigchld_handler(int sig)
 
 static void reap_jobs(void)
 {
-	int reaped = 0;
 	do {
 		int pid, status;
 		pid = waitpid(-1, &status, WNOHANG);
@@ -528,7 +527,6 @@ static void reap_jobs(void)
 				continue;
 			}
 			cp->ret = status;
-			reaped++;
 			if (cp->ei->state != ESTALE)
 				finish_job(cp, cp->ei->state);
 			destroy_job(cp);

--- a/xdata/xodtemplate.c
+++ b/xdata/xodtemplate.c
@@ -445,7 +445,7 @@ int xodtemplate_read_config_data(const char *main_config_file, int options) {
 	in this particular case) return an error without printing any error
 	messages, so nothing will say what was wrong. */
 /*	if(result == OK) */
-		result |= xodtemplate_register_objects();
+	result |= xodtemplate_register_objects();
 	if(test_scheduling == TRUE)
 		gettimeofday(&tv[10], NULL);
 

--- a/xdata/xodtemplate.h
+++ b/xdata/xodtemplate.h
@@ -744,8 +744,8 @@ typedef struct xodtemplate_service_cursor_struct {
 /********* FUNCTION DEFINITIONS **********/
 
 int xodtemplate_read_config_data(const char *, int);    /* top-level routine processes all config files */
-int xodtemplate_process_config_file(char *, int);           /* process data in a specific config file */
-int xodtemplate_process_config_dir(char *, int);            /* process all files in a specific config directory */
+int xodtemplate_process_config_file(const char *, int);           /* process data in a specific config file */
+int xodtemplate_process_config_dir(const char *, int);            /* process all files in a specific config directory */
 
 int xodtemplate_expand_services(objectlist **, bitmap *, char *, char *, int, int);
 int xodtemplate_expand_contactgroups(objectlist **, bitmap *, char *, int, int);


### PR DESCRIPTION
This removes all the warnings I see with GCC & CLANG excluding `unused-result`.

      Remove const to fix warning passing mrtg_delimiter to free()
      Rewrite some path building areas to fix warnings.
      Shrink some string variables unneeded size to remove warnings about possible truncation during copy.
      Regenerate wpres-phash.h using ANSI-C output.
      Fix warning about indentation
      Remove unused function.
      Remove variables that are written to but never read.
      Cast RAND_MAX to float to avoid Clang warning.
