### PR TITLE
Update notes about local RPMs creation for 4.4.14 release

### DIFF
--- a/contrib/README
+++ b/contrib/README
@@ -38,14 +38,13 @@ Miscellaneous Goodies:
   interface.
 
 - Notes about "make rpm" addition, tested on RockyLinux 8
-  0. We need more people to learn how nagioscore rpm on epel was made.
-  1. Preparre epel-nagios.spec and epel-patches/* files.
+  1. Using 4.4.6 as example, download epel-nagios.spec and epel-patches/* files.
     wget https://download-ib01.fedoraproject.org/pub/epel/8/Everything/SRPMS/Packages/n/nagios-4.4.6-4.el8.src.rpm
     rpm -ivh nagios-4.4.6-4.el8.src.rpm # Install patches into ~/RPMBUILD/SOURCES and nagios into ~/RPMBUILD/SPECS
     cp ~/RPMBUILD/SOURCES/* epel-patches
     cp ~/RPMBUILD/SPECS/nagios ./epel-nagios.spec
 
-  2. Prepare your rpmbuild environment for CentOS/RHEL.
+  2. Prepare your rpmbuild environment to buuild EPEL8+ RPMs.
 
   sudo yum install -y rpmdevtools gcc libtool rpmbuild \
   policycoreutils-devel selinux-policy-devel \
@@ -60,7 +59,7 @@ Miscellaneous Goodies:
      make rpm          # Do the rpm build under ./rpmbuild directory
      make localsrc-rpm # tar up existing src code to create rpm
 
-  4. Testing upgrade Nagioscore 4.4.5 on this build host using RPMs created here.
+  4. Testing upgrade Nagioscore 4.4.6 on this build host using RPMs created here.
 
   sudo rpm -Uvh nagios-common-4.4.6-1el8.x86_64.rpm nagios-contrib-4.4.6-1el8.x86_64.rpm \
        nagios-devel-4.4.6-1el8.x86_64.rpm  nagios-4.4.6-1el8.x86_64.rpm

--- a/contrib/epel-nagios.spec
+++ b/contrib/epel-nagios.spec
@@ -39,11 +39,11 @@ Patch9: nagios-0009-fix-localstatedir-for-linux.patch
 ## their nagios location.
 Patch10: nagios-0010-remove-information-leak.patch
 ## Make it so it knows about all the arches fedora cares about
-Patch11: nagios-0011-remove-rpmbuild.patch
+# Patch11: nagios-0011-remove-rpmbuild.patch
 Patch12: nagios-0012-fix-spool.patch
 Patch13: nagios-0013-fix-plugin.patch
 Patch14: nagios-0014-fix-uidgid.patch
-Patch15: %{name}-0015-Changelog.patch
+#Patch15: %{name}-0015-Changelog.patch
 
 BuildRequires:  make
 BuildRequires:  doxygen


### PR DESCRIPTION
Minor update notes updates. Tested on RockyLinux 9

```
[me@rocky9t01 contrib]$ ../configure && make rpm
drwxr-xr-x 8 me me      89 Sep 16 05:23 rpmbuild
-rw-r--r-- 1 me me   11930 Sep 16 05:24 nagios-selinux-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me    8584 Sep 16 05:24 nagios-common-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me   25198 Sep 16 05:24 nagios-contrib-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me   19058 Sep 16 05:24 nagios-debugsource-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me   27238 Sep 16 05:24 nagios-contrib-debuginfo-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me   28238 Sep 16 05:24 nagios-debuginfo-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me  101525 Sep 16 05:24 nagios-devel-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me 1943209 Sep 16 05:24 nagios-4.4.14-4.el9.x86_64.rpm
-rw-r--r-- 1 me me    2614 Sep 16 05:31 README
[me@rocky9t01 contrib]$

```