### PR TITLE
fix some errors in example neb module

### DIFF
--- a/module/helloworld.c
+++ b/module/helloworld.c
@@ -2,7 +2,7 @@
  *
  * HELLOWORLD.C - Example of a simple NEB module
  *
- * Copyright (c) 2003-2007 Ethan Galstad (https://www.nagios.org)
+ * Copyright (c) 2003-2024 Ethan Galstad (https://www.nagios.org)
  *
  * Description:
  *
@@ -16,7 +16,10 @@
  *
  * Compile with the following command:
  *
- *     gcc -shared -o helloworld.o helloworld.c
+ *     cd nagioscore
+ *     ./configure
+ *     cd module
+ *     make helloworld.o
  *
  *****************************************************************************/
 
@@ -55,13 +58,13 @@ int nebmodule_init(int flags, char *args, nebmodule *handle) {
 	/* set some info - this is completely optional, as Nagios doesn't do anything with this data */
 	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_TITLE, "helloworld");
 	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_AUTHOR, "Ethan Galstad");
-	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_TITLE, "Copyright (c) 2003-2007 Ethan Galstad");
+	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_COPYRIGHT, "Copyright (c) 2003-2024 Ethan Galstad");
 	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_VERSION, "noversion");
 	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_LICENSE, "GPL v2");
 	neb_set_module_info(helloworld_module_handle, NEBMODULE_MODINFO_DESC, "A simple example to get you started with Nagios Event Broker (NEB) modules.");
 
 	/* log module info to the Nagios log file */
-	write_to_all_logs("helloworld: Copyright (c) 2003-2007 Ethan Galstad (egalstad@nagios.org)", NSLOG_INFO_MESSAGE);
+	write_to_all_logs("helloworld: Copyright (c) 2003-2024 Ethan Galstad (egalstad@nagios.org)", NSLOG_INFO_MESSAGE);
 
 	/* log a message to the Nagios log file */
 	snprintf(temp_buffer, sizeof(temp_buffer) - 1, "helloworld: Hello world!\n");


### PR DESCRIPTION
* update copyright years
* change the duplicate `NEBMODULE_MODINFO_TITLE` to `NEBMODULE_MODINFO_COPYRIGHT`
* update the directions for compiling (the `gcc` command that was there doesn't work, `./configure` is absolutely required before this works)