### PR TITLE
fix order of event queue initialization

### DIFF
--- a/base/nagios.c
+++ b/base/nagios.c
@@ -663,6 +663,9 @@ int main(int argc, char **argv) {
 			/* open debug log now that we're the right user */
 			open_debug_log();
 
+			init_event_queue();
+			timing_point("Event queue initialized\n");
+
 #ifdef USE_EVENT_BROKER
 			/* initialize modules */
 			neb_init_modules();
@@ -768,9 +771,6 @@ int main(int argc, char **argv) {
 			/* write the objects.cache file */
 			fcache_objects(object_cache_file);
 			timing_point("Objects cached\n");
-
-			init_event_queue();
-			timing_point("Event queue initialized\n");
 
 
 #ifdef USE_EVENT_BROKER


### PR DESCRIPTION
Before this fix, if you tried to schedule a `EVENT_USER_FUNCTION` using `schedule_new_event()` (for example, in the helloworld module (https://github.com/NagiosEnterprises/nagioscore/blob/master/module/helloworld.c#L74) it will error, since the neb module initialization functions all happen before init_event_queue() in the main loop.

It's easy enough for a module to schedule some callback, say a check result status or something, then `schedule_new_event()`, THEN deregister that same callback - but that seems cumbersome to me.

Anyway, this fixes it, and I've been running it locally with no issues for a bit. Might want to test it on something with a few thousand checks though.