### PR TITLE
Fix: Printf instead of putchar in command expansion page when there is dangling whitespace

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,10 @@
 Nagios Core 4 Change Log
 ########################
 
+4.5.1 - 2024-XX-XX
+-------------------
+* Fix printing in Command Expansion page when there is dangling whitespace (Thanks Joran LEREEC for reporting this issue)
+
 4.5.0 - 2023-11-16
 -------------------
 Note: this release is backward-compatible, but does include updates to the header files.

--- a/cgi/config.c
+++ b/cgi/config.c
@@ -2366,7 +2366,7 @@ void display_command_expansion(void) {
 							/* TODO: As long as the hyperlinks change all whitespace into actual spaces,
 							   we'll output "[WS]" (whitespace) instead of "[SP]"(ace). */
 							/* if ((*c)==' ')		printf("[SP]"); */
-							if((*c) == ' ') 		printf("[WS]");
+							if((*c) == ' ') 	printf("[WS]");
 							else if((*c) == '\f')	printf("[FF]");
 							else if((*c) == '\n')	printf("[LF]");
 							else if((*c) == '\r')	printf("[CR]");
@@ -2386,7 +2386,7 @@ void display_command_expansion(void) {
 							/* TODO: As long as the hyperlinks change all whitespace into actual spaces,
 							   we'll output "[WS]" (whitespace) instead of "[SP]"(ace). */
 							/* if ((*c)==' ')		printf("[SP]"); */
-							if((*c) == ' ')			printf("[WS]");
+							if((*c) == ' ')		printf("[WS]");
 							else if((*c) == '\f')	printf("[FF]");
 							else if((*c) == '\n')	printf("[LF]");
 							else if((*c) == '\r')	printf("[CR]");

--- a/cgi/config.c
+++ b/cgi/config.c
@@ -2366,7 +2366,7 @@ void display_command_expansion(void) {
 							/* TODO: As long as the hyperlinks change all whitespace into actual spaces,
 							   we'll output "[WS]" (whitespace) instead of "[SP]"(ace). */
 							/* if ((*c)==' ')		printf("[SP]"); */
-							if((*c) == ' ')		printf("[WS]");
+							if((*c) == ' ') 		printf("[WS]");
 							else if((*c) == '\f')	printf("[FF]");
 							else if((*c) == '\n')	printf("[LF]");
 							else if((*c) == '\r')	printf("[CR]");
@@ -2374,13 +2374,19 @@ void display_command_expansion(void) {
 							else if((*c) == '\v')	printf("[VT]");
 							else			printf("[0x%x]", *c);
 						printf("</FONT><FONT COLOR='%s'>", hash_color(i));
-						for(; c && ((*c) != '\0') && (j < (int)strlen(command_args[i]) - trail_space[i]); c++, j++) putchar(*c);
+						// Have to add some internal logic to pass the correct string to html_encode without the trailing whitespace.
+						int temp_command_length = (int)strlen(c) - trail_space[i];
+						char temp_commandline[temp_command_length+1];
+						strncpy(temp_commandline, c, temp_command_length);
+						temp_commandline[temp_command_length] = '\0';
+						c += temp_command_length;
+						printf("%s", html_encode(temp_commandline, FALSE));
 						printf("</FONT><FONT COLOR='#0000FF'>");
 						for(; c && ((*c) != '\0'); c++)
 							/* TODO: As long as the hyperlinks change all whitespace into actual spaces,
 							   we'll output "[WS]" (whitespace) instead of "[SP]"(ace). */
 							/* if ((*c)==' ')		printf("[SP]"); */
-							if((*c) == ' ')		printf("[WS]");
+							if((*c) == ' ')			printf("[WS]");
 							else if((*c) == '\f')	printf("[FF]");
 							else if((*c) == '\n')	printf("[LF]");
 							else if((*c) == '\r')	printf("[CR]");


### PR DESCRIPTION
There needs to be some specific logic to handle whitespace before and afterwards but the command should be printed with printf and html_encode like the surrounding instances instead of just using putchar on each character