### PR TITLE
Fix [#910]: Register downtime used current time in comment instread of entry time

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Nagios Core 4 Change Log
 ------------------
 * Fix handling of timeperiods w/ downtime availability calculations in the Availability CGI report (Sebastian Wolf)
 * Fix build when compiling against musl libc (#952) (Sebastian Wolf)
+* Fix downtime comment using current time instead of the downtime's entry time (#910) (Dylan Anderson)
 
 4.5.1 - 2024-02-28
 -------------------

--- a/common/downtime.c
+++ b/common/downtime.c
@@ -464,9 +464,9 @@ int register_downtime(int type, unsigned long downtime_id) {
 
 	/* add a non-persistent comment to the host or service regarding the scheduled outage */
 	if(temp_downtime->type == SERVICE_DOWNTIME)
-		add_new_comment(SERVICE_COMMENT, DOWNTIME_COMMENT, svc->host_name, svc->description, time(NULL), ( NULL == temp_downtime->author ? "(Nagios Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
+		add_new_comment(SERVICE_COMMENT, DOWNTIME_COMMENT, svc->host_name, svc->description, temp_downtime->entry_time, ( NULL == temp_downtime->author ? "(Nagios Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
 	else
-		add_new_comment(HOST_COMMENT, DOWNTIME_COMMENT, hst->name, NULL, time(NULL), ( NULL == temp_downtime->author ? "(Nagios Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
+		add_new_comment(HOST_COMMENT, DOWNTIME_COMMENT, hst->name, NULL, temp_downtime->entry_time, ( NULL == temp_downtime->author ? "(Nagios Process)" : temp_downtime->author), temp_buffer, 0, COMMENTSOURCE_INTERNAL, FALSE, (time_t)0, &(temp_downtime->comment_id));
 
 	my_free(temp_buffer);
 


### PR DESCRIPTION
## To Test

Schedule downtime for a host or service. Observe the entry time in the comment.

Restart nagios

Observe the comment again. Now the time shouldn't change.