### PR TITLE
Fix: Add a colon at the end of the encoding

### DIFF
--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -1116,7 +1116,7 @@ static inline char* encode_character(char in, char *outcp, int outcp_len, char *
 	if (out_len + 6 >= outcp_len - 1)
 		return outcp;
 
-	sprintf(outcp, "&#%u", (unsigned int)in);
+	sprintf(outcp, "&#%u;", (unsigned int)in);
 	outcp += strlen(outcp);
 
 	return outcp;


### PR DESCRIPTION
## To Test

Create a host and service like the following
```
define host {
    host_name               dummy_host
    address                 localhost
    max_check_attempts      5
    check_period            24x7
    notification_period     24x7
    check_command           check_dummy!0!'all sorts of ascii characters\! {2}3`7_8[7]9<script>alert(1)</script>^2&3@,'
}

define service {
    host_name               dummy_host
    service_description     dummy_service
    check_command           check_dummy!0!test^2^test^8^test
    max_check_attempts      5
    check_period            24x7
    notification_period     24x7
}
```
Ensure that they both have the expected output in the interface