### PR TITLE
expand macros for non-existant custom variable as empty string

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Nagios Core 4 Change Log
 ------------------
 * Fix inconsistent links for 'View {Trends,Alert Histogram} For This {Host,Service}' (Mauricio Faria de Oliveira)
 * Fix broken links from removing AngularJS pages in 4.5.3 (Dylan Anderson)
+* Expand the custom variable macros to an empty string, if the custom variable does not exist
 
 4.5.3 - 2024-06-11 
 ------------------

--- a/common/macros.c
+++ b/common/macros.c
@@ -2484,6 +2484,12 @@ int grab_custom_object_macro_r(nagios_macros *mac, char *macro_name, customvaria
 			}
 		}
 
+	/* expand nonexistant custom variables as an empty string */
+	if( result == ERROR ){
+		*output = "";
+		result = OK;
+		}
+
 	return result;
 	}
 


### PR DESCRIPTION
I hope adding the changelog entry to the topmost entry is the right place.