### PR TITLE
Fix [#595}: Scheduled downtime bugs

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,10 @@
 Nagios Core 4 Change Log
 ########################
 
+4.5.8 - 2024-XX-XX
+------------------
+* Fix issues with downtimes that are both flexible and triggered and improve downtime additions in general (#595) (Dylan Anderson)
+
 4.5.7 - 2024-10-24
 ------------------
 * Expand the custom variable macros to an empty string, if the custom variable does not exist (Andre Klärner)

--- a/base/events.c
+++ b/base/events.c
@@ -1300,13 +1300,25 @@ int handle_timed_event(timed_event *event) {
 			update_all_status_data();
 			break;
 
-		case EVENT_SCHEDULED_DOWNTIME:
+		case EVENT_SCHEDULED_DOWNTIME_START:
 
-			log_debug_info(DEBUGL_EVENTS, 0, "** Scheduled Downtime Event. Latency: %.3fs\n", latency);
+			log_debug_info(DEBUGL_EVENTS, 0, "** Scheduled Downtime Start Event. Latency: %.3fs\n", latency);
 
 			/* process scheduled downtime info */
 			if(event->event_data) {
-				handle_scheduled_downtime_by_id(*(unsigned long *)event->event_data);
+				handle_scheduled_downtime_start_by_id(*(unsigned long *)event->event_data);
+				free(event->event_data);
+				event->event_data = NULL;
+				}
+			break;
+
+		case EVENT_SCHEDULED_DOWNTIME_END:
+
+			log_debug_info(DEBUGL_EVENTS, 0, "** Scheduled Downtime End Event. Latency: %.3fs\n", latency);
+
+			/* process scheduled downtime info */
+			if(event->event_data) {
+				handle_scheduled_downtime_end_by_id(*(unsigned long *)event->event_data);
 				free(event->event_data);
 				event->event_data = NULL;
 				}

--- a/common/downtime.c
+++ b/common/downtime.c
@@ -386,6 +386,7 @@ int register_downtime(int type, unsigned long downtime_id) {
 	char flex_start_string[MAX_DATETIME_LENGTH] = "";
 	char end_time_string[MAX_DATETIME_LENGTH] = "";
 	scheduled_downtime *temp_downtime = NULL;
+	scheduled_downtime *triggering_downtime = NULL;
 	host *hst = NULL;
 	service *svc = NULL;
 	const char *type_string = NULL;
@@ -514,11 +515,12 @@ int register_downtime(int type, unsigned long downtime_id) {
 
 	/* If the triggering downtime is already in effect, trigger this now */
 	if(temp_downtime->triggered_by != 0 && was_in_effect == FALSE) {
-		for(scheduled_downtime *parent_downtime = scheduled_downtime_list; parent_downtime != NULL; parent_downtime = parent_downtime->next) {
-			if(temp_downtime->triggered_by == parent_downtime->downtime_id && parent_downtime->is_in_effect == TRUE)
+		/* This check shouldn't ever return NULL because of checking done before in other functions but just in case */
+		if((triggering_downtime = find_downtime(ANY_DOWNTIME, temp_downtime->triggered_by)) != NULL) {
+			if(triggering_downtime->is_in_effect == TRUE) 
 				schedule_event = TRUE;
+			}
 		}
-	}
 	
 	if (schedule_event == TRUE) {
 		log_debug_info(DEBUGL_DOWNTIME, 1, "Conditions to schedule downtime event have been met\n");

--- a/include/downtime.h
+++ b/include/downtime.h
@@ -80,8 +80,10 @@ int schedule_downtime(int, char *, char *, time_t, char *, char *, time_t, time_
 int unschedule_downtime(int, unsigned long);
 
 int register_downtime(int, unsigned long);
-int handle_scheduled_downtime(struct scheduled_downtime *);
-int handle_scheduled_downtime_by_id(unsigned long);
+int handle_scheduled_downtime_start(struct scheduled_downtime *);
+int handle_scheduled_downtime_end(struct scheduled_downtime *);
+int handle_scheduled_downtime_start_by_id(unsigned long);
+int handle_scheduled_downtime_end_by_id(unsigned long);
 
 int check_pending_flex_host_downtime(struct host *);
 int check_pending_flex_service_downtime(struct service *);

--- a/include/nagios.h
+++ b/include/nagios.h
@@ -354,25 +354,27 @@ extern struct load_control loadctl;
 
 	/******************* EVENT TYPES **********************/
 
-#define EVENT_SERVICE_CHECK		0	/* active service check */
-#define EVENT_COMMAND_CHECK		1	/* external command check */
-#define EVENT_LOG_ROTATION		2	/* log file rotation */
-#define EVENT_PROGRAM_SHUTDOWN		3	/* program shutdown */
-#define EVENT_PROGRAM_RESTART		4	/* program restart */
-#define EVENT_CHECK_REAPER              5       /* reaps results from host and service checks */
-#define EVENT_ORPHAN_CHECK		6	/* checks for orphaned hosts and services */
-#define EVENT_RETENTION_SAVE		7	/* save (dump) retention data */
-#define EVENT_STATUS_SAVE		8	/* save (dump) status data */
-#define EVENT_SCHEDULED_DOWNTIME	9	/* scheduled host or service downtime */
-#define EVENT_SFRESHNESS_CHECK          10      /* checks service result "freshness" */
-#define EVENT_EXPIRE_DOWNTIME		11      /* checks for (and removes) expired scheduled downtime */
-#define EVENT_HOST_CHECK                12      /* active host check */
-#define EVENT_HFRESHNESS_CHECK          13      /* checks host result "freshness" */
-#define EVENT_RESCHEDULE_CHECKS		14      /* adjust scheduling of host and service checks */
-#define EVENT_EXPIRE_COMMENT            15      /* removes expired comments */
-#define EVENT_CHECK_PROGRAM_UPDATE      16      /* checks for new version of Nagios */
-#define EVENT_SLEEP                     98      /* asynchronous sleep event that occurs when event queues are empty */
-#define EVENT_USER_FUNCTION             99      /* USER-defined function (modules) */
+#define EVENT_SERVICE_CHECK             0   /* active service check */
+#define EVENT_COMMAND_CHECK             1   /* external command check */
+#define EVENT_LOG_ROTATION              2   /* log file rotation */
+#define EVENT_PROGRAM_SHUTDOWN          3   /* program shutdown */
+#define EVENT_PROGRAM_RESTART           4   /* program restart */
+#define EVENT_CHECK_REAPER              5   /* reaps results from host and service checks */
+#define EVENT_ORPHAN_CHECK              6   /* checks for orphaned hosts and services */
+#define EVENT_RETENTION_SAVE            7   /* save (dump) retention data */
+#define EVENT_STATUS_SAVE               8   /* save (dump) status data */
+#define EVENT_SCHEDULED_DOWNTIME        9   /* scheduled host or service downtime */
+#define EVENT_SFRESHNESS_CHECK          10  /* checks service result "freshness" */
+#define EVENT_EXPIRE_DOWNTIME           11  /* checks for (and removes) expired scheduled downtime */
+#define EVENT_HOST_CHECK                12  /* active host check */
+#define EVENT_HFRESHNESS_CHECK          13  /* checks host result "freshness" */
+#define EVENT_RESCHEDULE_CHECKS         14  /* adjust scheduling of host and service checks */
+#define EVENT_EXPIRE_COMMENT            15  /* removes expired comments */
+#define EVENT_CHECK_PROGRAM_UPDATE      16  /* checks for new version of Nagios */
+#define EVENT_SCHEDULED_DOWNTIME_START  17  /* start scheduled host or service downtime */
+#define EVENT_SCHEDULED_DOWNTIME_END    18  /* end scheduled host or service downtime */
+#define EVENT_SLEEP                     98  /* asynchronous sleep event that occurs when event queues are empty */
+#define EVENT_USER_FUNCTION             99  /* USER-defined function (modules) */
 
 /*
  * VERSIONFIX: Make EVENT_SLEEP and EVENT_USER_FUNCTION appear
@@ -397,6 +399,8 @@ extern struct load_control loadctl;
 	type == EVENT_RESCHEDULE_CHECKS ? "RESCHEDULE_CHECKS" : \
 	type == EVENT_EXPIRE_COMMENT ? "EXPIRE_COMMENT" : \
 	type == EVENT_CHECK_PROGRAM_UPDATE ? "CHECK_PROGRAM_UPDATE" : \
+	type == EVENT_SCHEDULED_DOWNTIME_START ? "SCHEDULED_DOWNTIME_START" : \
+	type == EVENT_SCHEDULED_DOWNTIME_END ? "SCHEDULED_DOWNTIME_END" : \
 	type == EVENT_SLEEP ? "SLEEP" : \
 	type == EVENT_USER_FUNCTION ? "USER_FUNCTION" : \
 	"UNKNOWN" \

--- a/t-tap/stub_downtime.c
+++ b/t-tap/stub_downtime.c
@@ -12,7 +12,10 @@ int check_pending_flex_host_downtime(host *hst)
 int check_pending_flex_service_downtime(service *svc) 
 { return OK; }
 
-int handle_scheduled_downtime_by_id(unsigned long downtime_id) 
+int handle_scheduled_downtime_start_by_id(unsigned long downtime_id) 
+{ return OK; }
+
+int handle_scheduled_downtime_end_by_id(unsigned long downtime_id) 
 { return OK; }
 
 int check_for_expired_downtime(void) 
@@ -48,7 +51,10 @@ int delete_downtime(int id, unsigned long downtime_id)
 int register_downtime(int id, unsigned long downtime_id) 
 { return OK; }
 
-int handle_scheduled_downtime(struct scheduled_downtime *sd) 
+int handle_scheduled_downtime_start(struct scheduled_downtime *sd) 
+{ return OK; }
+
+int handle_scheduled_downtime_end(struct scheduled_downtime *sd) 
 { return OK; }
 
 int is_host_in_pending_flex_downtime(struct host *hst) 


### PR DESCRIPTION
Closes #595 

There was a lot of confusion around making sure events are not "double scheduled" resulting in the downtime just starting and ending immediately. So I got rid of it and moved the start and end logic into separate functions. This increases some repeated code but I think that it's worth it.

I also added refactored and added to the register_downtime function, so now a triggered downtime will start if the triggering downtime is already on and a flex downtime will start if the host/service is already down
## To Test
Play with downtimes. Add a variety of different downtimes under different conditions.  Make sure that behavior is expected.

## Issues still present
* I don't like how the downtime expiring sends a downtime end notification.
* When a downtime expires, events that would have been triggered by it are not deleted
* Instead of just not scheduling a downtime if the time is passed the downtime end, it'll just immediately scheduled a downtime end