### PR TITLE
Fix: Unreachable status should be notifiable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt remove libgd3 nginx
-        sudo apt install libgd-dev valgrind
+        sudo apt install libgd-dev valgrind binutils
     - name: configure
       run: ./configure --enable-testing
     - name: Run Tests

--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,10 @@
 Nagios Core 4 Change Log
 ########################
 
+4.5.9 - 2024-XX-XX
+------------------
+* Fix unreachable notifications (Dylan Anderson)
+
 4.5.8 - 2024-11-19
 ------------------
 * Improve new exfoliation theme and add back in PID information (Dylan Anderson)

--- a/base/notifications.c
+++ b/base/notifications.c
@@ -397,23 +397,6 @@ int check_service_notification_viability(service *svc, int type, int options) {
 			}
 		}
 
-	/* If all of the host parents are down, don't notify */
-	if (temp_host->parent_hosts != NULL) {
-		int bad_parents = 0, total_parents = 0;
-		hostsmember *temp_hostsmember = NULL;
-
-		for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
-			if (temp_hostsmember->host_ptr->current_state != HOST_UP)
-				bad_parents += !!temp_hostsmember->host_ptr->current_state;
-			total_parents++;
-			}
-		if(bad_parents == total_parents) {
-			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service has a host with no good parents, so notification will be blocked.\n");
-			return ERROR;
-			}
-		}
-
-
 	/* if the service has no notification period, inherit one from the host */
 	temp_period = svc->notification_period_ptr;
 	if(temp_period == NULL) {
@@ -629,6 +612,22 @@ int check_service_notification_viability(service *svc, int type, int options) {
 	if(temp_host->current_state != STATE_UP && temp_host->state_type == HARD_STATE) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "The host is either down or unreachable, so we won't notify contacts about this service.\n");
 		return ERROR;
+		}
+
+	/* If all of the host parents are down, don't notify */
+	if (temp_host->parent_hosts != NULL) {
+		int bad_parents = 0, total_parents = 0;
+		hostsmember *temp_hostsmember = NULL;
+
+		for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
+			if (temp_hostsmember->host_ptr->current_state != HOST_UP)
+				bad_parents += !!temp_hostsmember->host_ptr->current_state;
+			total_parents++;
+			}
+		if(bad_parents == total_parents) {
+			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service has a host with no good parents, so notification will be blocked.\n");
+			return ERROR;
+			}
 		}
 
 	/* don't notify if we haven't waited long enough since the last time (and the service is not marked as being volatile) */

--- a/base/notifications.c
+++ b/base/notifications.c
@@ -397,6 +397,23 @@ int check_service_notification_viability(service *svc, int type, int options) {
 			}
 		}
 
+	/* If all of the host parents are down, don't notify */
+	if (temp_host->parent_hosts != NULL) {
+		int bad_parents = 0, total_parents = 0;
+		hostsmember *temp_hostsmember = NULL;
+
+		for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
+			if (temp_hostsmember->host_ptr->current_state != HOST_UP)
+				bad_parents += !!temp_hostsmember->host_ptr->current_state;
+			total_parents++;
+			}
+		if(bad_parents == total_parents) {
+			log_debug_info(DEBUGL_NOTIFICATIONS, 1, "This service has a host with no good parents, so notification will be blocked.\n");
+			return ERROR;
+			}
+		}
+
+
 	/* if the service has no notification period, inherit one from the host */
 	temp_period = svc->notification_period_ptr;
 	if(temp_period == NULL) {
@@ -613,20 +630,6 @@ int check_service_notification_viability(service *svc, int type, int options) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "The host is either down or unreachable, so we won't notify contacts about this service.\n");
 		return ERROR;
 		}
-
-	/* If any of the parents are down, don't notify */
-	if (temp_host->parent_hosts != NULL) {
-		hostsmember *temp_hostsmember = NULL;
-		host *parent_host = NULL;
-
-		for(temp_hostsmember = temp_host->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
-			parent_host = temp_hostsmember->host_ptr;
-			if (parent_host->current_state != HOST_UP) {
-				log_debug_info(DEBUGL_NOTIFICATIONS, 1, "At least one parent (%s) is down, so we won't notify about this service.\n", parent_host->name);
-				return ERROR;
-			}
-		}
-	}
 
 	/* don't notify if we haven't waited long enough since the last time (and the service is not marked as being volatile) */
 	if((current_time < svc->next_notification) && svc->is_volatile == FALSE) {
@@ -1537,20 +1540,6 @@ int check_host_notification_viability(host *hst, int type, int options) {
 		log_debug_info(DEBUGL_NOTIFICATIONS, 1, "Next acceptable notification time: %s", ctime(&hst->next_notification));
 		return ERROR;
 		}
-
-	/* If any of the parents are down, don't notify */
-	if (hst->parent_hosts != NULL) {
-		hostsmember *temp_hostsmember = NULL;
-		host *parent_host = NULL;
-
-		for(temp_hostsmember = hst->parent_hosts; temp_hostsmember != NULL; temp_hostsmember = temp_hostsmember->next) {
-			parent_host = temp_hostsmember->host_ptr;
-			if (parent_host->current_state != HOST_UP) {
-				log_debug_info(DEBUGL_NOTIFICATIONS, 1, "At least one parent (%s) is down, so we won't notify about this host.\n", parent_host->name);
-				return ERROR;
-			}
-		}
-	}
 
 	return OK;
 	}


### PR DESCRIPTION
I was revisiting #873 and realized it was probably a mistake to stop notifications if only one of the parents are down (flukes are a thing, hence check_attempts). Making a host no longer notify if all it's parents are down would make sense, except that's what unreachable is, and you can configure whether or not you get unreachable notifications so I'm removing that check for hosts.

The thing I'm a little hung up on is what the expected behavior is for services. There isn't a host_unreachable equivalent (maybe state_unknown but I think that's a little different) so I feel a little bit better about disabling checks if it's host parents are all down, which is what I'm doing here.

Regardless, I'm looking for some feedback from the community as to what they expect from service notifications in instances described in #873 