### PR TITLE
Fix #1010: Re order authentication

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ Nagios Core 4 Change Log
 4.5.9 - 2024-XX-XX
 ------------------
 * Fix unreachable notifications (Dylan Anderson)
+* Fix authentication in trends.cgi (Dylan Anderson)
 
 4.5.8 - 2024-11-19
 ------------------

--- a/cgi/trends.c
+++ b/cgi/trends.c
@@ -317,9 +317,6 @@ int main(int argc, char **argv) {
 	/* get the arguments passed in the URL */
 	process_cgivars();
 
-	/* get authentication information */
-	get_authentication_information(&current_authdata);
-
 	result = read_all_object_configuration_data(main_config_file, READ_ALL_OBJECT_DATA);
 	if(result == ERROR) {
 		if(mode == CREATE_HTML) {
@@ -342,6 +339,9 @@ int main(int argc, char **argv) {
 		}
 
 	document_header(TRUE);
+
+	/* get authentication information */
+	get_authentication_information(&current_authdata);
 
 	if(compute_time_from_parts == TRUE)
 		compute_report_times();


### PR DESCRIPTION
Closes #1010 

Reorders authentication so that it does it like every other CGI