### PR TITLE
Insecure permissions nagios service

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Nagios Core 4 Change Log
 -------------------
 * Update quickstart and documentations links (Aaron Cieslicki)
 * Remove null coalescing operators and fix some php errors (Dylan Anderson and Robert Högberg)
+* Lower permissions for nagios.service to meet secuirty standards from RHEL (Nate Nelson)
 
 4.5.9 - 2024-12-19
 ------------------

--- a/Changelog
+++ b/Changelog
@@ -6,7 +6,7 @@ Nagios Core 4 Change Log
 -------------------
 * Update quickstart and documentations links (Aaron Cieslicki)
 * Remove null coalescing operators and fix some php errors (Dylan Anderson and Robert Högberg)
-* Lower permissions for nagios.service to meet secuirty standards from RHEL (Nate Nelson)
+* Lower permissions for nagios.service to meet security standards from RHEL (Nate Nelson)
 
 4.5.9 - 2024-12-19
 ------------------

--- a/Makefile.in
+++ b/Makefile.in
@@ -397,7 +397,7 @@ install-classicui:
 
 install-init:
 	$(INSTALL) -m 755 -d $(INIT_OPTS) $(DESTDIR)$(INIT_DIR)
-	$(INSTALL) -m 755 $(INIT_OPTS) startup/$(BLD_INIT) $(DESTDIR)$(INIT_DIR)/$(INIT_FILE)
+	$(INSTALL) -m 644 $(INIT_OPTS) startup/$(BLD_INIT) $(DESTDIR)$(INIT_DIR)/$(INIT_FILE)
 
 install-daemoninit: install-init
 	@if [ x$(INIT_TYPE) = xsysv ]; then \


### PR DESCRIPTION
This patch changes the permissions of the systemd unit file for Nagios from 755 to 644. The system is vulnerable because there are systemd unit files with insecure permissions. Systemd unit file permission are considered insecure in the following situations:

* At least one of user, group and others has an execute permission bit.
* Others has a write permission bit.
* Group has a write permission bit.

Making these changes are due to security concerns for Nagios XI which uses Nagios Core.  Switching 755 to 644 permissions removes the execution bits from all the groups thus making the systemd unit files secure.

https://www.baeldung.com/linux/systemd-unit-file-permissions

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_systemd_unit_files_to_customize_and_optimize_your_system/assembly_working-with-systemd-unit-files_working-with-systemd#proc_creating-custom-unit-files_assembly_working-with-systemd-unit-files
