### PR TITLE
configure.ac,Makefile.in: replace "which" with "command -v"

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -264,7 +264,7 @@ test-perl: cgis
 	cd t && $(MAKE) test
 
 coverage: test
-	@if ! which lcov >/dev/null 2>&1; then \
+	@if ! command -v lcov >/dev/null 2>&1; then \
 		echo "ERROR: You must install lcov and genhtml first"; \
 	else \
 		lcov -c -d . -o nagioscore.info-file; \
@@ -401,23 +401,23 @@ install-init:
 
 install-daemoninit: install-init
 	@if [ x$(INIT_TYPE) = xsysv ]; then \
-		if which chkconfig >/dev/null 2>&1; then \
+		if command -v chkconfig >/dev/null 2>&1; then \
 			chkconfig --add nagios; \
-		elif which update-rc.d >/dev/null 2>&1; then \
+		elif command -v update-rc.d >/dev/null 2>&1; then \
 			update-rc.d nagios defaults; \
 		fi \
 	elif [ x$(INIT_TYPE) = xsystemd ]; then \
-		if which systemctl >/dev/null 2>&1; then \
+		if command -v systemctl >/dev/null 2>&1; then \
 			systemctl daemon-reload; \
 			systemctl enable nagios.service; \
 		fi; \
 		chmod 0644 $(INIT_DIR)/$(INIT_FILE); \
 	elif [ x$(INIT_TYPE) = xupstart ]; then \
-		if which initctl >/dev/null 2>&1; then \
+		if command -v initctl >/dev/null 2>&1; then \
 			initctl reload-configuration; \
 		fi \
 	elif [ x$(INIT_TYPE) = xopenrc ]; then \
-		if which rc-update >/dev/null 2>&1; then \
+		if command -v rc-update >/dev/null 2>&1; then \
 			rc-update add nagios default; \
 		fi \
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -279,10 +279,10 @@ if test "x$MAIL_PROG" = "xno"; then
 fi 
 dnl Fix for systems that don't (yet) have mail/mailx installed...
 if test "x$MAIL_PROG" = "x"; then
-	if which mail >/dev/null; then
-		MAIL_PROG=`which mail`
-	elif which sendmail >/dev/null; then
-		MAIL_PROG=`which sendmail`
+	if command -v mail >/dev/null; then
+		MAIL_PROG=$(command -v mail)
+	elif command -v sendmail >/dev/null; then
+		MAIL_PROG=$(command -v sendmail)
 	else
 		MAIL_PROG="/bin/mail"
 	fi
@@ -290,14 +290,14 @@ fi
 AC_SUBST(MAIL_PROG)
 
 dnl Determine location of the rm binary
-BIN_RM=`which rm`
+BIN_RM=$(command -v rm)
 if test $? -ne 0; then
 	BIN_RM='/bin/rm'
 fi
 AC_SUBST(BIN_RM)
 
 dnl Determine location of the kill binary
-BIN_KILL=`which kill`
+BIN_KILL=$(command -v kill)
 if test $? -ne 0; then
 	BIN_KILL='/bin/kill'
 fi

--- a/t-tap/Makefile.in
+++ b/t-tap/Makefile.in
@@ -113,7 +113,7 @@ test_xsddefault: test_xsddefault.o $(XSD_OBJS) $(TAPOBJ)
 
 test: $(TESTS) smallconfig var
 	HARNESS_PERL=$(srcdir)/test_each.t perl -MTest::Harness -e '$$Test::Harness::switches=""; runtests(map { "./$$_" } @ARGV)' $(TESTS) 2>&1
-	if which valgrind >/dev/null 2>&1; then 	\
+	if command -v valgrind >/dev/null 2>&1; then 	\
 		valgrind ./test_macros;					\
 		valgrind ./test_checks;					\
 	fi


### PR DESCRIPTION
The _which_ utility is commonly used to test for programs in the user's `$PATH`. This has two downsides:

  1. Each invocation of _which_ launches a new process, and this can cause minor performance issues.
  2. The _which_ program need not be present on every system (it is certainly less common than, say, the _rm_ program that we are using it to find).

This commit changes each `which` to `command -v` to avoid these two issues. The _command_ utility is [standardized by POSIX](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/command.html), and is typically implemented as a shell built-in rather than as a separate utility.

### Note

I have not regenerated the autotools files (i.e. the configure script). That needs to be done before this will take effect.