### PR TITLE
*.*: replace sys/poll.h with poll.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ AC_CHECK_HEADERS(libgen.h limits.h math.h netdb.h netinet/in.h pwd.h regex.h)
 AC_CHECK_HEADERS(signal.h socket.h stdarg.h string.h strings.h sys/loadavg.h)
 AC_CHECK_HEADERS(sys/mman.h sys/types.h sys/time.h sys/resource.h sys/wait.h)
 AC_CHECK_HEADERS(sys/socket.h sys/stat.h sys/timeb.h sys/un.h sys/ipc.h)
-AC_CHECK_HEADERS(sys/msg.h sys/poll.h syslog.h uio.h unistd.h locale.h wchar.h)
+AC_CHECK_HEADERS(sys/msg.h poll.h syslog.h uio.h unistd.h locale.h wchar.h)
 AC_CHECK_HEADERS(sys/prctl.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -290,9 +290,9 @@
 #include <sys/un.h>
 #endif
 
-#undef HAVE_SYS_POLL_H
-#ifdef HAVE_SYS_POLL_H
-#include <sys/poll.h>
+#undef HAVE_POLL_H
+#ifdef HAVE_POLL_H
+#include <poll.h>
 #endif
 
 #undef HAVE_GETOPT_H

--- a/include/ignored_config.h.in
+++ b/include/ignored_config.h.in
@@ -146,8 +146,8 @@
 /* Define to 1 if you have the <sys/msg.h> header file. */
 #undef HAVE_SYS_MSG_H
 
-/* Define to 1 if you have the <sys/poll.h> header file. */
-#undef HAVE_SYS_POLL_H
+/* Define to 1 if you have the <poll.h> header file. */
+#undef HAVE_POLL_H
 
 /* Define to 1 if you have the <sys/prctl.h> header file. */
 #undef HAVE_SYS_PRCTL_H

--- a/lib/wproc.c
+++ b/lib/wproc.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <sys/wait.h>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>


### PR DESCRIPTION
According to POSIX, the standard name for this header is [poll.h](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/poll.h.html).  

This eliminates some compiler warnings like,

```
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~
```

**Note**: for this to take effect, the `./configure` script needs to be regenerated.