### PR TITLE
runcmd.c: change maxfd definition to static variable

### DIFF
--- a/lib/runcmd.c
+++ b/lib/runcmd.c
@@ -58,10 +58,10 @@ static pid_t *pids = NULL;
  * adequate and the program will die with SIGSEGV if it isn't and the
  * upper boundary is breached. */
 #ifdef OPEN_MAX
-# define maxfd OPEN_MAX
+static int maxfd = OPEN_MAX;
 #else
 # ifndef _SC_OPEN_MAX /* sysconf macro unavailable, so guess */
-#  define maxfd 256
+static int maxfd = 256;
 # else
 static int maxfd = 0;
 # endif /* _SC_OPEN_MAX */


### PR DESCRIPTION
This pull request updates how the maximum number of file descriptors (maxfd) is defined in `lib/runcmd.c`. The change replaces preprocessor macro definitions with a static variable.

There is a compile-time issue when `OPEN_MAX` is defined and `maxfd` therefore expands to a constant. If `RLIMIT_NOFILE` is also defined, the assignment in `runcmd_init()` expands to an assignment to a constant expression, which is invalid C and fails at compile time. 
https://github.com/NagiosEnterprises/nagioscore/blob/e1fd7d8b4dda82fc43ccbe4f8bf1897c9bad5398/lib/runcmd.c#L307-L312

This issue occurs on MacOS 15.6.1 (arm):

```
  runcmd.c:311:9: error: expression is not assignable
    311 |                 maxfd = rlim.rlim_cur;
        |                 ~~~~~ ^
  1 error generated.

```


