### PR TITLE
Add the Option for CSRF Cookie to Fail Open

### DIFF
--- a/cgi/cgiutils.c
+++ b/cgi/cgiutils.c
@@ -72,6 +72,7 @@ int             navbar_search_aliases = TRUE;
 int		ack_no_sticky  = FALSE;
 int		ack_no_send    = FALSE;
 int		tac_cgi_hard_only = FALSE;
+int		cgi_cookie_fail_open = FALSE;
 
 time_t          this_scheduled_log_rotation = 0L;
 time_t          last_scheduled_log_rotation = 0L;
@@ -443,6 +444,8 @@ int read_cgi_config_file(const char *filename, read_config_callback callback) {
 			ack_no_send = (atoi(val) > 0) ? TRUE : FALSE;
 		else if(!strcmp(var, "tac_cgi_hard_only"))
 			tac_cgi_hard_only = (atoi(val) > 0) ? TRUE : FALSE;
+		else if (!strcmp(var, "cgi_cookie_fail_open"))
+			cgi_cookie_fail_open = (atoi(val) > 0) ? TRUE : FALSE;
 		else if (callback)
 			(*callback)(var,val);
 		}

--- a/cgi/cmd.c
+++ b/cgi/cmd.c
@@ -44,6 +44,7 @@ extern int  lock_author_names;
 
 extern int ack_no_sticky;
 extern int ack_no_send;
+extern int cgi_cookie_fail_open;
 
 #define MAX_AUTHOR_LENGTH	64
 #define MAX_COMMENT_LENGTH	1024
@@ -112,7 +113,6 @@ int string_to_time(char *, time_t *);
 
 int main(void) {
 	int result = OK;
-	int formid_ok = ERROR;
 
 	/* Initialize shared configuration variables */                             
 	init_shared_cfg_vars(1);
@@ -217,6 +217,8 @@ int main(void) {
 
 		return OK;
         }
+
+	int formid_ok = cgi_cookie_fail_open ? OK : ERROR;
 
 	if (cookie_form_id && *cookie_form_id) {
 		if (form_id && *form_id) {

--- a/sample-config/cgi.cfg.in
+++ b/sample-config/cgi.cfg.in
@@ -404,6 +404,21 @@ navbar_search_for_aliases=1
 
 
 
+# CGI CSRF COOKIE CHECK BEHAVIOR
+# This option controls how the CGI handles a missing CSRF Cookie.
+# 0 (default): Fail closed - reject the request if the CSRF cookie is
+# missing or invalid. This is more secure.
+# 1: Fail open - allow the request even if the CSRF cookie check fails.
+# This reduces CSRF protection but may be required for some third-party
+# integrations.
+#
+# WARNING: Enabling fail open weakens security and should only be used
+# if you fully understand the risk.
+
+#cgi_cookie_fail_open=0
+
+
+
 # COMMAND COMMENTS
 # These options control whether or not comments are required, optional,
 # or not allowed for specific commands. The format for each line is:


### PR DESCRIPTION
While fixing a security vulnerability with the release of 4.5.12, the ability for legitimate third-party integrations to interact with cmd.cgi was also blocked. Given the nature of how CGIs work in Core, I don't know of a means to allow for integrations while blocking CSRF attacks. Thus, I've added a config option (called `cgi_cookie_fail_open`) in cgi.cfg that allows one to revert this functionality. This option changes the CSRF cookie behavior to how it was before 4.5.12.

Thanks to @dneuhaeuser for bringing this to our attention. 

To test,
1. Install this branch (either as a clean install or by pulling and compiling this branch).
2. Make sure the cmd.cgi is properly setup ([this forum](https://support.nagios.com/forum/viewtopic.php?t=76845) post is a great resource).
3. Login to the UI at least once.
4. DO NOT GO TO THE FOLLOWING LINK ON A PROD BOX. (It updates the status of localhost and might break perfdata)
5. In a new tab, go to the following link `http://<core address>/nagios/cgi-bin/cmd.cgi?cmd_typ=87&cmd_mod=2&host=localhost&plugin_state=0&plugin_output=CSRF_TEST&performance_data=&btnSubmit=Commit`.
6. If the option is set to 0 or not specified, one should get an error akin to `Error: Invalid or missing CSRF cookie!`.
7. If the option is set to 1, one should see that the command was successfully submitted and localhost should have new status information.