### PR TITLE
Ensure we don't confuse a future check time with a valid cached result

### DIFF
--- a/base/checks.c
+++ b/base/checks.c
@@ -1699,7 +1699,7 @@ inline void schedule_service_check(service *svc, time_t check_time, int options)
 
 	/* we may have to nudge this check a bit */
 	if (options == CHECK_OPTION_DEPENDENCY_CHECK) {
-		if (svc->last_check + cached_service_check_horizon > check_time) {
+		if (svc->last_check <= time(NULL) && svc->last_check + cached_service_check_horizon > check_time) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Last check result is recent enough (%s)", ctime(&svc->last_check));
 			return;
 		}
@@ -3122,12 +3122,14 @@ int run_async_host_check(host *hst, int check_options, double latency, int sched
 
 	/* abort if check is already running or was recently completed */
 	if (!(check_options & CHECK_OPTION_FORCE_EXECUTION)) {
+		time_t current_time = time(NULL);
+
 		if (hst->is_executing == TRUE) {
 			log_debug_info(DEBUGL_CHECKS, 1, "A check of this host is already being executed, so we'll pass for the moment...\n");
 			return ERROR;
 		}
 
-		if (hst->last_check + cached_host_check_horizon > time(NULL)) {
+		if (hst->last_check <= current_time && hst->last_check + cached_host_check_horizon > current_time) {
 			log_debug_info(DEBUGL_CHECKS, 0, "Host '%s' was last checked within its cache horizon. Aborting check\n", hst->name);
 			return ERROR;
 		}


### PR DESCRIPTION
If for some reason the last_check time is more than the horizon seconds into the future we'll always assume it's a valid cached result and never run the check. A difference of a few minutes is self recovering but weeks or years and the checks will never run.

|  |  |
| --- | --- |
Host Status: |	DOWN   (for ???)  (Has been acknowledged)
|Status Information: |	CRITICAL - Host Unreachable (xx.xx.xx.xx)
|Current Attempt: |	3/3  (HARD state)
|Last Check Time:|	***07-03-2031 05:06:16***
|Check Type:|	ACTIVE
|Check Latency / Duration:|	0.000 / 3.078 seconds
|Next Scheduled Active Check:|  	05-15-2026 21:03:40
|Last State Change:|	***03-01-2031 10:45:56***
|Last Notification:|	***03-01-2031 10:46:00*** (notification 1)
|Is This Host Flapping?|	  NO   (0.00% state change)
|In Scheduled Downtime?|	  NO
|Last Update:|	05-15-2026 20:54:09  (??? ago)